### PR TITLE
Helper function to find current interfaces/IPs of the host

### DIFF
--- a/fairmq/CMakeLists.txt
+++ b/fairmq/CMakeLists.txt
@@ -8,6 +8,8 @@
 Set(INCLUDE_DIRECTORIES
   ${CMAKE_SOURCE_DIR}/fairmq
   ${CMAKE_SOURCE_DIR}/fairmq/devices
+  ${CMAKE_SOURCE_DIR}/fairmq/examples/req-rep
+  ${CMAKE_SOURCE_DIR}/fairmq/tools
 )
 
 Set(SYSTEM_INCLUDE_DIRECTORIES
@@ -17,7 +19,6 @@ Set(SYSTEM_INCLUDE_DIRECTORIES
 If(PROTOBUF_FOUND)
   Set(INCLUDE_DIRECTORIES
     ${INCLUDE_DIRECTORIES}
-    ${CMAKE_SOURCE_DIR}/fairmq/examples/req-rep
     # # following directory is only for protobuf tests and is not essential part of FairMQ
     #${CMAKE_SOURCE_DIR}/fairmq/prototest
   )
@@ -129,9 +130,6 @@ Set(FairMQHDRFiles
   devices/GenericFileSink.tpl
 )
 install(FILES ${FairMQHDRFiles} DESTINATION include)
-
-
-
 
 set(DEPENDENCIES
   ${DEPENDENCIES}

--- a/fairmq/tools/FairMQTools.h
+++ b/fairmq/tools/FairMQTools.h
@@ -1,0 +1,64 @@
+#ifndef FAIRMQTOOLS_H_
+#define FAIRMQTOOLS_H_
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE     /* To get defns of NI_MAXSERV and NI_MAXHOST */
+#endif
+
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <netdb.h>
+#include <ifaddrs.h>
+#include <stdio.h>
+
+#include <map>
+#include <string>
+#include <iostream>
+
+using namespace std;
+
+namespace FairMQ
+{
+namespace tools
+{
+
+int getHostIPs(map<string, string>& addressMap)
+{
+    struct ifaddrs *ifaddr, *ifa;
+    int s;
+    char host[NI_MAXHOST];
+
+    if (getifaddrs(&ifaddr) == -1)
+    {
+        perror("getifaddrs");
+        return -1;
+    }
+
+    for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next)
+    {
+        if (ifa->ifa_addr == NULL)
+        {
+            continue;
+        }
+
+        if (ifa->ifa_addr->sa_family == AF_INET)
+        {
+            s = getnameinfo(ifa->ifa_addr, sizeof(struct sockaddr_in), host, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
+            if (s != 0)
+            {
+                cout << "getnameinfo() failed: " << gai_strerror(s) << endl;
+                return -1;
+            }
+
+            addressMap.insert(pair<string, string>(ifa->ifa_name, host));
+        }
+    }
+    freeifaddrs(ifaddr);
+
+    return 0;
+}
+
+} // namespace tools
+} // namespace FairMQ
+
+#endif

--- a/fairmq/tools/README.md
+++ b/fairmq/tools/README.md
@@ -1,0 +1,35 @@
+# FairMQ Tools
+
+Contains common tools for use by FairMQ and/or users.
+
+## FairMQ::tools::getHostIPs
+
+Fills a map with the network interfaces and their IP addresses available on the current host.
+
+#### Example usage
+
+```c++
+#include <map>
+#include <string>
+#include <iostream>
+
+#include "FairMQTools.h"
+
+void main()
+{
+    std::map<string,string> IPs;
+
+    FairMQ::tools::getHostIPs(IPs);
+
+    for (std::map<string,string>::iterator it = IPs.begin(); it != IPs.end(); ++it)
+    {
+        std::cout << it->first << ": " << it->second << std::endl;
+    }
+}
+```
+##### Example Output
+```
+eth0: 123.123.1.123
+ib0: 123.123.2.123
+lo: 127.0.0.1
+```


### PR DESCRIPTION
usage:

```c++
#include <map>
#include <string>
#include <iostream>

#include "FairMQTools.h"

void main()
{
    std::map<string, string> IPs;

    FairMQ::tools::getIPs(IPs);

    for (std::map<string,string>::iterator it = IPs.begin(); it != IPs.end(); ++it)
    {
        std::cout << it->first << ": " << it->second << std::endl;
    }
}
```

example output:
```
eth0: 123.123.1.123
ib0: 123.123.2.123
lo: 127.0.0.1
```