### PR TITLE
Issue#124 

### DIFF
--- a/base/source/FairFileSource.cxx
+++ b/base/source/FairFileSource.cxx
@@ -22,8 +22,8 @@
 #include <set> 
 #include <algorithm>                    // for find
 #include "TChainElement.h"
-#include "TFolder.h"
 #include "FairRuntimeDb.h"              // for FairRuntimeDb
+#include "FairRootManager.h"
 #include "TROOT.h"
 #include <list>                         // for _List_iterator, list, etc
 using std::map;
@@ -47,8 +47,6 @@ FairFileSource::FairFileSource(TFile *f, const char* Title, UInt_t identifier)
  fInChain(0),
  fInTree(0),
  fListFolder(new TObjArray(16)),
- fBranchSeqId(0),
- fBranchNameList(new TList()),
  fRtdb(FairRuntimeDb::instance()),
  fCbmout(0),
  fCbmroot(0),
@@ -80,8 +78,6 @@ FairFileSource::FairFileSource(const TString* RootFileName, const char* Title, U
  fInChain(0),
  fInTree(0),
  fListFolder(new TObjArray(16)),
- fBranchSeqId(0),
- fBranchNameList(new TList()),
  fRtdb(FairRuntimeDb::instance()),
  fCbmout(0),
  fCbmroot(0),
@@ -154,10 +150,7 @@ Bool_t FairFileSource::Init()
                 fLogger->Info(MESSAGE_ORIGIN, "Branch name %s", ObjName.Data());
                 fCheckInputBranches[chainName]->push_back(ObjName.Data());
                 
-                if(fBranchNameList->FindObject(ObjName.Data())==0) {
-                    fBranchNameList->AddLast(Obj);
-                    fBranchSeqId++;
-                 }
+                FairRootManager::Instance()->AddBranchToList(ObjName.Data());
             }
         }
     }
@@ -472,10 +465,7 @@ void FairFileSource::CreateNewFriendChain(TString inputFile, TString inputLevel)
         for(Int_t i =0; i< list->GetEntries(); i++) {
             Obj=dynamic_cast <TObjString*> (list->At(i));
             fCheckInputBranches[chainName]->push_back(Obj->GetString().Data());
-            if(fBranchNameList->FindObject(Obj->GetString().Data())==0) {
-                fBranchNameList->AddLast(Obj);
-                fBranchSeqId++;
-            }
+            FairRootManager::Instance()->AddBranchToList(Obj->GetString().Data());
         }
     }
     

--- a/base/source/FairFileSource.h
+++ b/base/source/FairFileSource.h
@@ -20,11 +20,11 @@
 #include <list>    
 #include "TChain.h"
 #include "TFile.h"
+#include "TFolder.h"
 class FairFileHeader;
 class TString;
 class FairLogger;
 class FairRuntimeDb;
-class TFolder;
 
 class FairFileSource : public FairSource
 {
@@ -82,10 +82,6 @@ private:
     TTree*                              fInTree;
     /** list of folders from all input (and friends) files*/
     TObjArray                           *fListFolder; //!
-    /**Branch id for this run */
-    Int_t                               fBranchSeqId;
-    /**List of branch names as TObjString*/
-    TList*                              fBranchNameList; //!
     /** RuntimeDb*/
     FairRuntimeDb*           fRtdb;
     /**folder structure of output*/
@@ -102,7 +98,7 @@ private:
     FairFileSource(const FairFileSource&);
     FairFileSource operator=(const FairFileSource&);
 
-    ClassDef(FairFileSource, 0)
+    ClassDef(FairFileSource, 1)
 };
 
 

--- a/base/steer/FairRootManager.cxx
+++ b/base/steer/FairRootManager.cxx
@@ -447,16 +447,24 @@ void  FairRootManager::Register(const char* name, const char* folderName , TName
   }
   AddMemoryBranch(name, obj );
   //cout << " FairRootManager::Register Adding branch:(Obj) " << name << " In folder : " << folderName << endl;
-  if(fBranchNameList->FindObject(name)==0) {
-    fBranchNameList->AddLast(new TObjString(name));
-    fBranchSeqId++;
-  }
-
+ 
+  AddBranchToList(name);
+    
   if (toFile == kFALSE) {
           FairLinkManager::Instance()->AddIgnoreType(GetBranchId(name));
    }
 }
 //_____________________________________________________________________________
+
+Int_t  FairRootManager::AddBranchToList(const char* name)
+{
+    if(fBranchNameList->FindObject(name)==0) {
+        fBranchNameList->AddLast(new TObjString(name));
+        fBranchSeqId++;
+    }
+    return fBranchSeqId;
+}
+
 
 //_____________________________________________________________________________
 void  FairRootManager::Register(const char* name,const char* Foldername ,TCollection* obj, Bool_t toFile)
@@ -500,10 +508,8 @@ void  FairRootManager::Register(const char* name,const char* Foldername ,TCollec
   }
   /**Keep the Object in Memory, and do not write it to the tree*/
   AddMemoryBranch(name, obj );
-  if(fBranchNameList->FindObject(name)==0) {
-    fBranchNameList->AddLast(new TObjString(name));
-    fBranchSeqId++;
-  }
+  AddBranchToList(name);
+  
   if (toFile == kFALSE) {
 	  FairLinkManager::Instance()->AddIgnoreType(GetBranchId(name));
   }

--- a/base/steer/FairRootManager.h
+++ b/base/steer/FairRootManager.h
@@ -61,7 +61,8 @@ class FairRootManager : public TObject
     /**Add input background file by name*/
     void                AddBackgroundFile(TString name);
      Bool_t             AllDataProcessed();
-
+    /** Add a branch name to the Branchlist and give it an id*/
+    Int_t AddBranchToList(const char* name);
     /**
     Check if Branch persistence or not (Memory branch)
     return value:


### PR DESCRIPTION
Problem:
the BranchList contains only the branch names of the branches registered in this run (e.g. all digi branches) but not any longer the branch names of the input file (e.g. sim branches). This causes massive problems with the usage of FairLinks because the method FairRootManager::GetBranchId(BranchName) returns in most cases -1 which breaks the links.

Solution:
The branchlist is now removed from the FairFileSource and exist only in the IO manager. The FileSource add its branches to the same list in the IO manager.

This problem was introduced as we separated the file source functionality from the IO Manager 
