### PR TITLE
Replace TRefArray and its iterators with std::list

### DIFF
--- a/base/sim/FairMCApplication.cxx
+++ b/base/sim/FairMCApplication.cxx
@@ -426,13 +426,15 @@ void FairMCApplication::FinishRun()
 {
 // Finish MC run.
 // ---
-  for_each(listActiveDetectors.begin(),listActiveDetectors.end(),[](FairDetector* det)
+  for( std::list<FairDetector *>::iterator  listIter = listActiveDetectors.begin();
+        listIter != listActiveDetectors.end();
+        listIter++)
   {
-    det->FinishRun();
-  });
-    
+        (*listIter)->FinishRun();
+  }
 
-    
+
+
   fFairTaskList->FinishTask();
   //fRootManager->Fill();
 
@@ -495,11 +497,13 @@ void FairMCApplication::BeginEvent()
 {
 // User actions at beginning of event
 // ---
-  for_each(listActiveDetectors.begin(),listActiveDetectors.end(),[](FairDetector* det)
-  {
-    det->BeginEvent();
-  });
     
+    for( std::list<FairDetector *>::iterator  listIter = listActiveDetectors.begin();
+                                              listIter != listActiveDetectors.end();
+                                              listIter++)
+    {
+        (*listIter)->BeginEvent();
+    }
 }
 
 //_____________________________________________________________________________
@@ -507,11 +511,12 @@ void FairMCApplication::BeginPrimary()
 {
 // User actions at beginning of a primary track
 // ---
-   for_each(listActiveDetectors.begin(),listActiveDetectors.end(),[](FairDetector* det)
-  {
-     det->BeginPrimary();
-  });
-
+    for( std::list<FairDetector *>::iterator  listIter = listActiveDetectors.begin();
+        listIter != listActiveDetectors.end();
+        listIter++)
+    {
+        (*listIter)->BeginPrimary();
+    }
 
 }
 //_____________________________________________________________________________
@@ -522,10 +527,12 @@ void FairMCApplication::PreTrack()
 // ---
 
   
- for_each(listActiveDetectors.begin(),listActiveDetectors.end(),[](FairDetector* det)
+ for( std::list<FairDetector *>::iterator  listIter = listActiveDetectors.begin();
+                                           listIter != listActiveDetectors.end();
+                                           listIter++)
  {
-    det->PreTrack();
- });
+        (*listIter)->PreTrack();
+ }
     
     
   fTrajAccepted=kFALSE;
@@ -669,10 +676,12 @@ void FairMCApplication::PostTrack()
 // User actions after finishing of each track
 // ---
     
-  for_each(listActiveDetectors.begin(),listActiveDetectors.end(),[](FairDetector* det)
+  for( std::list<FairDetector *>::iterator  listIter = listActiveDetectors.begin();
+        listIter != listActiveDetectors.end();
+        listIter++)
   {
-        det->PostTrack();
-  });
+        (*listIter)->PostTrack();
+  }
 
 
 
@@ -683,10 +692,12 @@ void FairMCApplication::FinishPrimary()
 {
 // User actions after finishing of a primary track
 // ---
-  for_each(listActiveDetectors.begin(),listActiveDetectors.end(),[](FairDetector* det)
+  for( std::list<FairDetector *>::iterator  listIter = listActiveDetectors.begin();
+        listIter != listActiveDetectors.end();
+        listIter++)
   {
-    det->FinishPrimary();
-  });
+        (*listIter)->FinishPrimary();
+  }
     
 
     
@@ -723,17 +734,22 @@ void FairMCApplication::FinishEvent()
     fFairTaskList->ExecuteTask("");
     fFairTaskList->FinishEvent();
   }
-  for_each(listActiveDetectors.begin(),listActiveDetectors.end(),[](FairDetector* det)
+  for( std::list<FairDetector *>::iterator  listIter = listActiveDetectors.begin();
+        listIter != listActiveDetectors.end();
+        listIter++)
   {
-    det->FinishEvent();
-  });
+        (*listIter)->FinishEvent();
+  }
     
     
   if (fRootManager) fRootManager->Fill();
-  for_each(listActiveDetectors.begin(),listActiveDetectors.end(),[](FairDetector* det)
+  
+  for( std::list<FairDetector *>::iterator  listIter = listActiveDetectors.begin();
+        listIter != listActiveDetectors.end();
+        listIter++)
   {
-     det->EndOfEvent();
-  });
+       (*listIter)->EndOfEvent();
+  }
     
     
     
@@ -889,12 +905,15 @@ void FairMCApplication::InitGeometry()
   /** Initialize the event generator */
   // if(fEvGen)fEvGen->Init();
   /** Initialize the detectors.    */
-  for_each(listActiveDetectors.begin(),listActiveDetectors.end(),[](FairDetector* det)
-  {
-     det->Initialize();
-     det->SetSpecialPhysicsCuts();
-     det->Register();
-  });
+  for( std::list<FairDetector *>::iterator  listIter = listActiveDetectors.begin();
+        listIter != listActiveDetectors.end();
+        listIter++)
+ {
+     
+     (*listIter)->Initialize();
+     (*listIter)->SetSpecialPhysicsCuts();
+     (*listIter)->Register();
+  }
   
     
   /**Tasks has to be initialized here, they have access to the detector branches and still can create objects in the tree*/

--- a/base/sim/FairMCApplication.cxx
+++ b/base/sim/FairMCApplication.cxx
@@ -627,7 +627,7 @@ void FairMCApplication::Stepping()
       fDisVol=fVolIter->second;
       fCopyNo=fDisVol->getCopyNo();
       if(copyNo==fCopyNo) {
-        fDisDet=dynamic_cast<FairDetector*> (fDisVol->GetModule());
+        fDisDet=fDisVol->GetDetector();
         if (fDisDet) {
           fDisDet->ProcessHits(fDisVol);
         }
@@ -643,7 +643,7 @@ void FairMCApplication::Stepping()
       fNewV->SetModule(fDisVol->GetModule());
       fNewV->setCopyNo(copyNo);
       fVolMap.insert(pair<Int_t, FairVolume* >(id, fNewV));
-      fDisDet=dynamic_cast<FairDetector*> (fDisVol->GetModule());
+      fDisDet=fDisVol->GetDetector();
       if ( fDisDet) {
         fDisDet->ProcessHits(fNewV);
       }

--- a/base/sim/FairMCApplication.h
+++ b/base/sim/FairMCApplication.h
@@ -22,7 +22,8 @@
 #include "TLorentzVector.h"             // for TLorentzVector
 #include "TString.h"                    // for TString
 
-#include <map>                          // for map, multimap, etc
+#include <map>                           // for map, multimap, etc
+#include <list>                           // for list
 
 class FairDetector;
 class FairEventHeader;
@@ -196,14 +197,10 @@ class FairMCApplication : public TVirtualMCApplication
     Int_t GetIonPdg(Int_t z, Int_t a) const;
 
     // data members
-    /**Iterator for active detector list*/
-    TIterator*           fActDetIter;//!
     /**List of active detector */
     TRefArray*           fActiveDetectors;
     /**List of FairTask*/
     FairTask*             fFairTaskList;//!
-    /**Iterator for detector list (Passive and Active)*/
-    TIterator*           fDetIter; //!
     /**detector list (Passive and Active)*/
     TRefArray*           fDetectors;
     /**Map used for dispatcher*/
@@ -271,8 +268,13 @@ class FairMCApplication : public TVirtualMCApplication
     FairEventHeader*    fEventHeader; //!
 
     FairMCEventHeader*  fMCEventHeader; //!
+    /** list of senstive detectors used in the simuation session*/
+    std::list <FairDetector *> listActiveDetectors; //!
+    /** list of all detectors used in the simuation session*/
+    std::list <FairDetector *> listDetectors;  //!
 
-    ClassDef(FairMCApplication,2)  //Interface to MonteCarlo application
+    
+    ClassDef(FairMCApplication,3)  //Interface to MonteCarlo application
 
   private:
     /** Protected copy constructor */

--- a/base/sim/FairVolume.cxx
+++ b/base/sim/FairVolume.cxx
@@ -25,6 +25,7 @@ FairVolume::FairVolume()
     fCopyNo(-1),        /**Volume Copy No*/
     fMotherId(-1),    /**Mother Volume Id*/
     fMotherCopyNo(-1),  /**Mother Volume Copy No*/
+    fDetector(0),
     fModule(NULL),         /**The Module (detector) which will proccess the hits for this volume*/
     fNode(NULL)            /**Node corre*/
 {
@@ -43,10 +44,14 @@ FairVolume::FairVolume(TString name, Int_t id, Int_t ModId, FairModule* fMod)
    fCopyNo(-1),        /**Volume Copy No*/
    fMotherId(0),     /**Mother Volume Id*/
    fMotherCopyNo(0),  /**Mother Volume Copy No*/
+   fDetector(0),
    fModule(fMod),        /**The Module (detector) which will proccess the hits for this volume*/
    fNode(NULL)            /**Node corre*/
 
 {
+    if (fModule && fModule->InheritsFrom("FairDetector")){
+        fDetector=dynamic_cast<FairDetector *>(fModule);
+    }
 
 }
 

--- a/base/sim/FairVolume.h
+++ b/base/sim/FairVolume.h
@@ -12,9 +12,9 @@
 
 #include "Rtypes.h"                     // for Int_t, FairVolume::Class, etc
 #include "TString.h"                    // for TString
-
+#include "FairModule.h"
+#include "FairDetector.h"
 class FairGeoNode;
-class FairModule;
 
 /**
  * This Object is only used for internal book keeping!
@@ -47,8 +47,14 @@ class FairVolume : public TNamed
     void  setMotherId(Int_t fM) {fMotherId=fM;}
     void  setMotherCopyNo(Int_t CopyNo) {fMotherCopyNo=CopyNo;}
 
-    FairModule* GetModule() {return fModule;}
-    void SetModule(FairModule* mod) {fModule=mod;}
+    FairModule*   GetModule()     {return fModule;}
+    FairDetector* GetDetector() { return fDetector;}
+    void SetModule(FairModule* mod) {
+        fModule=mod;
+        if (mod->InheritsFrom("FairDetector")){
+           fDetector=dynamic_cast<FairDetector *>(mod);
+        }
+    }
 
     Int_t getMCid() {return fMCid;}
     Int_t getCopyNo() { return fCopyNo;}
@@ -70,8 +76,10 @@ class FairVolume : public TNamed
     Int_t fCopyNo;         /**Volume Copy No*/
     Int_t fMotherId; /**Mother Volume Id*/
     Int_t fMotherCopyNo;   /**Mother Volume Copy No*/
-    FairModule* fModule; /**The Module (detector) which will proccess the hits for this volume*/
-    FairGeoNode* fNode;     /**Node corresponding to this volume*/
+    FairDetector* fDetector; /** The Detector which will proccess the hits for this volume*/
+    FairModule*   fModule;    /**The Module in which the volume is */
+    FairGeoNode*  fNode;     /**Node corresponding to this volume*/
+    
 
     ClassDef(FairVolume,2) // Volume Definition
 


### PR DESCRIPTION
Replace TRefArray and its iterators for detectors in simulation with std::list to git rid of the dynamic_cast.
This improve the performance by 3-4% when running Tutorial3.