### PR TITLE
ZeroMQ dependency for dbMQ for the case when FairMQ is compiled with nanomsg

### DIFF
--- a/cmake/modules/FindZeroMQ.cmake
+++ b/cmake/modules/FindZeroMQ.cmake
@@ -14,16 +14,19 @@ set(LIBZMQ_STATIC libzmq.a)
 
 find_path(ZMQ_INCLUDE_DIR NAMES ${ZMQ_H} ${ZMQ_UTILS_H}
   PATHS ${SIMPATH}/include
+  NO_DEFAULT_PATH
   DOC   "Path to ZeroMQ include header files."
 )
 
 find_library(ZMQ_LIBRARY_SHARED NAMES ${LIBZMQ_SHARED}
   PATHS ${SIMPATH}/lib
+  NO_DEFAULT_PATH
   DOC   "Path to ${LIBZMQ_SHARED}."
 )
 
 find_library(ZMQ_LIBRARY_STATIC NAMES ${LIBZMQ_STATIC}
   PATHS ${SIMPATH}/lib
+  NO_DEFAULT_PATH
   DOC   "Path to ${LIBZMQ_STATIC}."
 )
 

--- a/dbase/dbMQ/CMakeLists.txt
+++ b/dbase/dbMQ/CMakeLists.txt
@@ -53,7 +53,7 @@ set(LIBRARY_NAME FairDbMQ)
 
 if (Boost_FOUND)
   set(DEPENDENCIES
-    Base FairDB ParBase FairMQ boost_thread boost_system boost_serialization)
+    Base FairDB ParBase FairMQ ${ZMQ_LIBRARY_SHARED} boost_thread boost_system boost_serialization)
 else (Boost_FOUND)
   set(DEPENDENCIES Base  FairDB ParBase)
 endif (Boost_FOUND)


### PR DESCRIPTION
ZeroMQ dependency for dbMQ for the case when FairMQ is compiled with nanomsg.
