### PR TITLE
Fix backward compability issue in the fairmq logger

### DIFF
--- a/fairmq/logger/CMakeLists.txt
+++ b/fairmq/logger/CMakeLists.txt
@@ -19,8 +19,11 @@ set(LINK_DIRECTORIES ${Boost_LIBRARY_DIRS})
 
 link_directories(${LINK_DIRECTORIES})
 
-set(SRCS logger.cxx)
-
+if(NOT ("${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}" VERSION_LESS "1.56") )
+    set(SRCS logger.cxx)
+else()
+    set(SRCS logger_oldboost_version.cxx)
+endif()
 set(LIBRARY_NAME fairmq_logger)
 
 set(DEPENDENCIES

--- a/fairmq/logger/fairroot_null_deleter.h
+++ b/fairmq/logger/fairroot_null_deleter.h
@@ -1,0 +1,27 @@
+/* 
+ * File:   fairroot_null_deleter.h
+ * Author: winckler
+ *
+ * Created on September 21, 2015, 11:50 AM
+ */
+
+#ifndef FAIRROOT_NULL_DELETER_H
+#define	FAIRROOT_NULL_DELETER_H
+// boost like null_deleter introduced for backward compability if boost version < 1.56
+
+namespace fairroot
+{
+    struct null_deleter
+    {
+        //! Function object result type
+        typedef void result_type;
+        /*!
+         * Does nothing
+         */
+        template< typename T >
+        void operator() (T*) const noexcept {}
+    };
+
+}
+#endif	/* FAIRROOT_NULL_DELETER_H */
+

--- a/fairmq/logger/logger_oldboost_version.cxx
+++ b/fairmq/logger/logger_oldboost_version.cxx
@@ -1,3 +1,7 @@
+
+
+// fix backward compability issue with boost<1.56
+
 /********************************************************************************
  *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
  *                                                                              *
@@ -14,7 +18,7 @@
 #include <boost/log/sinks/text_ostream_backend.hpp>
 #include <boost/log/sources/severity_logger.hpp>
 #include <boost/log/support/date_time.hpp>
-#include <boost/core/null_deleter.hpp>
+
 #include <boost/log/sinks/text_file_backend.hpp>
 #include <boost/log/utility/setup/common_attributes.hpp>
 #include <boost/make_shared.hpp>
@@ -22,7 +26,7 @@
 #include <fstream>
 #include <ostream>
 
-
+#include "fairroot_null_deleter.h"
 
 namespace logging = boost::log;
 namespace src = boost::log::sources;
@@ -46,8 +50,7 @@ void init_log_console()
     typedef sinks::synchronous_sink<sinks::text_ostream_backend> text_sink;
     boost::shared_ptr<text_sink> sink = boost::make_shared<text_sink>();
     // add "console" output stream to our sink
-    //sink->locked_backend()->add_stream(boost::shared_ptr<std::ostream>(&std::clog, boost::null_deleter()));
-    sink->locked_backend()->add_stream(boost::shared_ptr<std::ostream>(&std::clog));
+    sink->locked_backend()->add_stream(boost::shared_ptr<std::ostream>(&std::clog, fairroot::null_deleter()));
     
     // specify the format of the log message 
     sink->set_formatter(&init_log_formatter<tag_console>);


### PR DESCRIPTION
add an other fairmq logger implementation in case boost version < 1.56 for backward compability