### PR TITLE
Added possibility to terminate timebased run

### DIFF
--- a/base/steer/FairRootManager.cxx
+++ b/base/steer/FairRootManager.cxx
@@ -466,6 +466,27 @@ TClonesArray* FairRootManager::GetData(TString branchName, BinaryFunctor* startF
 //_____________________________________________________________________________
 
 //_____________________________________________________________________________
+void FairRootManager::TerminateTSBuffer(TString branchName)
+{
+	if (fTSBufferMap.count(branchName) > 0){
+		fTSBufferMap[branchName]->Terminate();
+	}
+}
+//_____________________________________________________________________________
+
+//_____________________________________________________________________________
+
+void FairRootManager::TerminateAllTSBuffer()
+{
+	for (std::map<TString, FairTSBufferFunctional*>::iterator iter = fTSBufferMap.begin(); iter != fTSBufferMap.end(); iter++)
+	{
+		iter->second->Terminate();
+	}
+}
+
+//_____________________________________________________________________________
+
+//_____________________________________________________________________________
 Bool_t FairRootManager::AllDataProcessed()
 {
   for(std::map<TString, FairTSBufferFunctional*>::iterator it = fTSBufferMap.begin(); it != fTSBufferMap.end(); it++) {

--- a/base/steer/FairRootManager.h
+++ b/base/steer/FairRootManager.h
@@ -113,6 +113,8 @@ class FairRootManager : public TObject
     TClonesArray*     GetData(TString branchName, BinaryFunctor* function, Double_t parameter);
     TClonesArray*     GetData(TString branchName, BinaryFunctor* startFunction, Double_t startParameter, BinaryFunctor* stopFunction, Double_t stopParameter);
     void RegisterTSBuffer(TString branchName, FairTSBufferFunctional* functionalBuffer) {fTSBufferMap[branchName] = functionalBuffer;}
+    void TerminateTSBuffer(TString branchName);
+    void TerminateAllTSBuffer();
     FairTSBufferFunctional*   GetTSBuffer(TString branchName) {return fTSBufferMap[branchName];}
 
     /** static access method */

--- a/base/steer/FairTSBufferFunctional.cxx
+++ b/base/steer/FairTSBufferFunctional.cxx
@@ -31,6 +31,7 @@ FairTSBufferFunctional::FairTSBufferFunctional(TString branchName, TTree* source
    fBranch(NULL),
    fBranchIndex(-1),
    fStartIndex(-1),
+   fTerminate(kFALSE),
    fVerbose(0)
 {
   fBranch = sourceTree->GetBranch(branchName.Data());
@@ -266,6 +267,9 @@ void FairTSBufferFunctional::ReadInEntry(Int_t number)
 
 Bool_t FairTSBufferFunctional::AllDataProcessed()
 {
+  if (fTerminate == kTRUE){
+	return kTRUE;
+  }
   if (fBranchIndex + 1 >= fBranch->GetEntries()) {
     if(fBufferArray->GetEntriesFast() == 0) {
       if (fOutputArray->GetEntriesFast() == 0) {

--- a/base/steer/FairTSBufferFunctional.h
+++ b/base/steer/FairTSBufferFunctional.h
@@ -160,9 +160,10 @@ class FairTSBufferFunctional : public TObject
     TClonesArray* GetData(Double_t stopParameter);
     TClonesArray* GetData(Double_t startParameter, Double_t stopParameter);
     Int_t GetBranchIndex() {return fBranchIndex;}
-    void SetStartFunction(BinaryFunctor* function) {fStartFunction=function;}
-    void SetStopFunction(BinaryFunctor* function) {fStopFunction = function;}
+    void SetStartFunction(BinaryFunctor* function) { fStartFunction = function;}
+    void SetStopFunction(BinaryFunctor* function)  { fStopFunction  = function;}
     Bool_t AllDataProcessed();
+    void Terminate(){ fTerminate == kTRUE; }
 
     Bool_t TimeOut() {
       Bool_t stopTimeOut = fStopFunction->TimeOut();
@@ -199,6 +200,8 @@ class FairTSBufferFunctional : public TObject
     TBranch* fBranch;
     Int_t fBranchIndex;
     Int_t fStartIndex;
+
+    Bool_t fTerminate;
 
     Int_t fVerbose;
 


### PR DESCRIPTION
Modified FairTSBufferFunctional and FairRootManager to terminate the time based readout of data by setting a "Terminate" flag in the FairTSBufferFunctional