### PR TITLE
Allow disabling transfer rate logging per input/output (optional, default is on)

### DIFF
--- a/fairmq/FairMQDevice.h
+++ b/fairmq/FairMQDevice.h
@@ -49,6 +49,8 @@ class FairMQDevice : public FairMQStateMachine, public FairMQConfigurable
         OutputSndBufSize,
         OutputRcvBufSize,
         LogIntervalInMs,
+        LogInputRate,
+        LogOutputRate,
         Last
     };
 
@@ -78,12 +80,14 @@ class FairMQDevice : public FairMQStateMachine, public FairMQConfigurable
     vector<string> fInputSocketType;
     vector<int> fInputSndBufSize;
     vector<int> fInputRcvBufSize;
+    vector<int> fLogInputRate;
 
     vector<string> fOutputAddress;
     vector<string> fOutputMethod;
     vector<string> fOutputSocketType;
     vector<int> fOutputSndBufSize;
     vector<int> fOutputRcvBufSize;
+    vector<int> fLogOutputRate;
 
     vector<FairMQSocket*>* fPayloadInputs;
     vector<FairMQSocket*>* fPayloadOutputs;


### PR DESCRIPTION
This introduces new property to FairMQDevice to control whether rateLogger thread should print rates for a given input/output.
Per default logging is enabled, so existing code works as before and does not need to be updated.
To turn off logging for an initialized input/output, set the `LogInputRate`/`LogOutputRate` property to `0`.

Example:

``` c++
splitter.ChangeState(FairMQSplitter::INIT);
// turn off rate logging for input 1 and output 4
splitter.SetProperty(FairMQSplitter::LogInputRate, 0, 1);
splitter.SetProperty(FairMQSplitter::LogOutputRate, 0, 4);
```
