### PR TITLE
Several FairMQ fixes

### DIFF
--- a/fairmq/FairMQChannel.cxx
+++ b/fairmq/FairMQChannel.cxx
@@ -73,6 +73,7 @@ std::string FairMQChannel::GetType() const
     catch (boost::exception& e)
     {
         LOG(ERROR) << "Exception caught in FairMQChannel::GetType: " << boost::diagnostic_information(e);
+        exit(EXIT_FAILURE);
     }
 }
 
@@ -86,6 +87,7 @@ std::string FairMQChannel::GetMethod() const
     catch (boost::exception& e)
     {
         LOG(ERROR) << "Exception caught in FairMQChannel::GetMethod: " << boost::diagnostic_information(e);
+        exit(EXIT_FAILURE);
     }
 }
 
@@ -99,6 +101,7 @@ std::string FairMQChannel::GetAddress() const
     catch (boost::exception& e)
     {
         LOG(ERROR) << "Exception caught in FairMQChannel::GetAddress: " << boost::diagnostic_information(e);
+        exit(EXIT_FAILURE);
     }
 }
 
@@ -112,6 +115,7 @@ int FairMQChannel::GetSndBufSize() const
     catch (boost::exception& e)
     {
         LOG(ERROR) << "Exception caught in FairMQChannel::GetSndBufSize: " << boost::diagnostic_information(e);
+        exit(EXIT_FAILURE);
     }
 }
 
@@ -125,6 +129,7 @@ int FairMQChannel::GetRcvBufSize() const
     catch (boost::exception& e)
     {
         LOG(ERROR) << "Exception caught in FairMQChannel::GetRcvBufSize: " << boost::diagnostic_information(e);
+        exit(EXIT_FAILURE);
     }
 }
 
@@ -138,6 +143,7 @@ int FairMQChannel::GetRateLogging() const
     catch (boost::exception& e)
     {
         LOG(ERROR) << "Exception caught in FairMQChannel::GetRateLogging: " << boost::diagnostic_information(e);
+        exit(EXIT_FAILURE);
     }
 }
 
@@ -152,6 +158,7 @@ void FairMQChannel::UpdateType(const std::string& type)
     catch (boost::exception& e)
     {
         LOG(ERROR) << "Exception caught in FairMQChannel::UpdateType: " << boost::diagnostic_information(e);
+        exit(EXIT_FAILURE);
     }
 }
 
@@ -166,6 +173,7 @@ void FairMQChannel::UpdateMethod(const std::string& method)
     catch (boost::exception& e)
     {
         LOG(ERROR) << "Exception caught in FairMQChannel::UpdateMethod: " << boost::diagnostic_information(e);
+        exit(EXIT_FAILURE);
     }
 }
 
@@ -180,6 +188,7 @@ void FairMQChannel::UpdateAddress(const std::string& address)
     catch (boost::exception& e)
     {
         LOG(ERROR) << "Exception caught in FairMQChannel::UpdateAddress: " << boost::diagnostic_information(e);
+        exit(EXIT_FAILURE);
     }
 }
 
@@ -194,6 +203,7 @@ void FairMQChannel::UpdateSndBufSize(const int sndBufSize)
     catch (boost::exception& e)
     {
         LOG(ERROR) << "Exception caught in FairMQChannel::UpdateSndBufSize: " << boost::diagnostic_information(e);
+        exit(EXIT_FAILURE);
     }
 }
 
@@ -208,6 +218,7 @@ void FairMQChannel::UpdateRcvBufSize(const int rcvBufSize)
     catch (boost::exception& e)
     {
         LOG(ERROR) << "Exception caught in FairMQChannel::UpdateRcvBufSize: " << boost::diagnostic_information(e);
+        exit(EXIT_FAILURE);
     }
 }
 
@@ -222,6 +233,7 @@ void FairMQChannel::UpdateRateLogging(const int rateLogging)
     catch (boost::exception& e)
     {
         LOG(ERROR) << "Exception caught in FairMQChannel::UpdateRateLogging: " << boost::diagnostic_information(e);
+        exit(EXIT_FAILURE);
     }
 }
 
@@ -235,6 +247,7 @@ bool FairMQChannel::IsValid() const
     catch (boost::exception& e)
     {
         LOG(ERROR) << "Exception caught in FairMQChannel::IsValid: " << boost::diagnostic_information(e);
+        exit(EXIT_FAILURE);
     }
 }
 
@@ -347,6 +360,7 @@ bool FairMQChannel::ValidateChannel()
     catch (boost::exception& e)
     {
         LOG(ERROR) << "Exception caught in FairMQChannel::ValidateChannel: " << boost::diagnostic_information(e);
+        exit(EXIT_FAILURE);
     }
 }
 

--- a/fairmq/FairMQChannel.cxx
+++ b/fairmq/FairMQChannel.cxx
@@ -553,11 +553,9 @@ bool FairMQChannel::SetSendTimeout(const int timeout)
             return true;
         }
     }
-    else
-    {
-        LOG(ERROR) << "SetSendTimeout() failed - socket is not initialized!";
-        return false;
-    }
+
+    LOG(ERROR) << "SetSendTimeout() failed - socket is not initialized!";
+    return false;
 }
 
 int FairMQChannel::GetSendTimeout() const
@@ -583,11 +581,9 @@ bool FairMQChannel::SetReceiveTimeout(const int timeout)
             return true;
         }
     }
-    else
-    {
-        LOG(ERROR) << "SetReceiveTimeout() failed - socket is not initialized!";
-        return false;
-    }
+
+    LOG(ERROR) << "SetReceiveTimeout() failed - socket is not initialized!";
+    return false;
 }
 
 int FairMQChannel::GetReceiveTimeout() const

--- a/fairmq/FairMQDevice.cxx
+++ b/fairmq/FairMQDevice.cxx
@@ -311,6 +311,7 @@ void FairMQDevice::RunWrapper()
     catch(boost::thread_resource_error& e)
     {
         LOG(ERROR) << e.what();
+        exit(EXIT_FAILURE);
     }
 
     if (CheckCurrentState(RUNNING))

--- a/fairmq/FairMQStateMachine.cxx
+++ b/fairmq/FairMQStateMachine.cxx
@@ -104,6 +104,7 @@ bool FairMQStateMachine::ChangeState(int event)
     catch (boost::exception& e)
     {
         LOG(ERROR) << boost::diagnostic_information(e);
+        exit(EXIT_FAILURE);
     }
     return false;
 }
@@ -136,6 +137,7 @@ void FairMQStateMachine::WaitForEndOfState(int event)
                 catch (boost::exception& e)
                 {
                     LOG(ERROR) << boost::diagnostic_information(e);
+                    exit(EXIT_FAILURE);
                 }
                 break;
             }
@@ -184,7 +186,7 @@ bool FairMQStateMachine::WaitForEndOfStateForMs(int event, int durationInMs)
                 return false;
         }
     }
-    catch (boost::thread_interrupted &e)
+    catch (boost::thread_interrupted& e)
     {
         LOG(ERROR) << boost::diagnostic_information(e);
     }

--- a/fairmq/examples/4-copypush/FairMQExample4Sink.cxx
+++ b/fairmq/examples/4-copypush/FairMQExample4Sink.cxx
@@ -30,9 +30,10 @@ void FairMQExample4Sink::Run()
     {
         std::unique_ptr<FairMQMessage> msg(fTransportFactory->CreateMessage());
 
-        fChannels.at("data-in").at(0).Receive(msg);
-
-        LOG(INFO) << "Received message: \"" << *(static_cast<int*>(msg->GetData())) << "\"";
+        if (fChannels.at("data-in").at(0).Receive(msg) >= 0)
+        {
+            LOG(INFO) << "Received message: \"" << *(static_cast<int*>(msg->GetData())) << "\"";
+        }
     }
 }
 

--- a/fairmq/examples/5-req-rep/FairMQExample5Client.cxx
+++ b/fairmq/examples/5-req-rep/FairMQExample5Client.cxx
@@ -49,10 +49,11 @@ void FairMQExample5Client::Run()
 
         if (fChannels.at("data").at(0).Send(request) > 0)
         {
-            fChannels.at("data").at(0).Receive(reply);
-            LOG(INFO) << "Received reply from server: \"" << string(static_cast<char*>(reply->GetData()), reply->GetSize()) << "\"";
+            if (fChannels.at("data").at(0).Receive(reply) >= 0)
+            {
+                LOG(INFO) << "Received reply from server: \"" << string(static_cast<char*>(reply->GetData()), reply->GetSize()) << "\"";
+            }
         }
-
     }
 }
 

--- a/fairmq/nanomsg/FairMQSocketNN.cxx
+++ b/fairmq/nanomsg/FairMQSocketNN.cxx
@@ -103,6 +103,7 @@ int FairMQSocketNN::Send(FairMQMessage* msg, const string& flag)
         fBytesTx += nbytes;
         ++fMessagesTx;
         static_cast<FairMQMessageNN*>(msg)->fReceiving = false;
+        return nbytes;
     }
     if (nn_errno() == EAGAIN)
     {
@@ -126,6 +127,7 @@ int FairMQSocketNN::Send(FairMQMessage* msg, const int flags)
         fBytesTx += nbytes;
         ++fMessagesTx;
         static_cast<FairMQMessageNN*>(msg)->fReceiving = false;
+        return nbytes;
     }
     if (nn_errno() == EAGAIN)
     {
@@ -151,6 +153,7 @@ int FairMQSocketNN::Receive(FairMQMessage* msg, const string& flag)
         msg->Rebuild();
         msg->SetMessage(ptr, nbytes);
         static_cast<FairMQMessageNN*>(msg)->fReceiving = true;
+        return nbytes;
     }
     if (nn_errno() == EAGAIN)
     {
@@ -175,6 +178,7 @@ int FairMQSocketNN::Receive(FairMQMessage* msg, const int flags)
         ++fMessagesRx;
         msg->SetMessage(ptr, nbytes);
         static_cast<FairMQMessageNN*>(msg)->fReceiving = true;
+        return nbytes;
     }
     if (nn_errno() == EAGAIN)
     {

--- a/fairmq/test/pub-sub/FairMQTestPub.cxx
+++ b/fairmq/test/pub-sub/FairMQTestPub.cxx
@@ -24,20 +24,23 @@ FairMQTestPub::FairMQTestPub()
 void FairMQTestPub::Run()
 {
     std::unique_ptr<FairMQMessage> ready1Msg(fTransportFactory->CreateMessage());
-    fChannels.at("control").at(0).Receive(ready1Msg);
+    int r1 = fChannels.at("control").at(0).Receive(ready1Msg);
     std::unique_ptr<FairMQMessage> ready2Msg(fTransportFactory->CreateMessage());
-    fChannels.at("control").at(0).Receive(ready2Msg);
+    int r2 = fChannels.at("control").at(0).Receive(ready2Msg);
 
-    std::unique_ptr<FairMQMessage> msg(fTransportFactory->CreateMessage());
-    fChannels.at("data").at(0).Send(msg);
-
-    std::unique_ptr<FairMQMessage> ack1Msg(fTransportFactory->CreateMessage());
-    std::unique_ptr<FairMQMessage> ack2Msg(fTransportFactory->CreateMessage());
-    if (fChannels.at("control").at(0).Receive(ack1Msg) >= 0)
+    if (r1 >= 0 && r2 >= 0)
     {
-        if (fChannels.at("control").at(0).Receive(ack2Msg) >= 0)
+        std::unique_ptr<FairMQMessage> msg(fTransportFactory->CreateMessage());
+        fChannels.at("data").at(0).Send(msg);
+
+        std::unique_ptr<FairMQMessage> ack1Msg(fTransportFactory->CreateMessage());
+        std::unique_ptr<FairMQMessage> ack2Msg(fTransportFactory->CreateMessage());
+        if (fChannels.at("control").at(0).Receive(ack1Msg) >= 0)
         {
-            LOG(INFO) << "PUB-SUB test successfull";
+            if (fChannels.at("control").at(0).Receive(ack2Msg) >= 0)
+            {
+                LOG(INFO) << "PUB-SUB test successfull";
+            }
         }
     }
 }


### PR DESCRIPTION
- FairMQChannel: return if an unknown exception has been caught.
- FairMQChannel: add proper return values in set timeout.
- Examples: check return values of the Receive calls.
- nanomsg: fix return values of send/receive calls.