### PR TITLE
Dev nw

### DIFF
--- a/base/event/FairHit.cxx
+++ b/base/event/FairHit.cxx
@@ -33,16 +33,8 @@ FairHit::FairHit(Int_t detID, TVector3& pos, TVector3& dpos, Int_t index)
    fZ           (pos.Z())
 {
 }
-// -------------------------------------------------------------------------
 
 
-FairHit::FairHit(const FairHit &Hit) :
-  FairTimeStamp(Hit), 
-  fX(Hit.fX), fY(Hit.fY), fZ(Hit.fZ),
-  fDx(Hit.fDx), fDy(Hit.fDy), fDz(Hit.fDz),
-  fRefIndex(Hit.fRefIndex), fDetectorID(Hit.fDetectorID)
-{
-}
 // -------------------------------------------------------------------------
 
 

--- a/base/event/FairHit.h
+++ b/base/event/FairHit.h
@@ -31,8 +31,6 @@ class FairHit : public FairTimeStamp
     /** Constructor with hit parameters **/
     FairHit(Int_t detID, TVector3& pos, TVector3& dpos, Int_t index);
 
-    FairHit(const FairHit &Hit);
-
     /** Destructor **/
     virtual ~FairHit();
 
@@ -70,12 +68,7 @@ class FairHit : public FairTimeStamp
     virtual void Print(const Option_t* opt ="") const {;}
 
 
-
-  protected:
     
-   #ifndef __CINT__ // for BOOST serialization
-   friend class boost::serialization::access;
-
     template<class Archive>
     void serialize(Archive & ar, const unsigned int version) 
     {
@@ -89,6 +82,12 @@ class FairHit : public FairTimeStamp
         ar & fDy; 
         ar & fDz;
     }
+
+  protected:
+    
+   #ifndef __CINT__ // for BOOST serialization
+   friend class boost::serialization::access;
+
     #endif // for BOOST serialization
     
     

--- a/base/event/FairMCPoint.cxx
+++ b/base/event/FairMCPoint.cxx
@@ -46,16 +46,6 @@ FairMCPoint::FairMCPoint(Int_t trackID, Int_t detID, TVector3 pos,
 }
 // -------------------------------------------------------------------------
 
-FairMCPoint::FairMCPoint(const FairMCPoint &MCPoint) :
-  FairMultiLinkedData(), 
-  fTrackID(MCPoint.fTrackID), fEventId(MCPoint.fEventId), fDetectorID(MCPoint.fDetectorID),
-  fTime(MCPoint.fTime), fLength(MCPoint.fLength), fELoss(MCPoint.fELoss), 
-  fPx(MCPoint.fPx), fPy(MCPoint.fPy), fPz(MCPoint.fPz),
-  fX(MCPoint.fX), fY(MCPoint.fY), fZ(MCPoint.fZ)
-{
-}
-// -------------------------------------------------------------------------
-
 // -----   Destructor   ----------------------------------------------------
 FairMCPoint::~FairMCPoint() { }
 // -------------------------------------------------------------------------

--- a/base/event/FairMCPoint.h
+++ b/base/event/FairMCPoint.h
@@ -40,8 +40,6 @@ class FairMCPoint : public FairMultiLinkedData
      **/
     FairMCPoint(Int_t trackID, Int_t detID, TVector3 pos, TVector3 mom,
                 Double_t tof, Double_t length, Double_t eLoss, UInt_t EventId=0);
-
-    FairMCPoint(const FairMCPoint &MCPoint) ;
     
     /** Destructor **/
     virtual ~FairMCPoint();
@@ -85,12 +83,7 @@ class FairMCPoint : public FairMultiLinkedData
     virtual void Print(const Option_t* opt = 0) const;
 
 
-
-  protected:
-
-    #ifndef __CINT__ // for BOOST serialization
-    friend class boost::serialization::access;
-
+    
     template<class Archive>
     void serialize(Archive & ar, const unsigned int version) 
     {
@@ -108,6 +101,12 @@ class FairMCPoint : public FairMultiLinkedData
         ar & fLength; 
         ar & fELoss; 
     }
+
+  protected:
+
+    #ifndef __CINT__ // for BOOST serialization
+    friend class boost::serialization::access;
+
     #endif // for BOOST serialization
     
     Int_t fTrackID;               ///< Track index

--- a/base/event/FairTimeStamp.cxx
+++ b/base/event/FairTimeStamp.cxx
@@ -25,17 +25,6 @@ FairTimeStamp::FairTimeStamp(Double_t time, Double_t timeerror)
 {
 }
 
-
-
-FairTimeStamp::FairTimeStamp(const FairTimeStamp &TimeStamp) :
-  FairMultiLinkedData(), fTimeStamp(TimeStamp.fTimeStamp), fTimeStampError(TimeStamp.fTimeStampError), fEntryNr(TimeStamp.fEntryNr)
-//  fTimeStamp(TimeStamp.fTimeStamp), fTimeStampError(TimeStamp.fTimeStampError), fEntryNr(TimeStamp.fEntryNr)
-
-{
-    
-}
-
-
 // -----   Destructor   ----------------------------------------------------
 FairTimeStamp::~FairTimeStamp()
 {

--- a/base/event/FairTimeStamp.h
+++ b/base/event/FairTimeStamp.h
@@ -34,7 +34,6 @@ class FairTimeStamp : public FairMultiLinkedData
     /** Constructor with time and time error **/
     FairTimeStamp(Double_t time, Double_t timeerror);
 
-    FairTimeStamp(const FairTimeStamp &TimeStamp);
     /** Destructor **/
     virtual ~FairTimeStamp();
     /** Accessors **/
@@ -78,10 +77,6 @@ class FairTimeStamp : public FairMultiLinkedData
     }
 
 
-  protected:
-
-    #ifndef __CINT__ // for BOOST serialization
-    friend class boost::serialization::access;
     template<class Archive>
     void serialize(Archive & ar, const unsigned int version) 
     {
@@ -89,6 +84,13 @@ class FairTimeStamp : public FairMultiLinkedData
         ar & fTimeStamp;
         ar & fTimeStampError;
     } 
+    
+    
+  protected:
+
+    #ifndef __CINT__ // for BOOST serialization
+    friend class boost::serialization::access;
+    
     #endif // for BOOST serialization
     Double_t fTimeStamp;        /** Time of digit or Hit  [ns] */
     Double_t fTimeStampError;     /** Error on time stamp */

--- a/example/Tutorial3/CMakeLists.txt
+++ b/example/Tutorial3/CMakeLists.txt
@@ -50,6 +50,7 @@ Set(SRCS
   simulation/FairConstField.cxx
   simulation/FairConstPar.cxx
   simulation/FairMapPar.cxx
+  
   data/FairTestDetectorPoint.cxx
   data/FairTestDetectorHit.cxx
   digitization/FairTestDetectorHitProducerSmearing.cxx
@@ -66,12 +67,23 @@ If (Boost_FOUND)
   Set(SRCS
     ${SRCS}
     data/FairTestDetectorDigi.cxx
+    
   )
 
 
   Set(NO_DICT_SRCS
     data/FairMQFileSink.cxx
+    #data/has_BoostSerialization.cxx
   )
+
+  If(HAS_CXX11_AUTO AND HAS_CXX11_AUTO_RET_TYPE AND HAS_CXX11_CONSTEXPR AND HAS_CXX11_LAMBDA AND HAS_CXX11_DECLTYPE)
+    Set(NO_DICT_SRCS
+    ${NO_DICT_SRCS} data/has_BoostSerialization.cxx
+    )
+  Endif(HAS_CXX11_AUTO AND HAS_CXX11_AUTO_RET_TYPE AND HAS_CXX11_CONSTEXPR AND HAS_CXX11_LAMBDA AND HAS_CXX11_DECLTYPE)
+
+
+
   If(PROTOBUF_FOUND)
     Set(NO_DICT_SRCS
       ${NO_DICT_SRCS}

--- a/example/Tutorial3/data/FairMQFileSink.tpl
+++ b/example/Tutorial3/data/FairMQFileSink.tpl
@@ -5,62 +5,113 @@
  * Created on March 11, 2014, 12:12 PM
  */
 
-template <typename TIn, typename TBoostPayloadIn>
-void FairMQFileSink<TIn,TBoostPayloadIn>::Run()
+
+
+
+template <typename TIn, typename TPayloadIn>
+FairMQFileSink<TIn,TPayloadIn>::FairMQFileSink()
 {
-  LOG(INFO) << ">>>>>>> Run <<<<<<<";
-
-  boost::thread rateLogger(boost::bind(&FairMQDevice::LogSocketRates, this));
-
-  int receivedMsgs = 0;
-  bool received = false;
-
-  while ( fState == RUNNING ) {
-    FairMQMessage* msg = fTransportFactory->CreateMessage();
-    received = fPayloadInputs->at(0)->Receive(msg);
-
-    if (received) {
-      receivedMsgs++;
-      std::string msgStr( static_cast<char*>(msg->GetData()), msg->GetSize() );
-      std::istringstream ibuffer(msgStr);
-      TBoostPayloadIn InputArchive(ibuffer);
-      
-      try
-      {
-          InputArchive >> fHitVector;
-      }
-      catch (boost::archive::archive_exception e)
-      {
-          LOG(ERROR) << e.what();
-      }
-      
-      int numInput=fHitVector.size();
-      fOutput->Delete();
-
-      for (Int_t i = 0; i < numInput; ++i) 
-      {
-        new ((*fOutput)[i]) TIn(fHitVector.at(i));
-      }
-
-      if (!fOutput) {
-        cout << "-W- FairMQFileSink::Run: " << "No Output array!" << endl;
-      }
-
-      fTree->Fill();
-      received = false;
+    
+    fHasBoostSerialization=true;
+    #if __cplusplus >= 201103L
+    fHasBoostSerialization=false;
+    if(   std::is_same<TPayloadIn,boost::archive::binary_iarchive>::value || std::is_same<TPayloadIn,boost::archive::text_iarchive>::value)
+    {
+        if(has_BoostSerialization<TIn, void(TPayloadIn &, const unsigned int)>::value ==1) 
+                fHasBoostSerialization=true;
     }
+    #endif
+    
+}
 
-    delete msg;
+
+template <typename TIn, typename TPayloadIn>
+FairMQFileSink<TIn,TPayloadIn>::~FairMQFileSink()
+{
+    fTree->Write();
+    fOutFile->Close();
     if(fHitVector.size()>0) fHitVector.clear();
-   
-  }
+}
 
-  cout << "I've received " << receivedMsgs << " messages!" << endl;
 
-  boost::this_thread::sleep(boost::posix_time::milliseconds(5000));
+template <typename TIn, typename TPayloadIn>
+void FairMQFileSink<TIn,TPayloadIn>::InitOutputFile(TString defaultId)
+{
+    fOutput = new TClonesArray("FairTestDetectorHit");
+    char out[256];
+    sprintf(out, "filesink%s.root", defaultId.Data());
 
-  rateLogger.interrupt();
-  rateLogger.join();
+    fOutFile = new TFile(out,"recreate");
+    fTree = new TTree("MQOut", "Test output");
+    fTree->Branch("Output","TClonesArray", &fOutput, 64000, 99);
+}
+
+
+
+template <typename TIn, typename TPayloadIn>
+void FairMQFileSink<TIn,TPayloadIn>::Run()
+{
+  
+    if(fHasBoostSerialization)
+    {
+        LOG(INFO) << ">>>>>>> Run <<<<<<<";
+
+        boost::thread rateLogger(boost::bind(&FairMQDevice::LogSocketRates, this));
+        int receivedMsgs = 0;
+        bool received = false;
+
+
+        while ( fState == RUNNING ) 
+        {
+            FairMQMessage* msg = fTransportFactory->CreateMessage();
+            received = fPayloadInputs->at(0)->Receive(msg);
+
+            if (received) 
+            {
+                receivedMsgs++;
+                std::string msgStr( static_cast<char*>(msg->GetData()), msg->GetSize() );
+                std::istringstream ibuffer(msgStr);
+                TPayloadIn InputArchive(ibuffer);
+
+                try
+                {
+                    InputArchive >> fHitVector;
+                }
+                catch (boost::archive::archive_exception e)
+                {
+                    LOG(ERROR) << e.what();
+                }
+
+                int numInput=fHitVector.size();
+                fOutput->Delete();
+
+                for (Int_t i = 0; i < numInput; ++i) 
+                {
+                  new ((*fOutput)[i]) TIn(fHitVector.at(i));
+                }
+
+                if (!fOutput) 
+                {
+                  cout << "-W- FairMQFileSink::Run: " << "No Output array!" << endl;
+                }
+                
+                fTree->Fill();
+                received = false;
+            }
+            delete msg;
+            if(fHitVector.size()>0) 
+                fHitVector.clear();
+        }
+        
+        cout << "I've received " << receivedMsgs << " messages!" << endl;
+        boost::this_thread::sleep(boost::posix_time::milliseconds(5000));
+        rateLogger.interrupt();
+        rateLogger.join();
+    }
+    else
+    {
+        LOG(ERROR) <<" Boost Serialization not ok";
+    }
 }
 
 

--- a/example/Tutorial3/data/FairTestDetectorDigi.cxx
+++ b/example/Tutorial3/data/FairTestDetectorDigi.cxx
@@ -17,15 +17,8 @@ FairTestDetectorDigi::FairTestDetectorDigi():
 FairTestDetectorDigi::FairTestDetectorDigi(Int_t x, Int_t y, Int_t z, Double_t timeStamp):
   FairTimeStamp(timeStamp), fX(x), fY(y), fZ(z)
 {
- 
 }
 
-
-FairTestDetectorDigi::FairTestDetectorDigi(const FairTestDetectorDigi &Digi) :
-  FairTimeStamp(Digi), fX(Digi.fX), fY(Digi.fY), fZ(Digi.fZ)
-{
-    
-}
 
 FairTestDetectorDigi::~FairTestDetectorDigi()
 {

--- a/example/Tutorial3/data/FairTestDetectorDigi.h
+++ b/example/Tutorial3/data/FairTestDetectorDigi.h
@@ -25,7 +25,6 @@ class FairTestDetectorDigi : public FairTimeStamp
 {
   public:
     FairTestDetectorDigi();
-    FairTestDetectorDigi(const FairTestDetectorDigi &Digi);
     FairTestDetectorDigi(Int_t x, Int_t y, Int_t z, Double_t timeStamp);
     virtual ~FairTestDetectorDigi();
 
@@ -69,11 +68,7 @@ class FairTestDetectorDigi : public FairTimeStamp
       return out;
     }
 
-  private:
-      
-   #ifndef __CINT__ // for BOOST serialization
-   friend class boost::serialization::access;
-
+    
     template<class Archive>
     void serialize(Archive & ar, const unsigned int version) 
     {
@@ -82,6 +77,11 @@ class FairTestDetectorDigi : public FairTimeStamp
         ar & fY;
         ar & fZ;
     }
+  private:
+      
+   #ifndef __CINT__ // for BOOST serialization
+   friend class boost::serialization::access;
+    
     #endif // for BOOST serialization
 
     Int_t fX;

--- a/example/Tutorial3/data/FairTestDetectorHit.cxx
+++ b/example/Tutorial3/data/FairTestDetectorHit.cxx
@@ -5,17 +5,10 @@ FairTestDetectorHit::FairTestDetectorHit()
 {
 }
 
+
 FairTestDetectorHit::FairTestDetectorHit(Int_t detID, Int_t mcindex, TVector3& pos, TVector3& dpos)
   : FairHit(detID, pos, dpos, mcindex)
 {
-}
-
-
-
-FairTestDetectorHit::FairTestDetectorHit(const FairTestDetectorHit &Hit) :
-  FairHit(Hit)
-{
-    
 }
 
 FairTestDetectorHit::~FairTestDetectorHit()

--- a/example/Tutorial3/data/FairTestDetectorHit.h
+++ b/example/Tutorial3/data/FairTestDetectorHit.h
@@ -23,22 +23,22 @@ class FairTestDetectorHit : public FairHit
     /** Constructor **/
     FairTestDetectorHit(Int_t detID, Int_t mcindex, TVector3& pos, TVector3& dpos);
 
-    /** Copy Constructor **/
-    FairTestDetectorHit(const FairTestDetectorHit&);
-
     /** Destructor **/
     virtual ~FairTestDetectorHit();
 
-  private:
-
-#ifndef __CINT__ // for BOOST serialization
-    friend class boost::serialization::access;
-
+    
     template<class Archive>
     void serialize(Archive & ar, const unsigned int version) 
     {
         ar & boost::serialization::base_object<FairHit>(*this);
     }
+    
+  private:
+
+#ifndef __CINT__ // for BOOST serialization
+    friend class boost::serialization::access;
+
+    
 #endif // for BOOST serialization
 
     ClassDef(FairTestDetectorHit,1);

--- a/example/Tutorial3/data/has_BoostSerialization.cxx
+++ b/example/Tutorial3/data/has_BoostSerialization.cxx
@@ -1,0 +1,6 @@
+/* 
+ * File:   has_BoostSerialization.cxx
+ * Author: winckler
+ * 
+ * Created on April 28, 2014, 10:21 AM
+ */

--- a/example/Tutorial3/data/has_BoostSerialization.h
+++ b/example/Tutorial3/data/has_BoostSerialization.h
@@ -1,0 +1,55 @@
+/* 
+ * File:   has_BoostSerialization.h
+ * Author: winckler
+ *
+ * Created on April 28, 2014, 10:20 AM
+ */
+
+#ifndef HAS_BOOSTSERIALIZATION_H
+#define	HAS_BOOSTSERIALIZATION_H
+
+#include <type_traits>
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///  template function that check whether a class T is Boost serializable or not
+/// it search for a function member of T (and parent classes) named serialize with argument. c++11 required
+
+// Primary template with a static assertion
+// for a meaningful error message
+// if it ever gets instantiated.
+// We could leave it undefined if we didn't care.
+
+template<typename, typename T>
+struct has_BoostSerialization {
+    static_assert(
+        std::integral_constant<T, false>::value,
+        "Second template parameter needs to be of function type.");
+};
+
+// specialization that does the checking
+
+template<typename C, typename Ret, typename... Args>
+struct has_BoostSerialization<C, Ret(Args...)> 
+{
+private:
+    template<typename T>
+    static constexpr auto check(T*)
+    -> typename
+        std::is_same<
+            decltype( std::declval<T>().serialize( std::declval<Args>()... ) ),
+            Ret    // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        >::type{ return {}; };  // attempt to call it and see if the return type is correct
+
+    template<typename>
+    static constexpr std::false_type check(...){ return {}; };
+
+    typedef decltype(check<C>(0)) type;
+
+public:
+    static constexpr bool value = type::value;
+};
+
+
+
+#endif	/* HAS_BOOSTSERIALIZATION_H */
+

--- a/example/Tutorial3/digitization/TestDetectorDigiLoader.h
+++ b/example/Tutorial3/digitization/TestDetectorDigiLoader.h
@@ -19,56 +19,38 @@
 #include "FairTestDetectorPayload.h"
 #include <iostream> 
 
+#if __cplusplus >= 201103L
+#include "has_BoostSerialization.h"
+#include <type_traits>
+#endif
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/////////
+
+
 ////////// Base template header <T1,T2>
-template <typename T1, typename T2>//=boost::archive::text_oarchive>
+template <typename T1, typename T2>
 class TestDetectorDigiLoader : public FairMQSamplerTask
 { 
 public : 
  
-    TestDetectorDigiLoader() : FairMQSamplerTask("Load Digi class T1") {}
-    virtual ~TestDetectorDigiLoader()
-    {
-        if(fDigiVector.size()>0) fDigiVector.clear();
-    }
+    TestDetectorDigiLoader();
+    virtual ~TestDetectorDigiLoader();
     virtual void Exec(Option_t* opt);
+    
+    template<class Archive>
+    void serialize(Archive & ar, const unsigned int version)
+    {
+        ar & fDigiVector;
+    }
     
 private :
         
     friend class boost::serialization::access;
     std::vector<T1> fDigiVector;
-    template<class Archive>
-    void serialize(Archive & ar, const unsigned int version)
-    {
-        ar & fDigiVector;
-    }
+    bool fHasBoostSerialization;
     
 }; 
 
-
-////////// Partial specialisation header <T1,boost::archive::text_oarchive>
-template <typename T1>
-class TestDetectorDigiLoader<T1, boost::archive::text_oarchive> : public FairMQSamplerTask
-{ 
-public : 
- 
-    TestDetectorDigiLoader() : FairMQSamplerTask("Load Digi class T1") {}
-    virtual ~TestDetectorDigiLoader()
-    {
-        fDigiVector.clear();
-    }
-    virtual void Exec(Option_t* opt);
-    
-private :
-        
-    friend class boost::serialization::access;
-    std:: vector<T1> fDigiVector;
-    template<class Archive>
-    void serialize(Archive & ar, const unsigned int version)
-    {
-        ar & fDigiVector;
-    }
-    
-}; 
 
 ////////// Template implementation is in TestDetectorDigiLoader.tpl :
 #include "TestDetectorDigiLoader.tpl"

--- a/example/Tutorial3/digitization/TestDetectorDigiLoader.tpl
+++ b/example/Tutorial3/digitization/TestDetectorDigiLoader.tpl
@@ -8,54 +8,66 @@
 ////////// Base template class <T1,T2>
 
 
+
+template <typename T1, typename T2> 
+TestDetectorDigiLoader<T1,T2>::TestDetectorDigiLoader() : FairMQSamplerTask("Load class T1")
+{
+    fHasBoostSerialization=true;
+    #if __cplusplus >= 201103L
+    fHasBoostSerialization=false;
+    if(   std::is_same<T2,boost::archive::binary_oarchive>::value || std::is_same<T2,boost::archive::text_oarchive>::value)
+    {
+        if(has_BoostSerialization<T1, void(T2 &, const unsigned int)>::value ==1) 
+                fHasBoostSerialization=true;
+    }
+    #endif
+    
+}
+
+
+template <typename T1, typename T2> 
+TestDetectorDigiLoader<T1,T2>::~TestDetectorDigiLoader() 
+{
+    if(fDigiVector.size()>0) fDigiVector.clear();
+}
+
+
+
 template <typename T1, typename T2> 
 void TestDetectorDigiLoader<T1,T2>::Exec(Option_t* opt) 
 { 
-    std::ostringstream buffer;
-    T2 OutputArchive(buffer);
-    for (Int_t i = 0; i < fInput->GetEntriesFast(); ++i) 
-    {
-        T1* digi = reinterpret_cast<T1*>(fInput->At(i));
-        if (!digi) continue;
-        fDigiVector.push_back(*digi); 
-    }
     
-    OutputArchive << fDigiVector;
-    int size=buffer.str().length();
-    fOutput = fTransportFactory->CreateMessage(size);
-    std::memcpy(fOutput->GetData(), buffer.str().c_str(), size);
+    //Default implementation of the base template Exec function using boost
+    //the condition check if the input class has a function member with name
+    // void serialize(T2 & ar, const unsigned int version) and if the payload are of boost type
     
-    // delete the vector content
-    if(fDigiVector.size()>0) fDigiVector.clear();
-
-}
-
-
-
-////////// Partial Specialization <T1,boost::archive::text_oarchive>
-
-template <typename T1> void TestDetectorDigiLoader<T1,boost::archive::text_oarchive>::Exec(Option_t* opt) 
-{ 
-    std::ostringstream buffer;
-    boost::archive::text_oarchive OutputArchive(buffer);
-    for (Int_t i = 0; i < fInput->GetEntriesFast(); ++i) 
+    if(fHasBoostSerialization)
     {
-        T1* digi = reinterpret_cast<T1*>(fInput->At(i));
-        if (!digi) continue;
-        fDigiVector.push_back(*digi);
+        //LOG(INFO) <<" Boost Serialization ok ";
         
+        std::ostringstream buffer;
+        T2 OutputArchive(buffer);
+        for (Int_t i = 0; i < fInput->GetEntriesFast(); ++i) 
+        {
+            T1* digi = reinterpret_cast<T1*>(fInput->At(i));
+            if (!digi) continue;
+            fDigiVector.push_back(*digi); 
+        }
+
+        OutputArchive << fDigiVector;
+        int size=buffer.str().length();
+        fOutput = fTransportFactory->CreateMessage(size);
+        std::memcpy(fOutput->GetData(), buffer.str().c_str(), size);
+
+        // delete the vector content
+        if(fDigiVector.size()>0) fDigiVector.clear();
     }
-    
-    OutputArchive << fDigiVector;
-    int size=buffer.str().length();
-    fOutput = fTransportFactory->CreateMessage(size);
-    std::memcpy(fOutput->GetData(), buffer.str().c_str(), size);
-    
-    if(fDigiVector.size()>0) fDigiVector.clear();
-    
+    else
+    {
+        LOG(ERROR) <<" Boost Serialization not ok";
+    }
 }
 
-////////// FULL Specialization 
 
 template <>
 void TestDetectorDigiLoader<FairTestDetectorDigi, TestDetectorPayload::TestDetectorDigi>::Exec(Option_t* opt)

--- a/example/Tutorial3/reconstruction/FairTestDetectorMQRecoTask.h
+++ b/example/Tutorial3/reconstruction/FairTestDetectorMQRecoTask.h
@@ -3,8 +3,7 @@
 
 #include <iostream>
 #include <sstream>
-//#include <memory>
-//#include <chrono>
+
 
 #ifndef __CINT__ // Boost serialization 
 #include <boost/serialization/access.hpp>
@@ -28,47 +27,41 @@
 #include "FairTestDetectorHit.h"
 #include "FairTestDetectorDigi.h"
 
-
-
+#if __cplusplus >= 201103L
+//#include <memory>
+//#include <chrono>
+#include "has_BoostSerialization.h"
+#endif
 
 using std::cout;
 using std::endl;
 
 
 class TClonesArray;
-template <typename TIn, typename TOut, typename TBoostIArchive, typename TBoostOArchive>
+template <typename TIn, typename TOut, typename TPayloadIn, typename TPayloadOut>
 class FairTestDetectorMQRecoTask : public FairMQProcessorTask
 {
   public:
     /** Default constructor **/
-    FairTestDetectorMQRecoTask(): fRecoTask(NULL){}
-    FairTestDetectorMQRecoTask(Int_t verbose): fRecoTask(NULL){}
-
+    FairTestDetectorMQRecoTask();
+    FairTestDetectorMQRecoTask(Int_t verbose);
 
     /** Destructor **/
-    virtual ~FairTestDetectorMQRecoTask()
-    {
-        fRecoTask->fDigiArray->Delete();
-        fRecoTask->fHitArray->Delete();
-        delete fRecoTask;
-        if(fDigiVector.size()>0) fDigiVector.clear();
-        if(fHitVector.size()>0) fHitVector.clear();
-    }
-
+    virtual ~FairTestDetectorMQRecoTask();
 
     /** Virtual method Init **/
-    virtual InitStatus Init()
-    {
-        fRecoTask = new FairTestDetectorRecoTask();
-        fRecoTask->fDigiArray = new TClonesArray("FairTestDetectorDigi");
-        fRecoTask->fHitArray = new TClonesArray("FairTestDetectorHit");
-
-        return kSUCCESS;
-    }
-
+    virtual InitStatus Init();
 
     /** Virtual method Exec **/
     virtual void Exec(FairMQMessage* msg, Option_t* opt);
+    
+    // boost serialize function
+    template<class Archive>
+    void serialize(Archive & ar, const unsigned int version)
+    {
+        ar & fDigiVector;
+        ar & fHitVector;
+    }
 
   private:
     FairTestDetectorRecoTask* fRecoTask;
@@ -76,12 +69,7 @@ class FairTestDetectorMQRecoTask : public FairMQProcessorTask
     friend class boost::serialization::access;
     std:: vector<TIn >  fDigiVector;
     std:: vector<TOut>  fHitVector;
-    template<class Archive>
-    void serialize(Archive & ar, const unsigned int version)
-    {
-        ar & fDigiVector;
-        ar & fHitVector;
-    }
+    bool fHasBoostSerialization;
     #endif // for BOOST serialization
 };
 

--- a/example/Tutorial3/reconstruction/FairTestDetectorMQRecoTask.tpl
+++ b/example/Tutorial3/reconstruction/FairTestDetectorMQRecoTask.tpl
@@ -8,58 +8,166 @@
 
 ////////// Base template class <T1,T2>
 
-template <typename TIn, typename TOut, typename TBoostPayloadIn, typename TBoostPayloadOut> 
-void FairTestDetectorMQRecoTask<TIn,TOut,TBoostPayloadIn,TBoostPayloadOut>::Exec(FairMQMessage* msg, Option_t* opt)
-{ 
+template <typename TIn, typename TOut, typename TPayloadIn, typename TPayloadOut> 
+FairTestDetectorMQRecoTask<TIn,TOut,TPayloadIn,TPayloadOut>::FairTestDetectorMQRecoTask() :  fRecoTask(NULL)
+{
+    fHasBoostSerialization=true;
     
-    int inputSize = msg->GetSize();
-    
-    //prepare boost input archive
-    std::string msgStr( static_cast<char*>(msg->GetData()), msg->GetSize() );
-    std::istringstream ibuffer(msgStr);
-    TBoostPayloadIn InputArchive(ibuffer);
-    try
-     {
-         InputArchive >> fDigiVector;// get input Archive
-     }
-     catch (boost::archive::archive_exception e)
-     {
-         LOG(ERROR) << e.what();
-     }
-    fRecoTask->fDigiArray->Delete();
-    int numInput=fDigiVector.size();
+    #if __cplusplus >= 201103L
 
-    for (int i = 0; i < numInput; ++i) 
+    bool checkInputClass=false;
+    bool checkOutputClass=false;
+    fHasBoostSerialization=false;
+    
+    
+    if(std::is_same<TPayloadIn,boost::archive::binary_iarchive>::value || std::is_same<TPayloadIn,boost::archive::text_iarchive>::value)
     {
-      new ((*fRecoTask->fDigiArray)[i]) TIn(fDigiVector.at(i));
+        if(has_BoostSerialization<TIn, void(TPayloadIn &, const unsigned int)>::value ==1) 
+                checkInputClass=true;
     }
-
-    if (!fRecoTask->fDigiArray) {
-      cout << "-W- FairTestDetectorMQRecoTask::Init: " << "No Point array!" << endl;
-    }
-
-    fRecoTask->Exec(opt);
-    int numOutput = numInput;
-
-    if (inputSize > 0) 
-    {
-      for (int i = 0; i < numOutput; ++i) 
-      {
-        TOut* hit = (TOut*) fRecoTask->fHitArray->At(i);
-        fHitVector.push_back(*hit);
-      }
-    }
-    
-    //prepare boost output archive
-    std::ostringstream obuffer;
-    TBoostPayloadOut OutputArchive(obuffer); 
-    OutputArchive << fHitVector;
-    int outputSize=obuffer.str().length();
-    msg->Rebuild(outputSize);
-    std::memcpy(msg->GetData(), obuffer.str().c_str(), outputSize);
-    if(fDigiVector.size()>0) fDigiVector.clear();
-    if(fHitVector.size()>0) fHitVector.clear();
    
+    
+    
+    if(std::is_same<TPayloadOut,boost::archive::binary_oarchive>::value || std::is_same<TPayloadOut,boost::archive::text_oarchive>::value)
+    {
+        if(has_BoostSerialization<TOut, void(TPayloadOut &, const unsigned int)>::value ==1) 
+                checkOutputClass=true;
+    }
+   
+    
+    
+    if(checkInputClass && checkOutputClass) 
+        fHasBoostSerialization=true;
+    #endif
+    
+}
+
+
+template <typename TIn, typename TOut, typename TPayloadIn, typename TPayloadOut> 
+FairTestDetectorMQRecoTask<TIn,TOut,TPayloadIn,TPayloadOut>::FairTestDetectorMQRecoTask(Int_t verbose) :  fRecoTask(NULL)
+{
+    fHasBoostSerialization=true;
+    #if __cplusplus >= 201103L
+    bool checkInputClass=false;
+    bool checkOutputClass=false;
+    fHasBoostSerialization=false;
+    
+    
+    if(std::is_same<TPayloadIn,boost::archive::binary_iarchive>::value || std::is_same<TPayloadIn,boost::archive::text_iarchive>::value)
+    {
+        if(has_BoostSerialization<TIn, void(TPayloadIn &, const unsigned int)>::value ==1) 
+                checkInputClass=true;
+        else
+            LOG(ERROR) <<"Method 'void serialize(TIn & ar, const unsigned int version)' was not found in input class";
+    }
+    else
+    {
+        LOG(ERROR) <<"Output payload is not of supported boost archive type";
+        LOG(ERROR) <<"Boost inpput archive type supported : ";
+        LOG(ERROR) <<"boost::archive::binary_iarchive and boost::archive::text_iarchive";
+    }
+    
+    
+    if(std::is_same<TPayloadOut,boost::archive::binary_oarchive>::value || std::is_same<TPayloadOut,boost::archive::text_oarchive>::value)
+    {
+        if(has_BoostSerialization<TOut, void(TPayloadOut &, const unsigned int)>::value ==1) 
+                checkOutputClass=true;
+        else
+            LOG(ERROR) <<"Method 'void serialize(TOut & ar, const unsigned int version)' was not found in input class";
+    }
+    else
+    {
+        LOG(ERROR) <<"Output payload is not of supported boost archive type";
+        LOG(ERROR) <<"Boost output archive type supported : ";
+        LOG(ERROR) <<"boost::archive::binary_oarchive and boost::archive::text_oarchive";
+    }
+    
+    
+    
+    if(checkInputClass && checkOutputClass) 
+        fHasBoostSerialization=true;
+    
+    #endif
+}
+
+
+template <typename TIn, typename TOut, typename TPayloadIn, typename TPayloadOut> 
+FairTestDetectorMQRecoTask<TIn,TOut,TPayloadIn,TPayloadOut>::~FairTestDetectorMQRecoTask()
+{
+        fRecoTask->fDigiArray->Delete();
+        fRecoTask->fHitArray->Delete();
+        delete fRecoTask;
+        if(fDigiVector.size()>0) fDigiVector.clear();
+        if(fHitVector.size()>0) fHitVector.clear();
+}
+
+template <typename TIn, typename TOut, typename TPayloadIn, typename TPayloadOut> 
+InitStatus FairTestDetectorMQRecoTask<TIn,TOut,TPayloadIn,TPayloadOut>::Init()
+{
+        fRecoTask = new FairTestDetectorRecoTask();
+        fRecoTask->fDigiArray = new TClonesArray("FairTestDetectorDigi");
+        fRecoTask->fHitArray = new TClonesArray("FairTestDetectorHit");
+
+        return kSUCCESS;
+}
+
+template <typename TIn, typename TOut, typename TPayloadIn, typename TPayloadOut> 
+void FairTestDetectorMQRecoTask<TIn,TOut,TPayloadIn,TPayloadOut>::Exec(FairMQMessage* msg, Option_t* opt)
+{ 
+    if(fHasBoostSerialization)
+    {
+        int inputSize = msg->GetSize();
+
+        //prepare boost input archive
+        std::string msgStr( static_cast<char*>(msg->GetData()), msg->GetSize() );
+        std::istringstream ibuffer(msgStr);
+        TPayloadIn InputArchive(ibuffer);
+        try
+        {
+             InputArchive >> fDigiVector;// get input Archive
+        }
+        catch (boost::archive::archive_exception e)
+        {
+             LOG(ERROR) << e.what();
+        }
+        fRecoTask->fDigiArray->Delete();
+        int numInput=fDigiVector.size();
+
+        for (int i = 0; i < numInput; ++i) 
+        {
+          new ((*fRecoTask->fDigiArray)[i]) TIn(fDigiVector.at(i));
+        }
+
+        if (!fRecoTask->fDigiArray) {
+          cout << "-W- FairTestDetectorMQRecoTask::Init: " << "No Point array!" << endl;
+        }
+
+        fRecoTask->Exec(opt);
+        int numOutput = numInput;
+
+        if (inputSize > 0) 
+        {
+            for (int i = 0; i < numOutput; ++i) 
+            {
+              TOut* hit = (TOut*) fRecoTask->fHitArray->At(i);
+              fHitVector.push_back(*hit);
+            }
+        }
+
+        //prepare boost output archive
+        std::ostringstream obuffer;
+        TPayloadOut OutputArchive(obuffer); 
+        OutputArchive << fHitVector;
+        int outputSize=obuffer.str().length();
+        msg->Rebuild(outputSize);
+        std::memcpy(msg->GetData(), obuffer.str().c_str(), outputSize);
+        if(fDigiVector.size()>0) fDigiVector.clear();
+        if(fHitVector.size()>0) fHitVector.clear();
+    }
+    else
+    {
+        LOG(ERROR) <<" Boost Serialization not ok";
+    }
 }
 
 


### PR DESCRIPTION
 -Add template function in Tutorial3 to check whether …

1) input or output payloads are boost::archive::binary or boost::archive::text
2) input class has a function member named void serialize(TPayload &, const unsigned int)

-remove all explicit copy constructors in fairtimestamp, testdetectordigi, testdetectorhit, fairhit and fairMCpoint and relie on the compiler one (no deep copy was done)

-disable c++11 features of tutorial3 in case the compiler does not support c++11
