### PR TITLE
Set cmake-policy to new for clang compiler and rpath on MAC OS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,19 @@
 # Check if cmake has the required version
 CMAKE_MINIMUM_REQUIRED(VERSION  2.8.2 FATAL_ERROR)
 
+### CMP0025   Compiler id for Apple Clang is now AppleClang.
+### CMP0042   MACOSX_RPATH is enabled by default.
+
+foreach(p
+  CMP0025 # CMake 3.0
+  CMP0042 # CMake 3.0
+  )
+  if(POLICY ${p})
+  cmake_policy(SET ${p} NEW)
+  endif()
+endforeach()
+
+
 # Set name of our project to "FAIRROOT". Has to be done
 # after check of cmake version                        
 project(FAIRROOT)


### PR DESCRIPTION
### CMP0025   Compiler id for Apple Clang is now AppleClang.
### CMP0042   MACOSX_RPATH is enabled by default.
