### PR TITLE
Rename device property to have a common format and some code cleanup.

### DIFF
--- a/base/MQ/devices/FairMQSampler.h
+++ b/base/MQ/devices/FairMQSampler.h
@@ -64,8 +64,8 @@ class FairMQSampler : public FairMQDevice
 
     void ResetEventCounter();
 
-    virtual void SetProperty(const int key, const string& value, const int slot = 0);
-    virtual string GetProperty(const int key, const string& default_ = "", const int slot = 0);
+    virtual void SetProperty(const int key, const std::string& value, const int slot = 0);
+    virtual std::string GetProperty(const int key, const std::string& default_ = "", const int slot = 0);
     virtual void SetProperty(const int key, const int value, const int slot = 0);
     virtual int GetProperty(const int key, const int default_ = 0, const int slot = 0);
 
@@ -85,9 +85,9 @@ class FairMQSampler : public FairMQDevice
 
     FairRunAna *fFairRunAna;
     FairMQSamplerTask *fSamplerTask;
-    string fInputFile; // Filename of a root file containing the simulated digis.
-    string fParFile;
-    string fBranch; // The name of the sub-detector branch to stream the digis from.
+    std::string fInputFile; // Filename of a root file containing the simulated digis.
+    std::string fParFile;
+    std::string fBranch; // The name of the sub-detector branch to stream the digis from.
     int fNumEvents;
     int fEventRate;
     int fEventCounter;

--- a/base/MQ/devices/FairMQSampler.tpl
+++ b/base/MQ/devices/FairMQSampler.tpl
@@ -33,9 +33,8 @@ FairMQSampler<Loader>::~FairMQSampler()
   delete fSamplerTask;
 }
 
-/// Methods
-
-template <typename Loader> void FairMQSampler<Loader>::Init()
+template <typename Loader>
+void FairMQSampler<Loader>::Init()
 {
   FairMQDevice::Init();
 
@@ -68,7 +67,8 @@ template <typename Loader> void FairMQSampler<Loader>::Init()
   fNumEvents = int((ioman->GetInChain())->GetEntries());
 }
 
-template <typename Loader> void FairMQSampler<Loader>::Run()
+template <typename Loader>
+void FairMQSampler<Loader>::Run()
 {
   LOG(INFO) << ">>>>>>> Run <<<<<<<";
 
@@ -97,7 +97,7 @@ template <typename Loader> void FairMQSampler<Loader>::Run()
       //   boost::this_thread::sleep(boost::posix_time::milliseconds(1));
       // }
 
-      if(fState != RUNNING) { break; }
+      if (fState != RUNNING) { break; }
     }
   } while (fState == RUNNING && fContinuous);
 
@@ -130,7 +130,8 @@ void FairMQSampler<Loader>::SendPart()
   fSamplerTask->GetOutput()->CloseMessage();
 }
 
-template <typename Loader> void FairMQSampler<Loader>::ResetEventCounter()
+template <typename Loader>
+void FairMQSampler<Loader>::ResetEventCounter()
 {
   while (true) {
     try {
@@ -146,7 +147,7 @@ template <typename Loader> void FairMQSampler<Loader>::ResetEventCounter()
 }
 
 template <typename Loader>
-void FairMQSampler<Loader>::SetProperty(const int key, const string& value, const int slot/*= 0*/)
+void FairMQSampler<Loader>::SetProperty(const int key, const std::string& value, const int slot/*= 0*/)
 {
   switch (key)
   {
@@ -166,7 +167,7 @@ void FairMQSampler<Loader>::SetProperty(const int key, const string& value, cons
 }
 
 template <typename Loader>
-string FairMQSampler<Loader>::GetProperty(const int key, const string& default_/*= ""*/, const int slot/*= 0*/)
+std::string FairMQSampler<Loader>::GetProperty(const int key, const std::string& default_/*= ""*/, const int slot/*= 0*/)
 {
   switch (key)
   {

--- a/base/MQ/tasks/FairMQSamplerTask.cxx
+++ b/base/MQ/tasks/FairMQSamplerTask.cxx
@@ -14,6 +14,8 @@
 
 #include "FairMQSamplerTask.h"
 
+using namespace std;
+
 FairMQSamplerTask::FairMQSamplerTask() :
   FairTask("Abstract base task used for loading a branch from a root file into memory"),
   fInput(NULL),

--- a/base/MQ/tasks/FairMQSamplerTask.h
+++ b/base/MQ/tasks/FairMQSamplerTask.h
@@ -15,18 +15,17 @@
 #ifndef FAIRMQSAMPLERTASK_H_
 #define FAIRMQSAMPLERTASK_H_
 
-#include "FairTask.h"
-#include "FairEventHeader.h"
 #include <vector>
 #include <string>
 
 #include <boost/function.hpp>
 
-#include "FairTask.h"
-#include "TClonesArray.h"
-
 #include "FairMQMessage.h"
 #include "FairMQTransportFactory.h"
+
+#include "TClonesArray.h"
+#include "FairTask.h"
+#include "FairEventHeader.h"
 
 class FairMQSamplerTask : public FairTask
 {
@@ -40,13 +39,13 @@ class FairMQSamplerTask : public FairTask
     virtual void Exec(Option_t *opt);
     void SetSendPart(boost::function<void()>); // provides a callback to the Sampler.
     void SetEventIndex(Long64_t EventIndex);
-    void SetBranch(string branch);
+    void SetBranch(std::string branch);
     FairMQMessage *GetOutput();
     void SetTransport(FairMQTransportFactory *factory);
 
   protected:
     TClonesArray *fInput;
-    string fBranch;
+    std::string fBranch;
     FairMQMessage *fOutput;
     FairMQTransportFactory *fTransportFactory;
     Long64_t fEventIndex;

--- a/example/Tutorial3/FairTestDetectorLinkDef.h
+++ b/example/Tutorial3/FairTestDetectorLinkDef.h
@@ -30,22 +30,4 @@
 #pragma link C++ class FairTestDetectorDigiRingSorter+;
 #pragma link C++ class FairTestDetectorDigiSorterTask+;
 
-#pragma link C++ namespace TestDetectorPayload;
-#pragma link C++ nestedclass;
-#pragma link C++ nestedtypedef;
-
-#pragma link C++ class TestDetectorPayload::TimeStamp+;
-#pragma link C++ class TestDetectorPayload::Digi+;
-#pragma link C++ class TestDetectorPayload::Hit+;
-
-
-
-
-//#pragma link C++ namespace MyData;
-//#pragma link C++ class MyData::Base+;
-//#pragma link C++ class MyData::Derived1+;
-//#pragma link C++ class MyData::Derived2+;
-//#pragma link C++ class MyData::Derived3+;
-
-
 #endif

--- a/example/Tutorial3/data/FairTestDetectorPayload.h
+++ b/example/Tutorial3/data/FairTestDetectorPayload.h
@@ -19,13 +19,6 @@
 #include "FairTestDetectorDigi.h"
 #include "TString.h"
 
-
-// for boost serialization (must be hidden from CINT)
-#ifndef __CINT__
-#include <boost/serialization/access.hpp>
-#include <boost/serialization/base_object.hpp>
-#endif //__CINT__
-
 namespace TestDetectorPayload
 {
     class TimeStamp
@@ -33,18 +26,6 @@ namespace TestDetectorPayload
       public:
         Double_t fTimeStamp;
         Double_t fTimeStampError;
-        
-        // method to use boost serialization
-        #ifndef __CINT__
-        template<class Archive>
-        void serialize(Archive & ar, const unsigned int version) 
-        {
-            ar & fTimeStamp;
-            ar & fTimeStampError;
-        }
-        friend class boost::serialization::access;
-        #endif //__CINT__
-        
     };
 
     class Digi : public TimeStamp
@@ -53,20 +34,6 @@ namespace TestDetectorPayload
         Int_t fX;
         Int_t fY;
         Int_t fZ;
-        
-        // method to use boost serialization
-        #ifndef __CINT__
-        template<class Archive>
-        void serialize(Archive & ar, const unsigned int version) 
-        {
-            ar & boost::serialization::base_object<TimeStamp>(*this);
-            ar & fX;
-            ar & fY;
-            ar & fZ;
-        }
-        friend class boost::serialization::access;
-        #endif //__CINT__
-        
     };
 
     class Hit : public TimeStamp
@@ -80,24 +47,6 @@ namespace TestDetectorPayload
         Double_t dposX;
         Double_t dposY;
         Double_t dposZ;
-        
-        // method to use boost serialization
-        #ifndef __CINT__
-        template<class Archive>
-        void serialize(Archive & ar, const unsigned int version) 
-        {
-            ar & boost::serialization::base_object<TimeStamp>(*this);
-            ar & detID;
-            ar & mcindex;
-            ar & posX;
-            ar & posY;
-            ar & posZ;
-            ar & dposX;
-            ar & dposY;
-            ar & dposZ;
-        }
-        friend class boost::serialization::access;
-        #endif //__CINT__
     };
 }
 

--- a/fairmq/FairMQConfigurable.cxx
+++ b/fairmq/FairMQConfigurable.cxx
@@ -12,7 +12,10 @@
  * @author D. Klein, A. Rybalchenko
  */
 
+#include "FairMQLogger.h"
 #include "FairMQConfigurable.h"
+
+using namespace std;
 
 FairMQConfigurable::FairMQConfigurable()
 {
@@ -20,19 +23,25 @@ FairMQConfigurable::FairMQConfigurable()
 
 void FairMQConfigurable::SetProperty(const int key, const string& value, const int slot /*= 0*/)
 {
+    LOG(ERROR) << "Reached end of the property list. SetProperty(" << key << ", " << value << ") has no effect.";
+    exit(EXIT_FAILURE);
 }
 
 string FairMQConfigurable::GetProperty(const int key, const string& default_ /*= ""*/, const int slot /*= 0*/)
 {
+    LOG(ERROR) << "Reached end of the property list. The requested property " << key << " was not found.";
     return default_;
 }
 
 void FairMQConfigurable::SetProperty(const int key, const int value, const int slot /*= 0*/)
 {
+    LOG(ERROR) << "Reached end of the property list. SetProperty(" << key << ", " << value << ") has no effect.";
+    exit(EXIT_FAILURE);
 }
 
 int FairMQConfigurable::GetProperty(const int key, const int default_ /*= 0*/, const int slot /*= 0*/)
 {
+    LOG(ERROR) << "Reached end of the property list. The requested property " << key << " was not found.";
     return default_;
 }
 

--- a/fairmq/FairMQConfigurable.h
+++ b/fairmq/FairMQConfigurable.h
@@ -17,8 +17,6 @@
 
 #include <string>
 
-using namespace std;
-
 class FairMQConfigurable
 {
   public:
@@ -27,8 +25,8 @@ class FairMQConfigurable
         Last = 1
     };
     FairMQConfigurable();
-    virtual void SetProperty(const int key, const string& value, const int slot = 0);
-    virtual string GetProperty(const int key, const string& default_ = "", const int slot = 0);
+    virtual void SetProperty(const int key, const std::string& value, const int slot = 0);
+    virtual std::string GetProperty(const int key, const std::string& default_ = "", const int slot = 0);
     virtual void SetProperty(const int key, const int value, const int slot = 0);
     virtual int GetProperty(const int key, const int default_ = 0, const int slot = 0);
     virtual ~FairMQConfigurable();

--- a/fairmq/FairMQDevice.h
+++ b/fairmq/FairMQDevice.h
@@ -24,8 +24,6 @@
 #include "FairMQTransportFactory.h"
 #include "FairMQSocket.h"
 
-using namespace std;
-
 class FairMQDevice : public FairMQStateMachine, public FairMQConfigurable
 {
   public:
@@ -42,14 +40,16 @@ class FairMQDevice : public FairMQStateMachine, public FairMQConfigurable
         InputSocketType,
         InputSndBufSize,
         InputRcvBufSize,
+        InputRateLogging,
         OutputAddress,
         OutputMethod,
         OutputSocketType,
         OutputSndBufSize,
         OutputRcvBufSize,
+        OutputRateLogging,
+        LogInputRate, // keep this for backwards compatibility for a while
+        LogOutputRate, // keep this for backwards compatibility for a while
         LogIntervalInMs,
-        LogInputRate,
-        LogOutputRate,
         Last
     };
 
@@ -57,8 +57,8 @@ class FairMQDevice : public FairMQStateMachine, public FairMQConfigurable
 
     virtual void LogSocketRates();
 
-    virtual void SetProperty(const int key, const string& value, const int slot = 0);
-    virtual string GetProperty(const int key, const string& default_ = "", const int slot = 0);
+    virtual void SetProperty(const int key, const std::string& value, const int slot = 0);
+    virtual std::string GetProperty(const int key, const std::string& default_ = "", const int slot = 0);
     virtual void SetProperty(const int key, const int value, const int slot = 0);
     virtual int GetProperty(const int key, const int default_ = 0, const int slot = 0);
 
@@ -67,7 +67,7 @@ class FairMQDevice : public FairMQStateMachine, public FairMQConfigurable
     virtual ~FairMQDevice();
 
   protected:
-    string fId;
+    std::string fId;
 
     int fNumIoThreads;
 
@@ -77,22 +77,22 @@ class FairMQDevice : public FairMQStateMachine, public FairMQConfigurable
     int fPortRangeMin;
     int fPortRangeMax;
 
-    vector<string> fInputAddress;
-    vector<string> fInputMethod;
-    vector<string> fInputSocketType;
-    vector<int> fInputSndBufSize;
-    vector<int> fInputRcvBufSize;
-    vector<int> fLogInputRate;
+    std::vector<std::string> fInputAddress;
+    std::vector<std::string> fInputMethod;
+    std::vector<std::string> fInputSocketType;
+    std::vector<int> fInputSndBufSize;
+    std::vector<int> fInputRcvBufSize;
+    std::vector<int> fInputRateLogging;
 
-    vector<string> fOutputAddress;
-    vector<string> fOutputMethod;
-    vector<string> fOutputSocketType;
-    vector<int> fOutputSndBufSize;
-    vector<int> fOutputRcvBufSize;
-    vector<int> fLogOutputRate;
+    std::vector<std::string> fOutputAddress;
+    std::vector<std::string> fOutputMethod;
+    std::vector<std::string> fOutputSocketType;
+    std::vector<int> fOutputSndBufSize;
+    std::vector<int> fOutputRcvBufSize;
+    std::vector<int> fOutputRateLogging;
 
-    vector<FairMQSocket*>* fPayloadInputs;
-    vector<FairMQSocket*>* fPayloadOutputs;
+    std::vector<FairMQSocket*>* fPayloadInputs;
+    std::vector<FairMQSocket*>* fPayloadOutputs;
 
     int fLogIntervalInMs;
 

--- a/fairmq/FairMQLogger.cxx
+++ b/fairmq/FairMQLogger.cxx
@@ -17,6 +17,8 @@
 
 #include "FairMQLogger.h"
 
+using namespace std;
+
 FairMQLogger::FairMQLogger()
     : os()
 {

--- a/fairmq/FairMQLogger.h
+++ b/fairmq/FairMQLogger.h
@@ -21,8 +21,6 @@
 #include <iomanip>
 #include <ctime>
 
-using namespace std;
-
 class FairMQLogger
 {
   public:
@@ -36,10 +34,10 @@ class FairMQLogger
     };
     FairMQLogger();
     virtual ~FairMQLogger();
-    ostringstream& Log(int type);
+    std::ostringstream& Log(int type);
 
   private:
-    ostringstream os;
+    std::ostringstream os;
 };
 
 typedef unsigned long long timestamp_t;

--- a/fairmq/FairMQSocket.h
+++ b/fairmq/FairMQSocket.h
@@ -18,8 +18,6 @@
 #include <string>
 #include "FairMQMessage.h"
 
-using namespace std;
-
 class FairMQSocket
 {
   public:
@@ -33,14 +31,14 @@ class FairMQSocket
         , NOBLOCK(noBlock)
         {}
 
-    virtual string GetId() = 0;
+    virtual std::string GetId() = 0;
 
-    virtual bool Bind(const string& address) = 0;
-    virtual void Connect(const string& address) = 0;
+    virtual bool Bind(const std::string& address) = 0;
+    virtual void Connect(const std::string& address) = 0;
 
-    virtual int Send(FairMQMessage* msg, const string& flag="") = 0;
+    virtual int Send(FairMQMessage* msg, const std::string& flag="") = 0;
     virtual int Send(FairMQMessage* msg, const int flags) = 0;
-    virtual int Receive(FairMQMessage* msg, const string& flag="") = 0;
+    virtual int Receive(FairMQMessage* msg, const std::string& flag="") = 0;
     virtual int Receive(FairMQMessage* msg, const int flags) = 0;
 
     virtual void* GetSocket() = 0;
@@ -48,8 +46,8 @@ class FairMQSocket
     virtual void Close() = 0;
     virtual void Terminate() = 0;
 
-    virtual void SetOption(const string& option, const void* value, size_t valueSize) = 0;
-    virtual void GetOption(const string& option, void* value, size_t* valueSize) = 0;
+    virtual void SetOption(const std::string& option, const void* value, size_t valueSize) = 0;
+    virtual void GetOption(const std::string& option, void* value, size_t* valueSize) = 0;
 
     virtual unsigned long GetBytesTx() = 0;
     virtual unsigned long GetBytesRx() = 0;

--- a/fairmq/FairMQTransportFactory.h
+++ b/fairmq/FairMQTransportFactory.h
@@ -22,16 +22,14 @@
 #include "FairMQPoller.h"
 #include "FairMQLogger.h"
 
-using namespace std;
-
 class FairMQTransportFactory
 {
   public:
     virtual FairMQMessage* CreateMessage() = 0;
     virtual FairMQMessage* CreateMessage(size_t size) = 0;
     virtual FairMQMessage* CreateMessage(void* data, size_t size, fairmq_free_fn *ffn = NULL, void* hint = NULL) = 0;
-    virtual FairMQSocket* CreateSocket(const string& type, int num, int numIoThreads) = 0;
-    virtual FairMQPoller* CreatePoller(const vector<FairMQSocket*>& inputs) = 0;
+    virtual FairMQSocket* CreateSocket(const std::string& type, int num, int numIoThreads) = 0;
+    virtual FairMQPoller* CreatePoller(const std::vector<FairMQSocket*>& inputs) = 0;
 
     virtual ~FairMQTransportFactory() {};
 };

--- a/fairmq/devices/FairMQBenchmarkSampler.cxx
+++ b/fairmq/devices/FairMQBenchmarkSampler.cxx
@@ -20,6 +20,8 @@
 #include "FairMQBenchmarkSampler.h"
 #include "FairMQLogger.h"
 
+using namespace std;
+
 FairMQBenchmarkSampler::FairMQBenchmarkSampler()
     : fEventSize(10000)
     , fEventRate(1)

--- a/fairmq/devices/FairMQBenchmarkSampler.h
+++ b/fairmq/devices/FairMQBenchmarkSampler.h
@@ -37,8 +37,8 @@ class FairMQBenchmarkSampler : public FairMQDevice
     virtual ~FairMQBenchmarkSampler();
     void Log(int intervalInMs);
     void ResetEventCounter();
-    virtual void SetProperty(const int key, const string& value, const int slot = 0);
-    virtual string GetProperty(const int key, const string& default_ = "", const int slot = 0);
+    virtual void SetProperty(const int key, const std::string& value, const int slot = 0);
+    virtual std::string GetProperty(const int key, const std::string& default_ = "", const int slot = 0);
     virtual void SetProperty(const int key, const int value, const int slot = 0);
     virtual int GetProperty(const int key, const int default_ = 0, const int slot = 0);
 

--- a/fairmq/devices/GenericFileSink.h
+++ b/fairmq/devices/GenericFileSink.h
@@ -8,9 +8,10 @@
 #ifndef GENERICFILESINK_H
 #define	GENERICFILESINK_H
 
-#include "FairMQDevice.h"
 #include <boost/thread.hpp>
 #include <boost/bind.hpp>
+
+#include "FairMQDevice.h"
 #include "FairMQLogger.h"
 
 template <typename InputPolicy, typename OutputPolicy>
@@ -19,25 +20,24 @@ class GenericFileSink : public FairMQDevice, public InputPolicy, public OutputPo
     //using InputPolicy::message;
     //using OutputPolicy::InitOutFile;
     //using OutputPolicy::AddToFile;
-    
-public:
+
+  public:
     GenericFileSink();
     virtual ~GenericFileSink();
-    
+
     template <typename... Args>
         void InitInputPolicyContainer(Args... args)
         {
             InputPolicy::InitContainer(std::forward<Args>(args)...);
         }
-    
-    
+
     virtual void SetTransport(FairMQTransportFactory* transport);
     virtual void InitOutputFile();
-    
-protected:
+
+  protected:
     virtual void Run();
     virtual void Init();
-    
+
 };
 
 #include "GenericFileSink.tpl"

--- a/fairmq/devices/GenericProcessor.h
+++ b/fairmq/devices/GenericProcessor.h
@@ -17,44 +17,39 @@ class GenericProcessor: public FairMQDevice,
                         public TaskPolicy
 {
   public:
-   
     GenericProcessor() : InputPolicy(), OutputPolicy(), TaskPolicy()
     {}
-    
+
     virtual ~GenericProcessor()
     {}
-    
+
     void SetTransport(FairMQTransportFactory* transport)
     {
         FairMQDevice::SetTransport(transport);
         //InputPolicy::SetTransport(transport);
         //OutputPolicy::SetTransport(transport);
     }
-    
-    
+
     template <typename... Args>
         void InitTask(Args... args)
         {
             TaskPolicy::InitTask(std::forward<Args>(args)...);
         }
-    
+
     template <typename... Args>
         void InitInputContainer(Args... args)
         {
             InputPolicy::InitContainer(std::forward<Args>(args)...);
         }
-    
+
     template <typename... Args>
         void InitOutputContainer(Args... args)
         {
             OutputPolicy::InitContainer(std::forward<Args>(args)...);
         }
-    
-    
+
     //void SendPart();
     //bool ReceivePart();
-
-    
 
     void SendPart()
     {
@@ -81,7 +76,7 @@ class GenericProcessor: public FairMQDevice,
         }
     }
     */
-    
+
   protected:
     virtual void Init()
     {
@@ -91,7 +86,7 @@ class GenericProcessor: public FairMQDevice,
         //fProcessorTask->SetSendPart(boost::bind(&FairMQProcessor::SendPart, this));
         //fProcessorTask->SetReceivePart(boost::bind(&FairMQProcessor::ReceivePart, this));
     }
-    
+
     virtual void Run()
     {
         MQLOG(INFO) << ">>>>>>> Run <<<<<<<";
@@ -100,7 +95,7 @@ class GenericProcessor: public FairMQDevice,
         int receivedMsgs = 0;
         int sentMsgs = 0;
         int received = 0;
-      
+
         while ( fState == RUNNING ) 
         {
             FairMQMessage* msg = fTransportFactory->CreateMessage();
@@ -148,7 +143,6 @@ class GenericProcessor: public FairMQDevice,
         fRunningCondition.notify_one();
     }
 
-    
 };
 
 //#include "GenericSampler.tpl"

--- a/fairmq/devices/GenericSampler.h
+++ b/fairmq/devices/GenericSampler.h
@@ -8,21 +8,12 @@
 #ifndef GENERICSAMPLER_H
 #define	GENERICSAMPLER_H
 
-
-
-
 #include <vector>
 #include <iostream>
 
 #include <boost/thread.hpp>
 #include <boost/bind.hpp>
 #include <boost/timer/timer.hpp>
-
-#include "TList.h"
-#include "TObjString.h"
-#include "TClonesArray.h"
-#include "TROOT.h"
-
 
 #include "FairMQDevice.h"
 #include "FairMQLogger.h"
@@ -44,7 +35,7 @@ class GenericSampler: public FairMQDevice, public SamplerPolicy, public OutputPo
 {
     //using SamplerPolicy::GetDataBranch;   // get data from file
     //using OutputPolicy::message;        // serialize method
-    
+
   public:
     enum {
       InputFile = FairMQDevice::Last,
@@ -57,15 +48,15 @@ class GenericSampler: public FairMQDevice, public SamplerPolicy, public OutputPo
     virtual void SetTransport(FairMQTransportFactory* factory);
     void ResetEventCounter();
     virtual void ListenToCommands();
-    
+
     template <typename... Args>
         void SetFileProperties(Args&... args)
         {
             SamplerPolicy::SetFileProperties(args...);
         }
 
-    virtual void SetProperty(const int key, const string& value, const int slot = 0);
-    virtual string GetProperty(const int key, const string& default_ = "", const int slot = 0);
+    virtual void SetProperty(const int key, const std::string& value, const int slot = 0);
+    virtual std::string GetProperty(const int key, const std::string& default_ = "", const int slot = 0);
     virtual void SetProperty(const int key, const int value, const int slot = 0);
     virtual int GetProperty(const int key, const int default_ = 0, const int slot = 0);
 
@@ -84,9 +75,9 @@ protected:
   virtual void Run();
 
 protected:
-  string fInputFile; // Filename of a root file containing the simulated digis.
-  string fParFile;
-  string fBranch; // The name of the sub-detector branch to stream the digis from.
+  std::string fInputFile; // Filename of a root file containing the simulated digis.
+  std::string fParFile;
+  std::string fBranch; // The name of the sub-detector branch to stream the digis from.
   int fNumEvents;
   int fEventRate;
   int fEventCounter;

--- a/fairmq/devices/GenericSampler.tpl
+++ b/fairmq/devices/GenericSampler.tpl
@@ -6,29 +6,25 @@
  */
 
 template <typename SamplerPolicy, typename OutputPolicy>
-    GenericSampler<SamplerPolicy,OutputPolicy>::GenericSampler() :
-      fNumEvents(0),
-      fEventRate(1),
-      fEventCounter(0),
-      fContinuous(false)
-    {
-    }
-
-
-template <typename SamplerPolicy, typename OutputPolicy>
-    GenericSampler<SamplerPolicy,OutputPolicy>::~GenericSampler()
-    {
-    }
-
-
-
+GenericSampler<SamplerPolicy,OutputPolicy>::GenericSampler() :
+  fNumEvents(0),
+  fEventRate(1),
+  fEventCounter(0),
+  fContinuous(false)
+{
+}
 
 template <typename SamplerPolicy, typename OutputPolicy>
-    void GenericSampler<SamplerPolicy,OutputPolicy>::SetTransport(FairMQTransportFactory* factory)
-    {
-        FairMQDevice::SetTransport(factory);
-        //OutputPolicy::SetTransport(factory);
-    }
+GenericSampler<SamplerPolicy,OutputPolicy>::~GenericSampler()
+{
+}
+
+template <typename SamplerPolicy, typename OutputPolicy>
+void GenericSampler<SamplerPolicy,OutputPolicy>::SetTransport(FairMQTransportFactory* factory)
+{
+    FairMQDevice::SetTransport(factory);
+    //OutputPolicy::SetTransport(factory);
+}
 
 template <typename SamplerPolicy, typename OutputPolicy>
 void GenericSampler<SamplerPolicy,OutputPolicy>::Init()
@@ -57,7 +53,7 @@ void GenericSampler<SamplerPolicy,OutputPolicy>::Run()
 
     do 
     {
-        for ( Long64_t eventNr = 0 ; eventNr < fNumEvents; ++eventNr ) 
+        for ( unsigned long eventNr = 0 ; eventNr < fNumEvents; ++eventNr ) 
         {
             //fSamplerTask->SetEventIndex(eventNr);
             FairMQMessage* msg = fTransportFactory->CreateMessage();
@@ -166,7 +162,7 @@ void GenericSampler<SamplerPolicy,OutputPolicy>::ListenToCommands()
 }
 
 template <typename SamplerPolicy, typename OutputPolicy>
-void GenericSampler<SamplerPolicy,OutputPolicy>::SetProperty(const int key, const string& value, const int slot/*= 0*/)
+void GenericSampler<SamplerPolicy,OutputPolicy>::SetProperty(const int key, const std::string& value, const int slot/*= 0*/)
 {
   switch (key)
   {
@@ -186,7 +182,7 @@ void GenericSampler<SamplerPolicy,OutputPolicy>::SetProperty(const int key, cons
 }
 
 template <typename SamplerPolicy, typename OutputPolicy>
-string GenericSampler<SamplerPolicy,OutputPolicy>::GetProperty(const int key, const string& default_/*= ""*/, const int slot/*= 0*/)
+std::string GenericSampler<SamplerPolicy,OutputPolicy>::GetProperty(const int key, const std::string& default_/*= ""*/, const int slot/*= 0*/)
 {
   switch (key)
   {

--- a/fairmq/examples/req-rep/FairMQExampleClient.cxx
+++ b/fairmq/examples/req-rep/FairMQExampleClient.cxx
@@ -18,6 +18,8 @@
 #include "FairMQExampleClient.h"
 #include "FairMQLogger.h"
 
+using namespace std;
+
 FairMQExampleClient::FairMQExampleClient()
     : fText()
 {

--- a/fairmq/examples/req-rep/FairMQExampleClient.h
+++ b/fairmq/examples/req-rep/FairMQExampleClient.h
@@ -19,8 +19,6 @@
 
 #include "FairMQDevice.h"
 
-using namespace std;
-
 class FairMQExampleClient : public FairMQDevice
 {
   public:
@@ -34,13 +32,13 @@ class FairMQExampleClient : public FairMQDevice
 
     static void CustomCleanup(void *data, void* hint);
 
-    virtual void SetProperty(const int key, const string& value, const int slot = 0);
-    virtual string GetProperty(const int key, const string& default_ = "", const int slot = 0);
+    virtual void SetProperty(const int key, const std::string& value, const int slot = 0);
+    virtual std::string GetProperty(const int key, const std::string& default_ = "", const int slot = 0);
     virtual void SetProperty(const int key, const int value, const int slot = 0);
     virtual int GetProperty(const int key, const int default_ = 0, const int slot = 0);
 
   protected:
-    string fText;
+    std::string fText;
 
     virtual void Run();
 };

--- a/fairmq/nanomsg/FairMQPollerNN.cxx
+++ b/fairmq/nanomsg/FairMQPollerNN.cxx
@@ -16,6 +16,8 @@
 
 #include "FairMQPollerNN.h"
 
+using namespace std;
+
 FairMQPollerNN::FairMQPollerNN(const vector<FairMQSocket*>& inputs)
     : items()
     , fNumItems()

--- a/fairmq/nanomsg/FairMQPollerNN.h
+++ b/fairmq/nanomsg/FairMQPollerNN.h
@@ -20,12 +20,10 @@
 #include "FairMQPoller.h"
 #include "FairMQSocket.h"
 
-using namespace std;
-
 class FairMQPollerNN : public FairMQPoller
 {
   public:
-    FairMQPollerNN(const vector<FairMQSocket*>& inputs);
+    FairMQPollerNN(const std::vector<FairMQSocket*>& inputs);
 
     virtual void Poll(int timeout);
     virtual bool CheckInput(int index);

--- a/fairmq/nanomsg/FairMQSocketNN.cxx
+++ b/fairmq/nanomsg/FairMQSocketNN.cxx
@@ -18,6 +18,8 @@
 #include "FairMQMessageNN.h"
 #include "FairMQLogger.h"
 
+using namespace std;
+
 FairMQSocketNN::FairMQSocketNN(const string& type, int num, int numIoThreads)
     : FairMQSocket(0, 0, NN_DONTWAIT)
     , fSocket()

--- a/fairmq/nanomsg/FairMQSocketNN.h
+++ b/fairmq/nanomsg/FairMQSocketNN.h
@@ -26,16 +26,16 @@
 class FairMQSocketNN : public FairMQSocket
 {
   public:
-    FairMQSocketNN(const string& type, int num, int numIoThreads); // numIoThreads is not used in nanomsg.
+    FairMQSocketNN(const std::string& type, int num, int numIoThreads); // numIoThreads is not used in nanomsg.
 
-    virtual string GetId();
+    virtual std::string GetId();
 
-    virtual bool Bind(const string& address);
-    virtual void Connect(const string& address);
+    virtual bool Bind(const std::string& address);
+    virtual void Connect(const std::string& address);
 
-    virtual int Send(FairMQMessage* msg, const string& flag="");
+    virtual int Send(FairMQMessage* msg, const std::string& flag="");
     virtual int Send(FairMQMessage* msg, const int flags);
-    virtual int Receive(FairMQMessage* msg, const string& flag="");
+    virtual int Receive(FairMQMessage* msg, const std::string& flag="");
     virtual int Receive(FairMQMessage* msg, const int flags);
 
     virtual void* GetSocket();
@@ -43,21 +43,21 @@ class FairMQSocketNN : public FairMQSocket
     virtual void Close();
     virtual void Terminate();
 
-    virtual void SetOption(const string& option, const void* value, size_t valueSize);
-    virtual void GetOption(const string& option, void* value, size_t* valueSize);
+    virtual void SetOption(const std::string& option, const void* value, size_t valueSize);
+    virtual void GetOption(const std::string& option, void* value, size_t* valueSize);
 
     unsigned long GetBytesTx();
     unsigned long GetBytesRx();
     unsigned long GetMessagesTx();
     unsigned long GetMessagesRx();
 
-    static int GetConstant(const string& constant);
+    static int GetConstant(const std::string& constant);
 
     virtual ~FairMQSocketNN();
 
   private:
     int fSocket;
-    string fId;
+    std::string fId;
     unsigned long fBytesTx;
     unsigned long fBytesRx;
     unsigned long fMessagesTx;

--- a/fairmq/nanomsg/FairMQTransportFactoryNN.cxx
+++ b/fairmq/nanomsg/FairMQTransportFactoryNN.cxx
@@ -14,6 +14,8 @@
 
 #include "FairMQTransportFactoryNN.h"
 
+using namespace std;
+
 FairMQTransportFactoryNN::FairMQTransportFactoryNN()
 {
     LOG(INFO) << "Using nanomsg library";

--- a/fairmq/nanomsg/FairMQTransportFactoryNN.h
+++ b/fairmq/nanomsg/FairMQTransportFactoryNN.h
@@ -30,8 +30,8 @@ class FairMQTransportFactoryNN : public FairMQTransportFactory
     virtual FairMQMessage* CreateMessage();
     virtual FairMQMessage* CreateMessage(size_t size);
     virtual FairMQMessage* CreateMessage(void* data, size_t size, fairmq_free_fn *ffn = NULL, void* hint = NULL);
-    virtual FairMQSocket* CreateSocket(const string& type, int num, int numIoThreads);
-    virtual FairMQPoller* CreatePoller(const vector<FairMQSocket*>& inputs);
+    virtual FairMQSocket* CreateSocket(const std::string& type, int num, int numIoThreads);
+    virtual FairMQPoller* CreatePoller(const std::vector<FairMQSocket*>& inputs);
 
     virtual ~FairMQTransportFactoryNN() {};
 };

--- a/fairmq/prototest/FairMQProtoSampler.cxx
+++ b/fairmq/prototest/FairMQProtoSampler.cxx
@@ -22,6 +22,8 @@
 
 #include "payload.pb.h"
 
+using namespace std;
+
 FairMQProtoSampler::FairMQProtoSampler()
     : fEventSize(10000)
     , fEventRate(1)

--- a/fairmq/prototest/FairMQProtoSampler.h
+++ b/fairmq/prototest/FairMQProtoSampler.h
@@ -19,8 +19,6 @@
 
 #include "FairMQDevice.h"
 
-using namespace std;
-
 class FairMQProtoSampler : public FairMQDevice
 {
   public:
@@ -35,8 +33,8 @@ class FairMQProtoSampler : public FairMQDevice
     virtual ~FairMQProtoSampler();
     void Log(int intervalInMs);
     void ResetEventCounter();
-    virtual void SetProperty(const int key, const string& value, const int slot = 0);
-    virtual string GetProperty(const int key, const string& default_ = "", const int slot = 0);
+    virtual void SetProperty(const int key, const std::string& value, const int slot = 0);
+    virtual std::string GetProperty(const int key, const std::string& default_ = "", const int slot = 0);
     virtual void SetProperty(const int key, const int value, const int slot = 0);
     virtual int GetProperty(const int key, const int default_ = 0, const int slot = 0);
 

--- a/fairmq/zeromq/FairMQPollerZMQ.cxx
+++ b/fairmq/zeromq/FairMQPollerZMQ.cxx
@@ -17,6 +17,8 @@
 #include "FairMQPollerZMQ.h"
 #include "FairMQLogger.h"
 
+using namespace std;
+
 FairMQPollerZMQ::FairMQPollerZMQ(const vector<FairMQSocket*>& inputs)
     : items()
     , fNumItems()

--- a/fairmq/zeromq/FairMQPollerZMQ.h
+++ b/fairmq/zeromq/FairMQPollerZMQ.h
@@ -20,12 +20,10 @@
 #include "FairMQPoller.h"
 #include "FairMQSocket.h"
 
-using namespace std;
-
 class FairMQPollerZMQ : public FairMQPoller
 {
   public:
-    FairMQPollerZMQ(const vector<FairMQSocket*>& inputs);
+    FairMQPollerZMQ(const std::vector<FairMQSocket*>& inputs);
 
     virtual void Poll(int timeout);
     virtual bool CheckInput(int index);

--- a/fairmq/zeromq/FairMQSocketZMQ.cxx
+++ b/fairmq/zeromq/FairMQSocketZMQ.cxx
@@ -17,6 +17,8 @@
 #include "FairMQSocketZMQ.h"
 #include "FairMQLogger.h"
 
+using namespace std;
+
 boost::shared_ptr<FairMQContextZMQ> FairMQSocketZMQ::fContext = boost::shared_ptr<FairMQContextZMQ>(new FairMQContextZMQ(1));
 
 FairMQSocketZMQ::FairMQSocketZMQ(const string& type, int num, int numIoThreads)

--- a/fairmq/zeromq/FairMQSocketZMQ.h
+++ b/fairmq/zeromq/FairMQSocketZMQ.h
@@ -25,16 +25,16 @@
 class FairMQSocketZMQ : public FairMQSocket
 {
   public:
-    FairMQSocketZMQ(const string& type, int num, int numIoThreads);
+    FairMQSocketZMQ(const std::string& type, int num, int numIoThreads);
 
-    virtual string GetId();
+    virtual std::string GetId();
 
-    virtual bool Bind(const string& address);
-    virtual void Connect(const string& address);
+    virtual bool Bind(const std::string& address);
+    virtual void Connect(const std::string& address);
 
-    virtual int Send(FairMQMessage* msg, const string& flag="");
+    virtual int Send(FairMQMessage* msg, const std::string& flag="");
     virtual int Send(FairMQMessage* msg, const int flags);
-    virtual int Receive(FairMQMessage* msg, const string& flag="");
+    virtual int Receive(FairMQMessage* msg, const std::string& flag="");
     virtual int Receive(FairMQMessage* msg, const int flags);
 
     virtual void* GetSocket();
@@ -42,21 +42,21 @@ class FairMQSocketZMQ : public FairMQSocket
     virtual void Close();
     virtual void Terminate();
 
-    virtual void SetOption(const string& option, const void* value, size_t valueSize);
-    virtual void GetOption(const string& option, void* value, size_t* valueSize);
+    virtual void SetOption(const std::string& option, const void* value, size_t valueSize);
+    virtual void GetOption(const std::string& option, void* value, size_t* valueSize);
 
     virtual unsigned long GetBytesTx();
     virtual unsigned long GetBytesRx();
     virtual unsigned long GetMessagesTx();
     virtual unsigned long GetMessagesRx();
 
-    static int GetConstant(const string& constant);
+    static int GetConstant(const std::string& constant);
 
     virtual ~FairMQSocketZMQ();
 
   private:
     void* fSocket;
-    string fId;
+    std::string fId;
     unsigned long fBytesTx;
     unsigned long fBytesRx;
     unsigned long fMessagesTx;

--- a/fairmq/zeromq/FairMQTransportFactoryZMQ.cxx
+++ b/fairmq/zeromq/FairMQTransportFactoryZMQ.cxx
@@ -16,6 +16,8 @@
 
 #include "FairMQTransportFactoryZMQ.h"
 
+using namespace std;
+
 FairMQTransportFactoryZMQ::FairMQTransportFactoryZMQ()
 {
     int major, minor, patch;

--- a/fairmq/zeromq/FairMQTransportFactoryZMQ.h
+++ b/fairmq/zeromq/FairMQTransportFactoryZMQ.h
@@ -31,8 +31,8 @@ class FairMQTransportFactoryZMQ : public FairMQTransportFactory
     virtual FairMQMessage* CreateMessage();
     virtual FairMQMessage* CreateMessage(size_t size);
     virtual FairMQMessage* CreateMessage(void* data, size_t size, fairmq_free_fn *ffn = NULL, void* hint = NULL);
-    virtual FairMQSocket* CreateSocket(const string& type, int num, int numIoThreads);
-    virtual FairMQPoller* CreatePoller(const vector<FairMQSocket*>& inputs);
+    virtual FairMQSocket* CreateSocket(const std::string& type, int num, int numIoThreads);
+    virtual FairMQPoller* CreatePoller(const std::vector<FairMQSocket*>& inputs);
 
     virtual ~FairMQTransportFactoryZMQ() {};
 };


### PR DESCRIPTION
FairMQDevice: Rename property for socket rate logging to have common format (old name is still available for compatibility).
FairMQ: Avoid using std namespace in class headers (may require adding std namespace to some child devices).
FairMQ: A bit of code cleanup
FairMQConfigurable: Stop with an error if a property assignment failed due to incorrect key.