### PR TITLE
Lia has implemented in FairGenePro.cxx the functionality to propagate tr...

### DIFF
--- a/geane/FairGeanePro.cxx
+++ b/geane/FairGeanePro.cxx
@@ -447,8 +447,13 @@ Bool_t FairGeanePro::PropagateToVolume(TString VolName, Int_t CopyNo , Int_t opt
 Bool_t FairGeanePro::PropagateToLength(Float_t length)
 {
   // define final length (option "L")
-  xlf[0]=length;
-  fPropOption="LE";
+ if(length < 0) {
+     xlf[0]=-length;
+     fPropOption="BLE";
+  }else {
+     xlf[0]=length;
+     fPropOption="LE";
+  }
   ProMode=1; //need errors in representation 1 (SC)(see Geane doc)
   return kTRUE;
 }


### PR DESCRIPTION
...ack parameters to a negative length,

i.e. to backpropagate to some distance. Currently the code allows only a forward propagation,
with Lia’s modification it is possible also the back propagation using a negative distance value.
This functionality is needed for a recent modification of the PandaRoot kalman task.