### PR TITLE
Proper process termination

### DIFF
--- a/base/MQ/FairMQProcessor.cxx
+++ b/base/MQ/FairMQProcessor.cxx
@@ -52,7 +52,7 @@ void FairMQProcessor::Run()
   int receivedMsgs = 0;
   int sentMsgs = 0;
 
-  bool received = false;
+  int received = 0;
 
   while ( fState == RUNNING ) {
     fProcessorTask->SetPayload(fTransportFactory->CreateMessage());
@@ -60,20 +60,18 @@ void FairMQProcessor::Run()
     received = fPayloadInputs->at(0)->Receive(fProcessorTask->GetPayload());
     receivedMsgs++;
 
-    if (received) {
+    if (received > 0) {
       fProcessorTask->Exec();
 
       fPayloadOutputs->at(0)->Send(fProcessorTask->GetPayload());
       sentMsgs++;
-      received = false;
+      received = 0;
     }
 
     fProcessorTask->GetPayload()->CloseMessage();
   }
 
-  LOG(INFO) << "I've received " << receivedMsgs << " and sent " << sentMsgs << " messages!";
-
-  boost::this_thread::sleep(boost::posix_time::milliseconds(5000));
+  LOG(INFO) << "Received " << receivedMsgs << " and sent " << sentMsgs << " messages!";
 
   try {
     rateLogger.interrupt();
@@ -81,6 +79,8 @@ void FairMQProcessor::Run()
   } catch(boost::thread_resource_error& e) {
     LOG(ERROR) << e.what();
   }
+
+  FairMQDevice::Shutdown();
 }
 
 void FairMQProcessor::SendPart()
@@ -105,5 +105,3 @@ bool FairMQProcessor::ReceivePart()
         return false;
     }
 }
-
-

--- a/base/MQ/FairMQSampler.h
+++ b/base/MQ/FairMQSampler.h
@@ -1,9 +1,9 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH *
+ *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
  *                                                                              *
- *              This software is distributed under the terms of the *
- *         GNU Lesser General Public Licence version 3 (LGPL) version 3, *
- *                  copied verbatim in the file "LICENSE" *
+ *              This software is distributed under the terms of the             * 
+ *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *  
+ *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
 /**
  * FairMQSampler.h
@@ -37,46 +37,44 @@
 #include "FairMQLogger.h"
 
 /**
- * Reads simulated digis from a root file and samples the digi as a time-series
- *UDP stream.
- * Must be initialized with the filename to the root file and the name of the
- *sub-detector
+ * Reads simulated digis from a root file and samples the digi as a time-series UDP stream.
+ * Must be initialized with the filename to the root file and the name of the sub-detector
  * branch, whose digis should be streamed.
  *
- * The purpose of this class is to provide a data source of digis very similar
- *to the
- * future detector output at the point where the detector is connected to the
- *online
- * computing farm. For the development of online analysis algorithms, it is very
- *important
- * to simulate the future detector output as realistic as possible to evaluate
- *the
+ * The purpose of this class is to provide a data source of digis very similar to the
+ * future detector output at the point where the detector is connected to the online
+ * computing farm. For the development of online analysis algorithms, it is very important
+ * to simulate the future detector output as realistic as possible to evaluate the
  * feasibility and quality of the various possible online analysis features.
  */
 
-template <typename Loader> class FairMQSampler : public FairMQDevice {
-public:
-  enum { InputFile = FairMQDevice::Last, Branch, ParFile, EventRate };
-  FairMQSampler();
-  virtual ~FairMQSampler();
+template <typename Loader>
+class FairMQSampler: public FairMQDevice
+{
+  public:
+    enum {
+      InputFile = FairMQDevice::Last,
+      Branch,
+      ParFile,
+      EventRate
+    };
+    FairMQSampler();
+    virtual ~FairMQSampler();
 
-  void ResetEventCounter();
-  virtual void ListenToCommands();
+    void ResetEventCounter();
+    virtual void ListenToCommands();
 
-  virtual void SetProperty(const int key, const string &value,
-                           const int slot = 0);
-  virtual string GetProperty(const int key, const string &default_ = "",
-                             const int slot = 0);
-  virtual void SetProperty(const int key, const int value, const int slot = 0);
-  virtual int GetProperty(const int key, const int default_ = 0,
-                          const int slot = 0);
-  /**
-   * Sends the currently available output of the Sampler Task as part of a
-   * multipart message
-   * and reinitializes the message to be filled with the next part.
-   * This method can be given as a callback to the SamplerTask.
-   * The final message part must be sent with normal Send method.
-   */
+    virtual void SetProperty(const int key, const string& value, const int slot = 0);
+    virtual string GetProperty(const int key, const string& default_ = "", const int slot = 0);
+    virtual void SetProperty(const int key, const int value, const int slot = 0);
+    virtual int GetProperty(const int key, const int default_ = 0, const int slot = 0);
+
+    /**
+     * Sends the currently available output of the Sampler Task as part of a multipart message
+     * and reinitializes the message to be filled with the next part.
+     * This method can be given as a callback to the SamplerTask.
+     * The final message part must be sent with normal Send method.
+     */
   void SendPart();
 
 protected:

--- a/base/MQ/FairMQSamplerTask.cxx
+++ b/base/MQ/FairMQSamplerTask.cxx
@@ -1,9 +1,9 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH *
+ *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
  *                                                                              *
- *              This software is distributed under the terms of the *
- *         GNU Lesser General Public Licence version 3 (LGPL) version 3, *
- *                  copied verbatim in the file "LICENSE" *
+ *              This software is distributed under the terms of the             *
+ *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *
+ *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
 /**
  * FairMQSamplerTask.cxx
@@ -14,44 +14,66 @@
 
 #include "FairMQSamplerTask.h"
 
-FairMQSamplerTask::FairMQSamplerTask(const Text_t *name, int iVerbose)
-    : FairTask(name, iVerbose), fInput(NULL), fOutput(NULL),
-      fTransportFactory(NULL), fEventIndex(0) {}
+FairMQSamplerTask::FairMQSamplerTask(const Text_t* name, int iVerbose) :
+  FairTask(name, iVerbose),
+  fInput(NULL),
+  fOutput(NULL),
+  fTransportFactory(NULL),
+  fEventIndex(0)
+{
+}
 
-FairMQSamplerTask::FairMQSamplerTask()
-    : FairTask("Abstract base task used for loading a branch from a root file "
-               "into memory"),
-      fInput(NULL), fOutput(NULL), fEventIndex(0), fTransportFactory(NULL),
-      fEvtHeader(NULL) {}
+FairMQSamplerTask::FairMQSamplerTask() :
+  FairTask("Abstract base task used for loading a branch from a root file into memory"),
+  fInput(NULL),
+  fOutput(NULL),
+  fTransportFactory(NULL),
+  fEventIndex(0),
+  fEvtHeader(NULL)
+{
+}
 
-FairMQSamplerTask::~FairMQSamplerTask() {
+FairMQSamplerTask::~FairMQSamplerTask()
+{
   delete fInput;
   // fOutput->CloseMessage();
 }
 
-InitStatus FairMQSamplerTask::Init() {
-  FairRootManager *ioman = FairRootManager::Instance();
+InitStatus FairMQSamplerTask::Init()
+{
+  FairRootManager* ioman = FairRootManager::Instance();
   fEvtHeader = (FairEventHeader *)ioman->GetObject("EventHeader.");
-  fInput = (TClonesArray *)ioman->GetObject(fBranch.c_str());
+  fInput = (TClonesArray*) ioman->GetObject(fBranch.c_str());
 
   return kSUCCESS;
 }
 
-void FairMQSamplerTask::Exec(Option_t *opt) {}
+void FairMQSamplerTask::Exec(Option_t *opt)
+{
+}
 
 // initialize a callback to the Sampler for sending multipart messages.
-void FairMQSamplerTask::SetSendPart(boost::function<void()> callback) {
+void FairMQSamplerTask::SetSendPart(boost::function<void()> callback)
+{
   SendPart = callback;
 }
 
-void FairMQSamplerTask::SetBranch(string branch) { fBranch = branch; }
+void FairMQSamplerTask::SetBranch(string branch)
+{
+  fBranch = branch;
+}
 
-void FairMQSamplerTask::SetEventIndex(Long64_t EventIndex) {
+void FairMQSamplerTask::SetEventIndex(Long64_t EventIndex)
+{
   fEventIndex = EventIndex;
 }
 
-FairMQMessage *FairMQSamplerTask::GetOutput() { return fOutput; }
+FairMQMessage* FairMQSamplerTask::GetOutput()
+{
+  return fOutput;
+}
 
-void FairMQSamplerTask::SetTransport(FairMQTransportFactory *factory) {
+void FairMQSamplerTask::SetTransport(FairMQTransportFactory* factory)
+{
   fTransportFactory = factory;
 }

--- a/base/MQ/FairMQSamplerTask.h
+++ b/base/MQ/FairMQSamplerTask.h
@@ -1,9 +1,9 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH *
+ *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
  *                                                                              *
- *              This software is distributed under the terms of the *
- *         GNU Lesser General Public Licence version 3 (LGPL) version 3, *
- *                  copied verbatim in the file "LICENSE" *
+ *              This software is distributed under the terms of the             *
+ *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *
+ *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
 /**
  * FairMQSamplerTask.h
@@ -28,31 +28,31 @@
 #include "FairMQMessage.h"
 #include "FairMQTransportFactory.h"
 
-class FairMQSamplerTask : public FairTask {
-public:
-  FairMQSamplerTask();
-  FairMQSamplerTask(const Text_t *name, int iVerbose = 1);
+class FairMQSamplerTask : public FairTask
+{
+  public:
+    FairMQSamplerTask();
+    FairMQSamplerTask(const Text_t *name, int iVerbose = 1);
 
-  virtual ~FairMQSamplerTask();
+    virtual ~FairMQSamplerTask();
 
-  virtual InitStatus Init();
-  virtual void Exec(Option_t *opt);
-  void
-  SetSendPart(boost::function<void()>); // provides a callback to the Sampler.
-  void SetEventIndex(Long64_t EventIndex);
-  void SetBranch(string branch);
-  FairMQMessage *GetOutput();
-  void SetTransport(FairMQTransportFactory *factory);
+    virtual InitStatus Init();
+    virtual void Exec(Option_t *opt);
+    void
+    SetSendPart(boost::function<void()>); // provides a callback to the Sampler.
+    void SetEventIndex(Long64_t EventIndex);
+    void SetBranch(string branch);
+    FairMQMessage *GetOutput();
+    void SetTransport(FairMQTransportFactory *factory);
 
-protected:
-  TClonesArray *fInput;
-  string fBranch;
-  FairMQMessage *fOutput;
-  FairMQTransportFactory *fTransportFactory;
-  Long64_t fEventIndex;
-  boost::function<void()>
-  SendPart; // function pointer for the Sampler callback.
-  FairEventHeader *fEvtHeader;
+  protected:
+    TClonesArray *fInput;
+    string fBranch;
+    FairMQMessage *fOutput;
+    FairMQTransportFactory *fTransportFactory;
+    Long64_t fEventIndex;
+    boost::function<void()> SendPart; // function pointer for the Sampler callback.
+    FairEventHeader *fEvtHeader;
 };
 
 #endif /* FAIRMQSAMPLERTASK_H_ */

--- a/example/Tutorial3/data/FairMQFileSink.tpl
+++ b/example/Tutorial3/data/FairMQFileSink.tpl
@@ -55,14 +55,14 @@ void FairMQFileSink<TIn, TPayloadIn>::Run()
 
         boost::thread rateLogger(boost::bind(&FairMQDevice::LogSocketRates, this));
         int receivedMsgs = 0;
-        bool received = false;
+        int received = 0;
 
         while (fState == RUNNING)
         {
             FairMQMessage* msg = fTransportFactory->CreateMessage();
             received = fPayloadInputs->at(0)->Receive(msg);
 
-            if (received)
+            if (received > 0)
             {
                 receivedMsgs++;
                 std::string msgStr(static_cast<char*>(msg->GetData()), msg->GetSize());
@@ -92,7 +92,7 @@ void FairMQFileSink<TIn, TPayloadIn>::Run()
                 }
 
                 fTree->Fill();
-                received = false;
+                received = 0;
             }
             delete msg;
             if (fHitVector.size() > 0)
@@ -100,7 +100,6 @@ void FairMQFileSink<TIn, TPayloadIn>::Run()
         }
 
         LOG(INFO) << "I've received " << receivedMsgs << " messages!";
-        boost::this_thread::sleep(boost::posix_time::milliseconds(5000));
 
         try {
             rateLogger.interrupt();
@@ -108,6 +107,8 @@ void FairMQFileSink<TIn, TPayloadIn>::Run()
         } catch(boost::thread_resource_error& e) {
             LOG(ERROR) << e.what();
         }
+
+        FairMQDevice::Shutdown();
     }
     else
     {
@@ -125,7 +126,7 @@ void FairMQFileSink<FairTestDetectorHit, TestDetectorPayload::Hit>::Run()
     boost::thread rateLogger(boost::bind(&FairMQDevice::LogSocketRates, this));
 
     int receivedMsgs = 0;
-    bool received = false;
+    int received = 0;
 
     while (fState == RUNNING)
     {
@@ -133,8 +134,9 @@ void FairMQFileSink<FairTestDetectorHit, TestDetectorPayload::Hit>::Run()
 
         received = fPayloadInputs->at(0)->Receive(msg);
 
-        if (received)
+        if (received > 0)
         {
+            receivedMsgs++;
             Int_t inputSize = msg->GetSize();
             Int_t numInput = inputSize / sizeof(TestDetectorPayload::Hit);
             TestDetectorPayload::Hit* input = static_cast<TestDetectorPayload::Hit*>(msg->GetData());
@@ -154,7 +156,7 @@ void FairMQFileSink<FairTestDetectorHit, TestDetectorPayload::Hit>::Run()
             }
 
             fTree->Fill();
-            received = false;
+            received = 0;
         }
 
         delete msg;
@@ -162,14 +164,14 @@ void FairMQFileSink<FairTestDetectorHit, TestDetectorPayload::Hit>::Run()
 
     LOG(INFO) << "I've received " << receivedMsgs << " messages!";
 
-    boost::this_thread::sleep(boost::posix_time::milliseconds(5000));
-
     try {
         rateLogger.interrupt();
         rateLogger.join();
     } catch(boost::thread_resource_error& e) {
         LOG(ERROR) << e.what();
     }
+
+    FairMQDevice::Shutdown();
 }
 
 // ----- Implementation of FairMQFileSink::Run() with Root TMessage transport data format -----
@@ -193,7 +195,7 @@ void FairMQFileSink<FairTestDetectorHit, TMessage>::Run()
     boost::thread rateLogger(boost::bind(&FairMQDevice::LogSocketRates, this));
 
     int receivedMsgs = 0;
-    bool received = false;
+    int received = 0;
 
     while (fState == RUNNING)
     {
@@ -201,9 +203,9 @@ void FairMQFileSink<FairTestDetectorHit, TMessage>::Run()
 
         received = fPayloadInputs->at(0)->Receive(msg);
 
-        if (received)
+        if (received > 0)
         {
-
+            receivedMsgs++;
             TestDetectorTMessage tm(msg->GetData(), msg->GetSize());
 
             fOutput = (TClonesArray*)(tm.ReadObject(tm.GetClass()));
@@ -217,7 +219,7 @@ void FairMQFileSink<FairTestDetectorHit, TMessage>::Run()
 
             delete fOutput;
 
-            received = false;
+            received = 0;
         }
 
         delete msg;
@@ -225,14 +227,14 @@ void FairMQFileSink<FairTestDetectorHit, TMessage>::Run()
 
     LOG(INFO) << "I've received " << receivedMsgs << " messages!";
 
-    boost::this_thread::sleep(boost::posix_time::milliseconds(5000));
-
     try {
         rateLogger.interrupt();
         rateLogger.join();
     } catch(boost::thread_resource_error& e) {
         LOG(ERROR) << e.what();
     }
+
+    FairMQDevice::Shutdown();
 }
 
 // ----- Implementation of FairMQFileSink::Run() with Google Protocol Buffers transport data format -----
@@ -248,7 +250,7 @@ void FairMQFileSink<FairTestDetectorHit, TestDetectorProto::HitPayload>::Run()
     boost::thread rateLogger(boost::bind(&FairMQDevice::LogSocketRates, this));
 
     int receivedMsgs = 0;
-    bool received = false;
+    int received = 0;
 
     while (fState == RUNNING)
     {
@@ -256,9 +258,9 @@ void FairMQFileSink<FairTestDetectorHit, TestDetectorProto::HitPayload>::Run()
 
         received = fPayloadInputs->at(0)->Receive(msg);
 
-        if (received)
+        if (received > 0)
         {
-
+            receivedMsgs++;
             fOutput->Delete();
 
             TestDetectorProto::HitPayload hp;
@@ -280,7 +282,7 @@ void FairMQFileSink<FairTestDetectorHit, TestDetectorProto::HitPayload>::Run()
             }
 
             fTree->Fill();
-            received = false;
+            received = 0;
         }
 
         delete msg;
@@ -288,14 +290,14 @@ void FairMQFileSink<FairTestDetectorHit, TestDetectorProto::HitPayload>::Run()
 
     LOG(INFO) << "I've received " << receivedMsgs << " messages!";
 
-    boost::this_thread::sleep(boost::posix_time::milliseconds(5000));
-
     try {
         rateLogger.interrupt();
         rateLogger.join();
     } catch(boost::thread_resource_error& e) {
         LOG(ERROR) << e.what();
     }
+
+    FairMQDevice::Shutdown();
 }
 
 #endif /* PROTOBUF */

--- a/example/Tutorial3/run/runFileSinkRoot.cxx
+++ b/example/Tutorial3/run/runFileSinkRoot.cxx
@@ -1,5 +1,12 @@
+/********************************************************************************
+ *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             * 
+ *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *  
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
 /**
- * runFileSinkBin.cxx
+ * runFileSinkRoot.cxx
  *
  * @since 2013-01-21
  * @author A. Rybalchenko

--- a/example/Tutorial3/run/runTestDetectorProcessorBoost.cxx
+++ b/example/Tutorial3/run/runTestDetectorProcessorBoost.cxx
@@ -8,8 +8,8 @@
 /**
  * runTestDetectorProcessorBoost.cxx
  *
- *  Created on: Oct 26, 2012
- *      Author: dklein
+ * @since 2012-10-26
+ * @author D. Klein, A. Rybalchenko
  */
 
 #include <iostream>

--- a/example/Tutorial3/run/runTestDetectorProcessorProto.cxx
+++ b/example/Tutorial3/run/runTestDetectorProcessorProto.cxx
@@ -5,11 +5,11 @@
  *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *  
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
-/*
- * runTestDetectorProcessor.cxx
+/**
+ * runTestDetectorProcessorProto.cxx
  *
- *  Created on: Oct 26, 2012
- *      Author: dklein
+ * @since 2012-10-26
+ * @author D. Klein, A. Rybalchenko
  */
 
 #include <iostream>

--- a/example/Tutorial3/run/runTestDetectorProcessorRoot.cxx
+++ b/example/Tutorial3/run/runTestDetectorProcessorRoot.cxx
@@ -1,5 +1,12 @@
+/********************************************************************************
+ *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             * 
+ *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *  
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
 /**
- * runTestDetectorProcessorBin.cxx
+ * runTestDetectorProcessorRoot.cxx
  *
  * @since 2012-10-26
  * @author A. Rybalchenko, N. Winckler

--- a/example/Tutorial3/run/runTestDetectorSamplerBoost.cxx
+++ b/example/Tutorial3/run/runTestDetectorSamplerBoost.cxx
@@ -6,10 +6,10 @@
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
 /**
- * runTestDetectorSampler.cxx
+ * runTestDetectorSamplerBoost.cxx
  *
- *  @since 2013-04-29
- *  @author: A. Rybalchenko, N. Winckler
+ * @since 2013-04-29
+ * @author A. Rybalchenko, N. Winckler
  */
 
 #include <iostream>

--- a/example/Tutorial3/run/runTestDetectorSamplerProto.cxx
+++ b/example/Tutorial3/run/runTestDetectorSamplerProto.cxx
@@ -6,10 +6,10 @@
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
 /**
- * runTestDetectorSampler.cxx
+ * runTestDetectorSamplerProto.cxx
  *
- *  @since 2013-04-29
- *  @author: A. Rybalchenko, N. Winckler
+ * @since 2013-04-29
+ * @author A. Rybalchenko, N. Winckler
  */
 
 #include <iostream>

--- a/example/Tutorial3/run/runTestDetectorSamplerRoot.cxx
+++ b/example/Tutorial3/run/runTestDetectorSamplerRoot.cxx
@@ -1,5 +1,12 @@
+/********************************************************************************
+ *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             * 
+ *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *  
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
 /**
- * runTestDetectorSamplerBin.cxx
+ * runTestDetectorSamplerRoot.cxx
  *
  * @since 2013-04-29
  * @author A. Rybalchenko, N. Winckler

--- a/fairmq/CMakeLists.txt
+++ b/fairmq/CMakeLists.txt
@@ -15,7 +15,8 @@ if(PROTOBUF_FOUND)
   set(INCLUDE_DIRECTORIES
     ${INCLUDE_DIRECTORIES}
     ${PROTOBUF_INCLUDE_DIR}
-    ${CMAKE_SOURCE_DIR}/fairmq/prototest
+    # # following directory is only for protobuf tests and is not essential part of FairMQ
+    #${CMAKE_SOURCE_DIR}/fairmq/prototest
   )
 endif(PROTOBUF_FOUND)
 
@@ -59,14 +60,15 @@ set(SRCS
 )
 
 if(PROTOBUF_FOUND)
-  set(SRCS
-    ${SRCS}
-    "prototest/payload.pb.cc"
-    "prototest/FairMQProtoSampler.cxx"
-    "prototest/FairMQBinSampler.cxx"
-    "prototest/FairMQBinSink.cxx"
-    "prototest/FairMQProtoSink.cxx"
-  )
+  # following source files are only for protobuf tests and are not essential part of FairMQ
+  # set(SRCS
+  #   ${SRCS}
+  #   "prototest/payload.pb.cc"
+  #   "prototest/FairMQProtoSampler.cxx"
+  #   "prototest/FairMQBinSampler.cxx"
+  #   "prototest/FairMQBinSink.cxx"
+  #   "prototest/FairMQProtoSink.cxx"
+  # )
   set(DEPENDENCIES
     ${DEPENDENCIES}
     ${PROTOBUF_LIBRARY}
@@ -117,15 +119,16 @@ set(Exe_Names
   sink
   proxy)
 
-if(PROTOBUF_FOUND)
-  set(Exe_Names
-      ${Exe_Names}
-      binsampler
-      protosampler
-      binsink
-      protosink
-      )
-endif(PROTOBUF_FOUND)
+# following executables are only for protobuf tests and are not essential part of FairMQ
+# if(PROTOBUF_FOUND)
+#   set(Exe_Names
+#       ${Exe_Names}
+#       binsampler
+#       protosampler
+#       binsink
+#       protosink
+#       )
+# endif(PROTOBUF_FOUND)
 
 set(Exe_Source 
   run/runBenchmarkSampler.cxx
@@ -136,15 +139,16 @@ set(Exe_Source
   run/runProxy.cxx
 )
 
-if(PROTOBUF_FOUND)
-  set(Exe_Source
-      ${Exe_Source}
-      run/runBinSampler.cxx
-      run/runProtoSampler.cxx
-      run/runBinSink.cxx
-      run/runProtoSink.cxx
-      )
-endif(PROTOBUF_FOUND)
+# following source files are only for protobuf tests and are not essential part of FairMQ
+# if(PROTOBUF_FOUND)
+#   set(Exe_Source
+#       ${Exe_Source}
+#       run/runBinSampler.cxx
+#       run/runProtoSampler.cxx
+#       run/runBinSink.cxx
+#       run/runProtoSink.cxx
+#       )
+# endif(PROTOBUF_FOUND)
 
 list(LENGTH Exe_Names _length)
 math(EXPR _length ${_length}-1)

--- a/fairmq/FairMQDevice.h
+++ b/fairmq/FairMQDevice.h
@@ -88,6 +88,8 @@ class FairMQDevice : public FairMQStateMachine, public FairMQConfigurable
     vector<FairMQSocket*>* fPayloadInputs;
     vector<FairMQSocket*>* fPayloadOutputs;
 
+    FairMQSocket* fCommandSocket;
+
     int fLogIntervalInMs;
 
     FairMQTransportFactory* fTransportFactory;
@@ -98,6 +100,8 @@ class FairMQDevice : public FairMQStateMachine, public FairMQConfigurable
     virtual void Shutdown();
     virtual void InitOutput();
     virtual void InitInput();
+
+    virtual void Terminate();
 };
 
 #endif /* FAIRMQDEVICE_H_ */

--- a/fairmq/FairMQLogger.cxx
+++ b/fairmq/FairMQLogger.cxx
@@ -32,14 +32,6 @@ FairMQLogger::~FairMQLogger()
 
 std::ostringstream& FairMQLogger::Log(int type)
 {
-    timestamp_t tm = get_timestamp();
-    timestamp_t ms = tm / 1000.0L;
-    timestamp_t s = ms / 1000.0L;
-    std::time_t t = s;
-    // std::size_t fractional_seconds = ms % 1000;
-    char mbstr[100];
-    std::strftime(mbstr, 100, "%H:%M:%S", std::localtime(&t));
-
     string type_str;
     switch (type)
     {
@@ -60,6 +52,14 @@ std::ostringstream& FairMQLogger::Log(int type)
         default:
             break;
     }
+
+    timestamp_t tm = get_timestamp();
+    timestamp_t ms = tm / 1000.0L;
+    timestamp_t s = ms / 1000.0L;
+    std::time_t t = s;
+    // std::size_t fractional_seconds = ms % 1000;
+    char mbstr[100];
+    std::strftime(mbstr, 100, "%H:%M:%S", std::localtime(&t));
 
     os << "[\033[01;36m" << mbstr << "\033[0m]"
        << "[" << type_str << "]"

--- a/fairmq/FairMQPoller.h
+++ b/fairmq/FairMQPoller.h
@@ -20,6 +20,7 @@ class FairMQPoller
   public:
     virtual void Poll(int timeout) = 0;
     virtual bool CheckInput(int index) = 0;
+    virtual bool CheckOutput(int index) = 0;
 
     virtual ~FairMQPoller() {};
 };

--- a/fairmq/FairMQSocket.h
+++ b/fairmq/FairMQSocket.h
@@ -29,12 +29,13 @@ class FairMQSocket
     virtual void Bind(const string& address) = 0;
     virtual void Connect(const string& address) = 0;
 
-    virtual size_t Send(FairMQMessage* msg, const string& flag="") = 0;
-    virtual size_t Receive(FairMQMessage* msg, const string& flag="") = 0;
+    virtual int Send(FairMQMessage* msg, const string& flag="") = 0;
+    virtual int Receive(FairMQMessage* msg, const string& flag="") = 0;
 
     virtual void* GetSocket() = 0;
     virtual int GetSocket(int nothing) = 0;
     virtual void Close() = 0;
+    virtual void Terminate() = 0;
 
     virtual void SetOption(const string& option, const void* value, size_t valueSize) = 0;
     virtual void GetOption(const string& option, void* value, size_t* valueSize) = 0;

--- a/fairmq/FairMQStateMachine.h
+++ b/fairmq/FairMQStateMachine.h
@@ -33,27 +33,13 @@ namespace msmf = boost::msm::front;
 namespace FairMQFSM
 {
     // defining events for the boost MSM state machine
-    struct INIT
-    {
-    };
-    struct SETOUTPUT
-    {
-    };
-    struct SETINPUT
-    {
-    };
-    struct PAUSE
-    {
-    };
-    struct RUN
-    {
-    };
-    struct STOP
-    {
-    };
-    struct END
-    {
-    };
+    struct INIT {};
+    struct SETOUTPUT {};
+    struct SETINPUT {};
+    struct PAUSE {};
+    struct RUN {};
+    struct STOP {};
+    struct END {};
 
     // defining the boost MSM state machine
     struct FairMQFSM_ : public msm::front::state_machine_def<FairMQFSM_>
@@ -70,24 +56,12 @@ namespace FairMQFSM
             LOG(STATE) << "Exiting FairMQ state machine";
         }
         // The list of FSM states
-        struct IDLE_FSM : public msm::front::state<>
-        {
-        };
-        struct INITIALIZING_FSM : public msm::front::state<>
-        {
-        };
-        struct SETTINGOUTPUT_FSM : public msm::front::state<>
-        {
-        };
-        struct SETTINGINPUT_FSM : public msm::front::state<>
-        {
-        };
-        struct WAITING_FSM : public msm::front::state<>
-        {
-        };
-        struct RUNNING_FSM : public msm::front::state<>
-        {
-        };
+        struct IDLE_FSM : public msm::front::state<> {};
+        struct INITIALIZING_FSM : public msm::front::state<> {};
+        struct SETTINGOUTPUT_FSM : public msm::front::state<> {};
+        struct SETTINGINPUT_FSM : public msm::front::state<> {};
+        struct WAITING_FSM : public msm::front::state<> {};
+        struct RUNNING_FSM : public msm::front::state<> {};
         // Define initial state
         typedef IDLE_FSM initial_state;
         // Actions
@@ -141,8 +115,8 @@ namespace FairMQFSM
             void operator()(EVT const&, FSM& fsm, SourceState&, TargetState&)
             {
                 fsm.fState = IDLE;
+                fsm.Terminate();
                 fsm.running_state.join();
-                fsm.Shutdown();
             }
         };
         struct PauseFct
@@ -156,24 +130,13 @@ namespace FairMQFSM
             }
         };
         // actions to be overwritten by derived classes
-        virtual void Init()
-        {
-        }
-        virtual void Run()
-        {
-        }
-        virtual void Pause()
-        {
-        }
-        virtual void Shutdown()
-        {
-        }
-        virtual void InitOutput()
-        {
-        }
-        virtual void InitInput()
-        {
-        }
+        virtual void Init() {}
+        virtual void Run() {}
+        virtual void Pause() {}
+        virtual void Shutdown() {}
+        virtual void InitOutput() {}
+        virtual void InitInput() {}
+        virtual void Terminate() {} // Termination method called during StopFct action.
         // Transition table for FairMQFMS
         struct transition_table : mpl::vector<
             //        Start              Event      Next               Action        Guard

--- a/fairmq/devices/FairMQBenchmarkSampler.cxx
+++ b/fairmq/devices/FairMQBenchmarkSampler.cxx
@@ -68,12 +68,14 @@ void FairMQBenchmarkSampler::Run()
 
     try {
         rateLogger.interrupt();
-        resetEventCounter.interrupt();
         rateLogger.join();
+        resetEventCounter.interrupt();
         resetEventCounter.join();
     } catch(boost::thread_resource_error& e) {
         LOG(ERROR) << e.what();
     }
+
+    FairMQDevice::Shutdown();
 }
 
 void FairMQBenchmarkSampler::ResetEventCounter()

--- a/fairmq/devices/FairMQBuffer.cxx
+++ b/fairmq/devices/FairMQBuffer.cxx
@@ -30,17 +30,17 @@ void FairMQBuffer::Run()
 
     boost::thread rateLogger(boost::bind(&FairMQDevice::LogSocketRates, this));
 
-    bool received = false;
+    int received = 0;
     while (fState == RUNNING)
     {
         FairMQMessage* msg = fTransportFactory->CreateMessage();
 
         received = fPayloadInputs->at(0)->Receive(msg);
 
-        if (received)
+        if (received > 0)
         {
             fPayloadOutputs->at(0)->Send(msg);
-            received = false;
+            received = 0;
         }
 
         delete msg;
@@ -52,6 +52,8 @@ void FairMQBuffer::Run()
     } catch(boost::thread_resource_error& e) {
         LOG(ERROR) << e.what();
     }
+
+    FairMQDevice::Shutdown();
 }
 
 FairMQBuffer::~FairMQBuffer()

--- a/fairmq/devices/FairMQMerger.cxx
+++ b/fairmq/devices/FairMQMerger.cxx
@@ -35,7 +35,7 @@ void FairMQMerger::Run()
 
     FairMQPoller* poller = fTransportFactory->CreatePoller(*fPayloadInputs);
 
-    bool received = false;
+    int received = 0;
 
     while (fState == RUNNING)
     {
@@ -49,10 +49,10 @@ void FairMQMerger::Run()
             {
                 received = fPayloadInputs->at(i)->Receive(msg);
             }
-            if (received)
+            if (received > 0)
             {
                 fPayloadOutputs->at(0)->Send(msg);
-                received = false;
+                received = 0;
             }
         }
 
@@ -67,4 +67,6 @@ void FairMQMerger::Run()
     } catch(boost::thread_resource_error& e) {
         LOG(ERROR) << e.what();
     }
+
+    FairMQDevice::Shutdown();
 }

--- a/fairmq/devices/FairMQProxy.cxx
+++ b/fairmq/devices/FairMQProxy.cxx
@@ -34,15 +34,15 @@ void FairMQProxy::Run()
 
     FairMQMessage* msg = fTransportFactory->CreateMessage();
 
-    size_t bytes_received = 0;
+    int received = 0;
 
     while (fState == RUNNING)
     {
-        bytes_received = fPayloadInputs->at(0)->Receive(msg);
-        if (bytes_received)
+        received = fPayloadInputs->at(0)->Receive(msg);
+        if (received > 0)
         {
             fPayloadOutputs->at(0)->Send(msg);
-            bytes_received = 0;
+            received = 0;
         }
     }
 
@@ -54,4 +54,6 @@ void FairMQProxy::Run()
     } catch(boost::thread_resource_error& e) {
         LOG(ERROR) << e.what();
     }
+
+    FairMQDevice::Shutdown();
 }

--- a/fairmq/devices/FairMQSink.cxx
+++ b/fairmq/devices/FairMQSink.cxx
@@ -28,13 +28,13 @@ void FairMQSink::Run()
 
     boost::thread rateLogger(boost::bind(&FairMQDevice::LogSocketRates, this));
 
-    size_t bytes_received = 0;
+    int received = 0;
 
     while (fState == RUNNING)
     {
         FairMQMessage* msg = fTransportFactory->CreateMessage();
 
-        bytes_received = fPayloadInputs->at(0)->Receive(msg);
+        received = fPayloadInputs->at(0)->Receive(msg);
 
         delete msg;
     }
@@ -45,6 +45,8 @@ void FairMQSink::Run()
     } catch(boost::thread_resource_error& e) {
         LOG(ERROR) << e.what();
     }
+
+    FairMQDevice::Shutdown();
 }
 
 FairMQSink::~FairMQSink()

--- a/fairmq/devices/FairMQSplitter.cxx
+++ b/fairmq/devices/FairMQSplitter.cxx
@@ -32,7 +32,7 @@ void FairMQSplitter::Run()
 
     boost::thread rateLogger(boost::bind(&FairMQDevice::LogSocketRates, this));
 
-    bool received = false;
+    int received = 0;
     int direction = 0;
 
     while (fState == RUNNING)
@@ -41,7 +41,7 @@ void FairMQSplitter::Run()
 
         received = fPayloadInputs->at(0)->Receive(msg);
 
-        if (received)
+        if (received > 0)
         {
             fPayloadOutputs->at(direction)->Send(msg);
             direction++;
@@ -49,7 +49,7 @@ void FairMQSplitter::Run()
             {
                 direction = 0;
             }
-            received = false;
+            received = 0;
         }
 
         delete msg;
@@ -61,4 +61,6 @@ void FairMQSplitter::Run()
     } catch(boost::thread_resource_error& e) {
         LOG(ERROR) << e.what();
     }
+
+    FairMQDevice::Shutdown();
 }

--- a/fairmq/nanomsg/FairMQMessageNN.cxx
+++ b/fairmq/nanomsg/FairMQMessageNN.cxx
@@ -13,6 +13,7 @@
  */
 
 #include <cstring>
+#include <stdlib.h>
 
 #include <nanomsg/nn.h>
 

--- a/fairmq/nanomsg/FairMQPollerNN.cxx
+++ b/fairmq/nanomsg/FairMQPollerNN.cxx
@@ -41,6 +41,14 @@ bool FairMQPollerNN::CheckInput(int index)
     return false;
 }
 
+bool FairMQPollerNN::CheckOutput(int index)
+{
+    if (items[index].revents & NN_POLLOUT)
+        return true;
+
+    return false;
+}
+
 FairMQPollerNN::~FairMQPollerNN()
 {
     if (items != NULL)

--- a/fairmq/nanomsg/FairMQPollerNN.h
+++ b/fairmq/nanomsg/FairMQPollerNN.h
@@ -29,6 +29,7 @@ class FairMQPollerNN : public FairMQPoller
 
     virtual void Poll(int timeout);
     virtual bool CheckInput(int index);
+    virtual bool CheckOutput(int index);
 
     virtual ~FairMQPollerNN();
 

--- a/fairmq/nanomsg/FairMQSocketNN.cxx
+++ b/fairmq/nanomsg/FairMQSocketNN.cxx
@@ -69,7 +69,7 @@ void FairMQSocketNN::Connect(const string& address)
     }
 }
 
-size_t FairMQSocketNN::Send(FairMQMessage* msg, const string& flag)
+int FairMQSocketNN::Send(FairMQMessage* msg, const string& flag)
 {
     void* ptr = msg->GetMessage();
     int rc = nn_send(fSocket, &ptr, NN_MSG, 0);
@@ -87,7 +87,7 @@ size_t FairMQSocketNN::Send(FairMQMessage* msg, const string& flag)
     return rc;
 }
 
-size_t FairMQSocketNN::Receive(FairMQMessage* msg, const string& flag)
+int FairMQSocketNN::Receive(FairMQMessage* msg, const string& flag)
 {
     void* ptr = NULL;
     int rc = nn_recv(fSocket, &ptr, NN_MSG, 0);
@@ -106,6 +106,16 @@ size_t FairMQSocketNN::Receive(FairMQMessage* msg, const string& flag)
     return rc;
 }
 
+void FairMQSocketNN::Close()
+{
+    nn_close(fSocket);
+}
+
+void FairMQSocketNN::Terminate()
+{
+    nn_term();
+}
+
 void* FairMQSocketNN::GetSocket()
 {
     return NULL; // dummy method to comply with the interface. functionality not possible in zeromq.
@@ -114,11 +124,6 @@ void* FairMQSocketNN::GetSocket()
 int FairMQSocketNN::GetSocket(int nothing)
 {
     return fSocket;
-}
-
-void FairMQSocketNN::Close()
-{
-    nn_close(fSocket);
 }
 
 void FairMQSocketNN::SetOption(const string& option, const void* value, size_t valueSize)
@@ -186,6 +191,8 @@ int FairMQSocketNN::GetConstant(const string& constant)
         LOG(ERROR) << "Multipart messages functionality currently not supported by nanomsg!";
         return -1;
     }
+    if (constant == "linger")
+        return NN_LINGER;
 
     return -1;
 }

--- a/fairmq/nanomsg/FairMQSocketNN.h
+++ b/fairmq/nanomsg/FairMQSocketNN.h
@@ -31,12 +31,13 @@ class FairMQSocketNN : public FairMQSocket
     virtual void Bind(const string& address);
     virtual void Connect(const string& address);
 
-    virtual size_t Send(FairMQMessage* msg, const string& flag="");
-    virtual size_t Receive(FairMQMessage* msg, const string& flag="");
+    virtual int Send(FairMQMessage* msg, const string& flag="");
+    virtual int Receive(FairMQMessage* msg, const string& flag="");
 
     virtual void* GetSocket();
     virtual int GetSocket(int nothing);
     virtual void Close();
+    virtual void Terminate();
 
     virtual void SetOption(const string& option, const void* value, size_t valueSize);
     virtual void GetOption(const string& option, void* value, size_t* valueSize);

--- a/fairmq/zeromq/FairMQContextZMQ.cxx
+++ b/fairmq/zeromq/FairMQContextZMQ.cxx
@@ -51,8 +51,11 @@ void FairMQContextZMQ::Close()
     int rc = zmq_ctx_destroy(fContext);
     if (rc != 0)
     {
-        LOG(ERROR) << "failed closing context, reason: " << zmq_strerror(errno);
+        if (errno == EINTR) {
+            LOG(ERROR) << " failed closing context, reason: " << zmq_strerror(errno);
+        } else {
+            fContext = NULL;
+            return;
+        }
     }
-
-    fContext = NULL;
 }

--- a/fairmq/zeromq/FairMQPollerZMQ.cxx
+++ b/fairmq/zeromq/FairMQPollerZMQ.cxx
@@ -15,6 +15,7 @@
 #include <zmq.h>
 
 #include "FairMQPollerZMQ.h"
+#include "FairMQLogger.h"
 
 FairMQPollerZMQ::FairMQPollerZMQ(const vector<FairMQSocket*>& inputs)
 {
@@ -32,12 +33,24 @@ FairMQPollerZMQ::FairMQPollerZMQ(const vector<FairMQSocket*>& inputs)
 
 void FairMQPollerZMQ::Poll(int timeout)
 {
-    zmq_poll(items, fNumItems, timeout);
+    int rc = zmq_poll(items, fNumItems, timeout);
+    if (rc < 0)
+    {
+        LOG(ERROR) << "polling failed, reason: " << zmq_strerror(errno);
+    }
 }
 
 bool FairMQPollerZMQ::CheckInput(int index)
 {
     if (items[index].revents & ZMQ_POLLIN)
+        return true;
+
+    return false;
+}
+
+bool FairMQPollerZMQ::CheckOutput(int index)
+{
+    if (items[index].revents & ZMQ_POLLOUT)
         return true;
 
     return false;

--- a/fairmq/zeromq/FairMQPollerZMQ.h
+++ b/fairmq/zeromq/FairMQPollerZMQ.h
@@ -29,6 +29,7 @@ class FairMQPollerZMQ : public FairMQPoller
 
     virtual void Poll(int timeout);
     virtual bool CheckInput(int index);
+    virtual bool CheckOutput(int index);
 
     virtual ~FairMQPollerZMQ();
 

--- a/fairmq/zeromq/FairMQSocketZMQ.h
+++ b/fairmq/zeromq/FairMQSocketZMQ.h
@@ -32,12 +32,13 @@ class FairMQSocketZMQ : public FairMQSocket
     virtual void Bind(const string& address);
     virtual void Connect(const string& address);
 
-    virtual size_t Send(FairMQMessage* msg, const string& flag="");
-    virtual size_t Receive(FairMQMessage* msg, const string& flag="");
+    virtual int Send(FairMQMessage* msg, const string& flag="");
+    virtual int Receive(FairMQMessage* msg, const string& flag="");
 
     virtual void* GetSocket();
     virtual int GetSocket(int nothing);
     virtual void Close();
+    virtual void Terminate();
 
     virtual void SetOption(const string& option, const void* value, size_t valueSize);
     virtual void GetOption(const string& option, void* value, size_t* valueSize);


### PR DESCRIPTION
- Proper process termination:
  if interrupted with `CTRL+C` blocking socket calls will return with -1. Each device should call `FairMQDevice::Shutdown()` before ending the running state to close open sockets, otherwise the interrupt call itself will block.
- FIX: Update number of received messages for `FairMQFileSink`.
- Add ability to poll on outputs for `FairMQPoller`.
