### PR TITLE
FairMQStateMachine: add helper method to wait for the end of a state with a timeout

### DIFF
--- a/fairmq/CMakeLists.txt
+++ b/fairmq/CMakeLists.txt
@@ -141,7 +141,7 @@ install(FILES ${FairMQHDRFiles} DESTINATION include)
 
 set(DEPENDENCIES
   ${DEPENDENCIES}
-  boost_thread boost_timer boost_system boost_program_options boost_random
+  boost_thread boost_timer boost_system boost_program_options boost_random boost_chrono
 )
 
 set(LIBRARY_NAME FairMQ)

--- a/fairmq/FairMQDevice.cxx
+++ b/fairmq/FairMQDevice.cxx
@@ -103,12 +103,12 @@ void FairMQDevice::InitWrapper()
 
     Init();
 
-    // notify parent thread about end of processing.
-    boost::lock_guard<boost::mutex> lock(fInitializingMutex);
-    fInitializingFinished = true;
-    fInitializingCondition.notify_one();
-
     ChangeState(internal_DEVICE_READY);
+
+    // notify parent thread about end of processing.
+    boost::lock_guard<boost::mutex> lock(fStateMutex);
+    fStateFinished = true;
+    fStateCondition.notify_one();
 }
 
 void FairMQDevice::Init()
@@ -173,12 +173,12 @@ void FairMQDevice::InitTaskWrapper()
 {
     InitTask();
 
-    // notify parent thread about end of processing.
-    boost::lock_guard<boost::mutex> lock(fInitializingTaskMutex);
-    fInitializingTaskFinished = true;
-    fInitializingTaskCondition.notify_one();
-
     ChangeState(internal_READY);
+
+    // notify parent thread about end of processing.
+    boost::lock_guard<boost::mutex> lock(fStateMutex);
+    fStateFinished = true;
+    fStateCondition.notify_one();
 }
 
 void FairMQDevice::InitTask()
@@ -248,9 +248,9 @@ void FairMQDevice::RunWrapper()
     }
 
     // notify parent thread about end of processing.
-    boost::lock_guard<boost::mutex> lock(fRunningMutex);
-    fRunningFinished = true;
-    fRunningCondition.notify_one();
+    boost::lock_guard<boost::mutex> lock(fStateMutex);
+    fStateFinished = true;
+    fStateCondition.notify_one();
 }
 
 void FairMQDevice::Run()
@@ -278,12 +278,12 @@ void FairMQDevice::ResetTaskWrapper()
 {
     ResetTask();
 
-    // notify parent thread about end of processing.
-    boost::lock_guard<boost::mutex> lock(fResetTaskMutex);
-    fResetTaskFinished = true;
-    fResetTaskCondition.notify_one();
-
     ChangeState(internal_DEVICE_READY);
+
+    // notify parent thread about end of processing.
+    boost::lock_guard<boost::mutex> lock(fStateMutex);
+    fStateFinished = true;
+    fStateCondition.notify_one();
 }
 
 void FairMQDevice::ResetTask()
@@ -294,12 +294,12 @@ void FairMQDevice::ResetWrapper()
 {
     Reset();
 
-    // notify parent thread about end of processing.
-    boost::lock_guard<boost::mutex> lock(fResetMutex);
-    fResetFinished = true;
-    fResetCondition.notify_one();
-
     ChangeState(internal_IDLE);
+
+    // notify parent thread about end of processing.
+    boost::lock_guard<boost::mutex> lock(fStateMutex);
+    fStateFinished = true;
+    fStateCondition.notify_one();
 }
 
 void FairMQDevice::Reset()


### PR DESCRIPTION
- add helper method `bool WaitForEndOfStateForMs(state, durationInMs)`:
waits for the end of `state` for `durationInMs` milliseconds,
returns `true` if the state ended and `false` if it didn't.

- A little cleanup of the state machine code.