### PR TITLE
Fix the logger installation

### DIFF
--- a/cmake/modules/FindFairRoot.cmake
+++ b/cmake/modules/FindFairRoot.cmake
@@ -35,6 +35,18 @@ FIND_PATH(FAIRROOT_CMAKEMOD_DIR NAMES CMakeLists.txt  PATHS
   NO_DEFAULT_PATH
 )
 
+set(FAIRMQ_DEPENDENCIES
+  boost_log
+  boost_log_setup
+  boost_thread
+  boost_filesystem
+  boost_system
+  boost_date_time
+  boost_timer
+  boost_program_options
+  pthread
+  fairmq_logger
+)
 
 if(FAIRROOT_INCLUDE_DIR AND FAIRROOT_LIBRARY_DIR)
    set(FAIRROOT_FOUND TRUE)

--- a/fairmq/logger/CMakeLists.txt
+++ b/fairmq/logger/CMakeLists.txt
@@ -24,14 +24,16 @@ set(SRCS logger.cxx)
 set(LIBRARY_NAME fairmq_logger)
 
 set(DEPENDENCIES
-    boost_log 
-    boost_log_setup 
-    boost_thread 
-    boost_date_time 
-    boost_filesystem 
+    boost_log
+    boost_log_setup
+    boost_thread
+    boost_date_time
+    boost_filesystem
     boost_system
     pthread
   )
+
+install(FILES logger.h logger_def.h DESTINATION include/logger)
 
 GENERATE_LIBRARY()
 


### PR DESCRIPTION
- Fix installation of the new `logger.h` in FairRoot install directory. 
- set `FAIRMQ_DEPENDENCIES` cmake variable in `FindFairRoot.cmake` to contain the necessary FairMQ dependecies.