### PR TITLE
FairMQ Examples cleanup

### DIFF
--- a/base/MQ/devices/FairMQSampler.h
+++ b/base/MQ/devices/FairMQSampler.h
@@ -56,7 +56,8 @@ class FairMQSampler : public FairMQDevice
         InputFile = FairMQDevice::Last,
         ParFile,
         Branch,
-        EventRate
+        EventRate,
+        Last
     };
 
     FairMQSampler();
@@ -68,6 +69,9 @@ class FairMQSampler : public FairMQDevice
     virtual std::string GetProperty(const int key, const std::string& default_ = "");
     virtual void SetProperty(const int key, const int value);
     virtual int GetProperty(const int key, const int default_ = 0);
+
+    virtual std::string GetPropertyDescription(const int key);
+    virtual void ListProperties();
 
     /**
      * Sends the currently available output of the Sampler Task as part of a multipart message

--- a/base/MQ/devices/FairMQSampler.tpl
+++ b/base/MQ/devices/FairMQSampler.tpl
@@ -208,3 +208,32 @@ int FairMQSampler<Loader>::GetProperty(const int key, const int default_/*= 0*/)
             return FairMQDevice::GetProperty(key, default_);
     }
 }
+
+template <typename Loader>
+std::string FairMQSampler<Loader>::GetPropertyDescription(const int key)
+{
+    switch (key)
+    {
+        case InputFile:
+            return "InputFile: Input ROOT file.";
+        case ParFile:
+            return "ParFile: Input Parameter file.";
+        case Branch:
+            return "Branch: Name of the Branch (e.g. FairTestDetectorDigi).";
+        case EventRate:
+            return "EventRate: Upper limit for the message rate.";
+        default:
+            return FairMQDevice::GetPropertyDescription(key);
+    }
+}
+
+template <typename Loader>
+void FairMQSampler<Loader>::ListProperties()
+{
+    LOG(INFO) << "Properties of FairMQSampler:";
+    for (int p = FairMQConfigurable::Last; p < FairMQSampler::Last; ++p)
+    {
+        LOG(INFO) << " " << GetPropertyDescription(p);
+    }
+    LOG(INFO) << "---------------------------";
+}

--- a/cmake/modules/FindDDS.cmake
+++ b/cmake/modules/FindDDS.cmake
@@ -6,15 +6,17 @@
 #                  copied verbatim in the file "LICENSE"                       #
 ################################################################################
 
+MESSAGE(STATUS "Looking for DDS...")
+
 find_path(DDS_INCLUDE_DIR NAMES KeyValue.h PATHS
   ${DDS_PATH}/include
   ${SIMPATH}/DDS/include
   NO_DEFAULT_PATH
 )
 
-find_path(DDS_LIBRARY_DIR NAMES libdds-key-value-lib.so PATHS
-  ${DDS_PATH}/lib
-  ${SIMPATH}/DDS/lib
+find_path(DDS_LIBRARY_DIR NAMES libdds-key-value-lib.dylib libdds-key-value-lib.so
+  PATHS ${DDS_PATH}/lib
+  PATHS ${SIMPATH}/DDS/lib
   NO_DEFAULT_PATH
 )
 

--- a/cmake/modules/FindProtobuf.cmake
+++ b/cmake/modules/FindProtobuf.cmake
@@ -74,6 +74,8 @@
 # (To distribute this file outside of CMake, substitute the full
 #  License text for the above reference.)
 
+MESSAGE(STATUS "Looking for Protobuf...")
+
 function(PROTOBUF_GENERATE_CPP SRCS HDRS)
   if(NOT ARGN)
     message(SEND_ERROR "Error: PROTOBUF_GENERATE_CPP() called without any proto files")

--- a/cmake/modules/FindZeroMQ.cmake
+++ b/cmake/modules/FindZeroMQ.cmake
@@ -5,12 +5,10 @@
  #         GNU Lesser General Public Licence version 3 (LGPL) version 3,        #  
  #                  copied verbatim in the file "LICENSE"                       #
  ################################################################################
-set(ZMQ_H zmq.hpp)
-set(ZMQ_UTILS_H zmq_utils.h)
-set(LIBZMQ_SHARED libzmq.dylib libzmq.so)
-set(LIBZMQ_STATIC libzmq.a)
 
-find_path(ZMQ_INCLUDE_DIR NAMES ${ZMQ_H} ${ZMQ_UTILS_H}
+MESSAGE(STATUS "Looking for ZeroMQ...")
+
+find_path(ZMQ_INCLUDE_DIR NAMES zmq.hpp zmq_utils.h
   PATHS ${ZMQ_DIR}/include
   PATHS ${AlFa_DIR}/include
   PATHS ${SIMPATH}/include
@@ -18,20 +16,20 @@ find_path(ZMQ_INCLUDE_DIR NAMES ${ZMQ_H} ${ZMQ_UTILS_H}
   DOC   "Path to ZeroMQ include header files."
 )
 
-find_library(ZMQ_LIBRARY_SHARED NAMES ${LIBZMQ_SHARED}
+find_library(ZMQ_LIBRARY_SHARED NAMES libzmq.dylib libzmq.so
   PATHS ${ZMQ_DIR}/lib
   PATHS ${AlFa_DIR}/lib
   PATHS ${SIMPATH}/lib
   NO_DEFAULT_PATH
-  DOC   "Path to ${LIBZMQ_SHARED}."
+  DOC   "Path to libzmq.dylib libzmq.so."
 )
 
-find_library(ZMQ_LIBRARY_STATIC NAMES ${LIBZMQ_STATIC}
+find_library(ZMQ_LIBRARY_STATIC NAMES libzmq.a
   PATHS ${ZMQ_DIR}/lib
   PATHS ${AlFa_DIR}/lib
   PATHS ${SIMPATH}/lib
   NO_DEFAULT_PATH
-  DOC   "Path to ${LIBZMQ_STATIC}."
+  DOC   "Path to libzmq.a."
 )
 
 IF(ZMQ_INCLUDE_DIR AND ZMQ_LIBRARY_SHARED AND ZMQ_LIBRARY_STATIC)

--- a/cmake/modules/Findnanomsg.cmake
+++ b/cmake/modules/Findnanomsg.cmake
@@ -5,13 +5,8 @@
  #         GNU Lesser General Public Licence version 3 (LGPL) version 3,        #  
  #                  copied verbatim in the file "LICENSE"                       #
  ################################################################################
-if (APPLE)
-  set(LIBNANOMSG_SHARED libnanomsg.dylib)
-else (APPLE)
-  set(LIBNANOMSG_SHARED libnanomsg.so)
-endIf (APPLE)
 
-set(LIBNANOMSG_STATIC libnanomsg.a)
+MESSAGE(STATUS "Looking for nanomsg...")
 
 find_path(NANOMSG_INCLUDE_DIR NAMES nn.h
   PATHS ${SIMPATH}/include/nanomsg
@@ -19,16 +14,16 @@ find_path(NANOMSG_INCLUDE_DIR NAMES nn.h
   DOC   "Path to nanomsg include header files."
 )
 
-find_library(NANOMSG_LIBRARY_SHARED NAMES ${LIBNANOMSG_SHARED}
+find_library(NANOMSG_LIBRARY_SHARED NAMES libnanomsg.dylib libnanomsg.so
   PATHS ${SIMPATH}/lib
   NO_DEFAULT_PATH
-  DOC   "Path to ${LIBNANOMSG_SHARED}."
+  DOC   "Path to libnanomsg.dylib libnanomsg.so."
 )
 
-find_library(NANOMSG_LIBRARY_STATIC NAMES ${LIBNANOMSG_STATIC}
+find_library(NANOMSG_LIBRARY_STATIC NAMES libnanomsg.a
   PATHS ${SIMPATH}/lib
   NO_DEFAULT_PATH
-  DOC   "Path to ${LIBNANOMSG_STATIC}."
+  DOC   "Path to libnanomsg.a."
 )
 
 if(NANOMSG_INCLUDE_DIR AND NANOMSG_LIBRARY_SHARED AND NANOMSG_LIBRARY_STATIC)

--- a/example/Tutorial3/CMakeLists.txt
+++ b/example/Tutorial3/CMakeLists.txt
@@ -34,7 +34,7 @@ Set(SYSTEM_INCLUDE_DIRECTORIES
 Include_Directories(${INCLUDE_DIRECTORIES})
 Include_Directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
 
-If (Boost_FOUND)
+If (Boost_FOUND AND POS_C++11)
   configure_file(${CMAKE_SOURCE_DIR}/example/Tutorial3/macro/startAll.sh.in ${CMAKE_BINARY_DIR}/bin/startAll.sh)
   configure_file(${CMAKE_SOURCE_DIR}/example/Tutorial3/macro/startAllProxy.sh.in ${CMAKE_BINARY_DIR}/bin/startAllProxy.sh)
   configure_file(${CMAKE_SOURCE_DIR}/example/Tutorial3/macro/startPushPull.sh.in ${CMAKE_BINARY_DIR}/bin/startPushPull.sh)
@@ -44,7 +44,7 @@ If (Boost_FOUND)
   # following scripts are only for protobuf tests and are not essential part of FairMQ
   # configure_file(${CMAKE_SOURCE_DIR}/example/Tutorial3/macro/startBin.sh.in ${CMAKE_BINARY_DIR}/bin/startBin.sh)
   # configure_file(${CMAKE_SOURCE_DIR}/example/Tutorial3/macro/startProto.sh.in ${CMAKE_BINARY_DIR}/bin/startProto.sh)
-EndIf (Boost_FOUND)
+EndIf (Boost_FOUND AND POS_C++11)
 
 Set(LINK_DIRECTORIES
   ${ROOT_LIBRARY_DIR}
@@ -82,7 +82,7 @@ Set(SRCS
   timeBasedSimulation/FairTestDetectorTimeRecoTask.cxx
 )
 
-If (Boost_FOUND)
+If (Boost_FOUND AND POS_C++11)
   Set(SRCS
     ${SRCS}
     data/FairTestDetectorDigi.cxx
@@ -102,23 +102,23 @@ If (Boost_FOUND)
     ${NO_DICT_SRCS}
     ${CMAKE_CURRENT_BINARY_DIR}/FairTestDetectorPayload.pb.cc
   )
-EndIf (Boost_FOUND)
+EndIf (Boost_FOUND AND POS_C++11)
 
 Set(LINKDEF FairTestDetectorLinkDef.h)
 Set(LIBRARY_NAME FairTestDetector)
 
-If (Boost_FOUND)
+If (Boost_FOUND AND POS_C++11)
   Set(DEPENDENCIES
     Base MCStack FairMQ BaseMQ boost_thread boost_system boost_serialization boost_program_options)
-Else (Boost_FOUND)
+Else (Boost_FOUND AND POS_C++11)
   Set(DEPENDENCIES Base MCStack)
-EndIf (Boost_FOUND)
+EndIf (Boost_FOUND AND POS_C++11)
 
 GENERATE_LIBRARY()
 
 Add_Subdirectory(macro)
 
-If (Boost_FOUND)
+If (Boost_FOUND AND POS_C++11)
   Set(Exe_Names
     testDetectorSampler
     testDetectorProcessor
@@ -128,7 +128,7 @@ If (Boost_FOUND)
   set(Exe_Source
     run/runTestDetectorSampler.cxx
     run/runTestDetectorProcessor.cxx
-    run/runFileSink.cxx
+    run/runTestDetectorFileSink.cxx
     )
 
   List(LENGTH Exe_Names _length)
@@ -142,4 +142,4 @@ If (Boost_FOUND)
     Set(DEPENDENCIES FairTestDetector)
     GENERATE_EXECUTABLE()
   EndForEach(_file RANGE 0 ${_length})
-EndIf (Boost_FOUND)
+EndIf (Boost_FOUND AND POS_C++11)

--- a/example/Tutorial3/data/FairTestDetectorFileSink.cxx
+++ b/example/Tutorial3/data/FairTestDetectorFileSink.cxx
@@ -6,8 +6,9 @@
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
 /**
- * File:   TestDetectorDigiLoader.cxx
- * Author: winckler
+ * FairTestDetectorFileSink.cxx
  *
- * Created on February 8, 2014, 1:48 AM
+ * @since 2013-06-05
+ * @author A. Rybalchenko
  */
+// must be empty. Template function members defined in .h and .tpl

--- a/example/Tutorial3/data/FairTestDetectorFileSink.h
+++ b/example/Tutorial3/data/FairTestDetectorFileSink.h
@@ -6,14 +6,14 @@
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
 /**
- * FairMQFileSink.h
+ * FairTestDetectorFileSink.h
  *
  * @since 2013-06-05
  * @author A. Rybalchenko
  */
 
-#ifndef FAIRMQFILESINK_H_
-#define FAIRMQFILESINK_H_
+#ifndef FAIRTESTDETECTORFILESINK_H_
+#define FAIRTESTDETECTORFILESINK_H_
 
 #include <iostream>
 
@@ -31,9 +31,7 @@
 #include "FairTestDetectorPayload.h"
 #include "FairTestDetectorHit.h"
 
-#if __cplusplus >= 201103L
 #include "baseMQtools.h"
-#endif
 
 #include "TMessage.h"
 
@@ -54,11 +52,11 @@ class TClonesArray;
 using namespace std;
 
 template <typename TIn, typename TPayloadIn>
-class FairMQFileSink : public FairMQDevice
+class FairTestDetectorFileSink : public FairMQDevice
 {
   public:
-    FairMQFileSink();
-    virtual ~FairMQFileSink();
+    FairTestDetectorFileSink();
+    virtual ~FairTestDetectorFileSink();
     virtual void InitOutputFile(TString defaultId = "100");
 
     template <class Archive>
@@ -81,11 +79,11 @@ class FairMQFileSink : public FairMQDevice
 #endif // for BOOST serialization
 
     /// Copy Constructor
-    FairMQFileSink(const FairMQFileSink&);
-    FairMQFileSink operator=(const FairMQFileSink&);
+    FairTestDetectorFileSink(const FairTestDetectorFileSink&);
+    FairTestDetectorFileSink operator=(const FairTestDetectorFileSink&);
 };
 
-////////// Template implementation of Run() in FairMQFileSink.tpl :
-#include "FairMQFileSink.tpl"
+////////// Template implementation of Run() in FairTestDetectorFileSink.tpl :
+#include "FairTestDetectorFileSink.tpl"
 
-#endif /* FAIRMQFILESINK_H_ */
+#endif /* FAIRTESTDETECTORFILESINK_H_ */

--- a/example/Tutorial3/data/FairTestDetectorFileSink.tpl
+++ b/example/Tutorial3/data/FairTestDetectorFileSink.tpl
@@ -1,36 +1,32 @@
 /*
- * File:   FairMQFileSink.tpl
+ * File:   FairTestDetectorFileSink.tpl
  * Author: winckler, A. Rybalchenko
  *
  * Created on March 11, 2014, 12:12 PM
  */
 
 template <typename TIn, typename TPayloadIn>
-FairMQFileSink<TIn, TPayloadIn>::FairMQFileSink()
+FairTestDetectorFileSink<TIn, TPayloadIn>::FairTestDetectorFileSink()
     : fOutFile(NULL)
     , fTree(NULL)
     , fOutput(NULL)
     , fHitVector()
-    , fHasBoostSerialization()
+    , fHasBoostSerialization(false)
 {
     gSystem->ResetSignal(kSigInterrupt);
     gSystem->ResetSignal(kSigTermination);
 
-    fHasBoostSerialization = true;
-#if __cplusplus >= 201103L
     using namespace baseMQ::tools::resolve;
-    fHasBoostSerialization = false;
     // coverity[pointless_expression]: suppress coverity warnings on apparant if(const).
     if (is_same<TPayloadIn, boost::archive::binary_iarchive>::value || is_same<TPayloadIn, boost::archive::text_iarchive>::value)
     {
         if (has_BoostSerialization<TIn, void(TPayloadIn&, const unsigned int)>::value == 1)
             fHasBoostSerialization = true;
     }
-#endif
 }
 
 template <typename TIn, typename TPayloadIn>
-FairMQFileSink<TIn, TPayloadIn>::~FairMQFileSink()
+FairTestDetectorFileSink<TIn, TPayloadIn>::~FairTestDetectorFileSink()
 {
     fTree->Write();
     fOutFile->Close();
@@ -39,7 +35,7 @@ FairMQFileSink<TIn, TPayloadIn>::~FairMQFileSink()
 }
 
 template <typename TIn, typename TPayloadIn>
-void FairMQFileSink<TIn, TPayloadIn>::InitOutputFile(TString defaultId)
+void FairTestDetectorFileSink<TIn, TPayloadIn>::InitOutputFile(TString defaultId)
 {
     fOutput = new TClonesArray("FairTestDetectorHit");
     char out[256];
@@ -50,10 +46,10 @@ void FairMQFileSink<TIn, TPayloadIn>::InitOutputFile(TString defaultId)
     fTree->Branch("Output", "TClonesArray", &fOutput, 64000, 99);
 }
 
-// ----- Implementation of FairMQFileSink::Run() with Boost transport data format -----
+// ----- Implementation of FairTestDetectorFileSink::Run() with Boost transport data format -----
 
 template <typename TIn, typename TPayloadIn>
-void FairMQFileSink<TIn, TPayloadIn>::Run()
+void FairTestDetectorFileSink<TIn, TPayloadIn>::Run()
 {
     if (fHasBoostSerialization)
     {
@@ -92,7 +88,7 @@ void FairMQFileSink<TIn, TPayloadIn>::Run()
 
                 if (fOutput->IsEmpty())
                 {
-                    LOG(ERROR) << "FairMQFileSink::Run(): No Output array!";
+                    LOG(ERROR) << "FairTestDetectorFileSink::Run(): No Output array!";
                 }
 
                 fTree->Fill();
@@ -112,10 +108,10 @@ void FairMQFileSink<TIn, TPayloadIn>::Run()
     }
 }
 
-// ----- Implementation of FairMQFileSink::Run() with pure binary transport data format -----
+// ----- Implementation of FairTestDetectorFileSink::Run() with pure binary transport data format -----
 
 template <>
-void FairMQFileSink<FairTestDetectorHit, TestDetectorPayload::Hit>::Run()
+void FairTestDetectorFileSink<FairTestDetectorHit, TestDetectorPayload::Hit>::Run()
 {
     int receivedMsgs = 0;
 
@@ -144,7 +140,7 @@ void FairMQFileSink<FairTestDetectorHit, TestDetectorPayload::Hit>::Run()
 
             if (fOutput->IsEmpty())
             {
-                LOG(ERROR) << "FairMQFileSink::Run(): No Output array!";
+                LOG(ERROR) << "FairTestDetectorFileSink::Run(): No Output array!";
             }
 
             fTree->Fill();
@@ -156,7 +152,7 @@ void FairMQFileSink<FairTestDetectorHit, TestDetectorPayload::Hit>::Run()
     LOG(INFO) << "I've received " << receivedMsgs << " messages!";
 }
 
-// ----- Implementation of FairMQFileSink::Run() with Root TMessage transport data format -----
+// ----- Implementation of FairTestDetectorFileSink::Run() with Root TMessage transport data format -----
 
 // special class to expose protected TMessage constructor
 class TestDetectorTMessage : public TMessage
@@ -170,7 +166,7 @@ class TestDetectorTMessage : public TMessage
 };
 
 template <>
-void FairMQFileSink<FairTestDetectorHit, TMessage>::Run()
+void FairTestDetectorFileSink<FairTestDetectorHit, TMessage>::Run()
 {
     int receivedMsgs = 0;
 
@@ -190,7 +186,7 @@ void FairMQFileSink<FairTestDetectorHit, TMessage>::Run()
 
             if (fOutput->IsEmpty())
             {
-                LOG(ERROR) << "FairMQFileSink::Run(): No Output array!";
+                LOG(ERROR) << "FairTestDetectorFileSink::Run(): No Output array!";
             }
 
             fTree->Fill();
@@ -204,13 +200,13 @@ void FairMQFileSink<FairTestDetectorHit, TMessage>::Run()
     LOG(INFO) << "I've received " << receivedMsgs << " messages!";
 }
 
-// ----- Implementation of FairMQFileSink::Run() with Google Protocol Buffers transport data format -----
+// ----- Implementation of FairTestDetectorFileSink::Run() with Google Protocol Buffers transport data format -----
 
 #ifdef PROTOBUF
 #include "FairTestDetectorPayload.pb.h"
 
 template <>
-void FairMQFileSink<FairTestDetectorHit, TestDetectorProto::HitPayload>::Run()
+void FairTestDetectorFileSink<FairTestDetectorHit, TestDetectorProto::HitPayload>::Run()
 {
     int receivedMsgs = 0;
 
@@ -241,7 +237,7 @@ void FairMQFileSink<FairTestDetectorHit, TestDetectorProto::HitPayload>::Run()
 
             if (fOutput->IsEmpty())
             {
-                LOG(ERROR) << "FairMQFileSink::Run(): No Output array!";
+                LOG(ERROR) << "FairTestDetectorFileSink::Run(): No Output array!";
             }
 
             fTree->Fill();

--- a/example/Tutorial3/digitization/FairTestDetectorDigiLoader.cxx
+++ b/example/Tutorial3/digitization/FairTestDetectorDigiLoader.cxx
@@ -6,9 +6,8 @@
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
 /**
- * FairMQFileSink.cxx
+ * File:   FairTestDetectorDigiLoader.cxx
+ * Author: winckler
  *
- * @since 2013-06-05
- * @author A. Rybalchenko
+ * Created on February 8, 2014, 1:48 AM
  */
-// must be empty. Template function members defined in .h and .tpl

--- a/example/Tutorial3/digitization/FairTestDetectorDigiLoader.h
+++ b/example/Tutorial3/digitization/FairTestDetectorDigiLoader.h
@@ -6,13 +6,13 @@
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
 /**
- * File:   TestDetectorDigiLoader.h
+ * File:   FairTestDetectorDigiLoader.h
  * @since 2014-02-08
  * @author: A. Rybalchenko, N. Winckler
  */
 
-#ifndef TESTDETECTORDIGILOADER_H
-#define TESTDETECTORDIGILOADER_H
+#ifndef FAIRTESTDETECTORDIGILOADER_H
+#define FAIRTESTDETECTORDIGILOADER_H
 
 #include <iostream>
 
@@ -28,20 +28,18 @@
 #include "FairMQSamplerTask.h"
 #include "FairMQLogger.h"
 
-#if __cplusplus >= 201103L
 #include "baseMQtools.h"
 #include <type_traits>
-#endif
 
 using namespace std;
 
 // Base template header <T1,T2>
 template <typename T1, typename T2>
-class TestDetectorDigiLoader : public FairMQSamplerTask
+class FairTestDetectorDigiLoader : public FairMQSamplerTask
 {
   public:
-    TestDetectorDigiLoader();
-    virtual ~TestDetectorDigiLoader();
+    FairTestDetectorDigiLoader();
+    virtual ~FairTestDetectorDigiLoader();
     virtual void Exec(Option_t* opt);
 
     template <class Archive>
@@ -56,7 +54,7 @@ class TestDetectorDigiLoader : public FairMQSamplerTask
     bool fHasBoostSerialization;
 };
 
-// Template implementation is in TestDetectorDigiLoader.tpl :
-#include "TestDetectorDigiLoader.tpl"
+// Template implementation is in FairTestDetectorDigiLoader.tpl :
+#include "FairTestDetectorDigiLoader.tpl"
 
-#endif /* TESTDETECTORDIGILOADER_H */
+#endif /* FAIRTESTDETECTORDIGILOADER_H */

--- a/example/Tutorial3/digitization/FairTestDetectorDigiLoader.tpl
+++ b/example/Tutorial3/digitization/FairTestDetectorDigiLoader.tpl
@@ -1,12 +1,12 @@
 /*
- * File:   TestDetectorDigiLoader.tpl
+ * File:   FairTestDetectorDigiLoader.tpl
  * @since 2014-02-08
  * @author: A. Rybalchenko, N. Winckler
  *
  */
 
 template <typename T1, typename T2>
-TestDetectorDigiLoader<T1, T2>::TestDetectorDigiLoader()
+FairTestDetectorDigiLoader<T1, T2>::FairTestDetectorDigiLoader()
     : FairMQSamplerTask("Load class T1")
     , fDigiVector()
     , fHasBoostSerialization(false)
@@ -23,7 +23,7 @@ TestDetectorDigiLoader<T1, T2>::TestDetectorDigiLoader()
 }
 
 template <typename T1, typename T2>
-TestDetectorDigiLoader<T1, T2>::~TestDetectorDigiLoader()
+FairTestDetectorDigiLoader<T1, T2>::~FairTestDetectorDigiLoader()
 {
     if (fDigiVector.size() > 0)
     {
@@ -31,10 +31,10 @@ TestDetectorDigiLoader<T1, T2>::~TestDetectorDigiLoader()
     }
 }
 
-// Default implementation of TestDetectorDigiLoader::Exec() with Boost transport data format
+// Default implementation of FairTestDetectorDigiLoader::Exec() with Boost transport data format
 
 template <typename T1, typename T2>
-void TestDetectorDigiLoader<T1, T2>::Exec(Option_t* opt)
+void FairTestDetectorDigiLoader<T1, T2>::Exec(Option_t* opt)
 {
     // Default implementation of the base template Exec function using boost
     // the condition check if the input class has a function member with name
@@ -73,10 +73,10 @@ void TestDetectorDigiLoader<T1, T2>::Exec(Option_t* opt)
     }
 }
 
-// Implementation of TestDetectorDigiLoader::Exec() with pure binary transport data format
+// Implementation of FairTestDetectorDigiLoader::Exec() with pure binary transport data format
 
 template <>
-void TestDetectorDigiLoader<FairTestDetectorDigi, TestDetectorPayload::Digi>::Exec(Option_t* opt)
+void FairTestDetectorDigiLoader<FairTestDetectorDigi, TestDetectorPayload::Digi>::Exec(Option_t* opt)
 {
     // // Example of how to send multipart messages (uncomment the code lines to test).
     // // 1. create some data and put it into message (optionaly in one step with zero-copy):
@@ -111,7 +111,7 @@ void TestDetectorDigiLoader<FairTestDetectorDigi, TestDetectorPayload::Digi>::Ex
     }
 }
 
-// Implementation of TestDetectorDigiLoader::Exec() with Root TMessage transport data format
+// Implementation of FairTestDetectorDigiLoader::Exec() with Root TMessage transport data format
 
 // helper function to clean up the object holding the data after it is transported.
 void free_tmessage (void *data, void *hint)
@@ -120,7 +120,7 @@ void free_tmessage (void *data, void *hint)
 }
 
 template <>
-void TestDetectorDigiLoader<FairTestDetectorDigi, TMessage>::Exec(Option_t* opt)
+void FairTestDetectorDigiLoader<FairTestDetectorDigi, TMessage>::Exec(Option_t* opt)
 {
     TMessage* message = new TMessage(kMESS_OBJECT);
     message->WriteObject(fInput);
@@ -128,7 +128,7 @@ void TestDetectorDigiLoader<FairTestDetectorDigi, TMessage>::Exec(Option_t* opt)
     // note: transport will cleanup the message object when the transfer is done using the provided deallocator (free_tmessage).
 }
 
-// Implementation of TestDetectorDigiLoader::Exec() with Google Protocol Buffers transport data format
+// Implementation of FairTestDetectorDigiLoader::Exec() with Google Protocol Buffers transport data format
 
 #ifdef PROTOBUF
 #include "FairTestDetectorPayload.pb.h"
@@ -140,7 +140,7 @@ void free_string (void *data, void *hint)
 }
 
 template <>
-void TestDetectorDigiLoader<FairTestDetectorDigi, TestDetectorProto::DigiPayload>::Exec(Option_t* opt)
+void FairTestDetectorDigiLoader<FairTestDetectorDigi, TestDetectorProto::DigiPayload>::Exec(Option_t* opt)
 {
     int nDigis = fInput->GetEntriesFast();
 

--- a/example/Tutorial3/reconstruction/FairTestDetectorMQRecoTask.h
+++ b/example/Tutorial3/reconstruction/FairTestDetectorMQRecoTask.h
@@ -33,11 +33,9 @@
 #include "FairTestDetectorHit.h"
 #include "FairTestDetectorDigi.h"
 
-#if __cplusplus >= 201103L
 //#include <memory>
 //#include <chrono>
 #include "baseMQtools.h"
-#endif
 
 #include "TMessage.h"
 

--- a/example/Tutorial3/run/runTestDetectorFileSink.cxx
+++ b/example/Tutorial3/run/runTestDetectorFileSink.cxx
@@ -17,7 +17,7 @@
 #include "boost/program_options.hpp"
 
 #include "FairMQLogger.h"
-#include "FairMQFileSink.h"
+#include "FairTestDetectorFileSink.h"
 
 #ifdef NANOMSG
 #include "nanomsg/FairMQTransportFactoryNN.h"
@@ -43,15 +43,15 @@
 
 using namespace std;
 
-typedef TestDetectorPayload::Hit TPayloadIn; // binary payload
-typedef boost::archive::binary_iarchive TBoostBinPayload; // boost binary format
-typedef boost::archive::text_iarchive TBoostTextPayload;  // boost text format
-typedef TestDetectorProto::HitPayload TProtoPayload; // protobuf payload
+using TPayloadIn = TestDetectorPayload::Hit; // binary payload
+using TBoostBinPayload = boost::archive::binary_iarchive; // boost binary format
+using TBoostTextPayload = boost::archive::text_iarchive;  // boost text format
+using TProtoPayload = TestDetectorProto::HitPayload; // protobuf payload
 
-typedef FairMQFileSink<FairTestDetectorHit, TPayloadIn> TSinkBin;
-typedef FairMQFileSink<FairTestDetectorHit, TBoostBinPayload> TSinkBoost;
-typedef FairMQFileSink<FairTestDetectorHit, TProtoPayload> TSinkProtobuf;
-typedef FairMQFileSink<FairTestDetectorHit, TMessage> TSinkTMessage;
+using TSinkBin = FairTestDetectorFileSink<FairTestDetectorHit, TPayloadIn>;
+using TSinkBoost = FairTestDetectorFileSink<FairTestDetectorHit, TBoostBinPayload>;
+using TSinkProtobuf = FairTestDetectorFileSink<FairTestDetectorHit, TProtoPayload>;
+using TSinkTMessage = FairTestDetectorFileSink<FairTestDetectorHit, TMessage>;
 
 typedef struct DeviceOptions
 {

--- a/example/Tutorial3/run/runTestDetectorProcessor.cxx
+++ b/example/Tutorial3/run/runTestDetectorProcessor.cxx
@@ -48,21 +48,21 @@
 
 using namespace std;
 
-typedef TestDetectorPayload::Digi TPayloadIn; // binary input payload
-typedef TestDetectorPayload::Hit TPayloadOut; // binary output payload
+using TPayloadIn = TestDetectorPayload::Digi; // binary input payload
+using TPayloadOut = TestDetectorPayload::Hit; // binary output payload
 
-typedef boost::archive::binary_iarchive TBoostBinPayloadIn;  // boost binary format
-typedef boost::archive::text_iarchive TBoostTextPayloadIn;   // boost text format
-typedef boost::archive::binary_oarchive TBoostBinPayloadOut; // boost binary format
-typedef boost::archive::text_oarchive TBoostTextPayloadOut;  // boost text format
+using TBoostBinPayloadIn = boost::archive::binary_iarchive;  // boost binary format
+using TBoostTextPayloadIn = boost::archive::text_iarchive;   // boost text format
+using TBoostBinPayloadOut = boost::archive::binary_oarchive; // boost binary format
+using TBoostTextPayloadOut = boost::archive::text_oarchive;  // boost text format
 
-typedef TestDetectorProto::DigiPayload TProtoDigiPayload; // protobuf payload
-typedef TestDetectorProto::HitPayload TProtoHitPayload;   // protobuf payload
+using TProtoDigiPayload = TestDetectorProto::DigiPayload; // protobuf payload
+using TProtoHitPayload = TestDetectorProto::HitPayload;   // protobuf payload
 
-typedef FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TPayloadIn, TPayloadOut> TProcessorTaskBin;
-typedef FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TBoostBinPayloadIn, TBoostBinPayloadOut> TProcessorTaskBoost;
-typedef FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TProtoDigiPayload, TProtoHitPayload> TProcessorTaskProtobuf;
-typedef FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TMessage, TMessage> TProcessorTaskTMessage;
+using TProcessorTaskBin = FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TPayloadIn, TPayloadOut>;
+using TProcessorTaskBoost = FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TBoostBinPayloadIn, TBoostBinPayloadOut>;
+using TProcessorTaskProtobuf = FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TProtoDigiPayload, TProtoHitPayload>;
+using TProcessorTaskTMessage = FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TMessage, TMessage>;
 
 typedef struct DeviceOptions
 {

--- a/example/Tutorial3/run/runTestDetectorSampler.cxx
+++ b/example/Tutorial3/run/runTestDetectorSampler.cxx
@@ -25,7 +25,7 @@
 #include "zeromq/FairMQTransportFactoryZMQ.h"
 #endif
 
-#include "TestDetectorDigiLoader.h"
+#include "FairTestDetectorDigiLoader.h"
 
 // data format for the task
 #include "FairTestDetectorDigi.h"
@@ -45,15 +45,15 @@
 
 using namespace std;
 
-typedef TestDetectorPayload::Digi TPayloadOut; // binary payload
-typedef boost::archive::binary_oarchive TBoostBinPayloadOut; // boost binary format
-typedef boost::archive::text_oarchive TBoostTextPayloadOut;  // boost text format
-typedef TestDetectorProto::DigiPayload TProtoDigiPayload; // protobuf payload
+using TPayloadOut = TestDetectorPayload::Digi; // binary payload
+using TBoostBinPayloadOut = boost::archive::binary_oarchive; // boost binary format
+using TBoostTextPayloadOut = boost::archive::text_oarchive;  // boost text format
+using TProtoDigiPayload = TestDetectorProto::DigiPayload; // protobuf payload
 
-typedef FairMQSampler<TestDetectorDigiLoader<FairTestDetectorDigi, TPayloadOut>> TSamplerBin;
-typedef FairMQSampler<TestDetectorDigiLoader<FairTestDetectorDigi, TBoostBinPayloadOut>> TSamplerBoost;
-typedef FairMQSampler<TestDetectorDigiLoader<FairTestDetectorDigi, TProtoDigiPayload>> TSamplerProtobuf;
-typedef FairMQSampler<TestDetectorDigiLoader<FairTestDetectorDigi, TMessage>> TSamplerTMessage;
+using TSamplerBin = FairMQSampler<FairTestDetectorDigiLoader<FairTestDetectorDigi, TPayloadOut>>;
+using TSamplerBoost = FairMQSampler<FairTestDetectorDigiLoader<FairTestDetectorDigi, TBoostBinPayloadOut>>;
+using TSamplerProtobuf = FairMQSampler<FairTestDetectorDigiLoader<FairTestDetectorDigi, TProtoDigiPayload>>;
+using TSamplerTMessage = FairMQSampler<FairTestDetectorDigiLoader<FairTestDetectorDigi, TMessage>>;
 
 typedef struct DeviceOptions
 {

--- a/example/Tutorial7/devices/policy/task/BaseDigiToHitTask.h
+++ b/example/Tutorial7/devices/policy/task/BaseDigiToHitTask.h
@@ -5,8 +5,8 @@
  * Created on December 8, 2014, 2:40 PM
  */
 
-#ifndef BASEDIGITOHIT_H
-#define	BASEDIGITOHIT_H
+#ifndef BASEDIGITOHITTASK_H
+#define BASEDIGITOHITTASK_H
 
 // std
 #include <iostream>
@@ -39,46 +39,42 @@
 // from tutorial3 or tutorial 7 data class/payload
 // Note : better would be to check the API...
 template <typename T>
-    struct AllowedNonPodType
+struct AllowedNonPodType
+{
+    template <typename U>
+    static constexpr bool testType()
     {
-        template <typename U>
-            static constexpr bool testType()
-            {
-                return 
-                        std::is_base_of<MyDigi,U>::value ||
-                        std::is_base_of<MyHit,U>::value ||
-                        std::is_base_of<FairTestDetectorDigi,U>::value ||
-                        std::is_base_of<FairHit,U>::value;
-            }
-        static constexpr bool value = testType<T>();
-    };
+        return
+                std::is_base_of<MyDigi,U>::value ||
+                std::is_base_of<MyHit,U>::value ||
+                std::is_base_of<FairTestDetectorDigi,U>::value ||
+                std::is_base_of<FairHit,U>::value;
+    }
+    static constexpr bool value = testType<T>();
+};
 
 template <typename T>
-    struct AllowedPodType
+struct AllowedPodType
+{
+    template <typename U>
+    static constexpr bool testType()
     {
-        template <typename U>
-            static constexpr bool testType()
-            {
-                return 
-                        std::is_base_of<MyPodData::Digi,U>::value ||
-                        std::is_base_of<MyPodData::Hit,U>::value ||
-                        std::is_base_of<TestDetectorPayload::Digi,U>::value ||
-                        std::is_base_of<TestDetectorPayload::Hit,U>::value;
-            }
-        static constexpr bool value = testType<T>();
-    };
+        return
+                std::is_base_of<MyPodData::Digi,U>::value ||
+                std::is_base_of<MyPodData::Hit,U>::value ||
+                std::is_base_of<TestDetectorPayload::Digi,U>::value ||
+                std::is_base_of<TestDetectorPayload::Hit,U>::value;
+    }
+    static constexpr bool value = testType<T>();
+};
 
-    
-    
-    
+
 // use of the checks struct into std::enable_if, to enable the corresponding implementations
 template<typename T>
-    using enable_if_AllowedType = typename std::enable_if<AllowedNonPodType<T>::value,int>::type;
+using enable_if_AllowedType = typename std::enable_if<AllowedNonPodType<T>::value, int>::type;
 
 template<typename T>
-    using enable_if_AllowedPodType = typename std::enable_if<AllowedPodType<T>::value,int>::type;
-
-
+using enable_if_AllowedPodType = typename std::enable_if<AllowedPodType<T>::value, int>::type;
 
 ////////////////////////////////////////////////////////////////////////////////////
 // the base class
@@ -86,70 +82,63 @@ template <typename DigiType, typename HitType>
 class BaseDigiToHitTask
 {
   public:
-      
     BaseDigiToHitTask() : fTaskName(), fDetID(-1), fMCIndex(-1)
     {}
-    
+
     virtual ~BaseDigiToHitTask()
     {}
-        
+
   protected:
-      
     std::string fTaskName;
     Int_t fDetID;
     Int_t fMCIndex;
-    
-    template < typename T=DigiType, enable_if_AllowedType<T> = 0 >
-        void ProcessDigi(const DigiType &Digi, TVector3 &pos, TVector3 &dpos, Double_t &t, Double_t &t_err)
-        {
-            pos.SetXYZ(Digi.GetX() + 0.5, Digi.GetY() + 0.5, Digi.GetZ() + 0.5);
-            dpos.SetXYZ(1 / TMath::Sqrt(12), 1 / TMath::Sqrt(12), 1 / TMath::Sqrt(12));
-            t=Digi.GetTimeStamp();
-            t_err=Digi.GetTimeStampError();
-        }
-    
-    template < typename T=DigiType, enable_if_AllowedPodType<T> = 0  >
-        void ProcessDigi(const DigiType &Digi, TVector3 &pos, TVector3 &dpos, Double_t &t, Double_t &t_err)
-        {
-            pos.SetXYZ(Digi.fX + 0.5, Digi.fY + 0.5, Digi.fZ + 0.5);
-            dpos.SetXYZ(1 / TMath::Sqrt(12), 1 / TMath::Sqrt(12), 1 / TMath::Sqrt(12));
-            t=Digi.fTimeStamp;
-            t_err=Digi.fTimeStampError;
-        }
-    
-    template < typename T=HitType, enable_if_AllowedType<T> = 0 >
-        void FillHit(HitType &Hit, const Int_t &detID, const Int_t &MCIndex, const TVector3 &pos, const TVector3 &dpos, const Double_t &t, const Double_t &t_err)
-        {
-            Hit.SetDetectorID(detID);
-            Hit.SetRefIndex(MCIndex);
-            Hit.SetPosition(pos);
-            Hit.SetPositionError(dpos);
-            Hit.SetTimeStamp(t);
-            Hit.SetTimeStampError(t_err);
-        }
-    
-    template < typename T=HitType, enable_if_AllowedPodType<T> = 0 >
-        void FillHit(HitType &Hit, const Int_t &detID, const Int_t &MCIndex, const TVector3 &pos, const TVector3 &dpos, const Double_t &t, const Double_t &t_err)
-        {
-            Hit.detID=detID;
-            Hit.mcindex=MCIndex;
-            
-            Hit.fTimeStamp=t;
-            Hit.fTimeStampError=t_err;
-            
-            Hit.posX=pos.X();
-            Hit.posY=pos.Y();
-            Hit.posZ=pos.Z();
-            
-            Hit.dposX=dpos.X();
-            Hit.dposY=dpos.Y();
-            Hit.dposZ=dpos.Z();
-        }
-    
+
+    template <typename T = DigiType, enable_if_AllowedType<T> = 0>
+    void ProcessDigi(const DigiType &Digi, TVector3 &pos, TVector3 &dpos, Double_t &t, Double_t &t_err)
+    {
+        pos.SetXYZ(Digi.GetX() + 0.5, Digi.GetY() + 0.5, Digi.GetZ() + 0.5);
+        dpos.SetXYZ(1 / TMath::Sqrt(12), 1 / TMath::Sqrt(12), 1 / TMath::Sqrt(12));
+        t = Digi.GetTimeStamp();
+        t_err = Digi.GetTimeStampError();
+    }
+
+    template <typename T = DigiType, enable_if_AllowedPodType<T> = 0 >
+    void ProcessDigi(const DigiType &Digi, TVector3 &pos, TVector3 &dpos, Double_t &t, Double_t &t_err)
+    {
+        pos.SetXYZ(Digi.fX + 0.5, Digi.fY + 0.5, Digi.fZ + 0.5);
+        dpos.SetXYZ(1 / TMath::Sqrt(12), 1 / TMath::Sqrt(12), 1 / TMath::Sqrt(12));
+        t = Digi.fTimeStamp;
+        t_err = Digi.fTimeStampError;
+    }
+
+    template <typename T = HitType, enable_if_AllowedType<T> = 0>
+    void FillHit(HitType &Hit, const Int_t &detID, const Int_t &MCIndex, const TVector3 &pos, const TVector3 &dpos, const Double_t &t, const Double_t &t_err)
+    {
+        Hit.SetDetectorID(detID);
+        Hit.SetRefIndex(MCIndex);
+        Hit.SetPosition(pos);
+        Hit.SetPositionError(dpos);
+        Hit.SetTimeStamp(t);
+        Hit.SetTimeStampError(t_err);
+    }
+
+    template <typename T = HitType, enable_if_AllowedPodType<T> = 0>
+    void FillHit(HitType &Hit, const Int_t &detID, const Int_t &MCIndex, const TVector3 &pos, const TVector3 &dpos, const Double_t &t, const Double_t &t_err)
+    {
+        Hit.detID = detID;
+        Hit.mcindex = MCIndex;
+
+        Hit.fTimeStamp = t;
+        Hit.fTimeStampError = t_err;
+
+        Hit.posX = pos.X();
+        Hit.posY = pos.Y();
+        Hit.posZ = pos.Z();
+
+        Hit.dposX = dpos.X();
+        Hit.dposY = dpos.Y();
+        Hit.dposZ = dpos.Z();
+    }
 };
 
-
-
-
-#endif	/* BASEDIGITOHIT_H */
-
+#endif /* BASEDIGITOHITTASK_H */

--- a/example/Tutorial7/devices/policy/task/DigiToHitTask.h
+++ b/example/Tutorial7/devices/policy/task/DigiToHitTask.h
@@ -28,30 +28,29 @@
 #include "MyDigi.h"
 #include "MyHit.h"
 
-
 template <typename DigiType, typename HitType>
-class DigiToHitTask : public BaseDigiToHitTask<DigiType,HitType>
+class DigiToHitTask : public BaseDigiToHitTask<DigiType, HitType>
 {
   public:
-      
-    DigiToHitTask() : BaseDigiToHitTask<DigiType,HitType>()
+    DigiToHitTask() : BaseDigiToHitTask<DigiType, HitType>()
     {}
-    
+
     virtual ~DigiToHitTask()
-    {
-    }
-    
-    using BaseDigiToHitTask<DigiType,HitType>::fDetID;
-    using BaseDigiToHitTask<DigiType,HitType>::fMCIndex;
-    using BaseDigiToHitTask<DigiType,HitType>::fTaskName;
-    using BaseDigiToHitTask<DigiType,HitType>::ProcessDigi;
-    using BaseDigiToHitTask<DigiType,HitType>::FillHit;
-    
+    {}
+
+    using BaseDigiToHitTask<DigiType, HitType>::fDetID;
+    using BaseDigiToHitTask<DigiType, HitType>::fMCIndex;
+    using BaseDigiToHitTask<DigiType, HitType>::fTaskName;
+    using BaseDigiToHitTask<DigiType, HitType>::ProcessDigi;
+    using BaseDigiToHitTask<DigiType, HitType>::FillHit;
+
     void ExecuteTask(std::vector<DigiType>& inputdata)
     {
-        if(fOutputContainer.size()>0)
+        if (fOutputContainer.size() > 0)
+        {
             fOutputContainer.clear();
-        
+        }
+
         HitType Hit;
         for(unsigned int digi(0);digi<inputdata.size();digi++)
         {
@@ -60,61 +59,55 @@ class DigiToHitTask : public BaseDigiToHitTask<DigiType,HitType>
             Double_t timestamp=0;
             Double_t timestampErr=0;
             ProcessDigi(inputdata[digi], pos, dpos, timestamp, timestampErr);
-            FillHit(Hit,fDetID,fMCIndex, pos, dpos, timestamp, timestampErr);
+            FillHit(Hit, fDetID, fMCIndex, pos, dpos, timestamp, timestampErr);
             fOutputContainer.push_back(Hit);
         }
     }
-    
+
     std::vector<HitType>& GetOutputData()
     {
         return fOutputContainer;
     }
-    
+
   protected:
-      
     std::vector<HitType> fOutputContainer;
 };
-
-
 
 //////////////// TClonesArray container version
 
 template <typename DigiType, typename HitType>
-class DigiToHitTask_TCA : public BaseDigiToHitTask<DigiType,HitType>
+class DigiToHitTask_TCA : public BaseDigiToHitTask<DigiType, HitType>
 {
-    
-    using BaseDigiToHitTask<DigiType,HitType>::fDetID;
-    using BaseDigiToHitTask<DigiType,HitType>::fMCIndex;
-    using BaseDigiToHitTask<DigiType,HitType>::fTaskName;
-    using BaseDigiToHitTask<DigiType,HitType>::ProcessDigi;
-    using BaseDigiToHitTask<DigiType,HitType>::FillHit;
-    
+    using BaseDigiToHitTask<DigiType, HitType>::fDetID;
+    using BaseDigiToHitTask<DigiType, HitType>::fMCIndex;
+    using BaseDigiToHitTask<DigiType, HitType>::fTaskName;
+    using BaseDigiToHitTask<DigiType, HitType>::ProcessDigi;
+    using BaseDigiToHitTask<DigiType, HitType>::FillHit;
+
   public:
-      
-    DigiToHitTask_TCA() : 
-        BaseDigiToHitTask<DigiType,HitType>(), 
+    DigiToHitTask_TCA() :
+        BaseDigiToHitTask<DigiType,HitType>(),
         fOutputContainer(nullptr)
     {}
-    
+
     virtual ~DigiToHitTask_TCA()
     {}
-    
-    
+
     void InitTask(const std::string &ClassName)
     {
         InitContainer(ClassName.c_str());
     }
-    
+
     void InitContainer(const char* ClassName)
     {
         fOutputContainer = new TClonesArray(ClassName);
     }
-    
+
     void InitContainer(TClonesArray* array)
     {
         fOutputContainer = array;
     }
-    
+
     void ExecuteTask(TClonesArray* inputdata)
     {
         //HitType Hit;
@@ -125,30 +118,25 @@ class DigiToHitTask_TCA : public BaseDigiToHitTask<DigiType,HitType>
             TVector3 dpos;
             Double_t timestamp=0;
             Double_t timestampErr=0;
-            
+
             DigiType* digi = (DigiType*)inputdata->At(idigi);
             ProcessDigi(*digi, pos, dpos, timestamp, timestampErr);
             //FillHit(Hit,fDetID,fMCIndex, pos, dpos, timestamp, timestampErr);
-            
+
             HitType* hit = new ((*fOutputContainer)[idigi]) HitType(fDetID, fMCIndex, pos, dpos);
             hit->SetTimeStamp(digi->GetTimeStamp());
             hit->SetTimeStampError(digi->GetTimeStampError());
             //fOutputContainer.push_back(Hit);
         }
     }
-    
+
     TClonesArray* GetOutputData()
     {
         return fOutputContainer;
     }
-    
+
   protected:
-      
     TClonesArray* fOutputContainer;
 };
 
-
-
-
-#endif	/* DIGITOHITTASK_H */
-
+#endif /* DIGITOHITTASK_H */

--- a/fairmq/CMakeLists.txt
+++ b/fairmq/CMakeLists.txt
@@ -7,18 +7,18 @@
  ################################################################################
 
 configure_file(${CMAKE_SOURCE_DIR}/fairmq/options/ProgOptionTest/macro/bsampler-sink.json ${CMAKE_BINARY_DIR}/bin/config/bsampler-sink.json)
-configure_file(${CMAKE_SOURCE_DIR}/fairmq/examples/1-sampler-sink/ex1-sampler-sink.json ${CMAKE_BINARY_DIR}/bin/config/ex1-sampler-sink.json)
-configure_file(${CMAKE_SOURCE_DIR}/fairmq/examples/2-sampler-processor-sink/ex2-sampler-processor-sink.json ${CMAKE_BINARY_DIR}/bin/config/ex2-sampler-processor-sink.json)
-configure_file(${CMAKE_SOURCE_DIR}/fairmq/examples/3-dds/ex3-devices.json ${CMAKE_BINARY_DIR}/bin/config/ex3-devices.json)
-configure_file(${CMAKE_SOURCE_DIR}/fairmq/examples/3-dds/ex3-dds-topology.xml ${CMAKE_BINARY_DIR}/bin/config/ex3-dds-topology.xml)
-configure_file(${CMAKE_SOURCE_DIR}/fairmq/examples/3-dds/ex3-dds-hosts.cfg ${CMAKE_BINARY_DIR}/bin/config/ex3-dds-hosts.cfg COPYONLY)
-configure_file(${CMAKE_SOURCE_DIR}/fairmq/examples/4-copypush/ex4-copypush.json ${CMAKE_BINARY_DIR}/bin/config/ex4-copypush.json)
-
-configure_file(${CMAKE_SOURCE_DIR}/fairmq/test/test-fairmq-push-pull.sh.in ${CMAKE_BINARY_DIR}/fairmq/test/test-fairmq-push-pull.sh)
-configure_file(${CMAKE_SOURCE_DIR}/fairmq/test/test-fairmq-pub-sub.sh.in ${CMAKE_BINARY_DIR}/fairmq/test/test-fairmq-pub-sub.sh)
-configure_file(${CMAKE_SOURCE_DIR}/fairmq/test/test-fairmq-req-rep.sh.in ${CMAKE_BINARY_DIR}/fairmq/test/test-fairmq-req-rep.sh)
 
 add_subdirectory(logger)
+
+add_subdirectory(examples/1-sampler-sink)
+add_subdirectory(examples/2-sampler-processor-sink)
+If(DDS_FOUND)
+  add_subdirectory(examples/3-dds)
+EndIf(DDS_FOUND)
+add_subdirectory(examples/4-copypush)
+add_subdirectory(examples/5-req-rep)
+
+add_subdirectory(test)
 
 Set(INCLUDE_DIRECTORIES
   ${CMAKE_SOURCE_DIR}/fairmq
@@ -26,34 +26,14 @@ Set(INCLUDE_DIRECTORIES
   ${CMAKE_SOURCE_DIR}/fairmq/tools
   ${CMAKE_SOURCE_DIR}/fairmq/options
   ${CMAKE_SOURCE_DIR}/fairmq/logger
-  ${CMAKE_SOURCE_DIR}/fairmq/examples/1-sampler-sink
-  ${CMAKE_SOURCE_DIR}/fairmq/examples/2-sampler-processor-sink
-  ${CMAKE_SOURCE_DIR}/fairmq/examples/4-copypush
-  ${CMAKE_SOURCE_DIR}/fairmq/examples/5-req-rep
-  ${CMAKE_SOURCE_DIR}/fairmq/test/push-pull
-  ${CMAKE_SOURCE_DIR}/fairmq/test/pub-sub
-  ${CMAKE_SOURCE_DIR}/fairmq/test/req-rep
+  ${CMAKE_SOURCE_DIR}/fairmq/zeromq
   ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-if(DDS_FOUND)
-  add_definitions(-DENABLE_DDS)
-  Set(INCLUDE_DIRECTORIES
-    ${INCLUDE_DIRECTORIES}
-    ${CMAKE_SOURCE_DIR}/fairmq/examples/3-dds
-  )
-endif(DDS_FOUND)
-
 Set(SYSTEM_INCLUDE_DIRECTORIES
   ${Boost_INCLUDE_DIR}
+  ${ZMQ_INCLUDE_DIR}
 )
-
-If(DDS_FOUND)
-  Set(SYSTEM_INCLUDE_DIRECTORIES
-    ${SYSTEM_INCLUDE_DIRECTORIES}
-    ${DDS_INCLUDE_DIR}
-    )
-EndIf(DDS_FOUND)
 
 If(PROTOBUF_FOUND)
   Set(INCLUDE_DIRECTORIES
@@ -74,16 +54,7 @@ If(NANOMSG_FOUND)
   )
   Set(SYSTEM_INCLUDE_DIRECTORIES
     ${SYSTEM_INCLUDE_DIRECTORIES}
-    ${NANOMSG_LIBRARY_SHARED}
-  )
-Else(NANOMSG_FOUND)
-  Set(INCLUDE_DIRECTORIES
-    ${INCLUDE_DIRECTORIES}
-    ${CMAKE_SOURCE_DIR}/fairmq/zeromq
-  )
-  Set(SYSTEM_INCLUDE_DIRECTORIES
-    ${SYSTEM_INCLUDE_DIRECTORIES}
-    ${ZMQ_INCLUDE_DIR}
+    ${NANOMSG_INCLUDE_DIR}
   )
 EndIf(NANOMSG_FOUND)
 
@@ -94,16 +65,15 @@ Set(LINK_DIRECTORIES
   ${Boost_LIBRARY_DIRS}
 )
 
-if(DDS_FOUND)
-  set(LINK_DIRECTORIES
-    ${LINK_DIRECTORIES}
-    ${DDS_LIBRARY_DIR}
-  )
-endif(DDS_FOUND)
-
 Link_Directories(${LINK_DIRECTORIES})
 
-set(SRCS
+Set(SRCS
+  "zeromq/FairMQTransportFactoryZMQ.cxx"
+  "zeromq/FairMQMessageZMQ.cxx"
+  "zeromq/FairMQSocketZMQ.cxx"
+  "zeromq/FairMQPollerZMQ.cxx"
+  "zeromq/FairMQContextZMQ.cxx"
+
   "FairMQLogger.cxx"
   "FairMQConfigurable.cxx"
   "FairMQStateMachine.cxx"
@@ -124,39 +94,9 @@ set(SRCS
   "options/FairProgOptions.cxx"
   "options/FairMQProgOptions.cxx"
   "options/FairMQParser.cxx"
-
-  "examples/1-sampler-sink/FairMQExample1Sampler.cxx"
-  "examples/1-sampler-sink/FairMQExample1Sink.cxx"
-  "examples/2-sampler-processor-sink/FairMQExample2Sampler.cxx"
-  "examples/2-sampler-processor-sink/FairMQExample2Processor.cxx"
-  "examples/2-sampler-processor-sink/FairMQExample2Sink.cxx"
-  "examples/4-copypush/FairMQExample4Sampler.cxx"
-  "examples/4-copypush/FairMQExample4Sink.cxx"
-  "examples/5-req-rep/FairMQExample5Client.cxx"
-  "examples/5-req-rep/FairMQExample5Server.cxx"
-
-  "test/push-pull/FairMQTestPush.cxx"
-  "test/push-pull/FairMQTestPull.cxx"
-  "test/pub-sub/FairMQTestPub.cxx"
-  "test/pub-sub/FairMQTestSub.cxx"
-  "test/req-rep/FairMQTestReq.cxx"
-  "test/req-rep/FairMQTestRep.cxx"
 )
 
-if(DDS_FOUND)
-  set(SRCS
-    ${SRCS}
-    "examples/3-dds/FairMQExample3Sampler.cxx"
-    "examples/3-dds/FairMQExample3Processor.cxx"
-    "examples/3-dds/FairMQExample3Sink.cxx"
-  )
-  set(DEPENDENCIES
-    ${DEPENDENCIES}
-    dds-key-value-lib
-  )
-endif(DDS_FOUND)
-
-if(PROTOBUF_FOUND)
+If(PROTOBUF_FOUND)
   # following source files are only for protobuf tests and are not essential part of FairMQ
   # add_custom_command(
   #   OUTPUT
@@ -175,38 +115,25 @@ if(PROTOBUF_FOUND)
   #   "prototest/FairMQBinSink.cxx"
   #   "prototest/FairMQProtoSink.cxx"
   # )
-  set(DEPENDENCIES
+  Set(DEPENDENCIES
     ${DEPENDENCIES}
     ${PROTOBUF_LIBRARY}
   )
-endif(PROTOBUF_FOUND)
+Endif(PROTOBUF_FOUND)
 
-if(NANOMSG_FOUND)
-  set(SRCS
+If(NANOMSG_FOUND)
+  Set(SRCS
     ${SRCS}
     "nanomsg/FairMQTransportFactoryNN.cxx"
     "nanomsg/FairMQMessageNN.cxx"
     "nanomsg/FairMQSocketNN.cxx"
     "nanomsg/FairMQPollerNN.cxx"
   )
-  set(DEPENDENCIES
+  Set(DEPENDENCIES
     ${DEPENDENCIES}
     ${NANOMSG_LIBRARY_SHARED}
   )
-else(NANOMSG_FOUND)
-  set(SRCS
-    ${SRCS}
-    "zeromq/FairMQTransportFactoryZMQ.cxx"
-    "zeromq/FairMQMessageZMQ.cxx"
-    "zeromq/FairMQSocketZMQ.cxx"
-    "zeromq/FairMQPollerZMQ.cxx"
-    "zeromq/FairMQContextZMQ.cxx"
-  )
-  set(DEPENDENCIES
-    ${DEPENDENCIES}
-    ${ZMQ_LIBRARY_SHARED}
-  )
-endif(NANOMSG_FOUND)
+EndIf(NANOMSG_FOUND)
 
 # to copy src that are header-only files (e.g. c++ template) for FairRoot external installation
 # manual install (globbing add not recommended)
@@ -217,10 +144,11 @@ Set(FAIRMQHEADERS
   devices/GenericFileSink.h
   tools/FairMQTools.h
 )
-install(FILES ${FAIRMQHEADERS} DESTINATION include)
+Install(FILES ${FAIRMQHEADERS} DESTINATION include)
 
-set(DEPENDENCIES
+Set(DEPENDENCIES
   ${DEPENDENCIES}
+  ${ZMQ_LIBRARY_SHARED}
   boost_thread
   fairmq_logger
   boost_timer
@@ -232,42 +160,18 @@ set(DEPENDENCIES
   boost_exception
 )
 
-set(LIBRARY_NAME FairMQ)
+Set(LIBRARY_NAME FairMQ)
 
 GENERATE_LIBRARY()
 
-set(Exe_Names
+Set(Exe_Names
   bsampler
   sink
   buffer
   splitter
   merger
   proxy
-  ex1-sampler
-  ex1-sink
-  ex2-sampler
-  ex2-processor
-  ex2-sink
-  ex4-sampler
-  ex4-sink
-  ex5-client
-  ex5-server
-  test-fairmq-push
-  test-fairmq-pull
-  test-fairmq-pub
-  test-fairmq-sub
-  test-fairmq-req
-  test-fairmq-rep
 )
-
-if(DDS_FOUND)
-  set(Exe_Names
-    ${Exe_Names}
-    ex3-sampler-dds
-    ex3-processor-dds
-    ex3-sink-dds
-  )
-endif(DDS_FOUND)
 
 # following executables are only for protobuf tests and are not essential part of FairMQ
 # if(PROTOBUF_FOUND)
@@ -280,38 +184,14 @@ endif(DDS_FOUND)
 #       )
 # endif(PROTOBUF_FOUND)
 
-set(Exe_Source
+Set(Exe_Source
   run/runBenchmarkSampler.cxx
   run/runSink.cxx
   run/runBuffer.cxx
   run/runSplitter.cxx
   run/runMerger.cxx
   run/runProxy.cxx
-  examples/1-sampler-sink/runExample1Sampler.cxx
-  examples/1-sampler-sink/runExample1Sink.cxx
-  examples/2-sampler-processor-sink/runExample2Sampler.cxx
-  examples/2-sampler-processor-sink/runExample2Processor.cxx
-  examples/2-sampler-processor-sink/runExample2Sink.cxx
-  examples/4-copypush/runExample4Sampler.cxx
-  examples/4-copypush/runExample4Sink.cxx
-  examples/5-req-rep/runExample5Client.cxx
-  examples/5-req-rep/runExample5Server.cxx
-  test/push-pull/runTestPush.cxx
-  test/push-pull/runTestPull.cxx
-  test/pub-sub/runTestPub.cxx
-  test/pub-sub/runTestSub.cxx
-  test/req-rep/runTestReq.cxx
-  test/req-rep/runTestRep.cxx
 )
-
-if(DDS_FOUND)
-  set(Exe_Source
-    ${Exe_Source}
-    examples/3-dds/runExample3Sampler.cxx
-    examples/3-dds/runExample3Processor.cxx
-    examples/3-dds/runExample3Sink.cxx
-  )
-endif(DDS_FOUND)
 
 # following source files are only for protobuf tests and are not essential part of FairMQ
 # if(PROTOBUF_FOUND)
@@ -330,20 +210,8 @@ math(EXPR _length ${_length}-1)
 ForEach(_file RANGE 0 ${_length})
   list(GET Exe_Names ${_file} _name)
   list(GET Exe_Source ${_file} _src)
-  set(EXE_NAME ${_name})
-  set(SRCS ${_src})
-  set(DEPENDENCIES FairMQ)
+  Set(EXE_NAME ${_name})
+  Set(SRCS ${_src})
+  Set(DEPENDENCIES FairMQ)
   GENERATE_EXECUTABLE()
 EndForEach(_file RANGE 0 ${_length})
-
-add_test(NAME run_fairmq_push_pull COMMAND ${CMAKE_BINARY_DIR}/fairmq/test/test-fairmq-push-pull.sh)
-set_tests_properties(run_fairmq_push_pull PROPERTIES TIMEOUT "30")
-set_tests_properties(run_fairmq_push_pull PROPERTIES PASS_REGULAR_EXPRESSION "PUSH-PULL test successfull")
-
-add_test(NAME run_fairmq_pub_sub COMMAND ${CMAKE_BINARY_DIR}/fairmq/test/test-fairmq-pub-sub.sh)
-set_tests_properties(run_fairmq_pub_sub PROPERTIES TIMEOUT "30")
-set_tests_properties(run_fairmq_pub_sub PROPERTIES PASS_REGULAR_EXPRESSION "PUB-SUB test successfull")
-
-add_test(NAME run_fairmq_req_rep COMMAND ${CMAKE_BINARY_DIR}/fairmq/test/test-fairmq-req-rep.sh)
-set_tests_properties(run_fairmq_req_rep PROPERTIES TIMEOUT "30")
-set_tests_properties(run_fairmq_req_rep PROPERTIES PASS_REGULAR_EXPRESSION "REQ-REP test successfull")

--- a/fairmq/FairMQChannel.h
+++ b/fairmq/FairMQChannel.h
@@ -32,48 +32,111 @@ class FairMQChannel
     friend class FairMQDevice;
 
   public:
+    /// Default constructor
     FairMQChannel();
+
+    /// Constructor
+    /// @param type Socket type (push/pull/pub/sub/spub/xsub/pair/req/rep/dealer/router/)
+    /// @param method Socket method (bind/connect)
+    /// @param address Network address to bind/connect to (e.g. "tcp://127.0.0.1:5555" or "ipc://abc")
     FairMQChannel(const std::string& type, const std::string& method, const std::string& address);
+
+    /// Default destructor
     virtual ~FairMQChannel();
 
+    /// Get socket type
+    /// @return Returns socket type (push/pull/pub/sub/spub/xsub/pair/req/rep/dealer/router/)
     std::string GetType() const;
+    /// Get socket method
+    /// @return Returns socket method (bind/connect)
     std::string GetMethod() const;
+    /// Get socket address (e.g. "tcp://127.0.0.1:5555" or "ipc://abc")
+    /// @return Returns socket type (e.g. "tcp://127.0.0.1:5555" or "ipc://abc")
     std::string GetAddress() const;
+    /// Get socket send buffer size (in number of messages)
+    /// @return Returns socket send buffer size (in number of messages)
     int GetSndBufSize() const;
+    /// Get socket receive buffer size (in number of messages)
+    /// @return Returns socket receive buffer size (in number of messages)
     int GetRcvBufSize() const;
+    /// Get socket rate logging setting (1/0)
+    /// @return Returns socket rate logging setting (1/0)
     int GetRateLogging() const;
 
+    /// Set socket type
+    /// @param type Socket type (push/pull/pub/sub/spub/xsub/pair/req/rep/dealer/router/)
     void UpdateType(const std::string& type);
+    /// Set socket method
+    /// @param method Socket method (bind/connect)
     void UpdateMethod(const std::string& method);
+    /// Set socket address
+    /// @param address Socket address (e.g. "tcp://127.0.0.1:5555" or "ipc://abc")
     void UpdateAddress(const std::string& address);
+    /// Set socket send buffer size
+    /// @param sndBufSize Socket send buffer size (in number of messages)
     void UpdateSndBufSize(const int sndBufSize);
+    /// Set socket receive buffer size
+    /// @param rcvBufSize Socket receive buffer size (in number of messages)
     void UpdateRcvBufSize(const int rcvBufSize);
+    /// Set socket rate logging setting
+    /// @param rateLogging Socket rate logging setting (1/0)
     void UpdateRateLogging(const int rateLogging);
 
+    /// Checks if the configured channel settings are valid (checks the validity parameter, without running full validation (as oposed to ValidateChannel()))
+    /// @return true if channel settings are valid, false otherwise.
     bool IsValid() const;
 
+    /// Validates channel configuration
+    /// @return true if channel settings are valid, false otherwise.
     bool ValidateChannel();
-    bool InitCommandInterface(FairMQTransportFactory* factory);
 
+    /// Resets the channel (requires validation to be used again).
     void ResetChannel();
 
     FairMQSocket* fSocket;
 
-    // Wrappers for the socket methods to simplify the usage of channels
+    /// Sends a message to the socket queue.
+    /// @details Send method attempts to send a message by
+    /// putting it in the output queue. If the queue is full or queueing is not possible
+    /// for some other reason (e.g. no peers connected for a binding socket), the method blocks.
+    ///
+    /// @param msg Constant reference of unique_ptr to a FairMQMessage
+    /// @return Returns the number of bytes that have been queued. In case of errors, returns -1.
     int Send(const std::unique_ptr<FairMQMessage>& msg) const;
 
-    /// \brief Sends a message in non-blocking mode.
-    /// \details SendAsync method attempts to send the message without blocking by
+    /// Sends a message in non-blocking mode.
+    /// @details SendAsync method attempts to send a message without blocking by
     /// putting it in the queue. If the queue is full or queueing is not possible
     /// for some other reason (e.g. no peers connected for a binding socket), the method returns 0.
     /// 
-    /// \param msg Constant reference of unique_ptr to a FairMQMessage
-    /// \return Returns the number of bytes that have been queued. If queueing failed due to
+    /// @param msg Constant reference of unique_ptr to a FairMQMessage
+    /// @return Returns the number of bytes that have been queued. If queueing failed due to
     /// full queue or no connected peers (when binding), returns 0. In case of errors, returns -1.
     int SendAsync(const std::unique_ptr<FairMQMessage>& msg) const;
+
+    /// Queues the current message as a part of a multi-part message
+    /// @details SendPart method queues the provided message as a part of a multi-part message.
+    /// The actual transfer over the network is initiated once final part has been queued with the Send() or SendAsync methods.
+    /// 
+    /// @param msg Constant reference of unique_ptr to a FairMQMessage
+    /// @return Returns the number of bytes that have been queued. In case of errors, returns -1.
     int SendPart(const std::unique_ptr<FairMQMessage>& msg) const;
 
+    /// Receives a message from the socket queue.
+    /// @details Receive method attempts to receive a message from the input queue.
+    /// If the queue is empty the method blocks.
+    ///
+    /// @param msg Constant reference of unique_ptr to a FairMQMessage
+    /// @return Returns the number of bytes that have been received. In case of errors, returns -1.
     int Receive(const std::unique_ptr<FairMQMessage>& msg) const;
+
+    /// Receives a message in non-blocking mode.
+    /// @details ReceiveAsync method attempts to receive a message without blocking from the input queue.
+    /// If the queue is empty the method returns 0.
+    ///
+    /// @param msg Constant reference of unique_ptr to a FairMQMessage
+    /// @return Returns the number of bytes that have been received. If queue is empty, returns 0.
+    /// In case of errors, returns -1.
     int ReceiveAsync(const std::unique_ptr<FairMQMessage>& msg) const;
 
     // DEPRECATED socket method wrappers with raw pointers and flag checks
@@ -82,8 +145,8 @@ class FairMQChannel
     int Receive(FairMQMessage* msg, const std::string& flag = "") const;
     int Receive(FairMQMessage* msg, const int flags) const;
 
-    /// \brief Checks if the socket is expecting to receive another part of a multipart message.
-    /// \return Return true if the socket expects another part of a multipart message and false otherwise.
+    /// Checks if the socket is expecting to receive another part of a multipart message.
+    /// @return Return true if the socket expects another part of a multipart message and false otherwise.
     bool ExpectsAnotherPart() const;
 
   private:
@@ -104,6 +167,8 @@ class FairMQChannel
 
     int fNoBlockFlag;
     int fSndMoreFlag;
+
+    bool InitCommandInterface(FairMQTransportFactory* factory);
 
     bool HandleUnblock() const;
 

--- a/fairmq/FairMQConfigurable.cxx
+++ b/fairmq/FairMQConfigurable.cxx
@@ -45,6 +45,12 @@ int FairMQConfigurable::GetProperty(const int key, const int default_ /*= 0*/)
     return default_;
 }
 
+string FairMQConfigurable::GetPropertyDescription(const int key)
+{
+    LOG(ERROR) << "Reached end of the property list. The description of the requested property " << key << " was not found.";
+    return "0";
+}
+
 FairMQConfigurable::~FairMQConfigurable()
 {
 }

--- a/fairmq/FairMQConfigurable.h
+++ b/fairmq/FairMQConfigurable.h
@@ -31,6 +31,8 @@ class FairMQConfigurable
     virtual std::string GetProperty(const int key, const std::string& default_ = "");
     virtual void SetProperty(const int key, const int value);
     virtual int GetProperty(const int key, const int default_ = 0);
+
+    virtual std::string GetPropertyDescription(const int key);
 };
 
 #endif /* FAIRMQCONFIGURABLE_H_ */

--- a/fairmq/FairMQDevice.cxx
+++ b/fairmq/FairMQDevice.cxx
@@ -397,6 +397,37 @@ string FairMQDevice::GetProperty(const int key, const string& default_ /*= ""*/)
     }
 }
 
+string FairMQDevice::GetPropertyDescription(const int key)
+{
+    switch (key)
+    {
+        case Id:
+            return "Id: Device ID";
+        case NumIoThreads:
+            return "NumIoThreads: Number of I/O Threads (size of the 0MQ thread pool to handle I/O operations. If your application is using only the inproc transport for messaging you may set this to zero, otherwise set it to at least one.)";
+        case MaxInitializationTime:
+            return "MaxInitializationTime: Timeout for retrying validation and initialization of the channels.";
+        case PortRangeMin:
+            return "PortRangeMin: Minumum value for the port range (when binding to dynamic port).";
+        case PortRangeMax:
+            return "PortRangeMax: Maximum value for the port range (when binding to dynamic port).";
+        case LogIntervalInMs:
+            return "LogIntervalInMs: Time between socket rates logging outputs.";
+        default:
+            return FairMQConfigurable::GetPropertyDescription(key);
+    }
+}
+
+void FairMQDevice::ListProperties()
+{
+    LOG(INFO) << "Properties of FairMQDevice:";
+    for (int p = FairMQConfigurable::Last; p < FairMQDevice::Last; ++p)
+    {
+        LOG(INFO) << " " << GetPropertyDescription(p);
+    }
+    LOG(INFO) << "---------------------------";
+}
+
 // Method for getting properties represented as an integer.
 int FairMQDevice::GetProperty(const int key, const int default_ /*= 0*/)
 {

--- a/fairmq/FairMQDevice.h
+++ b/fairmq/FairMQDevice.h
@@ -29,12 +29,14 @@
 
 class FairMQDevice : public FairMQStateMachine, public FairMQConfigurable
 {
+    friend class FairMQChannel;
+
   public:
     enum
     {
         Id = FairMQConfigurable::Last,
-        MaxInitializationTime,
         NumIoThreads,
+        MaxInitializationTime,
         PortRangeMin,
         PortRangeMax,
         LogIntervalInMs,
@@ -59,6 +61,13 @@ class FairMQDevice : public FairMQStateMachine, public FairMQConfigurable
     virtual std::string GetProperty(const int key, const std::string& default_ = "");
     virtual void SetProperty(const int key, const int value);
     virtual int GetProperty(const int key, const int default_ = 0);
+
+    /// Get property description for a given property name
+    /// @param key Property name/key
+    /// @return String with the property description 
+    virtual std::string GetPropertyDescription(const int key);
+    /// Print all properties of this and the parent class to LOG(INFO)
+    virtual void ListProperties();
 
     virtual void SetTransport(FairMQTransportFactory* factory);
 

--- a/fairmq/README.md
+++ b/fairmq/README.md
@@ -4,9 +4,7 @@ The standard FairRoot is running all the different analysis tasks within one pro
 
 ## Devices
 
-The components encapsulating the tasks are called **devices** and derive from the common base class `FairMQDevice`.  FairMQ provides ready to use devices to organize the dataflow between the components (without touching the contents of a message), providing functionality like merging and splitting of the data stream (see subdirectory `devices`).
-
-A number of devices to handle the data from the Tutorial3 detector of FairRoot are provided as an example and can be found in `FairRoot/base/MQ` directory. The implementation of the tasks run by these devices can be found `FairRoot/example/Tutorial3`. The implementation includes sending raw binary data as well as serializing the data with either [Boost Serialization](http://www.boost.org/doc/libs/release/libs/serialization/), [Google Protocol Buffers](https://developers.google.com/protocol-buffers/) or [Root TMessage](http://root.cern.ch/root/html/TMessage.html). Following the examples you can implement your own devices to transport arbitrary data.
+The components encapsulating the tasks are called **devices** and derive from the common base class `FairMQDevice`. FairMQ provides ready to use devices to organize the dataflow between the components (without touching the contents of a message), providing functionality like merging and splitting of the data stream (see subdirectory `devices`).
 
 ## Topology
 
@@ -17,6 +15,10 @@ Example of a simple FairMQ topology:
 ![example of FairMQ topology](../docs/images/fairmq-example-topology.png?raw=true "Example of possible FairMQ topology")
 
 Topology configuration is currently happening via setup scripts. This is very rudimentary and a much more flexible system is now in development. For now, example setup scripts can be found in directory `FairRoot/example/Tutorial3/` along with some additional documentation.
+
+## Communication Patterns
+
+FairMQ devices communicate via the communication patterns offered by ZeroMQ (or nanomsg): PUSH-PULL, PUB-SUB, REQ-REP, PAIR, [more info here](http://api.zeromq.org/4-0:zmq-socket).
 
 ## Messages
 
@@ -33,3 +35,8 @@ The communication layer is available through an interface. Two interface impleme
 
 ![FairMQ transport interface](../docs/images/fairmq-transport-interface.png?raw=true "FairMQ transport interface")
 
+## Examples
+
+A collection of simple examples in `examples` directory demonstrates some common usage patterns of FairMQ.
+
+A number of devices to handle the data from the Tutorial3 FairTestDetector of FairRoot are provided as an example and can be found in `FairRoot/base/MQ` directory. The implementation of the tasks run by these devices can be found `FairRoot/example/Tutorial3`. The implementation includes sending raw binary data as well as serializing the data with either [Boost Serialization](http://www.boost.org/doc/libs/release/libs/serialization/), [Google Protocol Buffers](https://developers.google.com/protocol-buffers/) or [Root TMessage](http://root.cern.ch/root/html/TMessage.html). Following the examples you can implement your own devices to transport arbitrary data.

--- a/fairmq/devices/FairMQBenchmarkSampler.cxx
+++ b/fairmq/devices/FairMQBenchmarkSampler.cxx
@@ -130,3 +130,26 @@ int FairMQBenchmarkSampler::GetProperty(const int key, const int default_ /*= 0*
             return FairMQDevice::GetProperty(key, default_);
     }
 }
+
+string FairMQBenchmarkSampler::GetPropertyDescription(const int key)
+{
+    switch (key)
+    {
+        case EventSize:
+            return "EventSize: Size of the transfered message buffer.";
+        case EventRate:
+            return "EventRate: Upper limit for the message rate.";
+        default:
+            return FairMQDevice::GetPropertyDescription(key);
+    }
+}
+
+void FairMQBenchmarkSampler::ListProperties()
+{
+    LOG(INFO) << "Properties of FairMQBenchmarkSampler:";
+    for (int p = FairMQConfigurable::Last; p < FairMQBenchmarkSampler::Last; ++p)
+    {
+        LOG(INFO) << " " << GetPropertyDescription(p);
+    }
+    LOG(INFO) << "---------------------------";
+}

--- a/fairmq/devices/FairMQBenchmarkSampler.h
+++ b/fairmq/devices/FairMQBenchmarkSampler.h
@@ -44,6 +44,9 @@ class FairMQBenchmarkSampler : public FairMQDevice
     virtual void SetProperty(const int key, const int value);
     virtual int GetProperty(const int key, const int default_ = 0);
 
+    virtual std::string GetPropertyDescription(const int key);
+    virtual void ListProperties();
+
   protected:
     int fEventSize;
     int fEventRate;

--- a/fairmq/examples/1-sampler-sink/CMakeLists.txt
+++ b/fairmq/examples/1-sampler-sink/CMakeLists.txt
@@ -1,0 +1,79 @@
+ ################################################################################
+ #    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    #
+ #                                                                              #
+ #              This software is distributed under the terms of the             #
+ #         GNU Lesser General Public Licence version 3 (LGPL) version 3,        #
+ #                  copied verbatim in the file "LICENSE"                       #
+ ################################################################################
+
+configure_file(${CMAKE_SOURCE_DIR}/fairmq/examples/1-sampler-sink/ex1-sampler-sink.json ${CMAKE_BINARY_DIR}/bin/config/ex1-sampler-sink.json)
+
+Set(INCLUDE_DIRECTORIES
+  ${CMAKE_SOURCE_DIR}/fairmq
+  ${CMAKE_SOURCE_DIR}/fairmq/devices
+  ${CMAKE_SOURCE_DIR}/fairmq/tools
+  ${CMAKE_SOURCE_DIR}/fairmq/options
+  ${CMAKE_SOURCE_DIR}/fairmq/examples/1-sampler-sink
+  ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+Set(SYSTEM_INCLUDE_DIRECTORIES
+  ${Boost_INCLUDE_DIR}
+)
+
+If(NANOMSG_FOUND)
+  Set(INCLUDE_DIRECTORIES
+    ${INCLUDE_DIRECTORIES}
+    ${CMAKE_SOURCE_DIR}/fairmq/nanomsg
+  )
+Else(NANOMSG_FOUND)
+  Set(INCLUDE_DIRECTORIES
+    ${INCLUDE_DIRECTORIES}
+    ${CMAKE_SOURCE_DIR}/fairmq/zeromq
+  )
+EndIf(NANOMSG_FOUND)
+
+Include_Directories(${INCLUDE_DIRECTORIES})
+Include_Directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
+
+Set(LINK_DIRECTORIES
+  ${Boost_LIBRARY_DIRS}
+)
+
+Link_Directories(${LINK_DIRECTORIES})
+
+Set(SRCS
+  "FairMQExample1Sampler.cxx"
+  "FairMQExample1Sink.cxx"
+)
+
+Set(DEPENDENCIES
+  ${DEPENDENCIES}
+  FairMQ
+)
+
+Set(LIBRARY_NAME FairMQExample1)
+
+GENERATE_LIBRARY()
+
+Set(Exe_Names
+  ex1-sampler
+  ex1-sink
+)
+
+Set(Exe_Source
+  runExample1Sampler.cxx
+  runExample1Sink.cxx
+)
+
+list(LENGTH Exe_Names _length)
+math(EXPR _length ${_length}-1)
+
+ForEach(_file RANGE 0 ${_length})
+  list(GET Exe_Names ${_file} _name)
+  list(GET Exe_Source ${_file} _src)
+  set(EXE_NAME ${_name})
+  set(SRCS ${_src})
+  set(DEPENDENCIES FairMQExample1)
+  GENERATE_EXECUTABLE()
+EndForEach(_file RANGE 0 ${_length})

--- a/fairmq/examples/1-sampler-sink/FairMQExample1Sampler.cxx
+++ b/fairmq/examples/1-sampler-sink/FairMQExample1Sampler.cxx
@@ -15,7 +15,6 @@
 #include <memory> // unique_ptr
 
 #include <boost/thread.hpp>
-#include <boost/bind.hpp>
 
 #include "FairMQExample1Sampler.h"
 #include "FairMQLogger.h"

--- a/fairmq/examples/1-sampler-sink/FairMQExample1Sink.cxx
+++ b/fairmq/examples/1-sampler-sink/FairMQExample1Sink.cxx
@@ -12,9 +12,6 @@
  * @author A. Rybalchenko
  */
 
-#include <boost/thread.hpp>
-#include <boost/bind.hpp>
-
 #include "FairMQExample1Sink.h"
 #include "FairMQLogger.h"
 

--- a/fairmq/examples/1-sampler-sink/README.md
+++ b/fairmq/examples/1-sampler-sink/README.md
@@ -5,4 +5,4 @@ A simple topology of two devices - **Sampler** and **Sink**. **Sampler** sends d
 
 `runExample1Sampler.cxx` and `runExample1Sink.cxx` configure and run the devices in their main function.
 
-The executables take two required command line parameters: `--id` and `--config-json-file`. The value of `--id` should be a unique identifier and the value for `-config-json-file` a path to a config file. The config file for this example is `ex1-sampler-sink.json` and it contains configuration for the communication channels of the devices. The mapping between a specific device and the configuration (which can contain multiple devices) is done based on the **id**.
+The executables take two required command line parameters: `--id` and `--config-json-file`. The value of `--id` should be a unique identifier and the value for `--config-json-file` a path to a config file. The config file for this example is `ex1-sampler-sink.json` and it contains configuration for the communication channels of the devices. The mapping between a specific device and the configuration (which can contain multiple devices) is done based on the **id**.

--- a/fairmq/examples/2-sampler-processor-sink/CMakeLists.txt
+++ b/fairmq/examples/2-sampler-processor-sink/CMakeLists.txt
@@ -1,0 +1,82 @@
+ ################################################################################
+ #    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    #
+ #                                                                              #
+ #              This software is distributed under the terms of the             #
+ #         GNU Lesser General Public Licence version 3 (LGPL) version 3,        #
+ #                  copied verbatim in the file "LICENSE"                       #
+ ################################################################################
+
+configure_file(${CMAKE_SOURCE_DIR}/fairmq/examples/2-sampler-processor-sink/ex2-sampler-processor-sink.json ${CMAKE_BINARY_DIR}/bin/config/ex2-sampler-processor-sink.json)
+
+Set(INCLUDE_DIRECTORIES
+  ${CMAKE_SOURCE_DIR}/fairmq
+  ${CMAKE_SOURCE_DIR}/fairmq/devices
+  ${CMAKE_SOURCE_DIR}/fairmq/tools
+  ${CMAKE_SOURCE_DIR}/fairmq/options
+  ${CMAKE_SOURCE_DIR}/fairmq/examples/2-sampler-processor-sink
+  ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+Set(SYSTEM_INCLUDE_DIRECTORIES
+  ${Boost_INCLUDE_DIR}
+)
+
+If(NANOMSG_FOUND)
+  Set(INCLUDE_DIRECTORIES
+    ${INCLUDE_DIRECTORIES}
+    ${CMAKE_SOURCE_DIR}/fairmq/nanomsg
+  )
+Else(NANOMSG_FOUND)
+  Set(INCLUDE_DIRECTORIES
+    ${INCLUDE_DIRECTORIES}
+    ${CMAKE_SOURCE_DIR}/fairmq/zeromq
+  )
+EndIf(NANOMSG_FOUND)
+
+Include_Directories(${INCLUDE_DIRECTORIES})
+Include_Directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
+
+Set(LINK_DIRECTORIES
+  ${Boost_LIBRARY_DIRS}
+)
+
+Link_Directories(${LINK_DIRECTORIES})
+
+Set(SRCS
+  "FairMQExample2Sampler.cxx"
+  "FairMQExample2Processor.cxx"
+  "FairMQExample2Sink.cxx"
+)
+
+Set(DEPENDENCIES
+  ${DEPENDENCIES}
+  FairMQ
+)
+
+Set(LIBRARY_NAME FairMQExample2)
+
+GENERATE_LIBRARY()
+
+Set(Exe_Names
+  ex2-sampler
+  ex2-processor
+  ex2-sink
+)
+
+Set(Exe_Source
+  runExample2Sampler.cxx
+  runExample2Processor.cxx
+  runExample2Sink.cxx
+)
+
+list(LENGTH Exe_Names _length)
+math(EXPR _length ${_length}-1)
+
+ForEach(_file RANGE 0 ${_length})
+  list(GET Exe_Names ${_file} _name)
+  list(GET Exe_Source ${_file} _src)
+  Set(EXE_NAME ${_name})
+  Set(SRCS ${_src})
+  Set(DEPENDENCIES FairMQExample2)
+  GENERATE_EXECUTABLE()
+EndForEach(_file RANGE 0 ${_length})

--- a/fairmq/examples/3-dds/CMakeLists.txt
+++ b/fairmq/examples/3-dds/CMakeLists.txt
@@ -1,0 +1,93 @@
+ ################################################################################
+ #    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    #
+ #                                                                              #
+ #              This software is distributed under the terms of the             #
+ #         GNU Lesser General Public Licence version 3 (LGPL) version 3,        #
+ #                  copied verbatim in the file "LICENSE"                       #
+ ################################################################################
+
+configure_file(${CMAKE_SOURCE_DIR}/fairmq/examples/3-dds/ex3-devices.json ${CMAKE_BINARY_DIR}/bin/config/ex3-devices.json)
+configure_file(${CMAKE_SOURCE_DIR}/fairmq/examples/3-dds/ex3-dds-topology.xml ${CMAKE_BINARY_DIR}/bin/config/ex3-dds-topology.xml)
+configure_file(${CMAKE_SOURCE_DIR}/fairmq/examples/3-dds/ex3-dds-hosts.cfg ${CMAKE_BINARY_DIR}/bin/config/ex3-dds-hosts.cfg COPYONLY)
+
+add_definitions(-DENABLE_DDS)
+
+Set(INCLUDE_DIRECTORIES
+  ${CMAKE_SOURCE_DIR}/fairmq
+  ${CMAKE_SOURCE_DIR}/fairmq/devices
+  ${CMAKE_SOURCE_DIR}/fairmq/tools
+  ${CMAKE_SOURCE_DIR}/fairmq/options
+  ${CMAKE_SOURCE_DIR}/fairmq/examples/3-dds
+  ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+Set(SYSTEM_INCLUDE_DIRECTORIES
+  ${SYSTEM_INCLUDE_DIRECTORIES}
+  ${DDS_INCLUDE_DIR}
+)
+
+If(NANOMSG_FOUND)
+  Set(INCLUDE_DIRECTORIES
+    ${INCLUDE_DIRECTORIES}
+    ${CMAKE_SOURCE_DIR}/fairmq/nanomsg
+  )
+Else(NANOMSG_FOUND)
+  Set(INCLUDE_DIRECTORIES
+    ${INCLUDE_DIRECTORIES}
+    ${CMAKE_SOURCE_DIR}/fairmq/zeromq
+  )
+EndIf(NANOMSG_FOUND)
+
+Include_Directories(${INCLUDE_DIRECTORIES})
+Include_Directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
+
+Set(LINK_DIRECTORIES
+  ${LINK_DIRECTORIES}
+  ${Boost_LIBRARY_DIRS}
+  ${DDS_LIBRARY_DIR}
+)
+
+Link_Directories(${LINK_DIRECTORIES})
+
+Set(SRCS
+  ${SRCS}
+  "FairMQExample3Sampler.cxx"
+  "FairMQExample3Processor.cxx"
+  "FairMQExample3Sink.cxx"
+)
+
+Set(DEPENDENCIES
+  ${DEPENDENCIES}
+  FairMQ
+  dds-key-value-lib
+)
+
+set(LIBRARY_NAME FairMQExample3)
+
+GENERATE_LIBRARY()
+
+Set(Exe_Names
+  ${Exe_Names}
+  ex3-sampler-dds
+  ex3-processor-dds
+  ex3-sink-dds
+)
+
+Set(Exe_Source
+  ${Exe_Source}
+  runExample3Sampler.cxx
+  runExample3Processor.cxx
+  runExample3Sink.cxx
+)
+
+list(LENGTH Exe_Names _length)
+math(EXPR _length ${_length}-1)
+
+ForEach(_file RANGE 0 ${_length})
+  list(GET Exe_Names ${_file} _name)
+  list(GET Exe_Source ${_file} _src)
+  set(EXE_NAME ${_name})
+  set(SRCS ${_src})
+  set(DEPENDENCIES FairMQExample3)
+  GENERATE_EXECUTABLE()
+EndForEach(_file RANGE 0 ${_length})

--- a/fairmq/examples/3-dds/README.md
+++ b/fairmq/examples/3-dds/README.md
@@ -3,6 +3,12 @@ Example 3: DDS
 
 This example demonstrates usage of the Dynamic Deployment System ([DDS](http://dds.gsi.de/)) to dynamically deploy and configure a topology of devices. The topology is similar to those of Example 2, but now it can be easily distributed on different computing nodes without the need for manual reconfiguration of the devices.
 
+This example is compiled only if the DDS is found by CMake. Custom DDS installation location can be given to CMake like this:
+
+```bash
+cmake -DDDS_PATH="/path/to/dds/install/dir/" ..
+```
+
 The description below outlines the minimal steps needed to run the example with DDS. For more details please refer to DDS documentation on [DDS Website](http://dds.gsi.de/).
 
 ##### 1. The devices that bind their sockets need to advertise their bound addresses to DDS by writing a property.
@@ -56,9 +62,9 @@ After this step each device will have the necessary connection information.
 
 We run this example on the local machine for simplicity. The file below defines one worker `wn0` with 12 DDS Agents (thus able to accept 12 tasks). The parameters for each worker node are:
  - user-chosen worker ID (must be unique)
- - a host name with or without a login, in a form: login@host.fqdn
+ - a host name with or without a login, in a form: login@host.fqdn (password-less SSH access to these hosts must be possible)
  - additional SSH params (can be empty)
- - a remote working directory
+ - a remote working directory (most exist on the worker nodes)
  - number of DDS Agents for this worker
 
 ```bash

--- a/fairmq/examples/3-dds/runExample3Processor.cxx
+++ b/fairmq/examples/3-dds/runExample3Processor.cxx
@@ -46,11 +46,11 @@ int main(int argc, char** argv)
     {
         int ddsTaskIndex = 0;
 
-        options_description samplerOptions("Processor options");
-        samplerOptions.add_options()
-            ("index", value<int>(&ddsTaskIndex)->default_value(0), "Store DDS task index");
+        options_description processorOptions("Processor options");
+        processorOptions.add_options()
+            ("index", value<int>(&ddsTaskIndex)->default_value(0), "DDS task index");
 
-        config.AddToCmdLineOptions(samplerOptions);
+        config.AddToCmdLineOptions(processorOptions);
 
         if (config.ParseAll(argc, argv))
         {

--- a/fairmq/examples/3-dds/runExample3Sampler.cxx
+++ b/fairmq/examples/3-dds/runExample3Sampler.cxx
@@ -45,11 +45,13 @@ int main(int argc, char** argv)
 
     try
     {
-        std::string text;
+        std::string text; // text to be sent for processing.
+        std::string interfaceName; // name of the network interface to use for communication.
 
         options_description samplerOptions("Sampler options");
         samplerOptions.add_options()
-            ("text", value<std::string>(&text)->default_value("Hello"), "Text to send out");
+            ("text", value<std::string>(&text)->default_value("Hello"), "Text to send out")
+            ("network-interface", value<std::string>(&interfaceName)->default_value("eth0"), "Name of the network interface to use (e.g. eth0, ib0, wlan0, en0...)");
 
         config.AddToCmdLineOptions(samplerOptions);
 
@@ -83,22 +85,14 @@ int main(int argc, char** argv)
         FairMQ::tools::getHostIPs(IPs);
         stringstream ss;
         // Check if ib0 (infiniband) interface is available, otherwise try eth0 or wlan0.
-        if (IPs.count("ib0"))
+        if (IPs.count(interfaceName))
         {
-            ss << "tcp://" << IPs["ib0"] << ":1";
-        }
-        else if (IPs.count("eth0"))
-        {
-            ss << "tcp://" << IPs["eth0"] << ":1";
-        }
-        else if (IPs.count("wlan0"))
-        {
-            ss << "tcp://" << IPs["wlan0"] << ":1";
+            ss << "tcp://" << IPs[interfaceName] << ":1";
         }
         else
         {
             LOG(INFO) << ss.str();
-            LOG(ERROR) << "Could not find ib0, eth0 or wlan0";
+            LOG(ERROR) << "Could not find provided network interface: \"" << interfaceName << "\"!, exiting.";
             exit(EXIT_FAILURE);
         }
         string initialOutputAddress = ss.str();

--- a/fairmq/examples/3-dds/runExample3Sink.cxx
+++ b/fairmq/examples/3-dds/runExample3Sink.cxx
@@ -45,6 +45,14 @@ int main(int argc, char** argv)
 
     try
     {
+        std::string interfaceName; // name of the network interface to use for communication.
+
+        options_description sinkOptions("Sink options");
+        sinkOptions.add_options()
+            ("network-interface", value<std::string>(&interfaceName)->default_value("eth0"), "Name of the network interface to use (e.g. eth0, ib0, wlan0, en0...)");
+
+        config.AddToCmdLineOptions(sinkOptions);
+
         if (config.ParseAll(argc, argv))
         {
             return 0;
@@ -74,22 +82,14 @@ int main(int argc, char** argv)
         FairMQ::tools::getHostIPs(IPs);
         stringstream ss;
         // Check if ib0 (infiniband) interface is available, otherwise try eth0 or wlan0.
-        if (IPs.count("ib0"))
+        if (IPs.count(interfaceName))
         {
-            ss << "tcp://" << IPs["ib0"] << ":1";
-        }
-        else if (IPs.count("eth0"))
-        {
-            ss << "tcp://" << IPs["eth0"] << ":1";
-        }
-        else if (IPs.count("wlan0"))
-        {
-            ss << "tcp://" << IPs["wlan0"] << ":1";
+            ss << "tcp://" << IPs[interfaceName] << ":1";
         }
         else
         {
             LOG(INFO) << ss.str();
-            LOG(ERROR) << "Could not find ib0, eth0 or wlan0";
+            LOG(ERROR) << "Could not find provided network interface: \"" << interfaceName << "\"!, exiting.";
             exit(EXIT_FAILURE);
         }
         string initialInputAddress = ss.str();

--- a/fairmq/examples/4-copypush/CMakeLists.txt
+++ b/fairmq/examples/4-copypush/CMakeLists.txt
@@ -1,0 +1,79 @@
+ ################################################################################
+ #    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    #
+ #                                                                              #
+ #              This software is distributed under the terms of the             #
+ #         GNU Lesser General Public Licence version 3 (LGPL) version 3,        #
+ #                  copied verbatim in the file "LICENSE"                       #
+ ################################################################################
+
+configure_file(${CMAKE_SOURCE_DIR}/fairmq/examples/4-copypush/ex4-copypush.json ${CMAKE_BINARY_DIR}/bin/config/ex4-copypush.json)
+
+Set(INCLUDE_DIRECTORIES
+  ${CMAKE_SOURCE_DIR}/fairmq
+  ${CMAKE_SOURCE_DIR}/fairmq/devices
+  ${CMAKE_SOURCE_DIR}/fairmq/tools
+  ${CMAKE_SOURCE_DIR}/fairmq/options
+  ${CMAKE_SOURCE_DIR}/fairmq/examples/4-copypush
+  ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+Set(SYSTEM_INCLUDE_DIRECTORIES
+  ${Boost_INCLUDE_DIR}
+)
+
+If(NANOMSG_FOUND)
+  Set(INCLUDE_DIRECTORIES
+    ${INCLUDE_DIRECTORIES}
+    ${CMAKE_SOURCE_DIR}/fairmq/nanomsg
+  )
+Else(NANOMSG_FOUND)
+  Set(INCLUDE_DIRECTORIES
+    ${INCLUDE_DIRECTORIES}
+    ${CMAKE_SOURCE_DIR}/fairmq/zeromq
+  )
+EndIf(NANOMSG_FOUND)
+
+Include_Directories(${INCLUDE_DIRECTORIES})
+Include_Directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
+
+Set(LINK_DIRECTORIES
+  ${Boost_LIBRARY_DIRS}
+)
+
+Link_Directories(${LINK_DIRECTORIES})
+
+Set(SRCS
+  "FairMQExample4Sampler.cxx"
+  "FairMQExample4Sink.cxx"
+)
+
+Set(DEPENDENCIES
+  ${DEPENDENCIES}
+  FairMQ
+)
+
+Set(LIBRARY_NAME FairMQExample4)
+
+GENERATE_LIBRARY()
+
+Set(Exe_Names
+  ex4-sampler
+  ex4-sink
+)
+
+Set(Exe_Source
+  runExample4Sampler.cxx
+  runExample4Sink.cxx
+)
+
+list(LENGTH Exe_Names _length)
+math(EXPR _length ${_length}-1)
+
+ForEach(_file RANGE 0 ${_length})
+  list(GET Exe_Names ${_file} _name)
+  list(GET Exe_Source ${_file} _src)
+  Set(EXE_NAME ${_name})
+  Set(SRCS ${_src})
+  Set(DEPENDENCIES FairMQExample4)
+  GENERATE_EXECUTABLE()
+EndForEach(_file RANGE 0 ${_length})

--- a/fairmq/examples/5-req-rep/CMakeLists.txt
+++ b/fairmq/examples/5-req-rep/CMakeLists.txt
@@ -1,0 +1,77 @@
+ ################################################################################
+ #    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    #
+ #                                                                              #
+ #              This software is distributed under the terms of the             #
+ #         GNU Lesser General Public Licence version 3 (LGPL) version 3,        #
+ #                  copied verbatim in the file "LICENSE"                       #
+ ################################################################################
+
+Set(INCLUDE_DIRECTORIES
+  ${CMAKE_SOURCE_DIR}/fairmq
+  ${CMAKE_SOURCE_DIR}/fairmq/devices
+  ${CMAKE_SOURCE_DIR}/fairmq/tools
+  ${CMAKE_SOURCE_DIR}/fairmq/options
+  ${CMAKE_SOURCE_DIR}/fairmq/examples/5-req-rep
+  ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+Set(SYSTEM_INCLUDE_DIRECTORIES
+  ${Boost_INCLUDE_DIR}
+)
+
+If(NANOMSG_FOUND)
+  Set(INCLUDE_DIRECTORIES
+    ${INCLUDE_DIRECTORIES}
+    ${CMAKE_SOURCE_DIR}/fairmq/nanomsg
+  )
+Else(NANOMSG_FOUND)
+  Set(INCLUDE_DIRECTORIES
+    ${INCLUDE_DIRECTORIES}
+    ${CMAKE_SOURCE_DIR}/fairmq/zeromq
+  )
+EndIf(NANOMSG_FOUND)
+
+Include_Directories(${INCLUDE_DIRECTORIES})
+Include_Directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
+
+Set(LINK_DIRECTORIES
+  ${Boost_LIBRARY_DIRS}
+)
+
+Link_Directories(${LINK_DIRECTORIES})
+
+set(SRCS
+  "FairMQExample5Client.cxx"
+  "FairMQExample5Server.cxx"
+)
+
+set(DEPENDENCIES
+  ${DEPENDENCIES}
+  FairMQ
+)
+
+set(LIBRARY_NAME FairMQExample5)
+
+GENERATE_LIBRARY()
+
+set(Exe_Names
+  ex5-client
+  ex5-server
+)
+
+set(Exe_Source
+  runExample5Client.cxx
+  runExample5Server.cxx
+)
+
+list(LENGTH Exe_Names _length)
+math(EXPR _length ${_length}-1)
+
+ForEach(_file RANGE 0 ${_length})
+  list(GET Exe_Names ${_file} _name)
+  list(GET Exe_Source ${_file} _src)
+  set(EXE_NAME ${_name})
+  set(SRCS ${_src})
+  set(DEPENDENCIES FairMQExample5)
+  GENERATE_EXECUTABLE()
+EndForEach(_file RANGE 0 ${_length})

--- a/fairmq/test/CMakeLists.txt
+++ b/fairmq/test/CMakeLists.txt
@@ -1,0 +1,107 @@
+ ################################################################################
+ #    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    #
+ #                                                                              #
+ #              This software is distributed under the terms of the             #
+ #         GNU Lesser General Public Licence version 3 (LGPL) version 3,        #
+ #                  copied verbatim in the file "LICENSE"                       #
+ ################################################################################
+
+configure_file(${CMAKE_SOURCE_DIR}/fairmq/test/test-fairmq-push-pull.sh.in ${CMAKE_BINARY_DIR}/fairmq/test/test-fairmq-push-pull.sh)
+configure_file(${CMAKE_SOURCE_DIR}/fairmq/test/test-fairmq-pub-sub.sh.in ${CMAKE_BINARY_DIR}/fairmq/test/test-fairmq-pub-sub.sh)
+configure_file(${CMAKE_SOURCE_DIR}/fairmq/test/test-fairmq-req-rep.sh.in ${CMAKE_BINARY_DIR}/fairmq/test/test-fairmq-req-rep.sh)
+
+Set(INCLUDE_DIRECTORIES
+  ${CMAKE_SOURCE_DIR}/fairmq
+  ${CMAKE_SOURCE_DIR}/fairmq/devices
+  ${CMAKE_SOURCE_DIR}/fairmq/tools
+  ${CMAKE_SOURCE_DIR}/fairmq/options
+  ${CMAKE_SOURCE_DIR}/fairmq/test/push-pull
+  ${CMAKE_SOURCE_DIR}/fairmq/test/pub-sub
+  ${CMAKE_SOURCE_DIR}/fairmq/test/req-rep
+  ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+Set(SYSTEM_INCLUDE_DIRECTORIES
+  ${Boost_INCLUDE_DIR}
+)
+
+If(NANOMSG_FOUND)
+  Set(INCLUDE_DIRECTORIES
+    ${INCLUDE_DIRECTORIES}
+    ${CMAKE_SOURCE_DIR}/fairmq/nanomsg
+  )
+Else(NANOMSG_FOUND)
+  Set(INCLUDE_DIRECTORIES
+    ${INCLUDE_DIRECTORIES}
+    ${CMAKE_SOURCE_DIR}/fairmq/zeromq
+  )
+EndIf(NANOMSG_FOUND)
+
+Include_Directories(${INCLUDE_DIRECTORIES})
+Include_Directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
+
+Set(LINK_DIRECTORIES
+  ${Boost_LIBRARY_DIRS}
+)
+
+Link_Directories(${LINK_DIRECTORIES})
+
+set(SRCS
+  "push-pull/FairMQTestPush.cxx"
+  "push-pull/FairMQTestPull.cxx"
+  "pub-sub/FairMQTestPub.cxx"
+  "pub-sub/FairMQTestSub.cxx"
+  "req-rep/FairMQTestReq.cxx"
+  "req-rep/FairMQTestRep.cxx"
+)
+
+set(DEPENDENCIES
+  ${DEPENDENCIES}
+  FairMQ
+)
+
+set(LIBRARY_NAME FairMQTest)
+
+GENERATE_LIBRARY()
+
+set(Exe_Names
+  test-fairmq-push
+  test-fairmq-pull
+  test-fairmq-pub
+  test-fairmq-sub
+  test-fairmq-req
+  test-fairmq-rep
+)
+
+set(Exe_Source
+  push-pull/runTestPush.cxx
+  push-pull/runTestPull.cxx
+  pub-sub/runTestPub.cxx
+  pub-sub/runTestSub.cxx
+  req-rep/runTestReq.cxx
+  req-rep/runTestRep.cxx
+)
+
+list(LENGTH Exe_Names _length)
+math(EXPR _length ${_length}-1)
+
+ForEach(_file RANGE 0 ${_length})
+  list(GET Exe_Names ${_file} _name)
+  list(GET Exe_Source ${_file} _src)
+  set(EXE_NAME ${_name})
+  set(SRCS ${_src})
+  set(DEPENDENCIES FairMQTest)
+  GENERATE_EXECUTABLE()
+EndForEach(_file RANGE 0 ${_length})
+
+add_test(NAME run_fairmq_push_pull COMMAND ${CMAKE_BINARY_DIR}/fairmq/test/test-fairmq-push-pull.sh)
+set_tests_properties(run_fairmq_push_pull PROPERTIES TIMEOUT "30")
+set_tests_properties(run_fairmq_push_pull PROPERTIES PASS_REGULAR_EXPRESSION "PUSH-PULL test successfull")
+
+add_test(NAME run_fairmq_pub_sub COMMAND ${CMAKE_BINARY_DIR}/fairmq/test/test-fairmq-pub-sub.sh)
+set_tests_properties(run_fairmq_pub_sub PROPERTIES TIMEOUT "30")
+set_tests_properties(run_fairmq_pub_sub PROPERTIES PASS_REGULAR_EXPRESSION "PUB-SUB test successfull")
+
+add_test(NAME run_fairmq_req_rep COMMAND ${CMAKE_BINARY_DIR}/fairmq/test/test-fairmq-req-rep.sh)
+set_tests_properties(run_fairmq_req_rep PROPERTIES TIMEOUT "30")
+set_tests_properties(run_fairmq_req_rep PROPERTIES PASS_REGULAR_EXPRESSION "REQ-REP test successfull")

--- a/fairmq/zeromq/FairMQContextZMQ.cxx
+++ b/fairmq/zeromq/FairMQContextZMQ.cxx
@@ -14,6 +14,8 @@
 
 #include <sstream>
 
+#include <zmq.h>
+
 #include "FairMQLogger.h"
 #include "FairMQContextZMQ.h"
 

--- a/fairmq/zeromq/FairMQContextZMQ.h
+++ b/fairmq/zeromq/FairMQContextZMQ.h
@@ -15,12 +15,9 @@
 #ifndef FAIRMQCONTEXTZMQ_H_
 #define FAIRMQCONTEXTZMQ_H_
 
-#include <zmq.h>
-
 class FairMQContextZMQ
 {
   public:
-
     /// Constructor
     FairMQContextZMQ(int numIoThreads);
 

--- a/fairmq/zeromq/FairMQSocketZMQ.cxx
+++ b/fairmq/zeromq/FairMQSocketZMQ.cxx
@@ -14,6 +14,8 @@
 
 #include <sstream>
 
+#include <zmq.h>
+
 #include "FairMQSocketZMQ.h"
 #include "FairMQLogger.h"
 

--- a/fairmq/zeromq/FairMQSocketZMQ.h
+++ b/fairmq/zeromq/FairMQSocketZMQ.h
@@ -17,8 +17,6 @@
 
 #include <boost/shared_ptr.hpp>
 
-#include <zmq.h>
-
 #include "FairMQSocket.h"
 #include "FairMQContextZMQ.h"
 


### PR DESCRIPTION
  - Rename Tutorial3 MQ files for uniform naming.
  - Add search for dylib in FindDDS.cmake (OSX).
  - Add more detail to the DDS example readme.
  - MQ Example 3 (DDS): choose network interface via command line option.
  - Give FairMQ examples their own CMakeLists.txt for clarity.
  - Remove C++11 checks in Tutorial3 from the code (they are now in CMake).
  - Add Serializer for device properties (FairMQDevice::ListProperties()).