### PR TITLE
fixed: correct amount of long words in a subevent

### DIFF
--- a/base/source/FairLmdSource.cxx
+++ b/base/source/FairLmdSource.cxx
@@ -136,18 +136,17 @@ Int_t FairLmdSource::ReadEvent()
   for(Int_t i = 1; i <= nrSubEvts; i++) {
     void* SubEvtptr = &fxSubEvent;
     void* EvtDataptr = &fxEventData;
-    Int_t* nrlongwords = new Int_t;
-    status = f_evt_get_subevent(fxEvent, i, (Int_t**)SubEvtptr, (Int_t**)EvtDataptr, nrlongwords);
+    Int_t nrlongwords;
+    status = f_evt_get_subevent(fxEvent, i, (Int_t**)SubEvtptr, (Int_t**)EvtDataptr, &nrlongwords);
     if(status) {
       return 1;
     }
-    sebuflength = fxSubEvent->l_dlen;
+    sebuflength = nrlongwords;
     setype = fxSubEvent->i_type;
     sesubtype = fxSubEvent->i_subtype;
     seprocid = fxSubEvent->i_procid;
     sesubcrate = fxSubEvent->h_subcrate;
     secontrol = fxSubEvent->h_control;
-    delete nrlongwords;
 
     if(! Unpack(fxEventData, sebuflength,
                 setype, sesubtype,


### PR DESCRIPTION
FairLmdSource: Take size of an MBS sub-event directly from f_evt_get_subevent()
