### PR TITLE
Multipart

### DIFF
--- a/base/MQ/FairMQProcessor.h
+++ b/base/MQ/FairMQProcessor.h
@@ -25,6 +25,10 @@ class FairMQProcessor: public FairMQDevice
     FairMQProcessor();
     virtual ~FairMQProcessor();
     void SetTask(FairMQProcessorTask* task);
+
+    void SendPart();
+    bool ReceivePart();
+
   protected:
     virtual void Init();
     virtual void Run();

--- a/base/MQ/FairMQProcessorTask.cxx
+++ b/base/MQ/FairMQProcessorTask.cxx
@@ -15,10 +15,40 @@
 #include "FairMQProcessorTask.h"
 
 
-FairMQProcessorTask::FairMQProcessorTask()
+FairMQProcessorTask::FairMQProcessorTask() :
+  fPayload(NULL)
 {
 }
 
 FairMQProcessorTask::~FairMQProcessorTask()
 {
+}
+
+// initialize a callback to the Processor for sending multipart messages.
+void FairMQProcessorTask::SetSendPart(boost::function<void()> callback)
+{
+    SendPart = callback;
+}
+
+// initialize a callback to the Processor for receiving multipart messages.
+void FairMQProcessorTask::SetReceivePart(boost::function<bool()> callback)
+{
+    ReceivePart = callback;
+}
+
+FairMQMessage* FairMQProcessorTask::GetPayload()
+{
+  return fPayload;
+}
+
+void FairMQProcessorTask::SetPayload(FairMQMessage* msg)
+{
+    if(msg)
+    {
+        fPayload = msg;
+    }
+    else
+    {
+        LOG(ERROR) << "FairMQMessage uninitialized or bad format";
+    }
 }

--- a/base/MQ/FairMQProcessorTask.h
+++ b/base/MQ/FairMQProcessorTask.h
@@ -17,8 +17,12 @@
 
 #include <vector>
 
-#include "FairMQMessage.h"
+#include <boost/function.hpp>
+
 #include "FairTask.h"
+
+#include "FairMQMessage.h"
+#include "FairMQTransportFactory.h"
 
 
 class FairMQProcessorTask : public FairTask
@@ -26,7 +30,16 @@ class FairMQProcessorTask : public FairTask
   public:
     FairMQProcessorTask();
     virtual ~FairMQProcessorTask();
-    virtual void Exec(FairMQMessage* msg, Option_t* opt) = 0;
+    virtual void Exec(Option_t* opt = "0") = 0;
+    void SetSendPart(boost::function<void()>); // provides a callback to the Processor.
+    void SetReceivePart(boost::function<bool()>); // provides a callback to the Processor.
+    FairMQMessage* GetPayload();
+    void SetPayload(FairMQMessage* msg);
+
+  protected:
+    FairMQMessage* fPayload;
+    boost::function<void()> SendPart; // function pointer for the Processor callback.
+    boost::function<bool()> ReceivePart; // function pointer for the Processor callback.
 };
 
 #endif /* FAIRMQPROCESSORTASK_H_ */

--- a/base/MQ/FairMQSampler.h
+++ b/base/MQ/FairMQSampler.h
@@ -63,10 +63,24 @@ class FairMQSampler: public FairMQDevice
 
     void ResetEventCounter();
     virtual void ListenToCommands();
+
     virtual void SetProperty(const int key, const string& value, const int slot = 0);
     virtual string GetProperty(const int key, const string& default_ = "", const int slot = 0);
     virtual void SetProperty(const int key, const int value, const int slot = 0);
     virtual int GetProperty(const int key, const int default_ = 0, const int slot = 0);
+
+    /**
+     * Sends the currently available output of the Sampler Task as part of a multipart message
+     * and reinitializes the message to be filled with the next part.
+     * This method can be given as a callback to the SamplerTask.
+     * The final message part must be sent with normal Send method.
+     */
+    void SendPart();
+
+  protected:
+    virtual void Init();
+    virtual void Run();
+
   protected:
     FairRunAna* fFairRunAna;
     FairMQSamplerTask* fSamplerTask;
@@ -76,13 +90,9 @@ class FairMQSampler: public FairMQDevice
     int fNumEvents;
     int fEventRate;
     int fEventCounter;
-
-    virtual void Init();
-    virtual void Run();
-
 };
 
-/// Template implementation is in FairMQSampler.tpl :
+// Template implementation is in FairMQSampler.tpl :
 #include "FairMQSampler.tpl"
 
 #endif /* FAIRMQSAMPLER_H_ */

--- a/base/MQ/FairMQSamplerTask.cxx
+++ b/base/MQ/FairMQSamplerTask.cxx
@@ -18,7 +18,6 @@
 FairMQSamplerTask::FairMQSamplerTask(const Text_t* name, int iVerbose) :
   FairTask(name, iVerbose),
   fInput(NULL),
-  fBranch(""),
   fOutput(NULL),
   fTransportFactory(NULL),
   fEventIndex(0)
@@ -26,20 +25,18 @@ FairMQSamplerTask::FairMQSamplerTask(const Text_t* name, int iVerbose) :
 }
 
 FairMQSamplerTask::FairMQSamplerTask() :
-  FairTask( "Abstract base task used for loading a branch from a root file into memory"),
+  FairTask("Abstract base task used for loading a branch from a root file into memory"),
   fInput(NULL),
-  fBranch(""),
   fOutput(NULL),
   fTransportFactory(NULL),
   fEventIndex(0)
-  {
+{
 }
 
 FairMQSamplerTask::~FairMQSamplerTask()
 {
   delete fInput;
-  fOutput->CloseMessage();
-  //delete fOutput; // leave fOutput in memory, because it is needed even after FairMQSamplerTask is terminated. ClearOutput will clean it when it is no longer needed.
+  // fOutput->CloseMessage();
 }
 
 InitStatus FairMQSamplerTask::Init()
@@ -50,25 +47,25 @@ InitStatus FairMQSamplerTask::Init()
   return kSUCCESS;
 }
 
-
-
 void FairMQSamplerTask::Exec(Option_t* opt)
 {
-  
 }
 
+// initialize a callback to the Sampler for sending multipart messages.
+void FairMQSamplerTask::SetSendPart(boost::function<void()> callback)
+{
+    SendPart = callback;
+}
 
 void FairMQSamplerTask::SetBranch(string branch)
 {
   fBranch = branch;
 }
 
-
 void FairMQSamplerTask::SetEventIndex(Long64_t EventIndex) 
 {
-    fEventIndex=EventIndex;
+    fEventIndex = EventIndex;
 }
-
 
 FairMQMessage* FairMQSamplerTask::GetOutput()
 {

--- a/base/MQ/FairMQSamplerTask.h
+++ b/base/MQ/FairMQSamplerTask.h
@@ -15,10 +15,14 @@
 #ifndef FAIRMQSAMPLERTASK_H_
 #define FAIRMQSAMPLERTASK_H_
 
-#include "FairTask.h"
 #include <vector>
-#include "TClonesArray.h"
 #include <string>
+
+#include <boost/function.hpp>
+
+#include "FairTask.h"
+#include "TClonesArray.h"
+
 #include "FairMQMessage.h"
 #include "FairMQTransportFactory.h"
 
@@ -27,10 +31,13 @@ class FairMQSamplerTask: public FairTask
 {
   public:
     FairMQSamplerTask();
-    FairMQSamplerTask(const Text_t* name, int iVerbose=1);
+    FairMQSamplerTask(const Text_t* name, int iVerbose = 1);
+
     virtual ~FairMQSamplerTask();
+
     virtual InitStatus Init();
     virtual void Exec(Option_t* opt);
+    void SetSendPart(boost::function<void()>); // provides a callback to the Sampler.
     void SetEventIndex(Long64_t EventIndex);
     void SetBranch(string branch);
     FairMQMessage* GetOutput();
@@ -42,6 +49,8 @@ class FairMQSamplerTask: public FairTask
     FairMQMessage* fOutput;
     FairMQTransportFactory* fTransportFactory;
     Long64_t fEventIndex;
+
+    boost::function<void()> SendPart; // function pointer for the Sampler callback.
 };
 
 #endif /* FAIRMQSAMPLERTASK_H_ */

--- a/example/Tutorial3/data/FairMQFileSink.tpl
+++ b/example/Tutorial3/data/FairMQFileSink.tpl
@@ -236,6 +236,7 @@ void FairMQFileSink<FairTestDetectorHit, TMessage>::Run()
 }
 
 // ----- Implementation of FairMQFileSink::Run() with Google Protocol Buffers transport data format -----
+
 #ifdef PROTOBUF
 #include "FairTestDetectorPayload.pb.h"
 

--- a/example/Tutorial3/digitization/TestDetectorDigiLoader.h
+++ b/example/Tutorial3/digitization/TestDetectorDigiLoader.h
@@ -14,11 +14,9 @@
 #ifndef TESTDETECTORDIGILOADER_H
 #define TESTDETECTORDIGILOADER_H
 
-#include "FairMQSamplerTask.h"
+#include <iostream>
 
-#include "FairMQLogger.h"
 #include <boost/timer/timer.hpp>
-
 #include <boost/archive/text_oarchive.hpp>
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/serialization/vector.hpp>
@@ -26,16 +24,16 @@
 #include "TMessage.h"
 
 #include "FairTestDetectorPayload.h"
-#include <iostream>
+
+#include "FairMQSamplerTask.h"
+#include "FairMQLogger.h"
 
 #if __cplusplus >= 201103L
 #include "has_BoostSerialization.h"
 #include <type_traits>
 #endif
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-/////////
 
-////////// Base template header <T1,T2>
+// Base template header <T1,T2>
 template <typename T1, typename T2>
 class TestDetectorDigiLoader : public FairMQSamplerTask
 {
@@ -56,7 +54,7 @@ class TestDetectorDigiLoader : public FairMQSamplerTask
     bool fHasBoostSerialization;
 };
 
-////////// Template implementation is in TestDetectorDigiLoader.tpl :
+// Template implementation is in TestDetectorDigiLoader.tpl :
 #include "TestDetectorDigiLoader.tpl"
 
 #endif /* TESTDETECTORDIGILOADER_H */

--- a/example/Tutorial3/digitization/TestDetectorDigiLoader.tpl
+++ b/example/Tutorial3/digitization/TestDetectorDigiLoader.tpl
@@ -29,12 +29,12 @@ TestDetectorDigiLoader<T1, T2>::~TestDetectorDigiLoader()
         fDigiVector.clear();
 }
 
+
 // ----- Default implementation of TestDetectorDigiLoader::Exec() with Boost transport data format -----
 
 template <typename T1, typename T2>
 void TestDetectorDigiLoader<T1, T2>::Exec(Option_t* opt)
 {
-
     // Default implementation of the base template Exec function using boost
     // the condition check if the input class has a function member with name
     // void serialize(T2 & ar, const unsigned int version) and if the payload are of boost type
@@ -73,6 +73,17 @@ void TestDetectorDigiLoader<T1, T2>::Exec(Option_t* opt)
 template <>
 void TestDetectorDigiLoader<FairTestDetectorDigi, TestDetectorPayload::Digi>::Exec(Option_t* opt)
 {
+    // // Example of how to send multipart messages (uncomment the code lines to test).
+    // // 1. create some data and put it into message (optionaly in one step with zero-copy):
+    // std::string test = "hello";
+    // fOutput = fTransportFactory->CreateMessage(test.size());
+    // memcpy ((void *) fOutput->GetData(), test.c_str(), test.size());
+    // // 2. Send the current message as a part:
+    // SendPart();
+    // // This will schedule the sending to queueing system.
+    // // For the next part, create new message object.
+    // // The final part will be sent by the sampler.
+
     int nDigis = fInput->GetEntriesFast();
     int size = nDigis * sizeof(TestDetectorPayload::Digi);
 

--- a/example/Tutorial3/reconstruction/FairTestDetectorMQRecoTask.h
+++ b/example/Tutorial3/reconstruction/FairTestDetectorMQRecoTask.h
@@ -60,7 +60,7 @@ class FairTestDetectorMQRecoTask : public FairMQProcessorTask
     virtual InitStatus Init();
 
     /** Virtual method Exec **/
-    virtual void Exec(FairMQMessage* msg, Option_t* opt);
+    virtual void Exec(Option_t* opt = "0");
 
     // boost serialize function
     template <class Archive>
@@ -80,7 +80,7 @@ class FairTestDetectorMQRecoTask : public FairMQProcessorTask
 #endif // for BOOST serialization
 };
 
-////////// Template implementation of exec in FairTestDetectorMQRecoTask.tpl :
+// Template implementation of exec in FairTestDetectorMQRecoTask.tpl :
 #include "FairTestDetectorMQRecoTask.tpl"
 
 #endif /* FAIRTESTDETECTORMQRECOTASK_H */

--- a/fairmq/FairMQLogger.cxx
+++ b/fairmq/FairMQLogger.cxx
@@ -52,8 +52,11 @@ std::ostringstream& FairMQLogger::Log(int type)
         case ERROR:
             type_str = "\033[01;31mERROR\033[0m";
             break;
+        case WARN:
+            type_str = "\033[01;33mWARN\033[0m";
+            break;
         case STATE:
-            type_str = "\033[01;33mSTATE\033[0m";
+            type_str = "\033[01;35mSTATE\033[0m";
         default:
             break;
     }

--- a/fairmq/FairMQLogger.h
+++ b/fairmq/FairMQLogger.h
@@ -31,6 +31,7 @@ class FairMQLogger
         DEBUG,
         INFO,
         ERROR,
+        WARN,
         STATE
     };
     FairMQLogger();
@@ -46,5 +47,6 @@ typedef unsigned long long timestamp_t;
 timestamp_t get_timestamp();
 
 #define LOG(type) FairMQLogger().Log(FairMQLogger::type)
+#define MQLOG(type) FairMQLogger().Log(FairMQLogger::type)
 
 #endif /* FAIRMQLOGGER_H_ */

--- a/fairmq/FairMQSocket.h
+++ b/fairmq/FairMQSocket.h
@@ -29,14 +29,15 @@ class FairMQSocket
     virtual void Bind(const string& address) = 0;
     virtual void Connect(const string& address) = 0;
 
-    virtual size_t Send(FairMQMessage* msg) = 0;
-    virtual size_t Receive(FairMQMessage* msg) = 0;
+    virtual size_t Send(FairMQMessage* msg, const string& flag="") = 0;
+    virtual size_t Receive(FairMQMessage* msg, const string& flag="") = 0;
 
     virtual void* GetSocket() = 0;
     virtual int GetSocket(int nothing) = 0;
     virtual void Close() = 0;
 
     virtual void SetOption(const string& option, const void* value, size_t valueSize) = 0;
+    virtual void GetOption(const string& option, void* value, size_t* valueSize) = 0;
 
     virtual unsigned long GetBytesTx() = 0;
     virtual unsigned long GetBytesRx() = 0;

--- a/fairmq/FairMQStateMachine.h
+++ b/fairmq/FairMQStateMachine.h
@@ -176,18 +176,18 @@ namespace FairMQFSM
         }
         // Transition table for FairMQFMS
         struct transition_table : mpl::vector<
-            //    Start     Event     Next    Action    Guard
-            //  +---------+---------+-------+---------+--------+
-            msmf::Row<IDLE_FSM, INIT, INITIALIZING_FSM, InitFct, msmf::none>,
-            msmf::Row<IDLE_FSM, END, msmf::none, TestFct, msmf::none>, // this is an invalid transition...
-            msmf::Row<INITIALIZING_FSM, SETOUTPUT, SETTINGOUTPUT_FSM, SetOutputFct, msmf::none>,
-            msmf::Row<SETTINGOUTPUT_FSM, SETINPUT, SETTINGINPUT_FSM, SetInputFct, msmf::none>,
-            msmf::Row<SETTINGINPUT_FSM, PAUSE, WAITING_FSM, PauseFct, msmf::none>,
-            msmf::Row<SETTINGINPUT_FSM, RUN, RUNNING_FSM, RunFct, msmf::none>,
-            msmf::Row<WAITING_FSM, RUN, RUNNING_FSM, RunFct, msmf::none>,
-            msmf::Row<WAITING_FSM, STOP, IDLE_FSM, StopFct, msmf::none>,
-            msmf::Row<RUNNING_FSM, PAUSE, WAITING_FSM, PauseFct, msmf::none>,
-            msmf::Row<RUNNING_FSM, STOP, IDLE_FSM, StopFct, msmf::none> >
+            //        Start              Event      Next               Action        Guard
+            //       +------------------+----------+------------------+-------------+---------+
+            msmf::Row<IDLE_FSM,          INIT,      INITIALIZING_FSM,  InitFct,      msmf::none>,
+            msmf::Row<IDLE_FSM,          END,       msmf::none,        TestFct,      msmf::none>, // this is an invalid transition...
+            msmf::Row<INITIALIZING_FSM,  SETOUTPUT, SETTINGOUTPUT_FSM, SetOutputFct, msmf::none>,
+            msmf::Row<SETTINGOUTPUT_FSM, SETINPUT,  SETTINGINPUT_FSM,  SetInputFct,  msmf::none>,
+            msmf::Row<SETTINGINPUT_FSM,  PAUSE,     WAITING_FSM,       PauseFct,     msmf::none>,
+            msmf::Row<SETTINGINPUT_FSM,  RUN,       RUNNING_FSM,       RunFct,       msmf::none>,
+            msmf::Row<WAITING_FSM,       RUN,       RUNNING_FSM,       RunFct,       msmf::none>,
+            msmf::Row<WAITING_FSM,       STOP,      IDLE_FSM,          StopFct,      msmf::none>,
+            msmf::Row<RUNNING_FSM,       PAUSE,     WAITING_FSM,       PauseFct,     msmf::none>,
+            msmf::Row<RUNNING_FSM,       STOP,      IDLE_FSM,          StopFct,      msmf::none> >
         {
         };
         // Replaces the default no-transition response.

--- a/fairmq/nanomsg/FairMQMessageNN.cxx
+++ b/fairmq/nanomsg/FairMQMessageNN.cxx
@@ -37,6 +37,12 @@ FairMQMessageNN::FairMQMessageNN(size_t size)
     fReceiving = false;
 }
 
+
+/* nanomsg does not offer support for creating a message out of an existing buffer,
+ * therefore the following method is using memcpy. For more efficient handling,
+ * create FairMQMessage object only with size parameter and fill it with data.
+ * possible TODO: make this zero copy (will should then be as efficient as ZeroMQ).
+*/
 FairMQMessageNN::FairMQMessageNN(void* data, size_t size, fairmq_free_fn *ffn, void* hint)
 {
     fMessage = nn_allocmsg(size, 0);

--- a/fairmq/nanomsg/FairMQSocketNN.cxx
+++ b/fairmq/nanomsg/FairMQSocketNN.cxx
@@ -69,7 +69,7 @@ void FairMQSocketNN::Connect(const string& address)
     }
 }
 
-size_t FairMQSocketNN::Send(FairMQMessage* msg)
+size_t FairMQSocketNN::Send(FairMQMessage* msg, const string& flag)
 {
     void* ptr = msg->GetMessage();
     int rc = nn_send(fSocket, &ptr, NN_MSG, 0);
@@ -87,7 +87,7 @@ size_t FairMQSocketNN::Send(FairMQMessage* msg)
     return rc;
 }
 
-size_t FairMQSocketNN::Receive(FairMQMessage* msg)
+size_t FairMQSocketNN::Receive(FairMQMessage* msg, const string& flag)
 {
     void* ptr = NULL;
     int rc = nn_recv(fSocket, &ptr, NN_MSG, 0);
@@ -130,6 +130,14 @@ void FairMQSocketNN::SetOption(const string& option, const void* value, size_t v
     }
 }
 
+void FairMQSocketNN::GetOption(const string& option, void* value, size_t* valueSize)
+{
+    int rc = nn_getsockopt(fSocket, NN_SOL_SOCKET, GetConstant(option), value, valueSize);
+    if (rc < 0) {
+        LOG(ERROR) << "failed getting socket option, reason: " << nn_strerror(errno);
+    }
+}
+
 unsigned long FairMQSocketNN::GetBytesTx()
 {
     return fBytesTx;
@@ -152,6 +160,8 @@ unsigned long FairMQSocketNN::GetMessagesRx()
 
 int FairMQSocketNN::GetConstant(const string& constant)
 {
+    if (constant == "")
+        return 0;
     if (constant == "sub")
         return NN_SUB;
     if (constant == "pub")
@@ -168,6 +178,14 @@ int FairMQSocketNN::GetConstant(const string& constant)
         return NN_SNDBUF;
     if (constant == "rcv-hwm")
         return NN_RCVBUF;
+    if (constant == "snd-more") {
+        LOG(ERROR) << "Multipart messages functionality currently not supported by nanomsg!";
+        return -1;
+    }
+    if (constant == "rcv-more") {
+        LOG(ERROR) << "Multipart messages functionality currently not supported by nanomsg!";
+        return -1;
+    }
 
     return -1;
 }

--- a/fairmq/nanomsg/FairMQSocketNN.h
+++ b/fairmq/nanomsg/FairMQSocketNN.h
@@ -31,14 +31,15 @@ class FairMQSocketNN : public FairMQSocket
     virtual void Bind(const string& address);
     virtual void Connect(const string& address);
 
-    virtual size_t Send(FairMQMessage* msg);
-    virtual size_t Receive(FairMQMessage* msg);
+    virtual size_t Send(FairMQMessage* msg, const string& flag="");
+    virtual size_t Receive(FairMQMessage* msg, const string& flag="");
 
     virtual void* GetSocket();
     virtual int GetSocket(int nothing);
     virtual void Close();
 
     virtual void SetOption(const string& option, const void* value, size_t valueSize);
+    virtual void GetOption(const string& option, void* value, size_t* valueSize);
 
     unsigned long GetBytesTx();
     unsigned long GetBytesRx();

--- a/fairmq/zeromq/FairMQSocketZMQ.cxx
+++ b/fairmq/zeromq/FairMQSocketZMQ.cxx
@@ -82,9 +82,9 @@ void FairMQSocketZMQ::Connect(const string& address)
     }
 }
 
-size_t FairMQSocketZMQ::Send(FairMQMessage* msg)
+size_t FairMQSocketZMQ::Send(FairMQMessage* msg, const string& flag)
 {
-    int nbytes = zmq_msg_send(static_cast<zmq_msg_t*>(msg->GetMessage()), fSocket, 0);
+    int nbytes = zmq_msg_send(static_cast<zmq_msg_t*>(msg->GetMessage()), fSocket, GetConstant(flag));
     if (nbytes >= 0)
     {
         fBytesTx += nbytes;
@@ -99,9 +99,9 @@ size_t FairMQSocketZMQ::Send(FairMQMessage* msg)
     return nbytes;
 }
 
-size_t FairMQSocketZMQ::Receive(FairMQMessage* msg)
+size_t FairMQSocketZMQ::Receive(FairMQMessage* msg, const string& flag)
 {
-    int nbytes = zmq_msg_recv(static_cast<zmq_msg_t*>(msg->GetMessage()), fSocket, 0);
+    int nbytes = zmq_msg_recv(static_cast<zmq_msg_t*>(msg->GetMessage()), fSocket, GetConstant(flag));
     if (nbytes >= 0)
     {
         fBytesRx += nbytes;
@@ -152,6 +152,14 @@ void FairMQSocketZMQ::SetOption(const string& option, const void* value, size_t 
     }
 }
 
+void FairMQSocketZMQ::GetOption(const string& option, void* value, size_t* valueSize)
+{
+    int rc = zmq_getsockopt(fSocket, GetConstant(option), value, valueSize);
+    if (rc < 0) {
+        LOG(ERROR) << "failed getting socket option, reason: " << zmq_strerror(errno);
+    }
+}
+
 unsigned long FairMQSocketZMQ::GetBytesTx()
 {
     return fBytesTx;
@@ -174,6 +182,8 @@ unsigned long FairMQSocketZMQ::GetMessagesRx()
 
 int FairMQSocketZMQ::GetConstant(const string& constant)
 {
+    if (constant == "")
+        return 0;
     if (constant == "sub")
         return ZMQ_SUB;
     if (constant == "pub")
@@ -190,6 +200,10 @@ int FairMQSocketZMQ::GetConstant(const string& constant)
         return ZMQ_SNDHWM;
     if (constant == "rcv-hwm")
         return ZMQ_RCVHWM;
+    if (constant == "snd-more")
+        return ZMQ_SNDMORE;
+    if (constant == "rcv-more")
+        return ZMQ_RCVMORE;
 
     return -1;
 }

--- a/fairmq/zeromq/FairMQSocketZMQ.h
+++ b/fairmq/zeromq/FairMQSocketZMQ.h
@@ -32,14 +32,15 @@ class FairMQSocketZMQ : public FairMQSocket
     virtual void Bind(const string& address);
     virtual void Connect(const string& address);
 
-    virtual size_t Send(FairMQMessage* msg);
-    virtual size_t Receive(FairMQMessage* msg);
+    virtual size_t Send(FairMQMessage* msg, const string& flag="");
+    virtual size_t Receive(FairMQMessage* msg, const string& flag="");
 
     virtual void* GetSocket();
     virtual int GetSocket(int nothing);
     virtual void Close();
 
     virtual void SetOption(const string& option, const void* value, size_t valueSize);
+    virtual void GetOption(const string& option, void* value, size_t* valueSize);
 
     virtual unsigned long GetBytesTx();
     virtual unsigned long GetBytesRx();


### PR DESCRIPTION
- Add multipart support to the interface and enable its use out of tasks.
  Examples on the use out of tasks are provided in:
  
  `example/Tutorial3/digitization/TestDetectorDigiLoader.tpl:76-85`: sending a part.
  `example/Tutorial3/reconstruction/FairTestDetectorMQRecoTask.tpl:177-182`: receiving a part.
- Make structure within processor task more consistent with sampler task.
- Add `WARN` option and MQLOG macro to FairMQLogger.
