### PR TITLE
Condition check before ending the main thread.

### DIFF
--- a/base/MQ/FairMQProcessor.cxx
+++ b/base/MQ/FairMQProcessor.cxx
@@ -81,6 +81,11 @@ void FairMQProcessor::Run()
   }
 
   FairMQDevice::Shutdown();
+
+  // notify parent thread about end of processing.
+  boost::lock_guard<boost::mutex> lock(fRunningMutex);
+  fRunningFinished = true;
+  fRunningCondition.notify_one();
 }
 
 void FairMQProcessor::SendPart()

--- a/base/MQ/FairMQSampler.tpl
+++ b/base/MQ/FairMQSampler.tpl
@@ -121,6 +121,11 @@ void FairMQSampler<Loader>::Run()
   }
 
   FairMQDevice::Shutdown();
+
+  // notify parent thread about end of processing.
+  boost::lock_guard<boost::mutex> lock(fRunningMutex);
+  fRunningFinished = true;
+  fRunningCondition.notify_one();
 }
 
 template <typename Loader>

--- a/example/Tutorial3/CMakeLists.txt
+++ b/example/Tutorial3/CMakeLists.txt
@@ -38,8 +38,9 @@ If (Boost_FOUND)
   configure_file( ${CMAKE_SOURCE_DIR}/example/Tutorial3/macro/startExtraProcessor.sh.in ${CMAKE_BINARY_DIR}/bin/startExtraProcessor.sh )
   configure_file( ${CMAKE_SOURCE_DIR}/example/Tutorial3/macro/startTestDetectorSampler.sh.in ${CMAKE_BINARY_DIR}/bin/startTestDetectorSampler.sh )
   configure_file( ${CMAKE_SOURCE_DIR}/example/Tutorial3/macro/startBenchmark.sh.in ${CMAKE_BINARY_DIR}/bin/startBenchmark.sh )
-  configure_file( ${CMAKE_SOURCE_DIR}/example/Tutorial3/macro/startBin.sh.in ${CMAKE_BINARY_DIR}/bin/startBin.sh )
-  configure_file( ${CMAKE_SOURCE_DIR}/example/Tutorial3/macro/startProto.sh.in ${CMAKE_BINARY_DIR}/bin/startProto.sh )
+  # following scripts are only for protobuf tests and are not essential part of FairMQ
+  # configure_file( ${CMAKE_SOURCE_DIR}/example/Tutorial3/macro/startBin.sh.in ${CMAKE_BINARY_DIR}/bin/startBin.sh )
+  # configure_file( ${CMAKE_SOURCE_DIR}/example/Tutorial3/macro/startProto.sh.in ${CMAKE_BINARY_DIR}/bin/startProto.sh )
 EndIf (Boost_FOUND)
 
 set(LINK_DIRECTORIES

--- a/example/Tutorial3/run/runFileSinkBin.cxx
+++ b/example/Tutorial3/run/runFileSinkBin.cxx
@@ -111,8 +111,12 @@ int main(int argc, char** argv)
     filesink.ChangeState(TSink::SETINPUT);
     filesink.ChangeState(TSink::RUN);
 
-    char ch;
-    cin.get(ch);
+    // wait until the running thread has finished processing.
+    boost::unique_lock<boost::mutex> lock(filesink.fRunningMutex);
+    while (!filesink.fRunningFinished)
+    {
+        filesink.fRunningCondition.wait(lock);
+    }
 
     filesink.ChangeState(TSink::STOP);
     filesink.ChangeState(TSink::END);

--- a/example/Tutorial3/run/runFileSinkBoost.cxx
+++ b/example/Tutorial3/run/runFileSinkBoost.cxx
@@ -113,8 +113,12 @@ int main(int argc, char** argv)
     filesink.ChangeState(TSink::SETINPUT);
     filesink.ChangeState(TSink::RUN);
 
-    char ch;
-    cin.get(ch);
+    // wait until the running thread has finished processing.
+    boost::unique_lock<boost::mutex> lock(filesink.fRunningMutex);
+    while (!filesink.fRunningFinished)
+    {
+        filesink.fRunningCondition.wait(lock);
+    }
 
     filesink.ChangeState(TSink::STOP);
     filesink.ChangeState(TSink::END);

--- a/example/Tutorial3/run/runFileSinkProto.cxx
+++ b/example/Tutorial3/run/runFileSinkProto.cxx
@@ -111,8 +111,12 @@ int main(int argc, char** argv)
     filesink.ChangeState(TSink::SETINPUT);
     filesink.ChangeState(TSink::RUN);
 
-    char ch;
-    cin.get(ch);
+    // wait until the running thread has finished processing.
+    boost::unique_lock<boost::mutex> lock(filesink.fRunningMutex);
+    while (!filesink.fRunningFinished)
+    {
+        filesink.fRunningCondition.wait(lock);
+    }
 
     filesink.ChangeState(TSink::STOP);
     filesink.ChangeState(TSink::END);

--- a/example/Tutorial3/run/runFileSinkRoot.cxx
+++ b/example/Tutorial3/run/runFileSinkRoot.cxx
@@ -109,8 +109,12 @@ int main(int argc, char** argv)
     filesink.ChangeState(TSink::SETINPUT);
     filesink.ChangeState(TSink::RUN);
 
-    char ch;
-    cin.get(ch);
+    // wait until the running thread has finished processing.
+    boost::unique_lock<boost::mutex> lock(filesink.fRunningMutex);
+    while (!filesink.fRunningFinished)
+    {
+        filesink.fRunningCondition.wait(lock);
+    }
 
     filesink.ChangeState(TSink::STOP);
     filesink.ChangeState(TSink::END);

--- a/example/Tutorial3/run/runTestDetectorProcessorBin.cxx
+++ b/example/Tutorial3/run/runTestDetectorProcessorBin.cxx
@@ -139,8 +139,12 @@ int main(int argc, char** argv)
     processor.ChangeState(FairMQProcessor::SETINPUT);
     processor.ChangeState(FairMQProcessor::RUN);
 
-    char ch;
-    cin.get(ch);
+    // wait until the running thread has finished processing.
+    boost::unique_lock<boost::mutex> lock(processor.fRunningMutex);
+    while (!processor.fRunningFinished)
+    {
+        processor.fRunningCondition.wait(lock);
+    }
 
     processor.ChangeState(FairMQProcessor::STOP);
     processor.ChangeState(FairMQProcessor::END);

--- a/example/Tutorial3/run/runTestDetectorProcessorBoost.cxx
+++ b/example/Tutorial3/run/runTestDetectorProcessorBoost.cxx
@@ -144,8 +144,12 @@ int main(int argc, char** argv)
     processor.ChangeState(FairMQProcessor::SETINPUT);
     processor.ChangeState(FairMQProcessor::RUN);
 
-    char ch;
-    cin.get(ch);
+    // wait until the running thread has finished processing.
+    boost::unique_lock<boost::mutex> lock(processor.fRunningMutex);
+    while (!processor.fRunningFinished)
+    {
+        processor.fRunningCondition.wait(lock);
+    }
 
     processor.ChangeState(FairMQProcessor::STOP);
     processor.ChangeState(FairMQProcessor::END);

--- a/example/Tutorial3/run/runTestDetectorProcessorProto.cxx
+++ b/example/Tutorial3/run/runTestDetectorProcessorProto.cxx
@@ -139,8 +139,12 @@ int main(int argc, char** argv)
     processor.ChangeState(FairMQProcessor::SETINPUT);
     processor.ChangeState(FairMQProcessor::RUN);
 
-    char ch;
-    cin.get(ch);
+    // wait until the running thread has finished processing.
+    boost::unique_lock<boost::mutex> lock(processor.fRunningMutex);
+    while (!processor.fRunningFinished)
+    {
+        processor.fRunningCondition.wait(lock);
+    }
 
     processor.ChangeState(FairMQProcessor::STOP);
     processor.ChangeState(FairMQProcessor::END);

--- a/example/Tutorial3/run/runTestDetectorProcessorRoot.cxx
+++ b/example/Tutorial3/run/runTestDetectorProcessorRoot.cxx
@@ -135,8 +135,12 @@ int main(int argc, char** argv)
     processor.ChangeState(FairMQProcessor::SETINPUT);
     processor.ChangeState(FairMQProcessor::RUN);
 
-    char ch;
-    cin.get(ch);
+    // wait until the running thread has finished processing.
+    boost::unique_lock<boost::mutex> lock(processor.fRunningMutex);
+    while (!processor.fRunningFinished)
+    {
+        processor.fRunningCondition.wait(lock);
+    }
 
     processor.ChangeState(FairMQProcessor::STOP);
     processor.ChangeState(FairMQProcessor::END);

--- a/example/Tutorial3/run/runTestDetectorSamplerBin.cxx
+++ b/example/Tutorial3/run/runTestDetectorSamplerBin.cxx
@@ -146,9 +146,13 @@ int main(int argc, char** argv)
     {
         LOG(ERROR) << e.what();
     }
-    // TODO: get rid of this hack!
-    char ch;
-    cin.get(ch);
+
+    // wait until the running thread has finished processing.
+    boost::unique_lock<boost::mutex> lock(sampler.fRunningMutex);
+    while (!sampler.fRunningFinished)
+    {
+        sampler.fRunningCondition.wait(lock);
+    }
 
     sampler.ChangeState(FairMQSampler<TLoader>::STOP);
     sampler.ChangeState(FairMQSampler<TLoader>::END);

--- a/example/Tutorial3/run/runTestDetectorSamplerBoost.cxx
+++ b/example/Tutorial3/run/runTestDetectorSamplerBoost.cxx
@@ -148,9 +148,13 @@ int main(int argc, char** argv)
     {
         LOG(ERROR) << e.what();
     }
-    // TODO: get rid of this hack!
-    char ch;
-    cin.get(ch);
+
+    // wait until the running thread has finished processing.
+    boost::unique_lock<boost::mutex> lock(sampler.fRunningMutex);
+    while (!sampler.fRunningFinished)
+    {
+        sampler.fRunningCondition.wait(lock);
+    }
 
     sampler.ChangeState(FairMQSampler<TLoader>::STOP);
     sampler.ChangeState(FairMQSampler<TLoader>::END);

--- a/example/Tutorial3/run/runTestDetectorSamplerProto.cxx
+++ b/example/Tutorial3/run/runTestDetectorSamplerProto.cxx
@@ -146,9 +146,13 @@ int main(int argc, char** argv)
     {
         LOG(ERROR) << e.what();
     }
-    // TODO: get rid of this hack!
-    char ch;
-    cin.get(ch);
+
+    // wait until the running thread has finished processing.
+    boost::unique_lock<boost::mutex> lock(sampler.fRunningMutex);
+    while (!sampler.fRunningFinished)
+    {
+        sampler.fRunningCondition.wait(lock);
+    }
 
     sampler.ChangeState(FairMQSampler<TLoader>::STOP);
     sampler.ChangeState(FairMQSampler<TLoader>::END);

--- a/example/Tutorial3/run/runTestDetectorSamplerRoot.cxx
+++ b/example/Tutorial3/run/runTestDetectorSamplerRoot.cxx
@@ -144,9 +144,13 @@ int main(int argc, char** argv)
     {
         LOG(ERROR) << e.what();
     }
-    // TODO: get rid of this hack!
-    char ch;
-    cin.get(ch);
+
+    // wait until the running thread has finished processing.
+    boost::unique_lock<boost::mutex> lock(sampler.fRunningMutex);
+    while (!sampler.fRunningFinished)
+    {
+        sampler.fRunningCondition.wait(lock);
+    }
 
     sampler.ChangeState(FairMQSampler<TLoader>::STOP);
     sampler.ChangeState(FairMQSampler<TLoader>::END);

--- a/fairmq/FairMQStateMachine.cxx
+++ b/fairmq/FairMQStateMachine.cxx
@@ -16,6 +16,7 @@
 #include "FairMQLogger.h"
 
 FairMQStateMachine::FairMQStateMachine()
+    : fRunningFinished(false)
 {
     start();
 }

--- a/fairmq/FairMQStateMachine.h
+++ b/fairmq/FairMQStateMachine.h
@@ -16,13 +16,16 @@
 #define FAIRMQSTATEMACHINE_H_
 
 #include <boost/thread.hpp>
+#include <boost/thread/mutex.hpp>
+#include <boost/thread/condition_variable.hpp>
 #include <boost/bind.hpp>
+#include <boost/function.hpp>
+
 #include <boost/msm/back/state_machine.hpp>
 #include <boost/msm/front/state_machine_def.hpp>
 #include <boost/msm/front/functor_row.hpp>
 #include <boost/msm/front/euml/common.hpp>
 #include <boost/msm/front/euml/operator.hpp>
-#include <boost/function.hpp>
 
 #include "FairMQLogger.h"
 
@@ -192,6 +195,11 @@ class FairMQStateMachine : public FairMQFSM::FairMQFSM
     FairMQStateMachine();
     virtual ~FairMQStateMachine();
     void ChangeState(int event);
+
+    // condition variable to notify parent thread about end of running state.
+    boost::condition_variable fRunningCondition;
+    boost::mutex fRunningMutex;
+    bool fRunningFinished;
 };
 
 #endif /* FAIRMQSTATEMACHINE_H_ */

--- a/fairmq/devices/FairMQBenchmarkSampler.cxx
+++ b/fairmq/devices/FairMQBenchmarkSampler.cxx
@@ -76,6 +76,11 @@ void FairMQBenchmarkSampler::Run()
     }
 
     FairMQDevice::Shutdown();
+
+    // notify parent thread about end of processing.
+    boost::lock_guard<boost::mutex> lock(fRunningMutex);
+    fRunningFinished = true;
+    fRunningCondition.notify_one();
 }
 
 void FairMQBenchmarkSampler::ResetEventCounter()

--- a/fairmq/devices/FairMQBuffer.cxx
+++ b/fairmq/devices/FairMQBuffer.cxx
@@ -54,6 +54,11 @@ void FairMQBuffer::Run()
     }
 
     FairMQDevice::Shutdown();
+
+    // notify parent thread about end of processing.
+    boost::lock_guard<boost::mutex> lock(fRunningMutex);
+    fRunningFinished = true;
+    fRunningCondition.notify_one();
 }
 
 FairMQBuffer::~FairMQBuffer()

--- a/fairmq/devices/FairMQMerger.cxx
+++ b/fairmq/devices/FairMQMerger.cxx
@@ -69,4 +69,9 @@ void FairMQMerger::Run()
     }
 
     FairMQDevice::Shutdown();
+
+    // notify parent thread about end of processing.
+    boost::lock_guard<boost::mutex> lock(fRunningMutex);
+    fRunningFinished = true;
+    fRunningCondition.notify_one();
 }

--- a/fairmq/devices/FairMQProxy.cxx
+++ b/fairmq/devices/FairMQProxy.cxx
@@ -56,4 +56,9 @@ void FairMQProxy::Run()
     }
 
     FairMQDevice::Shutdown();
+
+    // notify parent thread about end of processing.
+    boost::lock_guard<boost::mutex> lock(fRunningMutex);
+    fRunningFinished = true;
+    fRunningCondition.notify_one();
 }

--- a/fairmq/devices/FairMQSink.cxx
+++ b/fairmq/devices/FairMQSink.cxx
@@ -47,6 +47,11 @@ void FairMQSink::Run()
     }
 
     FairMQDevice::Shutdown();
+
+    // notify parent thread about end of processing.
+    boost::lock_guard<boost::mutex> lock(fRunningMutex);
+    fRunningFinished = true;
+    fRunningCondition.notify_one();
 }
 
 FairMQSink::~FairMQSink()

--- a/fairmq/devices/FairMQSplitter.cxx
+++ b/fairmq/devices/FairMQSplitter.cxx
@@ -63,4 +63,9 @@ void FairMQSplitter::Run()
     }
 
     FairMQDevice::Shutdown();
+
+    // notify parent thread about end of processing.
+    boost::lock_guard<boost::mutex> lock(fRunningMutex);
+    fRunningFinished = true;
+    fRunningCondition.notify_one();
 }

--- a/fairmq/run/runBenchmarkSampler.cxx
+++ b/fairmq/run/runBenchmarkSampler.cxx
@@ -113,8 +113,12 @@ int main(int argc, char** argv)
     sampler.ChangeState(FairMQBenchmarkSampler::SETINPUT);
     sampler.ChangeState(FairMQBenchmarkSampler::RUN);
 
-    char ch;
-    cin.get(ch);
+    // wait until the running thread has finished processing.
+    boost::unique_lock<boost::mutex> lock(sampler.fRunningMutex);
+    while (!sampler.fRunningFinished)
+    {
+        sampler.fRunningCondition.wait(lock);
+    }
 
     sampler.ChangeState(FairMQBenchmarkSampler::STOP);
     sampler.ChangeState(FairMQBenchmarkSampler::END);

--- a/fairmq/run/runBinSampler.cxx
+++ b/fairmq/run/runBinSampler.cxx
@@ -113,8 +113,12 @@ int main(int argc, char** argv)
     sampler.ChangeState(FairMQBinSampler::SETINPUT);
     sampler.ChangeState(FairMQBinSampler::RUN);
 
-    char ch;
-    cin.get(ch);
+    // wait until the running thread has finished processing.
+    boost::unique_lock<boost::mutex> lock(sampler.fRunningMutex);
+    while (!sampler.fRunningFinished)
+    {
+        sampler.fRunningCondition.wait(lock);
+    }
 
     sampler.ChangeState(FairMQBinSampler::STOP);
     sampler.ChangeState(FairMQBinSampler::END);

--- a/fairmq/run/runBinSink.cxx
+++ b/fairmq/run/runBinSink.cxx
@@ -103,8 +103,12 @@ int main(int argc, char** argv)
     sink.ChangeState(FairMQBinSink::SETINPUT);
     sink.ChangeState(FairMQBinSink::RUN);
 
-    char ch;
-    cin.get(ch);
+    // wait until the running thread has finished processing.
+    boost::unique_lock<boost::mutex> lock(sink.fRunningMutex);
+    while (!sink.fRunningFinished)
+    {
+        sink.fRunningCondition.wait(lock);
+    }
 
     sink.ChangeState(FairMQBinSink::STOP);
     sink.ChangeState(FairMQBinSink::END);

--- a/fairmq/run/runBuffer.cxx
+++ b/fairmq/run/runBuffer.cxx
@@ -114,8 +114,12 @@ int main(int argc, char** argv)
     buffer.ChangeState(FairMQBuffer::SETINPUT);
     buffer.ChangeState(FairMQBuffer::RUN);
 
-    char ch;
-    cin.get(ch);
+    // wait until the running thread has finished processing.
+    boost::unique_lock<boost::mutex> lock(buffer.fRunningMutex);
+    while (!buffer.fRunningFinished)
+    {
+        buffer.fRunningCondition.wait(lock);
+    }
 
     buffer.ChangeState(FairMQBuffer::STOP);
     buffer.ChangeState(FairMQBuffer::END);

--- a/fairmq/run/runMerger.cxx
+++ b/fairmq/run/runMerger.cxx
@@ -124,8 +124,12 @@ int main(int argc, char** argv)
     merger.ChangeState(FairMQMerger::SETINPUT);
     merger.ChangeState(FairMQMerger::RUN);
 
-    char ch;
-    cin.get(ch);
+    // wait until the running thread has finished processing.
+    boost::unique_lock<boost::mutex> lock(merger.fRunningMutex);
+    while (!merger.fRunningFinished)
+    {
+        merger.fRunningCondition.wait(lock);
+    }
 
     merger.ChangeState(FairMQMerger::STOP);
     merger.ChangeState(FairMQMerger::END);

--- a/fairmq/run/runProtoSampler.cxx
+++ b/fairmq/run/runProtoSampler.cxx
@@ -113,8 +113,12 @@ int main(int argc, char** argv)
     sampler.ChangeState(FairMQProtoSampler::SETINPUT);
     sampler.ChangeState(FairMQProtoSampler::RUN);
 
-    char ch;
-    cin.get(ch);
+    // wait until the running thread has finished processing.
+    boost::unique_lock<boost::mutex> lock(sampler.fRunningMutex);
+    while (!sampler.fRunningFinished)
+    {
+        sampler.fRunningCondition.wait(lock);
+    }
 
     sampler.ChangeState(FairMQProtoSampler::STOP);
     sampler.ChangeState(FairMQProtoSampler::END);

--- a/fairmq/run/runProtoSink.cxx
+++ b/fairmq/run/runProtoSink.cxx
@@ -103,8 +103,12 @@ int main(int argc, char** argv)
     sink.ChangeState(FairMQProtoSink::SETINPUT);
     sink.ChangeState(FairMQProtoSink::RUN);
 
-    char ch;
-    cin.get(ch);
+    // wait until the running thread has finished processing.
+    boost::unique_lock<boost::mutex> lock(sink.fRunningMutex);
+    while (!sink.fRunningFinished)
+    {
+        sink.fRunningCondition.wait(lock);
+    }
 
     sink.ChangeState(FairMQProtoSink::STOP);
     sink.ChangeState(FairMQProtoSink::END);

--- a/fairmq/run/runProxy.cxx
+++ b/fairmq/run/runProxy.cxx
@@ -115,8 +115,12 @@ int main(int argc, char** argv)
     proxy.ChangeState(FairMQProxy::SETINPUT);
     proxy.ChangeState(FairMQProxy::RUN);
 
-    char ch;
-    cin.get(ch);
+    // wait until the running thread has finished processing.
+    boost::unique_lock<boost::mutex> lock(proxy.fRunningMutex);
+    while (!proxy.fRunningFinished)
+    {
+        proxy.fRunningCondition.wait(lock);
+    }
 
     proxy.ChangeState(FairMQProxy::STOP);
     proxy.ChangeState(FairMQProxy::END);

--- a/fairmq/run/runSink.cxx
+++ b/fairmq/run/runSink.cxx
@@ -103,8 +103,12 @@ int main(int argc, char** argv)
     sink.ChangeState(FairMQSink::SETINPUT);
     sink.ChangeState(FairMQSink::RUN);
 
-    char ch;
-    cin.get(ch);
+    // wait until the running thread has finished processing.
+    boost::unique_lock<boost::mutex> lock(sink.fRunningMutex);
+    while (!sink.fRunningFinished)
+    {
+        sink.fRunningCondition.wait(lock);
+    }
 
     sink.ChangeState(FairMQSink::STOP);
     sink.ChangeState(FairMQSink::END);

--- a/fairmq/run/runSplitter.cxx
+++ b/fairmq/run/runSplitter.cxx
@@ -124,8 +124,12 @@ int main(int argc, char** argv)
     splitter.ChangeState(FairMQSplitter::SETINPUT);
     splitter.ChangeState(FairMQSplitter::RUN);
 
-    char ch;
-    cin.get(ch);
+    // wait until the running thread has finished processing.
+    boost::unique_lock<boost::mutex> lock(splitter.fRunningMutex);
+    while (!splitter.fRunningFinished)
+    {
+        splitter.fRunningCondition.wait(lock);
+    }
 
     splitter.ChangeState(FairMQSplitter::STOP);
     splitter.ChangeState(FairMQSplitter::END);


### PR DESCRIPTION
Make sure the main thread waits for the child thread with the Run() method.
- Add this at the end of your Run() method for each device:

```
boost::lock_guard<boost::mutex> lock(fRunningMutex);
fRunningFinished = true;
fRunningCondition.notify_one();
```
- Then you must replace the `char ch; cin.get(ch);` in your main() function with:

```
boost::unique_lock<boost::mutex> lock(processor.fRunningMutex);
while (!processor.fRunningFinished)
{
    processor.fRunningCondition.wait(lock);
}
```
