### PR TITLE
Getting MCTracks sorted by weight without C++11

### DIFF
--- a/base/event/FairMultiLinkedData.cxx
+++ b/base/event/FairMultiLinkedData.cxx
@@ -269,6 +269,14 @@ FairMultiLinkedData FairMultiLinkedData::GetLinksWithType(Int_t type) const
   return result;
 }
 
+std::vector<FairLink> FairMultiLinkedData::GetSortedMCTracks(){
+	FairMultiLinkedData mcLinks = GetLinksWithType(FairRootManager::Instance()->GetBranchId("MCTrack"));
+	std::set<FairLink> mcSet = mcLinks.GetLinks();
+	std::vector<FairLink> mcVector(mcSet.begin(), mcSet.end());
+	std::sort(begin(mcVector), end(mcVector), [](FairLink& val1, FairLink& val2){ return val1.GetWeight() > val2.GetWeight();});
+	return mcVector;
+}
+
 TObject* FairMultiLinkedData::GetData(FairLink& myLink)
 {
   FairRootManager* ioman = FairRootManager::Instance();

--- a/base/event/FairMultiLinkedData.cxx
+++ b/base/event/FairMultiLinkedData.cxx
@@ -269,11 +269,16 @@ FairMultiLinkedData FairMultiLinkedData::GetLinksWithType(Int_t type) const
   return result;
 }
 
+bool LargerWeight(FairLink val1, FairLink val2){
+	return val1.GetWeight() > val2.GetWeight();
+}
+
 std::vector<FairLink> FairMultiLinkedData::GetSortedMCTracks(){
 	FairMultiLinkedData mcLinks = GetLinksWithType(FairRootManager::Instance()->GetBranchId("MCTrack"));
 	std::set<FairLink> mcSet = mcLinks.GetLinks();
 	std::vector<FairLink> mcVector(mcSet.begin(), mcSet.end());
-	std::sort(begin(mcVector), end(mcVector), [](FairLink& val1, FairLink& val2){ return val1.GetWeight() > val2.GetWeight();});
+	//std::sort(begin(mcVector), end(mcVector), [](FairLink& val1, FairLink& val2){ return val1.GetWeight() > val2.GetWeight();});
+	std::sort(begin(mcVector), end(mcVector), LargerWeight);
 	return mcVector;
 }
 

--- a/base/event/FairMultiLinkedData.h
+++ b/base/event/FairMultiLinkedData.h
@@ -42,6 +42,7 @@ class FairMultiLinkedData : public  TObject
     virtual Int_t           GetNLinks() const { return fLinks.size(); }       ///< returns the number of stored links
     virtual FairLink        GetLink(Int_t pos) const;                 ///< returns the FairLink at the given position
     virtual FairMultiLinkedData   GetLinksWithType(Int_t type) const;             ///< Gives you a list of links which contain the given type
+    virtual std::vector<FairLink> GetSortedMCTracks();				///< Gives you a list of all FairLinks pointing to a "MCTrack" sorted by their weight
     TObject*         GetData(FairLink& myLink);                  ///< Get the TObject the Link is pointing to
     virtual Int_t GetDefaultType() { return fDefaultType;}
     Bool_t              GetPersistanceCheck() {return fPersistanceCheck;}     ///< Returns the value of PersistanceCheck

--- a/base/event/FairMultiLinkedData_Interface.cxx
+++ b/base/event/FairMultiLinkedData_Interface.cxx
@@ -127,6 +127,16 @@ FairMultiLinkedData   FairMultiLinkedData_Interface::GetLinksWithType(Int_t type
 	}
 }
 
+std::vector<FairLink> FairMultiLinkedData_Interface::GetSortedMCTracks()
+{
+	if (GetPointerToLinks() != 0){
+		return GetPointerToLinks()->GetSortedMCTracks();
+	} else {
+		std::vector<FairLink> empty;
+		return empty;
+	}
+}
+
 void FairMultiLinkedData_Interface::SetLinks(FairMultiLinkedData links)
 {
 	CreateFairMultiLinkedData();

--- a/base/event/FairMultiLinkedData_Interface.h
+++ b/base/event/FairMultiLinkedData_Interface.h
@@ -46,6 +46,8 @@ class FairMultiLinkedData_Interface : public  TObject
     virtual FairLink            GetEntryNr() const;
     virtual FairMultiLinkedData* 		GetPointerToLinks() const {	return fLink;}
 
+    virtual std::vector<FairLink> GetSortedMCTracks();
+
     virtual void SetLinks(FairMultiLinkedData links);           ///< Sets the links as vector of FairLink
     virtual void SetLink(FairLink link);      					///< Sets the Links with a single FairLink
     virtual void SetInsertHistory(Bool_t val);


### PR DESCRIPTION
Code is rewritten to use a function instead of a lambda expression.
Runs on my Mac and Linux machine but both have C++11 support.