### PR TITLE
Fix warnings produced with -Weffc++ in fairmq, base/MQ and Tutorial3.

### DIFF
--- a/base/MQ/FairMQProcessor.cxx
+++ b/base/MQ/FairMQProcessor.cxx
@@ -52,20 +52,16 @@ void FairMQProcessor::Run()
   int receivedMsgs = 0;
   int sentMsgs = 0;
 
-  int received = 0;
-
   while ( fState == RUNNING ) {
     fProcessorTask->SetPayload(fTransportFactory->CreateMessage());
 
-    received = fPayloadInputs->at(0)->Receive(fProcessorTask->GetPayload());
     receivedMsgs++;
 
-    if (received > 0) {
+    if (fPayloadInputs->at(0)->Receive(fProcessorTask->GetPayload()) > 0) {
       fProcessorTask->Exec();
 
       fPayloadOutputs->at(0)->Send(fProcessorTask->GetPayload());
       sentMsgs++;
-      received = 0;
     }
 
     fProcessorTask->GetPayload()->CloseMessage();

--- a/base/MQ/FairMQProcessor.h
+++ b/base/MQ/FairMQProcessor.h
@@ -19,7 +19,7 @@
 #include "FairMQProcessorTask.h"
 
 
-class FairMQProcessor: public FairMQDevice
+class FairMQProcessor : public FairMQDevice
 {
   public:
     FairMQProcessor();
@@ -32,8 +32,13 @@ class FairMQProcessor: public FairMQDevice
   protected:
     virtual void Init();
     virtual void Run();
+
   private:
     FairMQProcessorTask* fProcessorTask;
+
+    /// Copy Constructor
+    FairMQProcessor(const FairMQProcessor&);
+    FairMQProcessor operator=(const FairMQProcessor&);
 };
 
 #endif /* FAIRMQPROCESSOR_H_ */

--- a/base/MQ/FairMQProcessorTask.cxx
+++ b/base/MQ/FairMQProcessorTask.cxx
@@ -24,6 +24,10 @@ FairMQProcessorTask::~FairMQProcessorTask()
 {
 }
 
+void FairMQProcessorTask::Exec(Option_t *opt)
+{
+}
+
 // initialize a callback to the Processor for sending multipart messages.
 void FairMQProcessorTask::SetSendPart(boost::function<void()> callback)
 {

--- a/base/MQ/FairMQProcessorTask.h
+++ b/base/MQ/FairMQProcessorTask.h
@@ -30,7 +30,7 @@ class FairMQProcessorTask : public FairTask
   public:
     FairMQProcessorTask();
     virtual ~FairMQProcessorTask();
-    virtual void Exec(Option_t* opt = "0") = 0;
+    virtual void Exec(Option_t* opt = "0");
     void SetSendPart(boost::function<void()>); // provides a callback to the Processor.
     void SetReceivePart(boost::function<bool()>); // provides a callback to the Processor.
     FairMQMessage* GetPayload();
@@ -40,6 +40,11 @@ class FairMQProcessorTask : public FairTask
     FairMQMessage* fPayload;
     boost::function<void()> SendPart; // function pointer for the Processor callback.
     boost::function<bool()> ReceivePart; // function pointer for the Processor callback.
+
+  private:
+    /// Copy Constructor
+    FairMQProcessorTask(const FairMQProcessorTask&);
+    FairMQProcessorTask operator=(const FairMQProcessorTask&);
 };
 
 #endif /* FAIRMQPROCESSORTASK_H_ */

--- a/base/MQ/FairMQSampler.h
+++ b/base/MQ/FairMQSampler.h
@@ -48,20 +48,21 @@
  * feasibility and quality of the various possible online analysis features.
  */
 
-template <typename Loader> class FairMQSampler: public FairMQDevice
+template <typename Loader>
+class FairMQSampler : public FairMQDevice
 {
   public:
     enum {
       InputFile = FairMQDevice::Last,
-      Branch,
       ParFile,
+      Branch,
       EventRate
     };
+
     FairMQSampler();
     virtual ~FairMQSampler();
 
     void ResetEventCounter();
-    virtual void ListenToCommands();
 
     virtual void SetProperty(const int key, const string& value, const int slot = 0);
     virtual string GetProperty(const int key, const string& default_ = "", const int slot = 0);
@@ -74,26 +75,28 @@ template <typename Loader> class FairMQSampler: public FairMQDevice
      * This method can be given as a callback to the SamplerTask.
      * The final message part must be sent with normal Send method.
      */
-  void SendPart();
+    void SendPart();
 
-  void SetContinuous(bool flag) { fContinuous = flag; }
+    void SetContinuous(bool flag) { fContinuous = flag; }
 
-protected:
-  virtual void Init();
-  virtual void Run();
+  protected:
+    virtual void Init();
+    virtual void Run();
 
+    FairRunAna *fFairRunAna;
+    FairMQSamplerTask *fSamplerTask;
+    string fInputFile; // Filename of a root file containing the simulated digis.
+    string fParFile;
+    string fBranch; // The name of the sub-detector branch to stream the digis from.
+    int fNumEvents;
+    int fEventRate;
+    int fEventCounter;
+    bool fContinuous;
 
-protected:
-  FairRunAna *fFairRunAna;
-  FairMQSamplerTask *fSamplerTask;
-  string fInputFile; // Filename of a root file containing the simulated digis.
-  string fParFile;
-  string
-  fBranch; // The name of the sub-detector branch to stream the digis from.
-  int fNumEvents;
-  int fEventRate;
-  int fEventCounter;
-  bool fContinuous;
+  private:
+    /// Copy Constructor
+    FairMQSampler(const FairMQSampler&);
+    FairMQSampler operator=(const FairMQSampler&);
 };
 
 // Template implementation is in FairMQSampler.tpl :

--- a/base/MQ/FairMQSamplerTask.cxx
+++ b/base/MQ/FairMQSamplerTask.cxx
@@ -14,21 +14,26 @@
 
 #include "FairMQSamplerTask.h"
 
-FairMQSamplerTask::FairMQSamplerTask(const Text_t* name, int iVerbose) :
-  FairTask(name, iVerbose),
-  fInput(NULL),
-  fOutput(NULL),
-  fTransportFactory(NULL),
-  fEventIndex(0)
-{
-}
-
 FairMQSamplerTask::FairMQSamplerTask() :
   FairTask("Abstract base task used for loading a branch from a root file into memory"),
   fInput(NULL),
+  fBranch(),
   fOutput(NULL),
   fTransportFactory(NULL),
   fEventIndex(0),
+  SendPart(),
+  fEvtHeader(NULL)
+{
+}
+
+FairMQSamplerTask::FairMQSamplerTask(const Text_t* name, int iVerbose) :
+  FairTask(name, iVerbose),
+  fInput(NULL),
+  fBranch(),
+  fOutput(NULL),
+  fTransportFactory(NULL),
+  fEventIndex(0),
+  SendPart(),
   fEvtHeader(NULL)
 {
 }

--- a/base/MQ/FairMQSamplerTask.h
+++ b/base/MQ/FairMQSamplerTask.h
@@ -38,8 +38,7 @@ class FairMQSamplerTask : public FairTask
 
     virtual InitStatus Init();
     virtual void Exec(Option_t *opt);
-    void
-    SetSendPart(boost::function<void()>); // provides a callback to the Sampler.
+    void SetSendPart(boost::function<void()>); // provides a callback to the Sampler.
     void SetEventIndex(Long64_t EventIndex);
     void SetBranch(string branch);
     FairMQMessage *GetOutput();
@@ -53,6 +52,11 @@ class FairMQSamplerTask : public FairTask
     Long64_t fEventIndex;
     boost::function<void()> SendPart; // function pointer for the Sampler callback.
     FairEventHeader *fEvtHeader;
+
+  private:
+    /// Copy Constructor
+    FairMQSamplerTask(const FairMQSamplerTask&);
+    FairMQSamplerTask operator=(const FairMQSamplerTask&);
 };
 
 #endif /* FAIRMQSAMPLERTASK_H_ */

--- a/example/Tutorial3/data/FairMQFileSink.h
+++ b/example/Tutorial3/data/FairMQFileSink.h
@@ -50,6 +50,8 @@ class TFile;
 class TTree;
 class TClonesArray;
 
+using namespace std;
+
 template <typename TIn, typename TPayloadIn>
 class FairMQFileSink : public FairMQDevice
 {
@@ -73,7 +75,7 @@ class FairMQFileSink : public FairMQDevice
     TClonesArray* fOutput;
 #ifndef __CINT__ // for BOOST serialization
     friend class boost::serialization::access;
-    std::vector<TIn> fHitVector;
+    vector<TIn> fHitVector;
     bool fHasBoostSerialization;
 #endif // for BOOST serialization
 };

--- a/example/Tutorial3/data/FairMQFileSink.tpl
+++ b/example/Tutorial3/data/FairMQFileSink.tpl
@@ -6,16 +6,18 @@
  */
 
 template <typename TIn, typename TPayloadIn>
-FairMQFileSink<TIn, TPayloadIn>::FairMQFileSink() :
-    fOutFile(NULL),
-    fTree(NULL),
-    fOutput(NULL)
+FairMQFileSink<TIn, TPayloadIn>::FairMQFileSink()
+    : fOutFile(NULL)
+    , fTree(NULL)
+    , fOutput(NULL)
+    , fHitVector()
+    , fHasBoostSerialization()
 {
 
     fHasBoostSerialization = true;
 #if __cplusplus >= 201103L
     fHasBoostSerialization = false;
-    if (std::is_same<TPayloadIn, boost::archive::binary_iarchive>::value || std::is_same<TPayloadIn, boost::archive::text_iarchive>::value)
+    if (is_same<TPayloadIn, boost::archive::binary_iarchive>::value || is_same<TPayloadIn, boost::archive::text_iarchive>::value)
     {
         if (has_BoostSerialization<TIn, void(TPayloadIn&, const unsigned int)>::value == 1)
             fHasBoostSerialization = true;
@@ -55,18 +57,16 @@ void FairMQFileSink<TIn, TPayloadIn>::Run()
 
         boost::thread rateLogger(boost::bind(&FairMQDevice::LogSocketRates, this));
         int receivedMsgs = 0;
-        int received = 0;
 
         while (fState == RUNNING)
         {
             FairMQMessage* msg = fTransportFactory->CreateMessage();
-            received = fPayloadInputs->at(0)->Receive(msg);
 
-            if (received > 0)
+            if (fPayloadInputs->at(0)->Receive(msg) > 0)
             {
                 receivedMsgs++;
-                std::string msgStr(static_cast<char*>(msg->GetData()), msg->GetSize());
-                std::istringstream ibuffer(msgStr);
+                string msgStr(static_cast<char*>(msg->GetData()), msg->GetSize());
+                istringstream ibuffer(msgStr);
                 TPayloadIn InputArchive(ibuffer);
 
                 try
@@ -92,9 +92,10 @@ void FairMQFileSink<TIn, TPayloadIn>::Run()
                 }
 
                 fTree->Fill();
-                received = 0;
             }
+
             delete msg;
+
             if (fHitVector.size() > 0)
                 fHitVector.clear();
         }
@@ -126,15 +127,12 @@ void FairMQFileSink<FairTestDetectorHit, TestDetectorPayload::Hit>::Run()
     boost::thread rateLogger(boost::bind(&FairMQDevice::LogSocketRates, this));
 
     int receivedMsgs = 0;
-    int received = 0;
 
     while (fState == RUNNING)
     {
         FairMQMessage* msg = fTransportFactory->CreateMessage();
 
-        received = fPayloadInputs->at(0)->Receive(msg);
-
-        if (received > 0)
+        if (fPayloadInputs->at(0)->Receive(msg) > 0)
         {
             receivedMsgs++;
             Int_t inputSize = msg->GetSize();
@@ -156,7 +154,6 @@ void FairMQFileSink<FairTestDetectorHit, TestDetectorPayload::Hit>::Run()
             }
 
             fTree->Fill();
-            received = 0;
         }
 
         delete msg;
@@ -195,15 +192,12 @@ void FairMQFileSink<FairTestDetectorHit, TMessage>::Run()
     boost::thread rateLogger(boost::bind(&FairMQDevice::LogSocketRates, this));
 
     int receivedMsgs = 0;
-    int received = 0;
 
     while (fState == RUNNING)
     {
         FairMQMessage* msg = fTransportFactory->CreateMessage();
 
-        received = fPayloadInputs->at(0)->Receive(msg);
-
-        if (received > 0)
+        if (fPayloadInputs->at(0)->Receive(msg) > 0)
         {
             receivedMsgs++;
             TestDetectorTMessage tm(msg->GetData(), msg->GetSize());
@@ -218,8 +212,6 @@ void FairMQFileSink<FairTestDetectorHit, TMessage>::Run()
             fTree->Fill();
 
             delete fOutput;
-
-            received = 0;
         }
 
         delete msg;
@@ -250,15 +242,12 @@ void FairMQFileSink<FairTestDetectorHit, TestDetectorProto::HitPayload>::Run()
     boost::thread rateLogger(boost::bind(&FairMQDevice::LogSocketRates, this));
 
     int receivedMsgs = 0;
-    int received = 0;
 
     while (fState == RUNNING)
     {
         FairMQMessage* msg = fTransportFactory->CreateMessage();
 
-        received = fPayloadInputs->at(0)->Receive(msg);
-
-        if (received > 0)
+        if (fPayloadInputs->at(0)->Receive(msg) > 0)
         {
             receivedMsgs++;
             fOutput->Delete();
@@ -282,7 +271,6 @@ void FairMQFileSink<FairTestDetectorHit, TestDetectorProto::HitPayload>::Run()
             }
 
             fTree->Fill();
-            received = 0;
         }
 
         delete msg;

--- a/example/Tutorial3/data/FairTestDetectorPayload.h
+++ b/example/Tutorial3/data/FairTestDetectorPayload.h
@@ -21,7 +21,6 @@
 
 namespace TestDetectorPayload
 {
-
     class TimeStamp
     {
       public:

--- a/example/Tutorial3/digitization/TestDetectorDigiLoader.h
+++ b/example/Tutorial3/digitization/TestDetectorDigiLoader.h
@@ -33,6 +33,8 @@
 #include <type_traits>
 #endif
 
+using namespace std;
+
 // Base template header <T1,T2>
 template <typename T1, typename T2>
 class TestDetectorDigiLoader : public FairMQSamplerTask
@@ -50,7 +52,7 @@ class TestDetectorDigiLoader : public FairMQSamplerTask
 
   private:
     friend class boost::serialization::access;
-    std::vector<T1> fDigiVector;
+    vector<T1> fDigiVector;
     bool fHasBoostSerialization;
 };
 

--- a/example/Tutorial3/digitization/TestDetectorDigiLoader.tpl
+++ b/example/Tutorial3/digitization/TestDetectorDigiLoader.tpl
@@ -10,11 +10,13 @@
 template <typename T1, typename T2>
 TestDetectorDigiLoader<T1, T2>::TestDetectorDigiLoader()
     : FairMQSamplerTask("Load class T1")
+    , fDigiVector()
+    , fHasBoostSerialization()
 {
     fHasBoostSerialization = true;
 #if __cplusplus >= 201103L
     fHasBoostSerialization = false;
-    if (std::is_same<T2, boost::archive::binary_oarchive>::value || std::is_same<T2, boost::archive::text_oarchive>::value)
+    if (is_same<T2, boost::archive::binary_oarchive>::value || is_same<T2, boost::archive::text_oarchive>::value)
     {
         if (has_BoostSerialization<T1, void(T2&, const unsigned int)>::value == 1)
             fHasBoostSerialization = true;
@@ -43,7 +45,7 @@ void TestDetectorDigiLoader<T1, T2>::Exec(Option_t* opt)
     {
         // LOG(INFO) <<" Boost Serialization ok ";
 
-        std::ostringstream buffer;
+        ostringstream buffer;
         T2 OutputArchive(buffer);
         for (Int_t i = 0; i < fInput->GetEntriesFast(); ++i)
         {
@@ -56,7 +58,7 @@ void TestDetectorDigiLoader<T1, T2>::Exec(Option_t* opt)
         OutputArchive << fDigiVector;
         int size = buffer.str().length();
         fOutput = fTransportFactory->CreateMessage(size);
-        std::memcpy(fOutput->GetData(), buffer.str().c_str(), size);
+        memcpy(fOutput->GetData(), buffer.str().c_str(), size);
 
         // delete the vector content
         if (fDigiVector.size() > 0)
@@ -75,7 +77,7 @@ void TestDetectorDigiLoader<FairTestDetectorDigi, TestDetectorPayload::Digi>::Ex
 {
     // // Example of how to send multipart messages (uncomment the code lines to test).
     // // 1. create some data and put it into message (optionaly in one step with zero-copy):
-    // std::string test = "hello";
+    // string test = "hello";
     // fOutput = fTransportFactory->CreateMessage(test.size());
     // memcpy ((void *) fOutput->GetData(), test.c_str(), test.size());
     // // 2. Send the current message as a part:
@@ -128,7 +130,7 @@ void TestDetectorDigiLoader<FairTestDetectorDigi, TMessage>::Exec(Option_t* opt)
 // helper function to clean up the object holding the data after it is transported.
 void free_string (void *data, void *hint)
 {
-    delete (std::string*)hint;
+    delete (string*)hint;
 }
 
 template <>
@@ -152,7 +154,7 @@ void TestDetectorDigiLoader<FairTestDetectorDigi, TestDetectorProto::DigiPayload
         d->set_ftimestamp(digi->GetTimeStamp());
     }
 
-    std::string* str = new std::string();
+    string* str = new string();
     dp.SerializeToString(str);
     size_t size = str->length();
 

--- a/example/Tutorial3/reconstruction/FairTestDetectorMQRecoTask.h
+++ b/example/Tutorial3/reconstruction/FairTestDetectorMQRecoTask.h
@@ -41,10 +41,10 @@
 
 #include "TMessage.h"
 
-using std::cout;
-using std::endl;
+using namespace std;
 
 class TClonesArray;
+
 template <typename TIn, typename TOut, typename TPayloadIn, typename TPayloadOut>
 class FairTestDetectorMQRecoTask : public FairMQProcessorTask
 {
@@ -74,10 +74,14 @@ class FairTestDetectorMQRecoTask : public FairMQProcessorTask
     FairTestDetectorRecoTask* fRecoTask;
 #ifndef __CINT__ // for BOOST serialization
     friend class boost::serialization::access;
-    std::vector<TIn> fDigiVector;
-    std::vector<TOut> fHitVector;
+    vector<TIn> fDigiVector;
+    vector<TOut> fHitVector;
     bool fHasBoostSerialization;
 #endif // for BOOST serialization
+
+    /// Copy Constructor
+    FairTestDetectorMQRecoTask(const FairTestDetectorMQRecoTask&);
+    FairTestDetectorMQRecoTask operator=(const FairTestDetectorMQRecoTask&);
 };
 
 // Template implementation of exec in FairTestDetectorMQRecoTask.tpl :

--- a/example/Tutorial3/reconstruction/FairTestDetectorMQRecoTask.tpl
+++ b/example/Tutorial3/reconstruction/FairTestDetectorMQRecoTask.tpl
@@ -10,6 +10,9 @@
 template <typename TIn, typename TOut, typename TPayloadIn, typename TPayloadOut>
 FairTestDetectorMQRecoTask<TIn, TOut, TPayloadIn, TPayloadOut>::FairTestDetectorMQRecoTask()
     : fRecoTask(NULL)
+    , fDigiVector()
+    , fHitVector()
+    , fHasBoostSerialization()
 {
     fHasBoostSerialization = true;
 
@@ -19,13 +22,13 @@ FairTestDetectorMQRecoTask<TIn, TOut, TPayloadIn, TPayloadOut>::FairTestDetector
     bool checkOutputClass = false;
     fHasBoostSerialization = false;
 
-    if (std::is_same<TPayloadIn, boost::archive::binary_iarchive>::value || std::is_same<TPayloadIn, boost::archive::text_iarchive>::value)
+    if (is_same<TPayloadIn, boost::archive::binary_iarchive>::value || is_same<TPayloadIn, boost::archive::text_iarchive>::value)
     {
         if (has_BoostSerialization<TIn, void(TPayloadIn&, const unsigned int)>::value == 1)
             checkInputClass = true;
     }
 
-    if (std::is_same<TPayloadOut, boost::archive::binary_oarchive>::value || std::is_same<TPayloadOut, boost::archive::text_oarchive>::value)
+    if (is_same<TPayloadOut, boost::archive::binary_oarchive>::value || is_same<TPayloadOut, boost::archive::text_oarchive>::value)
     {
         if (has_BoostSerialization<TOut, void(TPayloadOut&, const unsigned int)>::value == 1)
             checkOutputClass = true;
@@ -39,6 +42,9 @@ FairTestDetectorMQRecoTask<TIn, TOut, TPayloadIn, TPayloadOut>::FairTestDetector
 template <typename TIn, typename TOut, typename TPayloadIn, typename TPayloadOut>
 FairTestDetectorMQRecoTask<TIn, TOut, TPayloadIn, TPayloadOut>::FairTestDetectorMQRecoTask(Int_t verbose)
     : fRecoTask(NULL)
+    , fDigiVector()
+    , fHitVector()
+    , fHasBoostSerialization()
 {
     fHasBoostSerialization = true;
 #if __cplusplus >= 201103L
@@ -46,7 +52,7 @@ FairTestDetectorMQRecoTask<TIn, TOut, TPayloadIn, TPayloadOut>::FairTestDetector
     bool checkOutputClass = false;
     fHasBoostSerialization = false;
 
-    if (std::is_same<TPayloadIn, boost::archive::binary_iarchive>::value || std::is_same<TPayloadIn, boost::archive::text_iarchive>::value)
+    if (is_same<TPayloadIn, boost::archive::binary_iarchive>::value || is_same<TPayloadIn, boost::archive::text_iarchive>::value)
     {
         if (has_BoostSerialization<TIn, void(TPayloadIn&, const unsigned int)>::value == 1)
             checkInputClass = true;
@@ -60,7 +66,7 @@ FairTestDetectorMQRecoTask<TIn, TOut, TPayloadIn, TPayloadOut>::FairTestDetector
         LOG(ERROR) << "boost::archive::binary_iarchive and boost::archive::text_iarchive";
     }
 
-    if (std::is_same<TPayloadOut, boost::archive::binary_oarchive>::value || std::is_same<TPayloadOut, boost::archive::text_oarchive>::value)
+    if (is_same<TPayloadOut, boost::archive::binary_oarchive>::value || is_same<TPayloadOut, boost::archive::text_oarchive>::value)
     {
         if (has_BoostSerialization<TOut, void(TPayloadOut&, const unsigned int)>::value == 1)
             checkOutputClass = true;
@@ -112,8 +118,8 @@ void FairTestDetectorMQRecoTask<TIn, TOut, TPayloadIn, TPayloadOut>::Exec(Option
         int inputSize = fPayload->GetSize();
 
         // prepare boost input archive
-        std::string msgStr(static_cast<char*>(fPayload->GetData()), fPayload->GetSize());
-        std::istringstream ibuffer(msgStr);
+        string msgStr(static_cast<char*>(fPayload->GetData()), fPayload->GetSize());
+        istringstream ibuffer(msgStr);
         TPayloadIn InputArchive(ibuffer);
         try
         {
@@ -152,12 +158,12 @@ void FairTestDetectorMQRecoTask<TIn, TOut, TPayloadIn, TPayloadOut>::Exec(Option
         }
 
         // prepare boost output archive
-        std::ostringstream obuffer;
+        ostringstream obuffer;
         TPayloadOut OutputArchive(obuffer);
         OutputArchive << fHitVector;
         int outputSize = obuffer.str().length();
         fPayload->Rebuild(outputSize);
-        std::memcpy(fPayload->GetData(), obuffer.str().c_str(), outputSize);
+        memcpy(fPayload->GetData(), obuffer.str().c_str(), outputSize);
         if (fDigiVector.size() > 0)
             fDigiVector.clear();
         if (fHitVector.size() > 0)
@@ -176,7 +182,7 @@ void FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TestD
 {
     // // Example how to receive multipart message (uncomment the code lines to test).
     // // 1. receive the first part.
-    // std::string test = std::string(static_cast<char*>(fPayload->GetData()), fPayload->GetSize());
+    // string test = string(static_cast<char*>(fPayload->GetData()), fPayload->GetSize());
     // LOG(ERROR) << test;
     // // Ask Processor for the next part.
     // ReceivePart();
@@ -271,7 +277,7 @@ void FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TMess
 // helper function to clean up the object holding the data after it is transported.
 void free_string (void *data, void *hint)
 {
-    delete (std::string*)hint;
+    delete (string*)hint;
 }
 
 template <>
@@ -317,7 +323,7 @@ void FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TestD
         h->set_dposz(hit->GetDz());
     }
 
-    std::string* str = new std::string();
+    string* str = new string();
     hp.SerializeToString(str);
     size_t size = str->length();
 

--- a/fairmq/FairMQConfigurable.h
+++ b/fairmq/FairMQConfigurable.h
@@ -17,7 +17,7 @@
 
 #include <string>
 
-using std::string;
+using namespace std;
 
 class FairMQConfigurable
 {

--- a/fairmq/FairMQDevice.cxx
+++ b/fairmq/FairMQDevice.cxx
@@ -19,9 +19,22 @@
 #include "FairMQLogger.h"
 
 FairMQDevice::FairMQDevice()
-    : fNumIoThreads(1)
+    : fId()
+    , fNumIoThreads(1)
     , fNumInputs(0)
     , fNumOutputs(0)
+    , fInputAddress()
+    , fInputMethod()
+    , fInputSocketType()
+    , fInputSndBufSize()
+    , fInputRcvBufSize()
+    , fLogInputRate()
+    , fOutputAddress()
+    , fOutputMethod()
+    , fOutputSocketType()
+    , fOutputSndBufSize()
+    , fOutputRcvBufSize()
+    , fLogOutputRate()
     , fPayloadInputs(new vector<FairMQSocket*>())
     , fPayloadOutputs(new vector<FairMQSocket*>())
     , fLogIntervalInMs(1000)
@@ -78,7 +91,7 @@ void FairMQDevice::InitInput()
                 fPayloadInputs->at(i)->Connect(fInputAddress.at(i));
             }
         }
-        catch (std::out_of_range& e)
+        catch (out_of_range& e)
         {
             LOG(ERROR) << e.what();
         }
@@ -109,7 +122,7 @@ void FairMQDevice::InitOutput()
                 fPayloadOutputs->at(i)->Connect(fOutputAddress.at(i));
             }
         }
-        catch (std::out_of_range& e)
+        catch (out_of_range& e)
         {
             LOG(ERROR) << e.what();
         }

--- a/fairmq/FairMQDevice.h
+++ b/fairmq/FairMQDevice.h
@@ -24,10 +24,7 @@
 #include "FairMQTransportFactory.h"
 #include "FairMQSocket.h"
 
-using std::vector;
-using std::cin;
-using std::cout;
-using std::endl;
+using namespace std;
 
 class FairMQDevice : public FairMQStateMachine, public FairMQConfigurable
 {
@@ -92,8 +89,6 @@ class FairMQDevice : public FairMQStateMachine, public FairMQConfigurable
     vector<FairMQSocket*>* fPayloadInputs;
     vector<FairMQSocket*>* fPayloadOutputs;
 
-    FairMQSocket* fCommandSocket;
-
     int fLogIntervalInMs;
 
     FairMQTransportFactory* fTransportFactory;
@@ -106,6 +101,11 @@ class FairMQDevice : public FairMQStateMachine, public FairMQConfigurable
     virtual void InitInput();
 
     virtual void Terminate();
+
+  private:
+    /// Copy Constructor
+    FairMQDevice(const FairMQDevice&);
+    FairMQDevice operator=(const FairMQDevice&);
 };
 
 #endif /* FAIRMQDEVICE_H_ */

--- a/fairmq/FairMQLogger.cxx
+++ b/fairmq/FairMQLogger.cxx
@@ -17,11 +17,8 @@
 
 #include "FairMQLogger.h"
 
-using std::string;
-using std::cout;
-using std::endl;
-
 FairMQLogger::FairMQLogger()
+    : os()
 {
 }
 
@@ -30,7 +27,7 @@ FairMQLogger::~FairMQLogger()
     cout << os.str() << endl;
 }
 
-std::ostringstream& FairMQLogger::Log(int type)
+ostringstream& FairMQLogger::Log(int type)
 {
     string type_str;
     switch (type)
@@ -56,10 +53,10 @@ std::ostringstream& FairMQLogger::Log(int type)
     timestamp_t tm = get_timestamp();
     timestamp_t ms = tm / 1000.0L;
     timestamp_t s = ms / 1000.0L;
-    std::time_t t = s;
-    // std::size_t fractional_seconds = ms % 1000;
+    time_t t = s;
+    // size_t fractional_seconds = ms % 1000;
     char mbstr[100];
-    std::strftime(mbstr, 100, "%H:%M:%S", std::localtime(&t));
+    strftime(mbstr, 100, "%H:%M:%S", localtime(&t));
 
     os << "[\033[01;36m" << mbstr << "\033[0m]"
        << "[" << type_str << "]"

--- a/fairmq/FairMQLogger.h
+++ b/fairmq/FairMQLogger.h
@@ -21,7 +21,7 @@
 #include <iomanip>
 #include <ctime>
 
-using std::ostringstream;
+using namespace std;
 
 class FairMQLogger
 {

--- a/fairmq/FairMQSocket.h
+++ b/fairmq/FairMQSocket.h
@@ -18,8 +18,7 @@
 #include <string>
 #include "FairMQMessage.h"
 
-using std::string;
-using std::stringstream;
+using namespace std;
 
 class FairMQSocket
 {

--- a/fairmq/FairMQStateMachine.cxx
+++ b/fairmq/FairMQStateMachine.cxx
@@ -17,6 +17,8 @@
 
 FairMQStateMachine::FairMQStateMachine()
     : fRunningFinished(false)
+    , fRunningCondition()
+    , fRunningMutex()
 {
     start();
 }
@@ -59,6 +61,4 @@ void FairMQStateMachine::ChangeState(int event)
     {
         LOG(ERROR) << e.what();
     }
-
-
-    }
+}

--- a/fairmq/FairMQTransportFactory.h
+++ b/fairmq/FairMQTransportFactory.h
@@ -22,7 +22,7 @@
 #include "FairMQPoller.h"
 #include "FairMQLogger.h"
 
-using std::vector;
+using namespace std;
 
 class FairMQTransportFactory
 {

--- a/fairmq/devices/FairMQBenchmarkSampler.h
+++ b/fairmq/devices/FairMQBenchmarkSampler.h
@@ -46,6 +46,7 @@ class FairMQBenchmarkSampler : public FairMQDevice
     int fEventSize;
     int fEventRate;
     int fEventCounter;
+
     virtual void Init();
     virtual void Run();
 };

--- a/fairmq/examples/req-rep/FairMQExampleClient.cxx
+++ b/fairmq/examples/req-rep/FairMQExampleClient.cxx
@@ -19,6 +19,7 @@
 #include "FairMQLogger.h"
 
 FairMQExampleClient::FairMQExampleClient()
+    : fText()
 {
 }
 

--- a/fairmq/examples/req-rep/runExampleClient.cxx
+++ b/fairmq/examples/req-rep/runExampleClient.cxx
@@ -59,7 +59,7 @@ typedef struct DeviceOptions
 inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
 {
     if (_options == NULL)
-        throw std::runtime_error("Internal error: options' container is empty.");
+        throw runtime_error("Internal error: options' container is empty.");
 
     namespace bpo = boost::program_options;
     bpo::options_description desc("Options");

--- a/fairmq/nanomsg/FairMQMessageNN.cxx
+++ b/fairmq/nanomsg/FairMQMessageNN.cxx
@@ -20,14 +20,19 @@
 #include "FairMQMessageNN.h"
 #include "FairMQLogger.h"
 
+using namespace std;
+
 FairMQMessageNN::FairMQMessageNN()
-    : fSize(0)
-    , fMessage(NULL)
+    : fMessage(NULL)
+    , fSize(0)
     , fReceiving(false)
 {
 }
 
 FairMQMessageNN::FairMQMessageNN(size_t size)
+    : fMessage(NULL)
+    , fSize(0)
+    , fReceiving(false)
 {
     fMessage = nn_allocmsg(size, 0);
     if (!fMessage)
@@ -45,6 +50,9 @@ FairMQMessageNN::FairMQMessageNN(size_t size)
  * possible TODO: make this zero copy (will should then be as efficient as ZeroMQ).
 */
 FairMQMessageNN::FairMQMessageNN(void* data, size_t size, fairmq_free_fn *ffn, void* hint)
+    : fMessage(NULL)
+    , fSize(0)
+    , fReceiving(false)
 {
     fMessage = nn_allocmsg(size, 0);
     if (!fMessage)
@@ -146,7 +154,7 @@ void FairMQMessageNN::Copy(FairMQMessage* msg)
     {
         LOG(ERROR) << "failed allocating message, reason: " << nn_strerror(errno);
     }
-    std::memcpy(fMessage, msg->GetMessage(), size);
+    memcpy(fMessage, msg->GetMessage(), size);
     fSize = size;
 }
 

--- a/fairmq/nanomsg/FairMQMessageNN.h
+++ b/fairmq/nanomsg/FairMQMessageNN.h
@@ -49,6 +49,10 @@ class FairMQMessageNN : public FairMQMessage
     bool fReceiving;
 
     void Clear();
+
+    /// Copy Constructor
+    FairMQMessageNN(const FairMQMessageNN&);
+    FairMQMessageNN operator=(const FairMQMessageNN&);
 };
 
 #endif /* FAIRMQMESSAGENN_H_ */

--- a/fairmq/nanomsg/FairMQPollerNN.cxx
+++ b/fairmq/nanomsg/FairMQPollerNN.cxx
@@ -17,6 +17,8 @@
 #include "FairMQPollerNN.h"
 
 FairMQPollerNN::FairMQPollerNN(const vector<FairMQSocket*>& inputs)
+    : items()
+    , fNumItems()
 {
     fNumItems = inputs.size();
     items = new nn_pollfd[fNumItems];

--- a/fairmq/nanomsg/FairMQPollerNN.h
+++ b/fairmq/nanomsg/FairMQPollerNN.h
@@ -20,7 +20,7 @@
 #include "FairMQPoller.h"
 #include "FairMQSocket.h"
 
-using std::vector;
+using namespace std;
 
 class FairMQPollerNN : public FairMQPoller
 {
@@ -36,6 +36,10 @@ class FairMQPollerNN : public FairMQPoller
   private:
     nn_pollfd* items;
     int fNumItems;
+
+    /// Copy Constructor
+    FairMQPollerNN(const FairMQPollerNN&);
+    FairMQPollerNN operator=(const FairMQPollerNN&);
 };
 
 #endif /* FAIRMQPOLLERNN_H_ */

--- a/fairmq/nanomsg/FairMQSocketNN.cxx
+++ b/fairmq/nanomsg/FairMQSocketNN.cxx
@@ -19,7 +19,9 @@
 #include "FairMQLogger.h"
 
 FairMQSocketNN::FairMQSocketNN(const string& type, int num, int numIoThreads)
-    : fBytesTx(0)
+    : fSocket()
+    , fId()
+    , fBytesTx(0)
     , fBytesRx(0)
     , fMessagesTx(0)
     , fMessagesRx(0)

--- a/fairmq/prototest/FairMQProtoSampler.cxx
+++ b/fairmq/prototest/FairMQProtoSampler.cxx
@@ -65,7 +65,7 @@ void FairMQProtoSampler::Run()
             // LOG(INFO) << content->x() << " " << content->y() << " " << content->z() << " " << content->a() << " " << content->b();
         }
 
-        std::string str;
+        string str;
         p.SerializeToString(&str);
         size_t size = str.length();
 

--- a/fairmq/prototest/FairMQProtoSampler.h
+++ b/fairmq/prototest/FairMQProtoSampler.h
@@ -19,6 +19,8 @@
 
 #include "FairMQDevice.h"
 
+using namespace std;
+
 class FairMQProtoSampler : public FairMQDevice
 {
   public:

--- a/fairmq/run/runBenchmarkSampler.cxx
+++ b/fairmq/run/runBenchmarkSampler.cxx
@@ -66,7 +66,7 @@ typedef struct DeviceOptions
 inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
 {
     if (_options == NULL)
-        throw std::runtime_error("Internal error: options' container is empty.");
+        throw runtime_error("Internal error: options' container is empty.");
 
     namespace bpo = boost::program_options;
     bpo::options_description desc("Options");

--- a/fairmq/run/runBinSampler.cxx
+++ b/fairmq/run/runBinSampler.cxx
@@ -66,7 +66,7 @@ typedef struct DeviceOptions
 inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
 {
     if (_options == NULL)
-        throw std::runtime_error("Internal error: options' container is empty.");
+        throw runtime_error("Internal error: options' container is empty.");
 
     namespace bpo = boost::program_options;
     bpo::options_description desc("Options");

--- a/fairmq/run/runBinSink.cxx
+++ b/fairmq/run/runBinSink.cxx
@@ -64,7 +64,7 @@ typedef struct DeviceOptions
 inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
 {
     if (_options == NULL)
-        throw std::runtime_error("Internal error: options' container is empty.");
+        throw runtime_error("Internal error: options' container is empty.");
 
     namespace bpo = boost::program_options;
     bpo::options_description desc("Options");

--- a/fairmq/run/runBuffer.cxx
+++ b/fairmq/run/runBuffer.cxx
@@ -68,7 +68,7 @@ typedef struct DeviceOptions
 inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
 {
     if (_options == NULL)
-        throw std::runtime_error("Internal error: options' container is empty.");
+        throw runtime_error("Internal error: options' container is empty.");
 
     namespace bpo = boost::program_options;
     bpo::options_description desc("Options");

--- a/fairmq/run/runMerger.cxx
+++ b/fairmq/run/runMerger.cxx
@@ -69,7 +69,7 @@ typedef struct DeviceOptions
 inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
 {
     if (_options == NULL)
-        throw std::runtime_error("Internal error: options' container is empty.");
+        throw runtime_error("Internal error: options' container is empty.");
 
     namespace bpo = boost::program_options;
     bpo::options_description desc("Options");

--- a/fairmq/run/runProtoSampler.cxx
+++ b/fairmq/run/runProtoSampler.cxx
@@ -66,7 +66,7 @@ typedef struct DeviceOptions
 inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
 {
     if (_options == NULL)
-        throw std::runtime_error("Internal error: options' container is empty.");
+        throw runtime_error("Internal error: options' container is empty.");
 
     namespace bpo = boost::program_options;
     bpo::options_description desc("Options");

--- a/fairmq/run/runProtoSink.cxx
+++ b/fairmq/run/runProtoSink.cxx
@@ -64,7 +64,7 @@ typedef struct DeviceOptions
 inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
 {
     if (_options == NULL)
-        throw std::runtime_error("Internal error: options' container is empty.");
+        throw runtime_error("Internal error: options' container is empty.");
 
     namespace bpo = boost::program_options;
     bpo::options_description desc("Options");

--- a/fairmq/run/runProxy.cxx
+++ b/fairmq/run/runProxy.cxx
@@ -68,7 +68,7 @@ typedef struct DeviceOptions
 inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
 {
     if (_options == NULL)
-        throw std::runtime_error("Internal error: options' container is empty.");
+        throw runtime_error("Internal error: options' container is empty.");
 
     namespace bpo = boost::program_options;
     bpo::options_description desc("Options");

--- a/fairmq/run/runSink.cxx
+++ b/fairmq/run/runSink.cxx
@@ -64,7 +64,7 @@ typedef struct DeviceOptions
 inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
 {
     if (_options == NULL)
-        throw std::runtime_error("Internal error: options' container is empty.");
+        throw runtime_error("Internal error: options' container is empty.");
 
     namespace bpo = boost::program_options;
     bpo::options_description desc("Options");

--- a/fairmq/run/runSplitter.cxx
+++ b/fairmq/run/runSplitter.cxx
@@ -69,7 +69,7 @@ typedef struct DeviceOptions
 inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
 {
     if (_options == NULL)
-        throw std::runtime_error("Internal error: options' container is empty.");
+        throw runtime_error("Internal error: options' container is empty.");
 
     namespace bpo = boost::program_options;
     bpo::options_description desc("Options");

--- a/fairmq/zeromq/FairMQContextZMQ.cxx
+++ b/fairmq/zeromq/FairMQContextZMQ.cxx
@@ -17,6 +17,7 @@
 #include <sstream>
 
 FairMQContextZMQ::FairMQContextZMQ(int numIoThreads)
+    : fContext()
 {
     fContext = zmq_ctx_new();
     if (fContext == NULL)

--- a/fairmq/zeromq/FairMQContextZMQ.h
+++ b/fairmq/zeromq/FairMQContextZMQ.h
@@ -20,13 +20,20 @@
 class FairMQContextZMQ
 {
   public:
+
+    /// Constructor
     FairMQContextZMQ(int numIoThreads);
+
     virtual ~FairMQContextZMQ();
     void* GetContext();
     void Close();
 
   private:
     void* fContext;
+
+    /// Copy Constructor
+    FairMQContextZMQ(const FairMQContextZMQ&);
+    FairMQContextZMQ operator=(const FairMQContextZMQ&);
 };
 
 #endif /* FAIRMQCONTEXTZMQ_H_ */

--- a/fairmq/zeromq/FairMQMessageZMQ.cxx
+++ b/fairmq/zeromq/FairMQMessageZMQ.cxx
@@ -18,7 +18,10 @@
 #include "FairMQMessageZMQ.h"
 #include "FairMQLogger.h"
 
+using namespace std;
+
 FairMQMessageZMQ::FairMQMessageZMQ()
+    : fMessage()
 {
     int rc = zmq_msg_init(&fMessage);
     if (rc != 0)
@@ -28,6 +31,7 @@ FairMQMessageZMQ::FairMQMessageZMQ()
 }
 
 FairMQMessageZMQ::FairMQMessageZMQ(size_t size)
+    : fMessage()
 {
     int rc = zmq_msg_init_size(&fMessage, size);
     if (rc != 0)
@@ -37,6 +41,7 @@ FairMQMessageZMQ::FairMQMessageZMQ(size_t size)
 }
 
 FairMQMessageZMQ::FairMQMessageZMQ(void* data, size_t size, fairmq_free_fn *ffn, void* hint)
+    : fMessage()
 {
     int rc = zmq_msg_init_data(&fMessage, data, size, ffn ? ffn : &CleanUp, hint);
     if (rc != 0)
@@ -109,7 +114,7 @@ void FairMQMessageZMQ::Copy(FairMQMessage* msg)
     // CloseMessage();
     // size_t size = msg->GetSize();
     // zmq_msg_init_size(&fMessage, size);
-    // std::memcpy(zmq_msg_data(&fMessage), msg->GetData(), size);
+    // memcpy(zmq_msg_data(&fMessage), msg->GetData(), size);
 }
 
 inline void FairMQMessageZMQ::CloseMessage()

--- a/fairmq/zeromq/FairMQPollerZMQ.cxx
+++ b/fairmq/zeromq/FairMQPollerZMQ.cxx
@@ -18,6 +18,8 @@
 #include "FairMQLogger.h"
 
 FairMQPollerZMQ::FairMQPollerZMQ(const vector<FairMQSocket*>& inputs)
+    : items()
+    , fNumItems()
 {
     fNumItems = inputs.size();
     items = new zmq_pollitem_t[fNumItems];

--- a/fairmq/zeromq/FairMQPollerZMQ.h
+++ b/fairmq/zeromq/FairMQPollerZMQ.h
@@ -20,7 +20,7 @@
 #include "FairMQPoller.h"
 #include "FairMQSocket.h"
 
-using std::vector;
+using namespace std;
 
 class FairMQPollerZMQ : public FairMQPoller
 {
@@ -36,6 +36,10 @@ class FairMQPollerZMQ : public FairMQPoller
   private:
     zmq_pollitem_t* items;
     int fNumItems;
+
+    /// Copy Constructor
+    FairMQPollerZMQ(const FairMQPollerZMQ&);
+    FairMQPollerZMQ operator=(const FairMQPollerZMQ&);
 };
 
 #endif /* FAIRMQPOLLERZMQ_H_ */

--- a/fairmq/zeromq/FairMQSocketZMQ.cxx
+++ b/fairmq/zeromq/FairMQSocketZMQ.cxx
@@ -20,7 +20,9 @@
 boost::shared_ptr<FairMQContextZMQ> FairMQSocketZMQ::fContext = boost::shared_ptr<FairMQContextZMQ>(new FairMQContextZMQ(1));
 
 FairMQSocketZMQ::FairMQSocketZMQ(const string& type, int num, int numIoThreads)
-    : fBytesTx(0)
+    : fSocket(NULL)
+    , fId()
+    , fBytesTx(0)
     , fBytesRx(0)
     , fMessagesTx(0)
     , fMessagesRx(0)

--- a/fairmq/zeromq/FairMQSocketZMQ.h
+++ b/fairmq/zeromq/FairMQSocketZMQ.h
@@ -61,6 +61,10 @@ class FairMQSocketZMQ : public FairMQSocket
     unsigned long fMessagesRx;
 
     static boost::shared_ptr<FairMQContextZMQ> fContext;
+
+    /// Copy Constructor
+    FairMQSocketZMQ(const FairMQSocketZMQ&);
+    FairMQSocketZMQ operator=(const FairMQSocketZMQ&);
 };
 
 #endif /* FAIRMQSOCKETZMQ_H_ */


### PR DESCRIPTION
Remaining warnings originate from boost::msm and boost::mpl.
Warnings with missing initialization list entries for DeviceOptions and FairTestDetectorPayload are false positives, because those classes are PODs.
Also some minor cosmetic changes.