### PR TITLE
Tests are now done with Geant3 and Geant4.

### DIFF
--- a/example/Tutorial1/macros/CMakeLists.txt
+++ b/example/Tutorial1/macros/CMakeLists.txt
@@ -1,7 +1,11 @@
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/example/Tutorial1/macros/run_tutorial1.C)
-add_test(run_tutorial1 ${CMAKE_BINARY_DIR}/example/Tutorial1/macros/run_tutorial1.sh)
-SET_TESTS_PROPERTIES(run_tutorial1 PROPERTIES TIMEOUT "30")
-SET_TESTS_PROPERTIES(run_tutorial1 PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished succesfully")
+
+ForEach(_mcEngine IN ITEMS TGeant3 TGeant4) 
+  Add_Test(run_tutorial1_${_mcEngine} 
+           ${CMAKE_BINARY_DIR}/example/Tutorial1/macros/run_tutorial1.sh 10 \"${_mcEngine}\")
+  Set_Tests_Properties(run_tutorial1_${_mcEngine} PROPERTIES TIMEOUT "30")
+  Set_Tests_Properties(run_tutorial1_${_mcEngine} PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished succesfully")
+EndForEach(_mcEngine IN ITEMS TGeant3 TGeant4) 
 
 Install(FILES run_tutorial1.C
         DESTINATION share/fairbase/example/Tutorial1

--- a/example/Tutorial1/macros/run_tutorial1.C
+++ b/example/Tutorial1/macros/run_tutorial1.C
@@ -1,4 +1,4 @@
-void run_tutorial1(Int_t nEvents = 10)
+void run_tutorial1(Int_t nEvents = 10, TString mcEngine = "TGeant3")
 {
   
   TString dir = getenv("VMCWORKDIR");
@@ -50,7 +50,7 @@ void run_tutorial1(Int_t nEvents = 10)
 
   // -----   Create simulation run   ----------------------------------------
   FairRunSim* run = new FairRunSim();
-  run->SetName("TGeant3");              // Transport engine
+  run->SetName(mcEngine);              // Transport engine
   run->SetOutputFile(outFile);          // Output file
   FairRuntimeDb* rtdb = run->GetRuntimeDb();
   // ------------------------------------------------------------------------

--- a/example/Tutorial3/macro/CMakeLists.txt
+++ b/example/Tutorial3/macro/CMakeLists.txt
@@ -1,31 +1,39 @@
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/example/Tutorial3/macro/run_sim.C)
-add_test(run_sim ${CMAKE_BINARY_DIR}/example/Tutorial3/macro/run_sim.sh)
-SET_TESTS_PROPERTIES(run_sim PROPERTIES TIMEOUT "180")
-SET_TESTS_PROPERTIES(run_sim PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished succesfully")
-
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/example/Tutorial3/macro/run_digi.C)
-add_test(run_digi ${CMAKE_BINARY_DIR}/example/Tutorial3/macro/run_digi.sh)
-SET_TESTS_PROPERTIES(run_digi PROPERTIES DEPENDS run_sim)
-SET_TESTS_PROPERTIES(run_digi PROPERTIES TIMEOUT "30")
-SET_TESTS_PROPERTIES(run_digi PROPERTIES PASS_REGULAR_EXPRESSION "Test passed;All ok")
-
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/example/Tutorial3/macro/run_reco.C)
-add_test(run_reco ${CMAKE_BINARY_DIR}/example/Tutorial3/macro/run_reco.sh)
-SET_TESTS_PROPERTIES(run_reco PROPERTIES DEPENDS run_digi)
-SET_TESTS_PROPERTIES(run_reco PROPERTIES TIMEOUT "30")
-SET_TESTS_PROPERTIES(run_reco PROPERTIES PASS_REGULAR_EXPRESSION "Test passed;All ok")
-
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/example/Tutorial3/macro/run_digi_timebased.C)
-add_test(run_digi_timebased ${CMAKE_BINARY_DIR}/example/Tutorial3/macro/run_digi_timebased.sh)
-SET_TESTS_PROPERTIES(run_digi_timebased PROPERTIES DEPENDS run_sim)
-SET_TESTS_PROPERTIES(run_digi_timebased PROPERTIES TIMEOUT "30")
-SET_TESTS_PROPERTIES(run_digi_timebased PROPERTIES PASS_REGULAR_EXPRESSION "Test passed;All ok")
-
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/example/Tutorial3/macro/run_reco_timebased.C)
-add_test(run_reco_timebased ${CMAKE_BINARY_DIR}/example/Tutorial3/macro/run_reco_timebased.sh)
-SET_TESTS_PROPERTIES(run_reco_timebased PROPERTIES DEPENDS run_digi_timebased)
-SET_TESTS_PROPERTIES(run_reco_timebased PROPERTIES TIMEOUT "30")
-SET_TESTS_PROPERTIES(run_reco_timebased PROPERTIES PASS_REGULAR_EXPRESSION "Test passed;All ok")
+
+ForEach(_mcEngine IN ITEMS TGeant3 TGeant4) 
+  Add_Test(run_sim_${_mcEngine} 
+           ${CMAKE_BINARY_DIR}/example/Tutorial3/macro/run_sim.sh 1024 \"${_mcEngine}\")
+  Set_Tests_Properties(run_sim_${_mcEngine} PROPERTIES TIMEOUT "180")
+  Set_Tests_Properties(run_sim_${_mcEngine} PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished succesfully")
+
+  Add_Test(run_digi_${_mcEngine} ${CMAKE_BINARY_DIR}/example/Tutorial3/macro/run_digi.sh)
+  Set_Tests_Properties(run_digi_${_mcEngine} PROPERTIES DEPENDS run_sim_${_mcEngine})
+  Set_Tests_Properties(run_digi_${_mcEngine} PROPERTIES TIMEOUT "30")
+  Set_Tests_Properties(run_digi_${_mcEngine} PROPERTIES PASS_REGULAR_EXPRESSION "Test passed;All ok")
+
+
+  Add_Test(run_reco_${_mcEngine} ${CMAKE_BINARY_DIR}/example/Tutorial3/macro/run_reco.sh)
+  Set_Tests_Properties(run_reco_${_mcEngine} PROPERTIES DEPENDS run_digi_${_mcEngine})
+  Set_Tests_Properties(run_reco_${_mcEngine} PROPERTIES TIMEOUT "30")
+  Set_Tests_Properties(run_reco_${_mcEngine} PROPERTIES PASS_REGULAR_EXPRESSION "Test passed;All ok")
+
+
+  Add_Test(run_digi_timebased_${_mcEngine} ${CMAKE_BINARY_DIR}/example/Tutorial3/macro/run_digi_timebased.sh)
+  Set_Tests_Properties(run_digi_timebased_${_mcEngine} PROPERTIES DEPENDS run_sim_${_mcEngine})
+  Set_Tests_Properties(run_digi_timebased_${_mcEngine} PROPERTIES TIMEOUT "30")
+  Set_Tests_Properties(run_digi_timebased_${_mcEngine} PROPERTIES PASS_REGULAR_EXPRESSION "Test passed;All ok")
+
+
+  Add_Test(run_reco_timebased_${_mcEngine} ${CMAKE_BINARY_DIR}/example/Tutorial3/macro/run_reco_timebased.sh)
+  Set_Tests_Properties(run_reco_timebased_${_mcEngine} PROPERTIES DEPENDS run_digi_timebased_${_mcEngine})
+  Set_Tests_Properties(run_reco_timebased_${_mcEngine} PROPERTIES TIMEOUT "30")
+  Set_Tests_Properties(run_reco_timebased_${_mcEngine} PROPERTIES PASS_REGULAR_EXPRESSION "Test passed;All ok")
+EndForEach(_mcEngine IN ITEMS TGeant3 TGeant4) 
+
 
 Install(FILES run_sim.C run_digi.C run_reco.C eventDisplay.C
               run_digi_timebased.C run_reco_timebased.C

--- a/example/Tutorial3/macro/run_sim.C
+++ b/example/Tutorial3/macro/run_sim.C
@@ -1,4 +1,4 @@
-void run_sim(Int_t nEvents=1024)
+void run_sim(Int_t nEvents=1024, TString mcEngine="TGeant3")
 {
   TStopwatch timer;
   timer.Start();
@@ -20,7 +20,7 @@ void run_sim(Int_t nEvents=1024)
   // set the MC version used
   // ------------------------
 
-  fRun->SetName("TGeant3");
+  fRun->SetName(mcEngine);
   
   fRun->SetOutputFile("data/testrun.root");
 

--- a/example/Tutorial4/macros/CMakeLists.txt
+++ b/example/Tutorial4/macros/CMakeLists.txt
@@ -1,11 +1,17 @@
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/example/Tutorial4/macros/run_tutorial4.C)
-add_test(run_tutorial4 ${CMAKE_BINARY_DIR}/example/Tutorial4/macros/run_tutorial4.sh)
-SET_TESTS_PROPERTIES(run_tutorial4 PROPERTIES TIMEOUT "30")
-SET_TESTS_PROPERTIES(run_tutorial4 PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished succesfully")
-
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/example/Tutorial4/macros/run_reco.C)
-add_test(run_reco_tut4 ${CMAKE_BINARY_DIR}/example/Tutorial4/macros/run_reco.sh)
-SET_TESTS_PROPERTIES(run_reco_tut4 PROPERTIES DEPENDS run_tutorial4)
-SET_TESTS_PROPERTIES(run_reco_tut4 PROPERTIES TIMEOUT "30")
-SET_TESTS_PROPERTIES(run_reco_tut4 PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished successfully")
+
+
+ForEach(_mcEngine IN ITEMS TGeant3 TGeant4) 
+  Add_Test(run_tutorial4_${_mcEngine} 
+           ${CMAKE_BINARY_DIR}/example/Tutorial4/macros/run_tutorial4.sh 10 \"${_mcEngine}\")
+  Set_Tests_Properties(run_tutorial4_${_mcEngine} PROPERTIES TIMEOUT "30")
+  Set_Tests_Properties(run_tutorial4_${_mcEngine} PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished succesfully")
+
+
+  Add_Test(run_reco_tut4_${_mcEngine} ${CMAKE_BINARY_DIR}/example/Tutorial4/macros/run_reco.sh)
+  Set_Tests_Properties(run_reco_tut4_${_mcEngine} PROPERTIES DEPENDS run_tutorial4_${_mcEngine})
+  Set_Tests_Properties(run_reco_tut4_${_mcEngine} PROPERTIES TIMEOUT "30")
+  Set_Tests_Properties(run_reco_tut4_${_mcEngine} PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished successfully")
+EndForEach(_mcEngine IN ITEMS TGeant3 TGeant4) 
 

--- a/example/Tutorial4/macros/run_tutorial4.C
+++ b/example/Tutorial4/macros/run_tutorial4.C
@@ -1,4 +1,4 @@
-void run_tutorial4(Int_t nEvents = 10)
+void run_tutorial4(Int_t nEvents = 10, TString mcEngine="TGeant3")
 {
   
   TString dir = getenv("VMCWORKDIR");
@@ -46,7 +46,7 @@ void run_tutorial4(Int_t nEvents = 10)
  
   // -----   Create simulation run   ----------------------------------------
   FairRunSim* run = new FairRunSim();
-  run->SetName("TGeant3");              // Transport engine
+  run->SetName(mcEngine);              // Transport engine
   run->SetOutputFile(outFile);          // Output file
   FairRuntimeDb* rtdb = run->GetRuntimeDb();
   // ------------------------------------------------------------------------

--- a/example/rutherford/macros/CMakeLists.txt
+++ b/example/rutherford/macros/CMakeLists.txt
@@ -1,12 +1,19 @@
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/example/rutherford/macros/run_rutherford.C)
-add_test(run_rutherford ${CMAKE_BINARY_DIR}/example/rutherford/macros/run_rutherford.sh)
-SET_TESTS_PROPERTIES(run_rutherford PROPERTIES TIMEOUT "30")
-SET_TESTS_PROPERTIES(run_rutherford PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished succesfully")
-
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/example/rutherford/macros/run_rad.C)
-add_test(run_rad ${CMAKE_BINARY_DIR}/example/rutherford/macros/run_rad.sh)
-SET_TESTS_PROPERTIES(run_rad PROPERTIES TIMEOUT "30")
-SET_TESTS_PROPERTIES(run_rad PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished succesfully")
+
+ForEach(_mcEngine IN ITEMS TGeant3 TGeant4) 
+  Add_Test(run_rutherford_${_mcEngine}
+            ${CMAKE_BINARY_DIR}/example/rutherford/macros/run_rutherford.sh 10 \"${_mcEngine}\")
+  Set_Tests_Properties(run_rutherford_${_mcEngine} PROPERTIES TIMEOUT "30")
+  Set_Tests_Properties(run_rutherford_${_mcEngine} PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished succesfully")
+
+  Add_Test(run_rad_${_mcEngine} 
+           ${CMAKE_BINARY_DIR}/example/rutherford/macros/run_rad.sh 100 \"${_mcEngine}\")
+  Set_Tests_Properties(run_rad_${_mcEngine} PROPERTIES TIMEOUT "30")
+  Set_Tests_Properties(run_rad_${_mcEngine} PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished succesfully")
+EndForEach(_mcEngine IN ITEMS TGeant3 TGeant4) 
+
+
 
 Install(FILES run_rutherford.C run_rad.C eventDisplay.C
         DESTINATION share/fairbase/example/rutherford

--- a/example/rutherford/macros/run_rad.C
+++ b/example/rutherford/macros/run_rad.C
@@ -1,4 +1,4 @@
-void run_rad(Int_t nEvents = 100)
+void run_rad(Int_t nEvents = 100, TString mcEngine="TGeant3")
 {
   
   TString dir = gSystem->Getenv("VMCWORKDIR");
@@ -37,7 +37,7 @@ void run_rad(Int_t nEvents = 100)
  
   // -----   Create simulation run   ----------------------------------------
   FairRunSim* run = new FairRunSim();
-  run->SetName("TGeant3");              // Transport engine
+  run->SetName(mcEngine);              // Transport engine
   run->SetOutputFile(outFile);          // Output file
   FairRuntimeDb* rtdb = run->GetRuntimeDb();
   // ------------------------------------------------------------------------

--- a/example/rutherford/macros/run_rutherford.C
+++ b/example/rutherford/macros/run_rutherford.C
@@ -1,4 +1,4 @@
-void run_rutherford(Int_t nEvents = 10)
+void run_rutherford(Int_t nEvents = 10, TString mcEngine="TGeant3")
 {
   
   TString dir = gSystem->Getenv("VMCWORKDIR");
@@ -37,7 +37,7 @@ void run_rutherford(Int_t nEvents = 10)
  
   // -----   Create simulation run   ----------------------------------------
   FairRunSim* run = new FairRunSim();
-  run->SetName("TGeant3");              // Transport engine
+  run->SetName(mcEngine);              // Transport engine
   run->SetOutputFile(outFile);          // Output file
   FairRuntimeDb* rtdb = run->GetRuntimeDb();
   // ------------------------------------------------------------------------


### PR DESCRIPTION
Change CMakeLists.txt of the example macros to run the simulations with Geant3 and Geant4. Adapt the macros to cope with this changes.
