### PR TITLE
Add functionality which allows to swich persistency from the macro.

### DIFF
--- a/base/steer/FairTask.cxx
+++ b/base/steer/FairTask.cxx
@@ -29,7 +29,8 @@ FairTask::FairTask()
   : TTask(),
     fVerbose(0),
     fInputPersistance(-1),
-    fLogger(FairLogger::GetLogger())
+    fLogger(FairLogger::GetLogger()),
+    fOutputPersistance()
 {
 }
 // -------------------------------------------------------------------------
@@ -41,7 +42,8 @@ FairTask::FairTask(const char* name, Int_t iVerbose)
   : TTask(name, "FairTask"),
     fVerbose(iVerbose),
     fInputPersistance(-1),
-    fLogger(FairLogger::GetLogger())
+    fLogger(FairLogger::GetLogger()),
+    fOutputPersistance()
 {
 
 }
@@ -261,5 +263,19 @@ void FairTask::FinishEvents()
 }
 // -------------------------------------------------------------------------
 
+void FairTask::SetOutputBranchPersistent(TString branchName, Bool_t persistence)
+{
+  fOutputPersistance.insert ( std::pair<TString,Bool_t>(branchName, persistence) );
+}
+
+Bool_t FairTask::IsOutputBranchPersistent(TString branchName)
+{  
+  std::map<TString, Bool_t>::iterator it = fOutputPersistance.find(branchName);
+  if (it != fOutputPersistance.end()) {
+    return it->second;
+  } else {
+    return kTRUE;
+  }
+}
 
 ClassImp(FairTask)

--- a/base/steer/FairTask.h
+++ b/base/steer/FairTask.h
@@ -29,6 +29,8 @@
 #include "Rtypes.h"                     // for Int_t, FairTask::Class, etc
 #include "TString.h"                    // for TString
 
+#include <map>
+
 class FairLogger;
 
 enum InitStatus {kSUCCESS, kERROR, kFATAL};
@@ -84,6 +86,16 @@ class FairTask : public TTask
 
     virtual void  ExecuteTask(Option_t *option="0");  // *MENU*
 
+    /** Set persistency of branch with given name true or false
+     *  In case is is set to false the branch will not be written to the output.
+    **/   
+    void SetOutputBranchPersistent(TString, Bool_t);
+
+    /** Check if the branch with the given name is persistent.
+     *  If the branch is not in the map, the default return value is true.
+    **/  
+    Bool_t IsOutputBranchPersistent(TString);
+
   protected:
 
     Int_t        fVerbose;  //  Verbosity level
@@ -133,10 +145,13 @@ class FairTask : public TTask
     void FinishEvents();
 
   private:
+
+    std::map<TString, Bool_t> fOutputPersistance;
+
     FairTask(const FairTask&);
     FairTask& operator=(const FairTask&);
 
-    ClassDef(FairTask,2);
+    ClassDef(FairTask,3);
 
 };
 


### PR DESCRIPTION

Add a map and two functions which allow to define from the macro if a branch with a given name should be written to the output file.
In classes derived from FairTask the functions can be used to decide if the branch should be persistent or not and be registered accordingly.

Implements redmine feature request #107.