### PR TITLE
Change of FairLinks to run with Pointers

### DIFF
--- a/base/event/FairMultiLinkedData.h
+++ b/base/event/FairMultiLinkedData.h
@@ -38,6 +38,7 @@ class FairMultiLinkedData : public  TObject
     virtual ~FairMultiLinkedData() {};
 
     virtual std::set<FairLink>    GetLinks() const {    return fLinks;}           ///< returns stored links as FairLinks
+    virtual FairLink		GetEntryNr() const { return fEntryNr;}				///< gives back the entryNr
     virtual Int_t           GetNLinks() const { return fLinks.size(); }       ///< returns the number of stored links
     virtual FairLink        GetLink(Int_t pos) const;                 ///< returns the FairLink at the given position
     virtual FairMultiLinkedData   GetLinksWithType(Int_t type) const;             ///< Gives you a list of links which contain the given type
@@ -48,7 +49,9 @@ class FairMultiLinkedData : public  TObject
     virtual void SetDefaultType(Int_t type) {  fDefaultType = type;}
     virtual void SetPersistanceCheck(Bool_t check) {fPersistanceCheck = check;}       ///< Controls if a persistance check of a link is done or not
     virtual void SetVerbose(Int_t level) {fVerbose = level;}                ///< Sets the verbosity level
+    virtual void SetInsertHistory(Bool_t val){ fInsertHistory = val;}		///< Toggles if history of a link is inserted or not
 
+    virtual void SetEntryNr(FairLink entry){ fEntryNr = entry;}
     virtual void SetLinks(FairMultiLinkedData links, Float_t mult = 1.0);           ///< Sets the links as vector of FairLink
     virtual void SetLink(FairLink link, Bool_t bypass = kFALSE, Float_t mult = 1.0);      ///< Sets the Links with a single FairLink
 
@@ -78,7 +81,7 @@ class FairMultiLinkedData : public  TObject
 
     std::ostream& Print(std::ostream& out = std::cout) const
     {
-      out << "[";
+      out << GetEntryNr() << " -> [";
       for (Int_t i = 0; i < GetNLinks(); i++) {
         GetLink(i).Print(out);
         out << " ";
@@ -94,8 +97,10 @@ class FairMultiLinkedData : public  TObject
 
   protected:
     std::set<FairLink> fLinks;
-    Bool_t fPersistanceCheck;
-    Int_t fVerbose;
+    FairLink fEntryNr;
+    Bool_t fPersistanceCheck; //!
+    Bool_t fInsertHistory; //!
+    Int_t fVerbose; //!
 
     virtual void SimpleAddLinks(Int_t fileId, Int_t evtId, Int_t dataType, std::vector<Int_t> links, Bool_t bypass, Float_t mult) {
       for (UInt_t i = 0; i < links.size(); i++) {
@@ -105,7 +110,7 @@ class FairMultiLinkedData : public  TObject
     Int_t fDefaultType;
 
 
-    ClassDef(FairMultiLinkedData, 3);
+    ClassDef(FairMultiLinkedData, 4);
 };
 
 /**\fn virtual void FairMultiLinkedData::SetLinks(Int_t type, std::vector<Int_t> links)

--- a/base/event/FairMultiLinkedData_Interface.cxx
+++ b/base/event/FairMultiLinkedData_Interface.cxx
@@ -17,68 +17,63 @@
 ClassImp(FairMultiLinkedData_Interface);
 
 FairMultiLinkedData_Interface::FairMultiLinkedData_Interface()
-  :TObject(),
-   fVerbose(0),
-   fRefToLinks(0),
-   fLinkBranchName("FairLinkBranch")
+  :TObject(), fLink(0), fVerbose(0)
 {
 }
 
-
-
 FairMultiLinkedData_Interface::FairMultiLinkedData_Interface(FairMultiLinkedData& links, Bool_t persistanceCheck)
-  :TObject(),
-   fVerbose(0),
-   fRefToLinks(),
-   fLinkBranchName("FairLinkBranch")
+  :TObject(), fLink(0), fVerbose(0)
 {
-	CreateFairMultiLinkedData();
 	SetLinks(links);
 }
 
 FairMultiLinkedData_Interface::FairMultiLinkedData_Interface(TString dataType, std::vector<Int_t> links, Int_t fileId, Int_t evtId, Bool_t persistanceCheck, Bool_t bypass, Float_t mult)
-  :TObject(),
-   fVerbose(0),
-   fRefToLinks(),
-   fLinkBranchName("FairLinkBranch")
+  :TObject(), fLink(0), fVerbose(0)
 {
-
-	CreateFairMultiLinkedData();
 	FairMultiLinkedData data(dataType, links, fileId, evtId, persistanceCheck, bypass, mult);
 	SetLinks(data);
 }
 
 FairMultiLinkedData_Interface::FairMultiLinkedData_Interface( Int_t dataType, std::vector<Int_t> links, Int_t fileId, Int_t evtId, Bool_t persistanceCheck, Bool_t bypass, Float_t mult)
-  :TObject(),
-   fVerbose(0),
-   fRefToLinks(),
-   fLinkBranchName("FairLinkBranch")
+  :TObject(), fLink(0), fVerbose(0)
 {
-	CreateFairMultiLinkedData();
 	FairMultiLinkedData data(dataType, links, fileId, evtId, persistanceCheck, bypass, mult);
 	SetLinks(data);
+}
+
+FairMultiLinkedData_Interface::FairMultiLinkedData_Interface(const FairMultiLinkedData_Interface& toCopy)
+  :TObject(), fLink(0)
+{
+	if (toCopy.GetPointerToLinks() != 0){
+		SetLinks(*(toCopy.GetPointerToLinks()));
+        SetEntryNr(toCopy.GetEntryNr());
+    }
+}
+
+FairMultiLinkedData_Interface& FairMultiLinkedData_Interface::operator=(const FairMultiLinkedData_Interface& rhs)
+{
+	if (rhs.GetPointerToLinks() != 0){
+		SetLinks(*(rhs.GetPointerToLinks()));
+        SetEntryNr(rhs.GetEntryNr());
+    }
+    return *this;
 }
 
 FairMultiLinkedData* FairMultiLinkedData_Interface::CreateFairMultiLinkedData()
 {
 	if (FairRootManager::Instance()->GetUseFairLinks()){
-		fLinkBranchName = FairRootManager::Instance()->GetFairLinksBranchName();
-		if (fLinkBranchName != "" && !fRefToLinks.IsValid()){
-			FairRootManager* ioman = FairRootManager::Instance();
-			TClonesArray* container = ioman->GetTClonesArray(fLinkBranchName);
-			fRefToLinks = new ((*container)[container->GetEntriesFast()]) FairMultiLinkedData();
+		if (fLink == 0){
+			fLink = new FairMultiLinkedData();
 		}
-		return (FairMultiLinkedData*)fRefToLinks.GetObject();
-	} else {
-		fRefToLinks = 0;
-		return 0;
+		return fLink;
 	}
+	return 0;
 }
 
 std::set<FairLink>    FairMultiLinkedData_Interface::GetLinks() const
 {
-	if (GetPointerToData() != 0){
-		return GetPointerToData()->GetLinks();
+	if (GetPointerToLinks() != 0){
+		return GetPointerToLinks()->GetLinks();
 	} else {
 		std::set<FairLink> emptySet;
 		return emptySet;
@@ -87,8 +82,8 @@ std::set<FairLink>    FairMultiLinkedData_Interface::GetLinks() const
 
 Int_t           FairMultiLinkedData_Interface::GetNLinks() const
 {
-	if (GetPointerToData() != 0){
-		return GetPointerToData()->GetNLinks();
+	if (GetPointerToLinks() != 0){
+		return GetPointerToLinks()->GetNLinks();
 	} else {
 		return 0;
 	}
@@ -96,8 +91,18 @@ Int_t           FairMultiLinkedData_Interface::GetNLinks() const
 
 FairLink        FairMultiLinkedData_Interface::GetLink(Int_t pos) const
 {
-	if (GetPointerToData() != 0){
-		return GetPointerToData()->GetLink(pos);
+	if (GetPointerToLinks() != 0){
+		return GetPointerToLinks()->GetLink(pos);
+	} else {
+		FairLink emptyLink;
+		return emptyLink;
+	}
+}
+
+FairLink        FairMultiLinkedData_Interface::GetEntryNr() const
+{
+	if (GetPointerToLinks() != 0) {
+		return GetPointerToLinks()->GetEntryNr();
 	} else {
 		FairLink emptyLink;
 		return emptyLink;
@@ -106,8 +111,8 @@ FairLink        FairMultiLinkedData_Interface::GetLink(Int_t pos) const
 
 FairMultiLinkedData   FairMultiLinkedData_Interface::GetLinksWithType(Int_t type) const
 {
-	if (GetPointerToData() != 0){
-		return GetPointerToData()->GetLinksWithType(type);
+	if (GetPointerToLinks() != 0){
+		return GetPointerToLinks()->GetLinksWithType(type);
 	} else {
 		FairMultiLinkedData emptyLinks;
 		return emptyLinks;
@@ -117,39 +122,69 @@ FairMultiLinkedData   FairMultiLinkedData_Interface::GetLinksWithType(Int_t type
 void FairMultiLinkedData_Interface::SetLinks(FairMultiLinkedData links)
 {
 	CreateFairMultiLinkedData();
-	if (GetPointerToData() != 0){
-		GetPointerToData()->SetLinks(links);
+	if (GetPointerToLinks() != 0){
+		GetPointerToLinks()->SetLinks(links);
 	}
 }
 
 void FairMultiLinkedData_Interface::SetLink(FairLink link)
 {
 	CreateFairMultiLinkedData();
-	if (GetPointerToData() != 0){
-		GetPointerToData()->SetLink(link);
+	if (GetPointerToLinks() != 0){
+		GetPointerToLinks()->SetLink(link);
+	}
+}
+
+void FairMultiLinkedData_Interface::SetEntryNr(FairLink val)
+{
+	CreateFairMultiLinkedData();
+	if (GetPointerToLinks() != 0) {
+		GetPointerToLinks()->SetEntryNr(val);
 	}
 }
 
 void FairMultiLinkedData_Interface::AddLinks(FairMultiLinkedData links, Float_t mult)
 {
 	CreateFairMultiLinkedData();
-	if (GetPointerToData() != 0){
-		GetPointerToData()->AddLinks(links, mult);
+	if (GetPointerToLinks() != 0){
+		GetPointerToLinks()->AddLinks(links, mult);
 	}
 }
 
 void FairMultiLinkedData_Interface::AddLink(FairLink link)
 {
 	CreateFairMultiLinkedData();
-	if (GetPointerToData() != 0){
-		GetPointerToData()->AddLink(link);
+	if (GetPointerToLinks() != 0){
+		GetPointerToLinks()->AddLink(link);
 	}
 
 }
 
+void FairMultiLinkedData_Interface::AddInterfaceData(FairMultiLinkedData_Interface* data)
+{
+	SetInsertHistory(kFALSE); //todo add previous history value
+	if (data->GetEntryNr().GetType() != -1)
+		AddLink(data->GetEntryNr());
+	else
+		std::cout
+				<< "-E- FairMultiLinkedData_Interface::AddInterfaceData EntryNr == "
+				<< data->GetEntryNr() << std::endl;
+	if (data->GetPointerToLinks() != 0) {
+		AddLinks(*data->GetPointerToLinks());
+	}
+	SetInsertHistory(kTRUE);
+}
+
+void FairMultiLinkedData_Interface::SetInsertHistory(Bool_t val)
+{
+	if (GetPointerToLinks() != 0) {
+		GetPointerToLinks()->SetInsertHistory(val);
+	}
+}
+
 void FairMultiLinkedData_Interface::ResetLinks()
 {
-	if (GetPointerToData() != 0){
-		GetPointerToData()->ResetLinks();
+	if (GetPointerToLinks() != 0){
+		GetPointerToLinks()->ResetLinks();
 	}
 }

--- a/base/event/FairMultiLinkedData_Interface.h
+++ b/base/event/FairMultiLinkedData_Interface.h
@@ -31,37 +31,40 @@ class FairMultiLinkedData_Interface : public  TObject
     FairMultiLinkedData_Interface(FairMultiLinkedData& links, Bool_t persistanceCheck = kTRUE);///< Constructor
     FairMultiLinkedData_Interface(TString dataType, std::vector<Int_t> links, Int_t fileId = -1, Int_t evtId = -1,Bool_t persistanceCheck = kTRUE, Bool_t bypass = kFALSE, Float_t mult = 1.0);///< Constructor
     FairMultiLinkedData_Interface(Int_t dataType, std::vector<Int_t> links, Int_t fileId = -1, Int_t evtId = -1, Bool_t persistanceCheck = kTRUE, Bool_t bypass = kFALSE, Float_t mult = 1.0);///< Constructor
+    FairMultiLinkedData_Interface(const FairMultiLinkedData_Interface& toCopy);
 
-    virtual ~FairMultiLinkedData_Interface() {};
+    virtual ~FairMultiLinkedData_Interface() {
+    	delete(fLink);
+    };
+
+    FairMultiLinkedData_Interface& operator=(const FairMultiLinkedData_Interface& rhs);
 
     virtual std::set<FairLink>  GetLinks() const;           		///< returns stored links as FairLinks
     virtual Int_t           	GetNLinks() const;                	///< returns the number of stored links
     virtual FairLink        	GetLink(Int_t pos) const;         	///< returns the FairLink at the given position
     virtual FairMultiLinkedData GetLinksWithType(Int_t type) const; ///< returns all FairLinks with the corresponding type
+    virtual FairLink            GetEntryNr() const;
+    virtual FairMultiLinkedData* 		GetPointerToLinks() const {	return fLink;}
 
     virtual void SetLinks(FairMultiLinkedData links);           ///< Sets the links as vector of FairLink
     virtual void SetLink(FairLink link);      					///< Sets the Links with a single FairLink
+    virtual void SetInsertHistory(Bool_t val);
+    virtual void SetEntryNr(FairLink val);
+    virtual void SetPointerToLinks(FairMultiLinkedData* links) {fLink = links;}
 
     virtual void AddLinks(FairMultiLinkedData links, Float_t mult = 1.0);		///< Adds a List of FairLinks (FairMultiLinkedData_Interface) to fLinks
     virtual void AddLink(FairLink link);      									///< Adds a FairLink link at the end of fLinks. If multi is kTRUE a link is allowed more than once otherwise
+    virtual void AddInterfaceData(FairMultiLinkedData_Interface* data);
 
-    FairMultiLinkedData* 	GetPointerToData() const
-    {
-		if (fRefToLinks.GetObject() != 0)
-			return (FairMultiLinkedData*)fRefToLinks.GetObject();
-		else {
-//			std::cout << "-W- FairMultiLinkedData_Interface::GetPointerToData() fRefToLinks == 0" << std::endl;
-			return 0;
-		}
-    }
+
 
     virtual void ResetLinks();
 
 
     std::ostream& Print(std::ostream& out = std::cout) const {
 
-		if (fRefToLinks.GetObject() != 0)
-			GetPointerToData()->Print(out);
+		if (GetPointerToLinks() != 0)
+			GetPointerToLinks()->Print(out);
 		return out;
     }                                                     ///< Output
 
@@ -73,12 +76,11 @@ class FairMultiLinkedData_Interface : public  TObject
   protected:
 
     Int_t fVerbose; //!
-    TRef fRefToLinks;
-    TString fLinkBranchName; //!
+    FairMultiLinkedData* fLink;
 
     FairMultiLinkedData* CreateFairMultiLinkedData();
 
-    ClassDef(FairMultiLinkedData_Interface, 4);
+    ClassDef(FairMultiLinkedData_Interface, 5);
 };
 
 /**\fn virtual void FairMultiLinkedData_Interface::SetLinks(Int_t type, std::vector<Int_t> links)

--- a/base/steer/FairRootManager.cxx
+++ b/base/steer/FairRootManager.cxx
@@ -127,9 +127,7 @@ FairRootManager::FairRootManager()
     fCurrentEntry(),
     fEvtHeaderIsNew(kFALSE),
     fFillLastData(kFALSE),
-    fUseFairLinks(kFALSE), 
-    fInitFairLinksOnce(kFALSE),
-    fFairLinksBranchName("FairLinkBranch"),
+    fUseFairLinks(kFALSE),
     fEntryNr(0),
     fRootFileSource(0),
     fRootFileSourceSignal(0),
@@ -478,11 +476,6 @@ void  FairRootManager::Register(const char* name,const char* Foldername ,TCollec
   // execution with some error message if this is the case.
   if (strcmp (name, Foldername) == 0 ) {
     fLogger->Fatal(MESSAGE_ORIGIN,"The names for the object name %s and the folder name %s are equal. This isn't allowed. So we stop the execution at this point. Pleae change either the name or the folder name.", name, Foldername);
-  }
-
-  if (GetUseFairLinks() == kTRUE && fInitFairLinksOnce == kFALSE){
-            fInitFairLinksOnce = kTRUE;
-            Register(fFairLinksBranchName, "FairMultiLinkedData", "FairLinksBranch", kTRUE);
   }
 
   if(toFile) { /**Write the Object to the Tree*/

--- a/base/steer/FairRootManager.h
+++ b/base/steer/FairRootManager.h
@@ -229,8 +229,6 @@ class FairRootManager : public TObject
     Int_t GetEntryNr() {return fEntryNr;}
     void SetEntryNr(Int_t val) {fEntryNr = val;}
 
-    TString GetFairLinksBranchName() const {return fFairLinksBranchName;};
-
     void SetUseFairLinks(Bool_t val) {fUseFairLinks = val;};
     Bool_t GetUseFairLinks() const {return fUseFairLinks;};
 
@@ -414,11 +412,9 @@ class FairRootManager : public TObject
     FairFileSource                      *fRootFileSourceBKG;
 
     Bool_t fUseFairLinks; //!
-    Bool_t fInitFairLinksOnce; //!
-    TString fFairLinksBranchName; //!
 
 
-    ClassDef(FairRootManager,7) // Root IO manager
+    ClassDef(FairRootManager,8) // Root IO manager
 };
 
 


### PR DESCRIPTION
Storage of FairLinks is now handled via a simple FairMultiLinkedData*. Root takes care to store the pointer if it is filled.
The usage of TRef did not work.