### PR TITLE
request for ROOTMacros.cmake update - after unsuccessfully install of "master" version

### DIFF
--- a/cmake/modules/ROOTMacros.cmake
+++ b/cmake/modules/ROOTMacros.cmake
@@ -122,6 +122,13 @@ Macro(ROOT_GENERATE_DICTIONARY_NEW)
     EndIf (CMAKE_SYSTEM_NAME MATCHES Linux)
   endif (ROOT_FOUND_VERSION GREATER 59999)
 
+  if (CMAKE_COMPILER_IS_GNUCXX)
+    exec_program(${CMAKE_C_COMPILER} ARGS "-dumpversion" OUTPUT_VARIABLE _gcc_version_info)
+    string(REGEX REPLACE "^([0-9]+).*$"                   "\\1" GCC_MAJOR ${_gcc_version_info})
+    if(${GCC_MAJOR} GREATER 4)
+      set_source_files_properties( ${Int_DICTIONARY} PROPERTIES COMPILE_DEFINITIONS R__ACCESS_IN_SYMBOL)
+    endif()
+  endif()
 
 endmacro(ROOT_GENERATE_DICTIONARY_NEW)
 

--- a/example/Tutorial1/macros/CMakeLists.txt
+++ b/example/Tutorial1/macros/CMakeLists.txt
@@ -9,20 +9,22 @@ GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/example/Tutorial1/macros/run_tutor
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/example/Tutorial1/macros/run_tutorial1_mesh.C)
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/example/Tutorial1/macros/run_tutorial1_urqmd.C)
 
+Set(MaxTestTime 60)
+
 ForEach(_mcEngine IN ITEMS TGeant3 TGeant4) 
   Add_Test(run_tutorial1_${_mcEngine} 
            ${CMAKE_BINARY_DIR}/example/Tutorial1/macros/run_tutorial1.sh 10 \"${_mcEngine}\")
-  Set_Tests_Properties(run_tutorial1_${_mcEngine} PROPERTIES TIMEOUT "30")
+  Set_Tests_Properties(run_tutorial1_${_mcEngine} PROPERTIES TIMEOUT ${MaxTestTime})
   Set_Tests_Properties(run_tutorial1_${_mcEngine} PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished successfully")
 
   Add_Test(run_tutorial1_mesh_${_mcEngine} 
            ${CMAKE_BINARY_DIR}/example/Tutorial1/macros/run_tutorial1_mesh.sh 10 \"${_mcEngine}\")
-  Set_Tests_Properties(run_tutorial1_mesh_${_mcEngine} PROPERTIES TIMEOUT "30")
+  Set_Tests_Properties(run_tutorial1_mesh_${_mcEngine} PROPERTIES TIMEOUT ${MaxTestTime})
   Set_Tests_Properties(run_tutorial1_mesh_${_mcEngine} PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished successfully")
 
   Add_Test(run_tutorial1_urqmd_${_mcEngine} 
            ${CMAKE_BINARY_DIR}/example/Tutorial1/macros/run_tutorial1_urqmd.sh 2 \"${_mcEngine}\")
-  Set_Tests_Properties(run_tutorial1_urqmd_${_mcEngine} PROPERTIES TIMEOUT "30")
+  Set_Tests_Properties(run_tutorial1_urqmd_${_mcEngine} PROPERTIES TIMEOUT ${MaxTestTime})
   Set_Tests_Properties(run_tutorial1_urqmd_${_mcEngine} PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished successfully")
 EndForEach(_mcEngine IN ITEMS TGeant3 TGeant4) 
 

--- a/example/Tutorial2/macros/CMakeLists.txt
+++ b/example/Tutorial2/macros/CMakeLists.txt
@@ -5,24 +5,27 @@
  #         GNU Lesser General Public Licence version 3 (LGPL) version 3,        #  
  #                  copied verbatim in the file "LICENSE"                       #
  ################################################################################
+
+Set(MaxTestTime 60)
+
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/example/Tutorial2/macros/run_tutorial2.C)
 add_test(run_tutorial2 ${CMAKE_BINARY_DIR}/example/Tutorial2/macros/run_tutorial2.sh)
-SET_TESTS_PROPERTIES(run_tutorial2 PROPERTIES TIMEOUT "30")
+SET_TESTS_PROPERTIES(run_tutorial2 PROPERTIES TIMEOUT ${MaxTestTime})
 SET_TESTS_PROPERTIES(run_tutorial2 PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished successfully")
 
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/example/Tutorial2/macros/run_bg.C)
 add_test(run_bg ${CMAKE_BINARY_DIR}/example/Tutorial2/macros/run_bg.sh)
-SET_TESTS_PROPERTIES(run_bg PROPERTIES TIMEOUT "30")
+SET_TESTS_PROPERTIES(run_bg PROPERTIES TIMEOUT ${MaxTestTime})
 SET_TESTS_PROPERTIES(run_bg PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished successfully")
 
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/example/Tutorial2/macros/run_sg.C)
 add_test(run_sg ${CMAKE_BINARY_DIR}/example/Tutorial2/macros/run_sg.sh)
-SET_TESTS_PROPERTIES(run_sg PROPERTIES TIMEOUT "30")
+SET_TESTS_PROPERTIES(run_sg PROPERTIES TIMEOUT ${MaxTestTime})
 SET_TESTS_PROPERTIES(run_sg PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished successfully")
 
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/example/Tutorial2/macros/run_sg1.C)
 add_test(run_sg1 ${CMAKE_BINARY_DIR}/example/Tutorial2/macros/run_sg1.sh)
-SET_TESTS_PROPERTIES(run_sg1 PROPERTIES TIMEOUT "30")
+SET_TESTS_PROPERTIES(run_sg1 PROPERTIES TIMEOUT ${MaxTestTime})
 SET_TESTS_PROPERTIES(run_sg1 PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished successfully")
 
 
@@ -31,19 +34,19 @@ add_test(create_digis_mixed ${CMAKE_BINARY_DIR}/example/Tutorial2/macros/create_
 SET_TESTS_PROPERTIES(create_digis_mixed PROPERTIES DEPENDS run_bg)
 SET_TESTS_PROPERTIES(create_digis_mixed PROPERTIES DEPENDS run_sg)
 SET_TESTS_PROPERTIES(create_digis_mixed PROPERTIES DEPENDS run_sg1)
-SET_TESTS_PROPERTIES(create_digis_mixed PROPERTIES TIMEOUT "30")
+SET_TESTS_PROPERTIES(create_digis_mixed PROPERTIES TIMEOUT ${MaxTestTime})
 SET_TESTS_PROPERTIES(create_digis_mixed PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished successfully")
 
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/example/Tutorial2/macros/create_digis.C)
 add_test(create_digis ${CMAKE_BINARY_DIR}/example/Tutorial2/macros/create_digis.sh)
 SET_TESTS_PROPERTIES(create_digis PROPERTIES DEPENDS run_tutorial2)
-SET_TESTS_PROPERTIES(create_digis PROPERTIES TIMEOUT "30")
+SET_TESTS_PROPERTIES(create_digis PROPERTIES TIMEOUT ${MaxTestTime})
 SET_TESTS_PROPERTIES(create_digis PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished successfully")
 
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/example/Tutorial2/macros/read_digis.C)
 add_test(read_digis ${CMAKE_BINARY_DIR}/example/Tutorial2/macros/read_digis.sh)
 SET_TESTS_PROPERTIES(read_digis PROPERTIES DEPENDS create_digis)
-SET_TESTS_PROPERTIES(read_digis PROPERTIES TIMEOUT "30")
+SET_TESTS_PROPERTIES(read_digis PROPERTIES TIMEOUT ${MaxTestTime})
 SET_TESTS_PROPERTIES(read_digis PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished successfully")
 
 

--- a/example/Tutorial3/macro/CMakeLists.txt
+++ b/example/Tutorial3/macro/CMakeLists.txt
@@ -5,6 +5,10 @@
  #         GNU Lesser General Public Licence version 3 (LGPL) version 3,        #  
  #                  copied verbatim in the file "LICENSE"                       #
  ################################################################################
+
+
+Set(MaxTestTime 60)
+
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/example/Tutorial3/macro/run_sim.C)
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/example/Tutorial3/macro/run_digi.C)
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/example/Tutorial3/macro/run_reco.C)
@@ -14,30 +18,31 @@ GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/example/Tutorial3/macro/run_reco_t
 ForEach(_mcEngine IN ITEMS TGeant3 TGeant4) 
   Add_Test(run_sim_${_mcEngine} 
            ${CMAKE_BINARY_DIR}/example/Tutorial3/macro/run_sim.sh 100 \"${_mcEngine}\")
-  Set_Tests_Properties(run_sim_${_mcEngine} PROPERTIES TIMEOUT "180")
+  Math(EXPR TestTime 3*${MaxTestTime})
+  Set_Tests_Properties(run_sim_${_mcEngine} PROPERTIES TIMEOUT ${TestTime})
   Set_Tests_Properties(run_sim_${_mcEngine} PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished successfully")
 
   Add_Test(run_digi_${_mcEngine} ${CMAKE_BINARY_DIR}/example/Tutorial3/macro/run_digi.sh \"${_mcEngine}\")
   Set_Tests_Properties(run_digi_${_mcEngine} PROPERTIES DEPENDS run_sim_${_mcEngine})
-  Set_Tests_Properties(run_digi_${_mcEngine} PROPERTIES TIMEOUT "30")
+  Set_Tests_Properties(run_digi_${_mcEngine} PROPERTIES TIMEOUT ${MaxTestTime})
   Set_Tests_Properties(run_digi_${_mcEngine} PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished successfully")
 
 
   Add_Test(run_reco_${_mcEngine} ${CMAKE_BINARY_DIR}/example/Tutorial3/macro/run_reco.sh \"${_mcEngine}\")
   Set_Tests_Properties(run_reco_${_mcEngine} PROPERTIES DEPENDS run_digi_${_mcEngine})
-  Set_Tests_Properties(run_reco_${_mcEngine} PROPERTIES TIMEOUT "30")
+  Set_Tests_Properties(run_reco_${_mcEngine} PROPERTIES TIMEOUT ${MaxTestTime})
   Set_Tests_Properties(run_reco_${_mcEngine} PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished successfully")
 
 
   Add_Test(run_digi_timebased_${_mcEngine} ${CMAKE_BINARY_DIR}/example/Tutorial3/macro/run_digi_timebased.sh \"${_mcEngine}\")
   Set_Tests_Properties(run_digi_timebased_${_mcEngine} PROPERTIES DEPENDS run_sim_${_mcEngine})
-  Set_Tests_Properties(run_digi_timebased_${_mcEngine} PROPERTIES TIMEOUT "30")
+  Set_Tests_Properties(run_digi_timebased_${_mcEngine} PROPERTIES TIMEOUT ${MaxTestTime})
   Set_Tests_Properties(run_digi_timebased_${_mcEngine} PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished successfully")
 
 
   Add_Test(run_reco_timebased_${_mcEngine} ${CMAKE_BINARY_DIR}/example/Tutorial3/macro/run_reco_timebased.sh \"${_mcEngine}\")
   Set_Tests_Properties(run_reco_timebased_${_mcEngine} PROPERTIES DEPENDS run_digi_timebased_${_mcEngine})
-  Set_Tests_Properties(run_reco_timebased_${_mcEngine} PROPERTIES TIMEOUT "30")
+  Set_Tests_Properties(run_reco_timebased_${_mcEngine} PROPERTIES TIMEOUT ${MaxTestTime})
   Set_Tests_Properties(run_reco_timebased_${_mcEngine} PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished successfully")
 EndForEach(_mcEngine IN ITEMS TGeant3 TGeant4) 
 

--- a/example/Tutorial4/macros/CMakeLists.txt
+++ b/example/Tutorial4/macros/CMakeLists.txt
@@ -8,18 +8,19 @@
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/example/Tutorial4/macros/run_tutorial4.C)
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/example/Tutorial4/macros/run_reco.C)
 
+Set(MaxTestTime 60)
 
 ForEach(_mcEngine IN ITEMS TGeant3 TGeant4) 
   Add_Test(run_tutorial4_${_mcEngine} 
            ${CMAKE_BINARY_DIR}/example/Tutorial4/macros/run_tutorial4.sh 10 \"${_mcEngine}\")
-  Set_Tests_Properties(run_tutorial4_${_mcEngine} PROPERTIES TIMEOUT "30")
+  Set_Tests_Properties(run_tutorial4_${_mcEngine} PROPERTIES TIMEOUT ${MaxTestTime})
   Set_Tests_Properties(run_tutorial4_${_mcEngine} PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished successfully")
 
 
   Add_Test(run_reco_tut4_${_mcEngine} 
            ${CMAKE_BINARY_DIR}/example/Tutorial4/macros/run_reco.sh \"${_mcEngine}\")
   Set_Tests_Properties(run_reco_tut4_${_mcEngine} PROPERTIES DEPENDS run_tutorial4_${_mcEngine})
-  Set_Tests_Properties(run_reco_tut4_${_mcEngine} PROPERTIES TIMEOUT "30")
+  Set_Tests_Properties(run_reco_tut4_${_mcEngine} PROPERTIES TIMEOUT ${MaxTestTime})
   Set_Tests_Properties(run_reco_tut4_${_mcEngine} PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished successfully")
 EndForEach(_mcEngine IN ITEMS TGeant3 TGeant4) 
 

--- a/example/Tutorial6/macros/CMakeLists.txt
+++ b/example/Tutorial6/macros/CMakeLists.txt
@@ -8,15 +8,18 @@
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/example/Tutorial6/macros/run_sim.C)
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/example/Tutorial6/macros/run_digi.C)
 
+Set(MaxTestTime 60)
+
 ForEach(_mcEngine IN ITEMS TGeant3 TGeant4) 
   Add_Test(run_sim_Tut6_${_mcEngine} 
            ${CMAKE_BINARY_DIR}/example/Tutorial6/macros/run_sim.sh 100 \"${_mcEngine}\")
-  Set_Tests_Properties(run_sim_Tut6_${_mcEngine} PROPERTIES TIMEOUT "180")
+  Math(EXPR TestTime 3*${MaxTestTime})
+  Set_Tests_Properties(run_sim_Tut6_${_mcEngine} PROPERTIES TIMEOUT ${TestTime})
   Set_Tests_Properties(run_sim_Tut6_${_mcEngine} PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished successfully")
 
   Add_Test(run_digi_Tut6_${_mcEngine} ${CMAKE_BINARY_DIR}/example/Tutorial6/macros/run_digi.sh \"${_mcEngine}\")
   Set_Tests_Properties(run_digi_Tut6_${_mcEngine} PROPERTIES DEPENDS run_sim_Tut6_${_mcEngine})
-  Set_Tests_Properties(run_digi_Tut6_${_mcEngine} PROPERTIES TIMEOUT "30")
+  Set_Tests_Properties(run_digi_Tut6_${_mcEngine} PROPERTIES TIMEOUT ${MaxTestTime})
   Set_Tests_Properties(run_digi_Tut6_${_mcEngine} PROPERTIES PASS_REGULAR_EXPRESSION "Test passed;All ok")
 
   EndForEach(_mcEngine IN ITEMS TGeant3 TGeant4) 

--- a/example/rutherford/macros/CMakeLists.txt
+++ b/example/rutherford/macros/CMakeLists.txt
@@ -8,15 +8,17 @@
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/example/rutherford/macros/run_rutherford.C)
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/example/rutherford/macros/run_rad.C)
 
+Set(MaxTestTime 60)
+
 ForEach(_mcEngine IN ITEMS TGeant3 TGeant4) 
   Add_Test(run_rutherford_${_mcEngine}
             ${CMAKE_BINARY_DIR}/example/rutherford/macros/run_rutherford.sh 10 \"${_mcEngine}\")
-  Set_Tests_Properties(run_rutherford_${_mcEngine} PROPERTIES TIMEOUT "30")
+  Set_Tests_Properties(run_rutherford_${_mcEngine} PROPERTIES TIMEOUT ${MaxTestTime})
   Set_Tests_Properties(run_rutherford_${_mcEngine} PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished successfully")
 
   Add_Test(run_rad_${_mcEngine} 
            ${CMAKE_BINARY_DIR}/example/rutherford/macros/run_rad.sh 100 \"${_mcEngine}\")
-  Set_Tests_Properties(run_rad_${_mcEngine} PROPERTIES TIMEOUT "30")
+  Set_Tests_Properties(run_rad_${_mcEngine} PROPERTIES TIMEOUT ${MaxTestTime})
   Set_Tests_Properties(run_rad_${_mcEngine} PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished successfully")
 EndForEach(_mcEngine IN ITEMS TGeant3 TGeant4) 
 


### PR DESCRIPTION
Hello,

I try to install FairRoot on fc22, gcc-5.1.1, FairSoft(mar15p2) and I didn't succeed to install the standard version ("master" version), as it comes from FairRoot repository (git clone https://github.com/FairRootGroup/FairRoot.git). It crashes with the following error:
-------------------------------------------------------------------------------------------------------------------------------
In file included from  Path_to_FairRoot/source/example/Tutorial3/data/FairTestDetectorDigi.h:25:0,
                 from Path_to_FairRoot/source/example/Tutorial3/data/FairTestDetectorPayload.h:19,
                 from Path_to_FairRoot/build/example/Tutorial3/G__FairTestDetectorDict.h:41,
                 from Path_to_FairRoot/build/example/Tutorial3/G__FairTestDetectorDict.cxx:17:
/usr/include/c++/5.1.1/sstream:335:7: error: ‘struct std::basic_stringbuf<_CharT, _Traits, _Alloc>::__xfer_bufptrs’ redeclared with different access struct __xfer_bufptrs
       ^
example/Tutorial3/CMakeFiles/FairTestDetector.dir/build.make:523: recipe for target 'example/Tutorial3/CMakeFiles/FairTestDetector.dir/G__FairTestDetectorDict.cxx.o' failed
----------------------------------------------------------------------------------------------------------------------------

After searching what cause the error I found that the missing lines from cmake/modules/ROOTMacros.cmake, comparing with "RC-v-15.07" version (from 125 to 131 line number), is the problem. 

Please consider to update the ROOTMacros.cmake for "master" version.

Regards,
Madalin