### PR TITLE
FairMQSocket: add versions of Send/Receive methods with int flags

### DIFF
--- a/fairmq/FairMQSocket.h
+++ b/fairmq/FairMQSocket.h
@@ -23,13 +23,25 @@ using namespace std;
 class FairMQSocket
 {
   public:
+    const int SNDMORE;
+    const int RCVMORE;
+    const int NOBLOCK;
+
+    FairMQSocket(int sndMore, int rcvMore, int noBlock)
+        : SNDMORE(sndMore)
+        , RCVMORE(rcvMore)
+        , NOBLOCK(noBlock)
+        {}
+
     virtual string GetId() = 0;
 
     virtual void Bind(const string& address) = 0;
     virtual void Connect(const string& address) = 0;
 
     virtual int Send(FairMQMessage* msg, const string& flag="") = 0;
+    virtual int Send(FairMQMessage* msg, const int flags) = 0;
     virtual int Receive(FairMQMessage* msg, const string& flag="") = 0;
+    virtual int Receive(FairMQMessage* msg, const int flags) = 0;
 
     virtual void* GetSocket() = 0;
     virtual int GetSocket(int nothing) = 0;

--- a/fairmq/nanomsg/FairMQSocketNN.h
+++ b/fairmq/nanomsg/FairMQSocketNN.h
@@ -34,7 +34,9 @@ class FairMQSocketNN : public FairMQSocket
     virtual void Connect(const string& address);
 
     virtual int Send(FairMQMessage* msg, const string& flag="");
+    virtual int Send(FairMQMessage* msg, const int flags);
     virtual int Receive(FairMQMessage* msg, const string& flag="");
+    virtual int Receive(FairMQMessage* msg, const int flags);
 
     virtual void* GetSocket();
     virtual int GetSocket(int nothing);

--- a/fairmq/zeromq/FairMQSocketZMQ.h
+++ b/fairmq/zeromq/FairMQSocketZMQ.h
@@ -33,7 +33,9 @@ class FairMQSocketZMQ : public FairMQSocket
     virtual void Connect(const string& address);
 
     virtual int Send(FairMQMessage* msg, const string& flag="");
+    virtual int Send(FairMQMessage* msg, const int flags);
     virtual int Receive(FairMQMessage* msg, const string& flag="");
+    virtual int Receive(FairMQMessage* msg, const int flags);
 
     virtual void* GetSocket();
     virtual int GetSocket(int nothing);


### PR DESCRIPTION
FairMQSocket: add versions of Send/Receive methods with int flags instead of string, which is more flexible and faster.
Int flags are mapped to their ZeroMQ/nanomsg versions behind the transport interface.
Methods with string flags are kept for backwards compatibility.