### PR TITLE
Increase maximum number of zeromq sockets and improve output on errors.

### DIFF
--- a/base/MQ/devices/FairMQSampler.tpl
+++ b/base/MQ/devices/FairMQSampler.tpl
@@ -46,9 +46,9 @@ template <typename Loader> void FairMQSampler<Loader>::Init()
 
   fFairRunAna->SetInputFile(TString(fInputFile));
   // This loop can be used to duplicate input file to get more data. The output will still be a single file.
-  for (int i = 0; i < 0; ++i) {
-    fFairRunAna->AddFile(fInputFile);
-  }
+  // for (int i = 0; i < 0; ++i) {
+  //   fFairRunAna->AddFile(fInputFile);
+  // }
 
   TString output = fInputFile;
   output.Append(".out.root");

--- a/fairmq/FairMQDevice.cxx
+++ b/fairmq/FairMQDevice.cxx
@@ -117,14 +117,16 @@ void FairMQDevice::Bind()
         {
             if (!fPayloadOutputs->at(i)->Bind(fOutputAddress.at(i)))
             {
+                LOG(DEBUG) << "binding output #" << i << " on " << fOutputAddress.at(i) << "failed, trying to find port in range";
+                LOG(INFO) << "port range: " << fPortRangeMin << " - " << fPortRangeMax;
                 do {
-                    LOG(WARN) << "could not bind at " << fOutputAddress.at(i) << ", trying another port in range";
                     ++numAttempts;
 
-                    size_t pos = fOutputAddress.at(i).rfind(":");
                     stringstream ss;
                     ss << (int)randomPort(gen);
                     string portString = ss.str();
+
+                    size_t pos = fOutputAddress.at(i).rfind(":");
                     fOutputAddress.at(i) = fOutputAddress.at(i).substr(0, pos + 1) + portString;
                     if (numAttempts > maxAttempts)
                     {
@@ -144,18 +146,20 @@ void FairMQDevice::Bind()
         {
             if (!fPayloadInputs->at(i)->Bind(fInputAddress.at(i)))
             {
+                LOG(DEBUG) << "binding input #" << i << " on " << fInputAddress.at(i) << "failed, trying to find port in range";
+                LOG(INFO) << "port range: " << fPortRangeMin << " - " << fPortRangeMax;
                 do {
-                    LOG(WARN) << "could not bind at " << fInputAddress.at(i) << ", trying another port in range";
                     ++numAttempts;
 
-                    size_t pos = fInputAddress.at(i).rfind(":");
                     stringstream ss;
                     ss << (int)randomPort(gen);
                     string portString = ss.str();
+
+                    size_t pos = fInputAddress.at(i).rfind(":");
                     fInputAddress.at(i) = fInputAddress.at(i).substr(0, pos + 1) + portString;
                     if (numAttempts > maxAttempts)
                     {
-                        LOG(ERROR) << "could not bind output " << i << " to any port in the given range";
+                        LOG(ERROR) << "could not bind input " << i << " to any port in the given range";
                         break;
                     }
                 } while (!fPayloadInputs->at(i)->Bind(fInputAddress.at(i)));

--- a/fairmq/nanomsg/FairMQSocketNN.cxx
+++ b/fairmq/nanomsg/FairMQSocketNN.cxx
@@ -42,16 +42,25 @@ FairMQSocketNN::FairMQSocketNN(const string& type, int num, int numIoThreads)
         // http://250bpm.com/blog:14
         // http://www.freelists.org/post/nanomsg/a-stupid-load-balancing-question,1
         fSocket = nn_socket(AF_SP_RAW, GetConstant(type));
+        if (fSocket == -1)
+        {
+            LOG(ERROR) << "failed creating socket #" << fId << ", reason: " << nn_strerror(errno);
+            exit(EXIT_FAILURE);
+        }
     }
     else
     {
         fSocket = nn_socket(AF_SP, GetConstant(type));
+        if (fSocket == -1)
+        {
+            LOG(ERROR) << "failed creating socket #" << fId << ", reason: " << nn_strerror(errno);
+            exit(EXIT_FAILURE);
+        }
         if (type == "sub")
         {
             nn_setsockopt(fSocket, NN_SUB, NN_SUB_SUBSCRIBE, NULL, 0);
         }
     }
-
 
     LOG(INFO) << "created socket #" << fId;
 }

--- a/fairmq/zeromq/FairMQContextZMQ.cxx
+++ b/fairmq/zeromq/FairMQContextZMQ.cxx
@@ -12,9 +12,10 @@
  * @author D. Klein, A. Rybalchenko
  */
 
+#include <sstream>
+
 #include "FairMQLogger.h"
 #include "FairMQContextZMQ.h"
-#include <sstream>
 
 FairMQContextZMQ::FairMQContextZMQ(int numIoThreads)
     : fContext()
@@ -23,9 +24,17 @@ FairMQContextZMQ::FairMQContextZMQ(int numIoThreads)
     if (fContext == NULL)
     {
         LOG(ERROR) << "failed creating context, reason: " << zmq_strerror(errno);
+        exit(EXIT_FAILURE);
     }
 
     int rc = zmq_ctx_set(fContext, ZMQ_IO_THREADS, numIoThreads);
+    if (rc != 0)
+    {
+        LOG(ERROR) << "failed configuring context, reason: " << zmq_strerror(errno);
+    }
+
+    // Set the maximum number of allowed sockets on the context.
+    rc = zmq_ctx_set(fContext, ZMQ_MAX_SOCKETS, 10000);
     if (rc != 0)
     {
         LOG(ERROR) << "failed configuring context, reason: " << zmq_strerror(errno);


### PR DESCRIPTION
FairMQSampler: Modified: comment out an unused loop.
FairMQ: Modified: increase maximum number of ZeroMQ sockets (from default 1024).
FairMQ: Modified: reduce amount of output when finding port from a range.
FairMQ: Modified: stop the Device when socket creation fails and output an error.