### PR TITLE
Fixes to source / online classes

### DIFF
--- a/base/source/FairLmdSource.cxx
+++ b/base/source/FairLmdSource.cxx
@@ -119,7 +119,7 @@ Bool_t FairLmdSource::OpenNextFile(TString fileName)
 }
 
 
-Int_t FairLmdSource::ReadEvent()
+Int_t FairLmdSource::ReadEvent(UInt_t iev)
 {
   void* evtptr = &fxEvent;
   void* buffptr = &fxBuffer;
@@ -159,7 +159,8 @@ Int_t FairLmdSource::ReadEvent()
 
 
   // Decode event header
-  Bool_t result = Unpack((Int_t*)fxEvent, sizeof(s_ve10_1), -2, -2, -2, -2, -2);
+  Bool_t result = kFALSE;
+  /*Bool_t result = */Unpack((Int_t*)fxEvent, sizeof(s_ve10_1), -2, -2, -2, -2, -2);
 
   Int_t nrSubEvts = f_evt_get_subevent(fxEvent, 0, NULL, NULL, NULL);
   Int_t sebuflength;
@@ -179,18 +180,19 @@ Int_t FairLmdSource::ReadEvent()
   for(Int_t i = 1; i <= nrSubEvts; i++) {
     void* SubEvtptr = &fxSubEvent;
     void* EvtDataptr = &fxEventData;
-    Int_t* nrlongwords = new Int_t;
-    status = f_evt_get_subevent(fxEvent, i, (Int_t**)SubEvtptr, (Int_t**)EvtDataptr, nrlongwords);
+    Int_t nrlongwords;
+    status = f_evt_get_subevent(fxEvent, i, (Int_t**)SubEvtptr, (Int_t**)EvtDataptr, &nrlongwords);
     if(status) {
       return 1;
     }
-    sebuflength = fxSubEvent->l_dlen;
+    sebuflength = nrlongwords;
     setype = fxSubEvent->i_type;
     sesubtype = fxSubEvent->i_subtype;
     seprocid = fxSubEvent->i_procid;
     sesubcrate = fxSubEvent->h_subcrate;
     secontrol = fxSubEvent->h_control;
-    delete nrlongwords;
+
+    //cout << setype << "  " << sesubtype << "  " << seprocid << "  " << sesubcrate << "  " << secontrol << endl;
 
     if(Unpack(fxEventData, sebuflength,
               setype, sesubtype,

--- a/base/source/FairLmdSource.h
+++ b/base/source/FairLmdSource.h
@@ -41,7 +41,7 @@ class FairLmdSource : public FairMbsSource
     inline const TList* GetFileNames() const { return fFileNames; }
 
     virtual Bool_t Init();
-    virtual Int_t ReadEvent();
+    virtual Int_t ReadEvent(UInt_t=0);
     virtual void Close();
 
   protected:

--- a/base/source/FairMbsSource.h
+++ b/base/source/FairMbsSource.h
@@ -33,7 +33,7 @@ class FairMbsSource : public FairSource
     inline const TObjArray* GetUnpackers() const { return fUnpackers; }
 
     virtual Bool_t Init();
-    virtual Int_t ReadEvent() = 0;
+    virtual Int_t ReadEvent(UInt_t=0) = 0;
     virtual void Close() = 0;
 
     void Reset();

--- a/base/source/swaplw.c
+++ b/base/source/swaplw.c
@@ -30,38 +30,37 @@ long         l_len;
    p_source = (unsigned char *) pp_source;
    p_dest   = (unsigned char *) pp_dest;
 
-   switch ( (int) p_dest)
+   if(p_dest)
    {
-      case 0:                             /* source == destination */
-         for (p_d = (unsigned char *) p_source,
-              p_s = (unsigned char *) &lu_save;
-              p_d < p_source + (l_len * 4);
-              )
-         {
-             lu_save = *( (long *) p_d);
-             p_s    += 4;                 /* increment source      */
-             *(p_d++) = *(--p_s);
-             *(p_d++) = *(--p_s);
-             *(p_d++) = *(--p_s);
-             *(p_d++) = *(--p_s);
-         }
-         break;
-
-      default:                            /* source != destination */
-         for (p_s = (unsigned char *) p_source,
-              p_d = (unsigned char *) p_dest;
-              p_s < p_source + (l_len * 4);
-              p_s += 4)
-         {
-             p_s     += 4;                /* increment source      */
-             *(p_d++) = *(--p_s);
-             *(p_d++) = *(--p_s);
-             *(p_d++) = *(--p_s);
-             *(p_d++) = *(--p_s);
-         }
-         break;
-
-   }  /* switch */
+      /* source != destination */
+      for (p_s = (unsigned char *) p_source,
+           p_d = (unsigned char *) p_dest;
+           p_s < p_source + (l_len * 4);
+           p_s += 4)
+      {
+        p_s     += 4;                /* increment source      */
+        *(p_d++) = *(--p_s);
+        *(p_d++) = *(--p_s);
+        *(p_d++) = *(--p_s);
+        *(p_d++) = *(--p_s);
+      }
+    }
+    else
+    {
+       /* source == destination */
+       for (p_d = (unsigned char *) p_source,
+            p_s = (unsigned char *) &lu_save;
+            p_d < p_source + (l_len * 4);
+            )
+       {
+         lu_save = *( (long *) p_d);
+         p_s    += 4;                 /* increment source      */
+           *(p_d++) = *(--p_s);
+           *(p_d++) = *(--p_s);
+           *(p_d++) = *(--p_s);
+           *(p_d++) = *(--p_s);
+       }
+    }
 
    return(1);
 

--- a/base/steer/FairRunOnline.cxx
+++ b/base/steer/FairRunOnline.cxx
@@ -190,6 +190,7 @@ void FairRunOnline::Init()
   }
   LOG(INFO) << "FairRunOnline::InitContainers: event header at " << fEvtHeader << FairLogger::endl;
   fRootManager->Register("EventHeader.", "Event", fEvtHeader, kTRUE);
+  fEvtHeader->SetRunId(fRunId);
 
   // Initialize the source
   if(! fSource->Init()) {
@@ -385,12 +386,11 @@ void FairRunOnline::GenerateHtml()
            << "\"http://www.w3.org/TR/xhtml1/DTD/xhtml1transitional.dtd\">" << endl
            << "<html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" lang=\"en\">" << endl
            << "<head>" << endl
-           << "<title>Read a ROOT file in Javascript (Demonstration)</title>" << endl
-           << "<meta http-equiv=\"Content-type\" content=\"text/html; charset=utf-8\" />" << endl
-           << "<link rel=\"stylesheet\" type=\"text/css\" href=\"http://root.cern.ch/js/style/JSRootInterface.css\" />" << endl
-           << "<script type=\"text/javascript\" src=\"http://root.cern.ch/js/scripts/JSRootInterface.js\"></script>" << endl
+           << "<title>Read a ROOT file</title>" << endl
+           << "<meta http-equiv=\"X-UA-Compatible\" content=\"IE=Edge; text/html\">" << endl
+           << "<script type=\"text/javascript\" src=\"http:\/\/root.cern.ch/js/3.2/scripts/JSRootCore.js\"></script>" << endl
            << "</head>" << endl
-           << "<body onload=\"BuildSimpleGUI()\">" << endl
+           << "<body onload=\"JSROOT.BuildSimpleGUI()\">" << endl
            << "<div id=\"simpleGUI\"" << endl
            << "files=\"" << rootName << "\"></div>" << endl
            << "</body>" << endl


### PR DESCRIPTION
Adopt to new version of ROOT Java Script
introduced parameter in virtual function ReadEvent
bugfix: cast from pointer to integer of different type
ignore return value of event-header unpacker
set RunID in the event header
proper number of double-words in a sub-event