### PR TITLE
bugfix: handling empty _linux_flavour variable

### DIFF
--- a/cmake/modules/WriteConfigFile.cmake
+++ b/cmake/modules/WriteConfigFile.cmake
@@ -53,9 +53,10 @@ MACRO (WRITE_CONFIG_FILE filename)
                      OUTPUT_STRIP_TRAILING_WHITESPACE
                     )
 
-    STRING(REGEX REPLACE "^\"" "" _linux_flavour ${_linux_flavour})
-    STRING(REGEX REPLACE "\"$" "" _linux_flavour ${_linux_flavour})
-
+    IF(_linux_flavour)
+      STRING(REGEX REPLACE "^\"" "" _linux_flavour ${_linux_flavour})
+      STRING(REGEX REPLACE "\"$" "" _linux_flavour ${_linux_flavour})
+    ENDIF(_linux_flavour)
 
     EXECUTE_PROCESS(COMMAND uname -m 
                     OUTPUT_VARIABLE _system 


### PR DESCRIPTION
This is a follow-up bugfix for commit cb198d2909dd7a6eab062936daf02a7cc8bdc707
The STRING REGEX REPLACE produces an error if the _linux_flavour variable is empty, which happens if  lsb_release is not installed in the system
