### PR TITLE
Add :

### DIFF
--- a/base/MQ/CMakeLists.txt
+++ b/base/MQ/CMakeLists.txt
@@ -36,6 +36,7 @@ Set(SRCS
   devices/FairMQProcessor.cxx
   tasks/FairMQSamplerTask.cxx
   tasks/FairMQProcessorTask.cxx
+  devices/FairMQLmdSampler.cxx
 )
 
 # to copy src that are header-only files (e.g. c++ template) for FairRoot external installation
@@ -45,6 +46,8 @@ Set(BaseMQHDRFiles
   devices/FairMQSampler.h
   devices/FairMQSampler.tpl
   policies/Sampler/SimpleTreeReader.h
+  policies/Sampler/FairSourceMQInterface.h
+  policies/Sampler/FairMQFileSource.h
   policies/Serialization/BinaryBaseClassSerializer.h
   policies/Serialization/BoostSerializer.h
   policies/Serialization/RootSerializer.h
@@ -65,6 +68,7 @@ set(DEPENDENCIES
   boost_thread
   boost_timer
   boost_system
+  boost_filesystem
   FairMQ
 )
 

--- a/base/MQ/CMakeLists.txt
+++ b/base/MQ/CMakeLists.txt
@@ -12,6 +12,7 @@ Set(INCLUDE_DIRECTORIES
   ${CMAKE_SOURCE_DIR}/base/MQ/devices
   ${CMAKE_SOURCE_DIR}/base/MQ/tasks
   ${CMAKE_SOURCE_DIR}/fairmq
+  ${CMAKE_SOURCE_DIR}/MbsAPI
 )
 
 Include_Directories(${INCLUDE_DIRECTORIES})

--- a/base/MQ/devices/FairMQLmdSampler.cxx
+++ b/base/MQ/devices/FairMQLmdSampler.cxx
@@ -1,0 +1,387 @@
+/********************************************************************************
+ *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             * 
+ *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *  
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+ /* 
+ * File:   FairMQLmdSampler.cxx
+ * Author: winckler
+ *
+ * Created on October 27, 2015, 2:07 PM
+ */
+
+
+#include "FairMQLogger.h"
+#include "FairMQLmdSampler.h"
+
+
+FairMQLmdSampler::FairMQLmdSampler() : 
+	fCurrentFile(0),
+	fNEvent(0),
+    fCurrentEvent(0),
+    fFileNames(),
+    fxInputChannel(nullptr),
+    fxEvent(nullptr),
+    fxBuffer(nullptr),
+    fxEventData(nullptr),
+    fxSubEvent(nullptr),
+    fxInfoHeader(nullptr),
+    stop(false),
+    fMsgCounter(0)
+{
+}
+
+FairMQLmdSampler::~FairMQLmdSampler() 
+{
+}
+
+
+
+//______________________________________________________________________________
+void FairMQLmdSampler::AddSubEvtKey(short type, short subType, short procid, short subCrate, short control, const std::string& channelName)
+{
+	SubEvtKey key(type, subType, procid, subCrate, control);
+	if(!fSubEventChanMap.count(key))
+		fSubEventChanMap[key] = channelName;
+	else
+	{
+		LOG(WARN) 	<< "FairMQLmdSampler : subevent header key '(" 
+					<< type
+					<< "," 
+					<< subType
+					<< ","
+					<< procid
+					<< ","
+					<< subCrate
+					<< ","
+ 					<< control
+ 					<< ")' has already been defined with channel name '"
+					<< fSubEventChanMap.at(key)
+					<< "'. it will be overwritten with new channel name = "
+					<< channelName;
+		fSubEventChanMap[key] = channelName;
+	}
+}
+
+
+//______________________________________________________________________________
+void FairMQLmdSampler::InitTask()
+{
+  
+	if(fFileNames.size() == 0) 
+	{
+		//return false;
+	}
+
+	std::string name = fFileNames.at(fCurrentFile);
+	if(! OpenNextFile(name)) 
+	{
+		//return false;
+	}
+
+	fCurrentFile += 1;
+
+	// Init Counters
+	fNEvent=0;
+	fCurrentEvent=0;
+
+	//return true;
+}
+
+void FairMQLmdSampler::Run()
+{
+	
+	while (CheckCurrentState(RUNNING) && !stop)
+	{	
+		ReadEvent();
+	}
+	LOG(INFO)<<"Sent "<<fMsgCounter<<" messages.";
+
+}
+
+
+void free_buffer (void *data, void *hint)
+{
+    LOG(TRACE) << "empty deleter";
+}
+
+//______________________________________________________________________________
+int FairMQLmdSampler::ReadEvent()
+{
+	void* evtptr = &fxEvent;
+	void* buffptr = &fxBuffer;
+	
+	/*1+ C Main ****************+******************************************/
+	/*+ Module      : f_evt_get_event                                     */
+	/*--------------------------------------------------------------------*/
+	/*+ CALLING     : f_evt_get_event(s_evt_channel &s_chan, long **ppl_buffer, long **ppl_goobuf) */
+	/*--------------------------------------------------------------------*/
+	/*+ PURPOSE     : f_evt_get_event  returnes address of event          */
+	/*+ ARGUMENTS   :                                                     */
+	/*+   s_chan    : Input channel from open.                            */
+	/*+   ppl_buffer: Address of pointer. Returns address of event.       */
+	/*+   ppl_goobuf: Address of pointer. Returns address of buffer.      */
+	/*+ Return type : int.                                                */
+	/*+ Status codes:                                                     */
+	/*-               GETEVT__SUCCESS=0 : success.                        */
+	/*-               GETEVT__FRAGMENT=1: Event fragment found.           */
+	/*-               GETEVT__NOMORE=3  : No more events.                 */
+	/*-               GETEVT__RDERR=6   : read server or file error       */
+	/*-               GETEVT__TIMEOUT=9 : when enabled by f_evt_timeout   */
+	/*+ Declaration :                                                     */
+	/*                INTS4 f_evt_get_event(  */
+	/*                     s_evt_channel *, INTS4 **, INTS4 **); */
+	/*+ FUNCTION    : Get next event and returnes pointer. The pointer    */
+	/*                may point to the event in the buffer or internal    */
+	/*                event buffer (spanned events). The content of the   */
+	/*                pointer may be destroyed by next call.              */
+	/*1- C Main ****************+******************************************/
+	//INTS4 f_evt_get_event(s_evt_channel*, INTS4**, INTS4**); // -> in f_evt.h
+	
+	int status = f_evt_get_event(fxInputChannel, (INTS4**)evtptr, (INTS4**)buffptr);
+	//int fuEventCounter = fxEvent->l_count;
+	//int fCurrentMbsEventNo = fuEventCounter;
+	
+	LOG(DEBUG) << "STATUS = "<<status;
+	if(GETEVT__SUCCESS != status) // if f_evt_get_event not successfull close if nomore evt or look to another file and start again
+	{
+
+		LOG(DEBUG) << "FairMQLmdSampler::ReadEvent()";
+
+		CHARS* sErrorString = NULL;
+		f_evt_error(status, sErrorString , 0);
+
+		if(GETEVT__NOMORE == status) 
+		{
+			Close();
+		}
+
+
+		// fCurrentFile incremented in InitTask once
+		if(fCurrentFile >= fFileNames.size()) 
+		{
+			stop=true;
+			return 1;
+		}
+
+		std::string name = fFileNames.at(fCurrentFile);
+		if(! OpenNextFile(name) ) 
+		{
+			return 1;
+		} 
+		else 
+		{
+			fCurrentFile += 1;
+			return ReadEvent();
+		}
+	}
+
+		//Store Start Times
+	//if (fCurrentEvent==0 ) 
+	//  	Unpack((int*)fxBuffer, sizeof(s_bufhe), -4, -4, -4, -4, -4);
+
+
+	// Decode event header
+	bool result = false;
+	/*bool result = */
+	//Unpack((int*)fxEvent, sizeof(s_ve10_1), -2, -2, -2, -2, -2);
+
+	/*****************+***********+****************************************/
+	/*1+ C Procedure *************+****************************************/
+	/*+ Module      : f_evt_get_subevent                                  */
+	/*--------------------------------------------------------------------*/
+	/*+ CALLING     : l_sts = f_evt_get_subevent(ve10_1 *,subevent,**head,**data,*lwords) */
+	/*--------------------------------------------------------------------*/
+	/*+ PURPOSE     : get subevent pointer                                */
+	/*+ ARGUMENTS   :                                                     */
+	/*+   ve10_1    : (s_ve10_1 *) event header pointer                   */
+	/*+  subevent   : subevent number (1,2,3...)                          */
+	/*                If = 0, f_evt_get_subevent returns the number of    */
+	/*                subevents. In this case the following arguments     */
+	/*                might be NULL.                                      */
+	/*+   head      : Address of s_ves10_1 subevent header pointer        */
+	/*+   data      : Address of INTS4 event data pointer                 */
+	/*+   lwords    : Address of INTS4 to get number of data longwords    */
+	/*+ Return type : int                                                 */
+	/*-               GETEVT__SUCCESS   : Found subevent.                 */
+	/*-               GETEVT__NOMORE    : No more subevents.              */
+	/*+ Declaration :                                                     */
+	/*                INTS4 f_evt_get_subevent( */
+	/*                   s_ve10_1 *, INTS4, INTS4 **, INTS4 **, INTS4 *); */
+	/*1- C Procedure *************+****************************************/
+	int nrSubEvts = f_evt_get_subevent(fxEvent, 0, NULL, NULL, NULL);
+	int sebuflength;
+	short setype;
+	short sesubtype;
+	short seprocid;
+	short sesubcrate;
+	short secontrol;
+
+	LOG(TRACE) 	<< "FairMQLmdSampler::ReadEvent => Found " 
+				<< nrSubEvts 
+				<< " Sub-event ";
+	//if (fCurrentEvent%10000==0)
+	//cout << " -I- LMD_ANA:  evt# " <<  fCurrentEvent << "  n_subevt# " << nrSubEvts << " evt processed# " << fNEvent <<  " : " << fxEvent->l_count << endl;
+
+
+	//  int* SubEventDataPtr = new int;
+	for(int i = 1; i <= nrSubEvts; i++) 
+	{
+		void* SubEvtptr = &fxSubEvent;
+		void* EvtDataptr = &fxEventData;
+		int nrlongwords;
+		status = f_evt_get_subevent(fxEvent, i, (int**)SubEvtptr, (int**)EvtDataptr, &nrlongwords);
+
+		if(status) 
+		{
+			return 1;
+		}
+
+		sebuflength = nrlongwords;
+		setype = fxSubEvent->i_type;
+		sesubtype = fxSubEvent->i_subtype;
+		seprocid = fxSubEvent->i_procid;
+		sesubcrate = fxSubEvent->h_subcrate;
+		secontrol = fxSubEvent->h_control;
+
+		
+
+		//cout << setype << "  " << sesubtype << "  " << seprocid << "  " << sesubcrate << "  " << secontrol << endl;
+		
+		// Data to send : fxEventData
+
+
+		SubEvtKey key(setype, sesubtype, seprocid, sesubcrate, secontrol);
+
+		
+		if(!fSubEventChanMap.count(key))
+		{
+			LOG(ERROR)<<" key not registered!";
+			//TODO : throw something
+		}
+		LOG(TRACE)<<"array size = "<<sebuflength;
+		LOG(TRACE)<<"fxEventData = "<<*fxEventData;
+
+		std::string chanName=fSubEventChanMap.at(key);
+		LOG(TRACE)<<"chanName="<<chanName;
+
+
+
+		// send header
+		//std::unique_ptr<FairMQMessage> header(fTransportFactory->CreateMessage(fxSubEvent, sizeof(fxSubEvent), free_buffer, nullptr));
+		//fChannels.at(chanName).at(0).SendPart(header);
+
+		int* arraySize = new int(sebuflength);
+
+        std::unique_ptr<FairMQMessage> msgSize(fTransportFactory->CreateMessage(arraySize, sizeof(int)));
+        fChannels.at(chanName).at(0).SendPart(msgSize);
+		// send data
+		std::unique_ptr<FairMQMessage> msg(fTransportFactory->CreateMessage(fxEventData, sebuflength, free_buffer, nullptr));
+		fChannels.at(chanName).at(0).Send(msg);
+		fMsgCounter++;
+		/*
+		if(Unpack(fxEventData, sebuflength,
+		          setype, sesubtype,
+		          seprocid, sesubcrate, secontrol)) 
+		{
+	    	result = true;
+		}
+		*/
+	}
+
+	// Increment evt counters.
+	fNEvent++;
+	fCurrentEvent++;
+
+	if(! result)
+	{
+		return 2;
+	}
+
+	return 0;
+}
+
+//______________________________________________________________________________
+bool FairMQLmdSampler::OpenNextFile(const std::string& fileName)
+{
+	int inputMode = GETEVT__FILE;
+	fxInputChannel = new s_evt_channel;
+	void* headptr = &fxInfoHeader;
+	INTS4 status;
+
+	LOG(INFO) 	<< "File " 
+				<< fileName 
+				<< " will be opened.";
+
+	status = f_evt_get_open(inputMode,
+	                      const_cast<char*>(fileName.c_str()),
+	                      fxInputChannel,
+	                      (char**)headptr,
+	                      1,
+	                      1);
+
+	if(status) 
+	{
+		LOG(ERROR) 	<< "File " 
+					<< fileName 
+					<< " opening failed.";
+
+		return false;
+	}
+
+	LOG(INFO) 	<< "File " 
+				<< fileName 
+				<< " opened.";
+
+	// Decode File Header
+	//bool result = Unpack((int*)fxInfoHeader, sizeof(s_filhe), -4, -4, -4, -4, -4);
+
+	return true;
+}
+
+//______________________________________________________________________________
+void FairMQLmdSampler::AddDir(const std::string& dir)
+{
+	path directory = dir;
+
+	if (fs::exists(directory))
+	{
+		fs::directory_iterator end_itr;
+
+	    for (fs::directory_iterator itr(directory); itr != end_itr; ++itr)
+	    {
+	        if (fs::is_regular_file(itr->path())) {
+	            std::string current_file = itr->path().string();
+	            AddFile(current_file);
+	        }
+	    }
+    }
+	else
+	{
+	    LOG(WARN)<<"FairMQLmdSampler: directory '"<< directory.string() <<"' not found";
+	}
+}
+
+//______________________________________________________________________________
+void FairMQLmdSampler::AddFile(const std::string& fileName)
+{
+    path filepath = fileName;
+	if (fs::exists(filepath))
+	{
+	    fFileNames.push_back(fileName);
+	}
+	else
+	{
+	    LOG(WARN)<<"FairMQLmdSampler: file '"<< fileName <<"' not found";
+	}
+}
+
+//______________________________________________________________________________
+void FairMQLmdSampler::Close()
+{
+	f_evt_get_close(fxInputChannel);
+	//Unpack((Int_t*)fxBuffer, sizeof(s_bufhe), -4, -4, -4, -4, -4);  
+	fCurrentEvent=0;
+}

--- a/base/MQ/devices/FairMQLmdSampler.cxx
+++ b/base/MQ/devices/FairMQLmdSampler.cxx
@@ -184,7 +184,7 @@ int FairMQLmdSampler::ReadEvent()
 
 
 	// Decode event header
-	bool result = false;
+	//bool result = false;
 	/*bool result = */
 	//Unpack((int*)fxEvent, sizeof(s_ve10_1), -2, -2, -2, -2, -2);
 
@@ -295,10 +295,10 @@ int FairMQLmdSampler::ReadEvent()
 	fNEvent++;
 	fCurrentEvent++;
 
-	if(! result)
+	/*if(! result)
 	{
 		return 2;
-	}
+	}*/
 
 	return 0;
 }

--- a/base/MQ/devices/FairMQLmdSampler.h
+++ b/base/MQ/devices/FairMQLmdSampler.h
@@ -1,0 +1,82 @@
+/********************************************************************************
+ *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             * 
+ *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *  
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+ /* 
+ * File:   FairMQLmdSampler.h
+ * Author: winckler
+ *
+ * Created on October 27, 2015, 2:07 PM
+ */
+
+#ifndef FAIRMQLMDSAMPLER_H
+#define FAIRMQLMDSAMPLER_H
+
+extern "C"
+{
+#include "f_evt.h"
+#include "s_filhe_swap.h"
+#include "s_bufhe_swap.h"
+}
+
+#include <boost/filesystem.hpp>
+
+#include "FairMQDevice.h"
+#include "FairMQMessage.h"
+
+#include <string>
+#include <vector>
+#include <tuple>
+#include <map>
+
+
+namespace fs = boost::filesystem;
+
+
+class FairMQLmdSampler : public FairMQDevice
+{
+	typedef fs::path 		path;
+
+public:
+
+	FairMQLmdSampler();
+	virtual ~FairMQLmdSampler();
+
+ 	void AddSubEvtKey(short type, short subType, short procid, short subCrate, short control, const std::string& channelName);
+ 	void AddDir(const std::string& dir);
+	void AddFile(const std::string& fileName);
+	
+protected:
+
+	void InitTask();
+	void Run();
+	int ReadEvent();
+	bool OpenNextFile(const std::string& fileName);
+	
+	void Close();
+
+ 	////////////////////// data members
+ 	int fCurrentFile;
+	int fNEvent;
+	int fCurrentEvent;
+    std::vector<std::string> fFileNames;
+    s_evt_channel* fxInputChannel;
+    s_ve10_1* fxEvent;
+    s_bufhe* fxBuffer;
+    int* fxEventData;
+    
+    s_ves10_1* fxSubEvent;
+	
+	s_filhe* fxInfoHeader;
+	bool stop;
+	int fMsgCounter;
+
+	typedef std::tuple<short,short,short,short,short> SubEvtKey;
+	std::map<SubEvtKey,std::string > fSubEventChanMap;
+
+};
+
+#endif  /* !FAIRMQLMDSAMPLER_H */

--- a/base/MQ/policies/Sampler/FairMQFileSource.h
+++ b/base/MQ/policies/Sampler/FairMQFileSource.h
@@ -1,0 +1,6 @@
+
+
+
+#include "FairSourceMQInterface.h"
+
+typedef FairSourceMQInterface<FairFileSource,TClonesArray>  FairMQFileSource_t;

--- a/base/MQ/policies/Sampler/FairSourceMQInterface.h
+++ b/base/MQ/policies/Sampler/FairSourceMQInterface.h
@@ -8,11 +8,11 @@
 #include "FairRunOnline.h"
 
 #include "FairFileSource.h"
-#include "FairLmdSource.h"
-#include "FairMbsSource.h"
-#include "FairMbsStreamSource.h"
-#include "FairMixedSource.h"
-#include "FairRemoteSource.h"
+//#include "FairLmdSource.h"
+//#include "FairMbsSource.h"
+//#include "FairMbsStreamSource.h"
+//#include "FairMixedSource.h"
+//#include "FairRemoteSource.h"
 
 
 
@@ -130,7 +130,7 @@ public:
 
 	//______________________________________________________________________________
 	// FairLmdSource
-
+ 	/*
 	template <typename T = FairSourceType, enable_if_match<T, FairLmdSource> = 0>
 	void InitSource()
 	{
@@ -163,7 +163,7 @@ public:
  	void SetMaxIndex(int64_t max)
  	{
  		fMaxIndex=max;
- 	}
+ 	}*/
 
  	/*
 	//______________________________________________________________________________

--- a/base/MQ/policies/Sampler/FairSourceMQInterface.h
+++ b/base/MQ/policies/Sampler/FairSourceMQInterface.h
@@ -1,0 +1,233 @@
+
+
+//#include "FairSource.h"
+
+#include "BaseSourcePolicy.h"
+#include "FairMQLogger.h"
+#include "FairRunAna.h"
+#include "FairRunOnline.h"
+
+#include "FairFileSource.h"
+#include "FairLmdSource.h"
+#include "FairMbsSource.h"
+#include "FairMbsStreamSource.h"
+#include "FairMixedSource.h"
+#include "FairRemoteSource.h"
+
+
+
+#include <type_traits>
+#include <functional>
+
+
+template<typename T, typename U>
+using enable_if_match = typename std::enable_if<std::is_same<T,U>::value,int>::type;
+
+
+template<typename FairSourceType, typename DataType>
+class FairSourceMQInterface : public BaseSourcePolicy< FairSourceMQInterface<FairSourceType, DataType> >
+{
+	typedef DataType* DataType_ptr;
+	typedef FairSourceMQInterface<FairSourceType,DataType> this_type;
+public:
+	FairSourceMQInterface() : 
+			BaseSourcePolicy<FairSourceMQInterface<FairSourceType, DataType>>(), 
+			fSource(nullptr), 
+			fData(nullptr), 
+			fIndex(0),
+			fMaxIndex(-1),
+			fSourceName(),
+			fBranchName(),
+			fRunAna(nullptr),
+			fRunOnline(nullptr),
+			fCustomRO(false),
+			fCustomRA(false),
+			fCustomInitSourceRO(),
+			fCustomInitSourceRA()
+
+	{
+	}
+
+	virtual ~FairSourceMQInterface() 
+	{
+		if(fData)
+			delete fData;
+		fData=nullptr;
+		if(fSource)
+			delete fSource;
+		fSource=nullptr;
+		if(fRunAna)
+			delete fRunAna;
+		fRunAna=nullptr;
+		if(fRunOnline)
+			delete fRunOnline;
+		fRunOnline=nullptr;
+	}
+
+	//______________________________________________________________________________
+	// Custom source init via lambda
+
+	template <typename Lambda>
+	void CustomInitSourceRunOnline(Lambda func)
+	{
+		fCustomRO=true;
+		fCustomInitSourceRO=func;
+	}
+
+	template <typename Lambda>
+	void CustomInitSourceRunAna(Lambda func)
+	{
+		fCustomRA=true;
+		fCustomInitSourceRA=func;
+	}
+
+	int64_t GetNumberOfEvent()
+	{
+		return fMaxIndex;
+	}
+
+	void SetFileProperties(const std::string &filename, const std::string &branchname)
+    {
+        fSourceName = filename;
+        fBranchName = branchname;
+    }
+
+
+	//______________________________________________________________________________
+	// FairFileSource
+
+	template <typename T = FairSourceType, enable_if_match<T, FairFileSource> = 0>
+	void InitSource()
+	{
+		if(fCustomRA)
+		{
+			fCustomInitSourceRA(&fSource,&fData,&fRunAna);
+		}
+		else
+		{
+			fRunAna = new FairRunAna();
+			fSource = new FairSourceType(fSourceName.c_str());
+			fSource->Init();
+			fSource->ActivateObject((TObject**)&fData,fBranchName.c_str());
+			
+		}
+		fMaxIndex = fSource->CheckMaxEventNo();
+	}
+
+	template <typename T = FairSourceType, enable_if_match<T, FairFileSource> = 0>
+	void SetIndex(int64_t eventIdx)
+	{
+		fIndex=eventIdx;
+
+	}
+
+	template <typename T = FairSourceType, enable_if_match<T, FairFileSource> = 0>
+ 	DataType_ptr GetOutData()
+ 	{
+		fSource->ReadEvent(fIndex);
+		return fData;
+ 	}
+
+	//______________________________________________________________________________
+	// FairLmdSource
+
+	template <typename T = FairSourceType, enable_if_match<T, FairLmdSource> = 0>
+	void InitSource()
+	{
+		LOG(INFO)<<"start of out Lambda";
+		fCustomInitSourceRO(&fSource,fData,&fRunOnline);
+		LOG(INFO)<<"End of out Lambda";
+	}
+
+	template <typename T = FairSourceType, enable_if_match<T, FairLmdSource> = 0>
+	void SetIndex(int64_t eventIdx)
+	{
+		//fSource->Reset();
+		fIndex=eventIdx;
+	}
+	
+	template <typename T = FairSourceType, enable_if_match<T, FairLmdSource> = 0>
+	void Reset()
+	{
+		fSource->Reset();
+	}
+	
+	template <typename T = FairSourceType, enable_if_match<T, FairLmdSource> = 0>
+ 	DataType_ptr GetOutData()
+ 	{
+		fSource->ReadEvent();
+		return fData;
+ 	}
+
+	template <typename T = FairSourceType, enable_if_match<T, FairLmdSource> = 0>
+ 	void SetMaxIndex(int64_t max)
+ 	{
+ 		fMaxIndex=max;
+ 	}
+
+ 	/*
+	//______________________________________________________________________________
+	// FairMbsSource
+	template <typename T = FairSourceType, enable_if_match<T, FairMbsSource> = 0>
+	void InitSource()
+	{
+		fRunAna = new FairRunAna();
+		fSource = new FairSourceType();
+		fSource->Init();
+		fSource->ActivateObject((TObject**)&fData,fBranchName.c_str());
+	}
+
+
+	//______________________________________________________________________________
+	// FairMbsStreamSource
+	template <typename T = FairSourceType, enable_if_match<T, FairMbsStreamSource> = 0>
+	void InitSource()
+	{
+		fRunAna = new FairRunAna();
+		fSource = new FairSourceType(fSourceName.c_str());
+		fSource->Init();
+		fSource->ActivateObject((TObject**)&fData,fBranchName.c_str());
+	}
+
+	//______________________________________________________________________________
+	// FairMixedSource
+	template <typename T = FairSourceType, enable_if_match<T, FairMixedSource> = 0>
+	void InitSource()
+	{
+		fRunAna = new FairRunAna();
+		fSource = new FairSourceType(fSourceName.c_str());
+		fSource->Init();
+		fSource->ActivateObject((TObject**)&fData,fBranchName.c_str());
+	}
+
+	//______________________________________________________________________________
+	// FairRemoteSource
+	template <typename T = FairSourceType, enable_if_match<T, FairRemoteSource> = 0>
+	void InitSource()
+	{
+		fRunAna = new FairRunAna();
+		fSource = new FairSourceType(fSourceName.c_str());
+		fSource->Init();
+		fSource->ActivateObject((TObject**)&fData,fBranchName.c_str());
+	}
+	// */
+
+	
+protected:
+
+ 	FairSourceType* fSource;
+ 	DataType_ptr fData;
+ 	int64_t fIndex;
+ 	int64_t fMaxIndex;
+ 	std::string fClassName;
+ 	std::string fBranchName;
+ 	std::string fSourceName;
+ 	FairRunAna* fRunAna;
+ 	FairRunOnline* fRunOnline;
+
+	bool fCustomRO;
+	bool fCustomRA;
+ 	std::function<void(FairSourceType**,DataType_ptr,FairRunOnline**)> fCustomInitSourceRO;// when FairRunOnline required
+ 	std::function<void(FairSourceType**,DataType_ptr*,FairRunAna**)> fCustomInitSourceRA;// when FairRunAna required
+    
+};

--- a/base/MQ/policies/Sampler/SimpleTreeReader.h
+++ b/base/MQ/policies/Sampler/SimpleTreeReader.h
@@ -61,7 +61,7 @@ public:
     }
 
     // template < std::enable_if<std::is_base_of<TObject, DataType>::value,int> = 0>
-    void InitSampler()
+    void InitSource()
     {
         fInputFile = TFile::Open(fFileName.c_str(), "READ");
         if (fInputFile)
@@ -79,7 +79,7 @@ public:
         }
         else
         {
-            LOG(ERROR)<<"Could not open file "<<fFileName<<" in SimpleTreeReader::InitSampler()";
+            LOG(ERROR)<<"Could not open file "<<fFileName<<" in SimpleTreeReader::InitSource()";
         }
         
     }

--- a/base/MQ/policies/Serialization/RootSerializer.h
+++ b/base/MQ/policies/Serialization/RootSerializer.h
@@ -68,7 +68,7 @@ class RootSerializer
         fMessage->Rebuild(tm->Buffer(), tm->BufferSize(), free_tmessage, tm);
     }
 
-    virtual FairMQMessage* SerializeMsg(TClonesArray* array)
+    FairMQMessage* SerializeMsg(TClonesArray* array)
     {
         DoSerialization(array);
         return fMessage;
@@ -122,7 +122,7 @@ class RootDeSerializer
         fContainer  = (TClonesArray*)(tm.ReadObject(tm.GetClass()));
     }
 
-    virtual TClonesArray* DeSerializeMsg(FairMQMessage* msg)
+    TClonesArray* DeserializeMsg(FairMQMessage* msg)
     {
         DoDeSerialization(msg);
         return fContainer;

--- a/base/MQ/policies/Storage/RootOutFileManager.h
+++ b/base/MQ/policies/Storage/RootOutFileManager.h
@@ -20,14 +20,17 @@
 #include "TClonesArray.h"
 
 #include "TKey.h"
+#include "TFolder.h"
+#include "TObjString.h"
+#include "TList.h"
 
 // FairRoot
 #include "FairMQLogger.h"
 #include "FairMQMessage.h"
-
+#include "BaseSinkPolicy.h"
 
 template <typename DataType>
-class RootOutFileManager 
+class RootOutFileManager : public BaseSinkPolicy<RootOutFileManager<DataType>>
 {
 public:
     RootOutFileManager();
@@ -52,10 +55,7 @@ public:
     std::vector<std::vector<DataType> > GetAllObj(const std::string &filename, 
                                                   const std::string &treename, 
                                                   const std::string &branchname
-                                                  );
-    void ReadDir(TDirectory *dir);
-    void SeekObject(TKey *key);
-    
+                                                  );    
     
 protected:
 
@@ -74,6 +74,7 @@ protected:
     TTree* fTree;
     TClonesArray* fOutput;
     DataType* fOutputData;
+    TFolder* fFolder;
 };
 
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -19,6 +19,7 @@ If(GEANT3_FOUND)
 
  If(POS_C++11)
   add_subdirectory(Tutorial7)
+  add_subdirectory(MQ/LmdSampler)
  EndIf()
  add_subdirectory (rutherford)
 EndIf()

--- a/example/MQ/LmdSampler/CMakeLists.txt
+++ b/example/MQ/LmdSampler/CMakeLists.txt
@@ -1,0 +1,119 @@
+ ################################################################################
+ #    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    #
+ #                                                                              #
+ #              This software is distributed under the terms of the             # 
+ #         GNU Lesser General Public Licence version 3 (LGPL) version 3,        #  
+ #                  copied verbatim in the file "LICENSE"                       #
+ ################################################################################
+# Create a library called "libLmdMQSamplerExample" 
+
+set(INCLUDE_DIRECTORIES
+    ${BASE_INCLUDE_DIRECTORIES}
+    ${CMAKE_SOURCE_DIR}/fairmq
+    ${CMAKE_SOURCE_DIR}/fairmq/devices
+    ${CMAKE_SOURCE_DIR}/fairmq/options
+    ${CMAKE_SOURCE_DIR}/fairmq/tools
+
+    ${CMAKE_SOURCE_DIR}/base/MQ
+    ${CMAKE_SOURCE_DIR}/base/MQ/devices
+    ${CMAKE_SOURCE_DIR}/base/MQ/policies/Sampler
+    ${CMAKE_SOURCE_DIR}/base/MQ/policies/Serialization
+    ${CMAKE_SOURCE_DIR}/base/MQ/policies/Storage
+    ${CMAKE_SOURCE_DIR}/base/MQ/baseMQtools
+
+    ${CMAKE_SOURCE_DIR}/example/MQ/LmdSampler
+    ${CMAKE_SOURCE_DIR}/example/MQ/LmdSampler/devices
+    ${CMAKE_SOURCE_DIR}/example/MQ/LmdSampler/unpacker
+
+    ${CMAKE_SOURCE_DIR}/example/Tutorial7/run/helper_functions
+    
+    ${CMAKE_SOURCE_DIR}/MbsAPI
+
+    ${CMAKE_SOURCE_DIR}/example/Tutorial8
+    ${CMAKE_SOURCE_DIR}/example/Tutorial8/src
+    ${CMAKE_SOURCE_DIR}/example/Tutorial8/macro
+    
+)
+
+Set(SYSTEM_INCLUDE_DIRECTORIES
+    ${SYSTEM_INCLUDE_DIRECTORIES}
+    ${ZMQ_INCLUDE_DIR}
+)
+
+include_directories(${INCLUDE_DIRECTORIES})
+include_directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
+
+#configure_file( ${CMAKE_SOURCE_DIR}/example/MQ/LmdSampler/macro/startTuto7Sink.sh.in ${CMAKE_BINARY_DIR}/bin/startTuto7Sink.sh )
+#configure_file( ${CMAKE_SOURCE_DIR}/example/MQ/LmdSampler/options/tuto7Config.cfg.in ${CMAKE_BINARY_DIR}/bin/config/tuto7Config.cfg)
+configure_file( ${CMAKE_SOURCE_DIR}/example/MQ/LmdSampler/macro/startLmdMQChain.sh.in ${CMAKE_BINARY_DIR}/bin/startLmdMQChain.sh)
+
+
+set(LINK_DIRECTORIES
+    ${ROOT_LIBRARY_DIR}
+    ${Boost_LIBRARY_DIRS}
+)
+
+if(DDS_PATH)
+  set(LINK_DIRECTORIES
+    ${LINK_DIRECTORIES}
+    ${DDS_PATH}/lib
+  )
+endif(DDS_PATH)
+
+link_directories(${LINK_DIRECTORIES})
+
+Set(SRCS
+    unpacker/FairTut8Unpacker.cxx
+)
+
+Set(DEPENDENCIES
+    Base MbsAPI Tutorial8
+)
+
+Set(LINKDEF LmdSamplerLinkDef.h)
+Set(LIBRARY_NAME LmdMQSampler)
+
+
+
+GENERATE_LIBRARY()
+
+
+Set(Exe_Names
+    runLmdSampler
+    runTut8MQUnpacker
+    runTut8Sink
+)
+
+set(Exe_Source
+    run/runLmdSampler.cxx
+    run/runTut8MQUnpacker.cxx
+    run/runTut8Sink.cxx
+)
+
+
+
+List(LENGTH Exe_Names _length)
+Math(EXPR _length ${_length}-1)
+
+ForEach(_file RANGE 0 ${_length})
+    List(GET Exe_Names ${_file} _name)
+    List(GET Exe_Source ${_file} _src)
+    Set(EXE_NAME ${_name})
+    Set(SRCS ${_src})
+    #Set(DEPENDENCIES LmdMQSamplerExample ${UBUNTU_GREATERTHAN_v11_LINKER_FLAG})
+    Set(DEPENDENCIES
+        #Base 
+        FairMQ 
+        BaseMQ 
+        boost_thread 
+        boost_system 
+        boost_serialization 
+        boost_program_options 
+        Tutorial8
+        LmdMQSampler
+    )
+    GENERATE_EXECUTABLE()
+EndForEach(_file RANGE 0 ${_length})
+
+
+

--- a/example/MQ/LmdSampler/LmdSamplerLinkDef.h
+++ b/example/MQ/LmdSampler/LmdSamplerLinkDef.h
@@ -1,0 +1,20 @@
+/********************************************************************************
+ *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             * 
+ *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *  
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+/////////////////////////////// Tutorial 7 LinkDef ///////////////////////////////
+
+#ifdef __CINT__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class FairTut8Unpacker+;
+//#pragma link C++ class FairTut8RawItem+;
+
+#endif

--- a/example/MQ/LmdSampler/README.md
+++ b/example/MQ/LmdSampler/README.md
@@ -1,0 +1,11 @@
+# MQ tutorial : Lmd Sampler
+
+
+## Introduction
+In this tutorial a sampler read an lmd file (the one in tutorial8) and send the binary data to an unpacker device. The unpacker device unpack the binary data and serialize the data (using TMessage data format) and send the data to a FileSink device.
+
+To start the demo, go to the FairRoot/build/bin directory and do:
+```bash
+./startLmdMQChain.sh 
+```
+

--- a/example/MQ/LmdSampler/devices/FairMQUnpacker.h
+++ b/example/MQ/LmdSampler/devices/FairMQUnpacker.h
@@ -1,0 +1,159 @@
+/********************************************************************************
+ *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             * 
+ *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *  
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+ /* 
+ * File:   FairMQUnpacker.h
+ * Author: winckler
+ *
+ * Created on October 27, 2015, 2:07 PM
+ */
+
+#ifndef FAIRMQUNPACKER_H
+#define FAIRMQUNPACKER_H
+
+extern "C"
+{
+#include "f_evt.h"
+#include "s_filhe_swap.h"
+#include "s_bufhe_swap.h"
+}
+
+#include "FairMQDevice.h"
+#include "FairMQMessage.h"
+
+#include <string>
+#include <vector>
+#include <tuple>
+#include <map>
+#include "RootSerializer.h"
+
+
+template<typename U, typename T=RootSerializer>
+class FairMQUnpacker : public FairMQDevice, public T
+{
+	typedef U unpacker_type;
+	typedef T serialization_type;
+
+public:
+
+	FairMQUnpacker() : serialization_type(),
+		fSubEventChanMap(), 
+		fUnpacker(nullptr), 
+		fInputChannelName()
+	{
+
+	}
+	virtual ~FairMQUnpacker()
+	{}
+
+ 	void AddSubEvtKey(short type, short subType, short procid, short subCrate, short control, const std::string& channelName)
+ 	{
+ 		if(fSubEventChanMap.size()>0)
+ 		{
+ 			LOG(ERROR)<<"Only one input channel allowed for this device";
+ 		}
+ 		else
+ 		{
+	 		SubEvtKey key(type, subType, procid, subCrate, control);
+	 		fInputChannelName=channelName;
+
+			if(!fSubEventChanMap.count(fInputChannelName))
+				fSubEventChanMap[fInputChannelName] = key;
+			else
+			{
+				LOG(WARN) 	<< "FairMQLmdSampler : subevent header key '(" 
+							<< type
+							<< "," 
+							<< subType
+							<< ","
+							<< procid
+							<< ","
+							<< subCrate
+							<< ","
+		 					<< control
+		 					<< ")' has already been defined. "
+							<< "It will be overwritten with new channel name = "
+							<< fInputChannelName;
+							fSubEventChanMap[fInputChannelName] = key;
+			}
+		}
+ 	}
+
+	
+protected:
+
+	void InitTask()
+	{
+		// check if subevt map is configured
+		if(fInputChannelName.empty() || fSubEventChanMap.size()==0)
+		{
+			LOG(ERROR)<<"Sub-event map not configured.";
+			// TODO : throw something
+		}
+
+
+		// check if given channel exist
+		if(!fChannels.count(fInputChannelName))
+		{
+			LOG(ERROR)<<"MQ-channel name '"<< fInputChannelName <<"' does not exist. Check the MQ-channel configuration";
+			// TODO : throw something
+		}
+
+		short setype;
+		short sesubtype;
+		short seprocid;
+		short sesubcrate;
+		short secontrol;
+		std::tie (setype,sesubtype,seprocid,sesubcrate,secontrol) = fSubEventChanMap.at(fInputChannelName);
+		fUnpacker = new unpacker_type(setype,sesubtype,seprocid,sesubcrate,secontrol);
+		fUnpacker->Init();
+
+	}
+
+	void Run()
+	{
+
+		const FairMQChannel& inputChannel = fChannels.at(fInputChannelName).at(0);
+        const FairMQChannel& outputChannel = fChannels.at("data-out").at(0);
+
+		while (CheckCurrentState(RUNNING))
+		{
+
+			std::unique_ptr<FairMQMessage> msgSize(fTransportFactory->CreateMessage());
+			std::unique_ptr<FairMQMessage> msg(fTransportFactory->CreateMessage());
+
+			if(inputChannel.Receive(msgSize)>=0)
+				if(inputChannel.Receive(msg)>=0)
+				{
+					int dataSize=*(static_cast<int*>(msgSize->GetData()));
+					int* subEvt_ptr = static_cast<int*>(msg->GetData());
+
+					LOG(TRACE)<<"array size = "<<dataSize;
+					LOG(TRACE)<<"fxEventData = "<<*subEvt_ptr;
+					
+					fUnpacker->DoUnpack(subEvt_ptr,dataSize);
+
+					serialization_type::SetMessage(msg.get());
+					outputChannel.Send(serialization_type::SerializeMsg(fUnpacker->GetOutputData()));
+					fUnpacker->Reset();
+				}
+		}
+	}
+
+
+ 	////////////////////// data members
+
+	typedef std::tuple<short,short,short,short,short> SubEvtKey;
+	std::map<std::string, SubEvtKey> fSubEventChanMap;
+
+	unpacker_type* fUnpacker;
+	std::string fInputChannelName;
+
+};
+
+#endif  /* !FAIRMQUNPACKER_H */
+

--- a/example/MQ/LmdSampler/macro/startLmdMQChain.sh.in
+++ b/example/MQ/LmdSampler/macro/startLmdMQChain.sh.in
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+
+CONFIGFILE="@CMAKE_SOURCE_DIR@/example/MQ/LmdSampler/options/LmdHeaderConfig.INI"
+MQCONFIGFILE="@CMAKE_SOURCE_DIR@/example/MQ/LmdSampler/options/LmdMQConfig.json"
+LMDFILE="@CMAKE_SOURCE_DIR@/example/Tutorial8/data/sample_data_2.lmd"
+VERBOSE="INFO"
+
+########################## start SAMPLER
+SAMPLER="runLmdSampler"
+SAMPLER+=" --id LmdSampler -c $CONFIGFILE --config-json-file $MQCONFIGFILE"
+SAMPLER+=" --input-file-name $LMDFILE --verbose $VERBOSE"
+#uncomment if you like to test the task container of the generic sampler
+#SAMPLER+=" --register-task-sampler true"
+xterm -geometry 120x27+0+0 -hold -e @CMAKE_BINARY_DIR@/bin/$SAMPLER &
+
+
+
+########################## start Unpacker
+UNPACKER="runTut8MQUnpacker"
+UNPACKER+=" --id unpacker1 -c $CONFIGFILE --config-json-file $MQCONFIGFILE"
+UNPACKER+=" --verbose $VERBOSE"
+xterm -geometry 120x27+0+0 -hold -e @CMAKE_BINARY_DIR@/bin/$UNPACKER &
+
+
+########################## start FILESINK
+FILESINK="runTut8Sink"
+FILESINK+=" --id sink1 --config-json-file $MQCONFIGFILE"
+FILESINK+=" --output-file-name @CMAKE_SOURCE_DIR@/example/MQ/LmdSampler/datasource/MQLmdOutput.root"
+FILESINK+=" --verbose $VERBOSE"
+xterm +aw -geometry 120x27+0+500 -hold -e @CMAKE_BINARY_DIR@/bin/$FILESINK &

--- a/example/MQ/LmdSampler/options/LmdHeaderConfig.INI
+++ b/example/MQ/LmdSampler/options/LmdHeaderConfig.INI
@@ -1,0 +1,11 @@
+
+
+[LmdHeader.Tutorial8]
+chanName 	= ToTuto8Unpacker
+type 		= 94
+subType 	= 9400
+procId 		= 12
+subCrate 	= 0
+control 	= 3
+
+

--- a/example/MQ/LmdSampler/options/LmdMQConfig.json
+++ b/example/MQ/LmdSampler/options/LmdMQConfig.json
@@ -1,0 +1,73 @@
+{
+    "fairMQOptions":
+    {
+"_______COMMENT:" : "SAMPLER CONFIG",
+        "device":
+        {
+            "id": "LmdSampler",
+            "channel":
+            {
+                "name": "ToTuto8Unpacker",
+                "socket":
+                {
+                    "type": "push",
+                    "method": "bind",
+                    "address": "tcp://*:5565",
+                    "sndBufSize": "1000",
+                    "rcvBufSize": "1000",
+                    "rateLogging": "1"
+                }
+            }
+        },
+"_______COMMENT:" : "UNPACKER CONFIG",
+        "device":
+        {
+            "id": "unpacker1",
+            "channel":
+            {
+                "name": "ToTuto8Unpacker",
+                "socket":
+                {
+                    "type": "pull",
+                    "method": "connect",
+                    "address": "tcp://localhost:5565",
+                    "sndBufSize": "1000",
+                    "rcvBufSize": "1000",
+                    "rateLogging": "1"
+                }
+            },
+            "channel":
+            {
+                "name": "data-out",
+                "socket":
+                {
+                    "type": "push",
+                    "method": "connect",
+                    "address": "tcp://localhost:5570",
+                    "sndBufSize": "1000",
+                    "rcvBufSize": "1000",
+                    "rateLogging": "1"
+                }
+            }
+        },
+"_______COMMENT:" : "FILESINK CONFIG",
+        "device":
+        {
+            "id": "sink1",
+            "channel":
+            {
+                "name": "data-in",
+                "socket":
+                {
+                    "type": "pull",
+                    "method": "bind",
+                    "address": "tcp://*:5570",
+                    "sndBufSize": "1000",
+                    "rcvBufSize": "1000",
+                    "rateLogging": "1"
+                }
+            }
+        }
+    }
+}
+

--- a/example/MQ/LmdSampler/run/runLmdSampler.cxx
+++ b/example/MQ/LmdSampler/run/runLmdSampler.cxx
@@ -1,0 +1,120 @@
+/********************************************************************************
+ *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+/*
+ * File:   runSamplerRoot.cxx
+ * Author: winckler
+ *
+ * Created on January 15, 2015, 1:57 PM
+ */
+
+// FairRoot - FairMQ
+#include "FairMQLogger.h"
+
+// FairRoot - Base/MQ
+
+#include "FairMQLmdSampler.h"
+
+// FairRoot - Tutorial 7
+//#include "tuto7SamplerFunctions.h"
+
+#include "TString.h"
+//#include "FairMQLmdSource.h"
+//#include "boost/program_options.hpp"
+#include "FairMQProgOptions.h"
+
+ #include "runGenericDevices.h"
+// ////////////////////////////////////////////////////////////////////////
+
+
+
+
+int main(int argc, char** argv)
+{
+    try
+    {
+        namespace po = boost::program_options;
+        FairMQProgOptions config;
+
+        std::string filename;
+        /*TString dir = getenv("VMCWORKDIR");
+        std::string defaultfilename(dir.Data());
+        defaultfilename+="/Tutorial8/data/sample_data_2.lmd";*/
+
+        // sampler-specific commandline configuration
+        po::options_description sampler_options("Sampler options");
+        sampler_options.add_options()
+            ("input-file-name", po::value<std::string>(&filename), "Path to the input file")
+        ;
+
+        /*
+        short type = 94;
+        short subType = 9400;
+        short procId = 12;
+        short subCrate = 0;
+        short control = 3;
+        std::string chanName("ToTuto8Unpacker");
+        */
+
+
+        short type;
+        short subType;
+        short procId;
+        short subCrate;
+        short control;
+        std::string chanName;
+        // INI-FILE CONFIGURATION
+        po::options_description lmd_header_def("Lmd-header definition");
+        lmd_header_def.add_options()
+            ("LmdHeader.Tutorial8.chanName",    po::value<std::string>(&chanName),  "MQ-channel name for this sub-event")
+            ("LmdHeader.Tutorial8.type",        po::value<short>(&type),            "sub-event type")
+            ("LmdHeader.Tutorial8.subType",     po::value<short>(&subType),         "sub-event subType")
+            ("LmdHeader.Tutorial8.procId",      po::value<short>(&procId),          "sub-event procId")
+            ("LmdHeader.Tutorial8.subCrate",    po::value<short>(&subCrate),        "sub-event subCrate")
+            ("LmdHeader.Tutorial8.control",     po::value<short>(&control),         "sub-event control")
+        ;
+
+        config.AddToCmdLineOptions(sampler_options);
+        config.AddToCfgFileOptions(lmd_header_def);
+
+        if (config.ParseAll(argc, argv, true))
+        {
+            return 1;
+        }
+
+        FairMQLmdSampler sampler;
+        sampler.AddFile(filename);
+        // combination of sub-event header value = one special channel
+        // this channel MUST be defined in the json file for the MQ configuration
+        sampler.AddSubEvtKey(type, subType, procId, subCrate, control, chanName);
+        runStateMachine(sampler, config);
+
+
+
+    }
+    catch (std::exception& e)
+    {
+        LOG(ERROR)  << "Unhandled Exception reached the top of main: " 
+                    << e.what() << ", application will now exit";
+        return 1;
+    }
+
+    return 0;
+}
+
+
+
+
+
+
+
+
+
+
+///////////
+
+        

--- a/example/MQ/LmdSampler/run/runTut8MQUnpacker.cxx
+++ b/example/MQ/LmdSampler/run/runTut8MQUnpacker.cxx
@@ -1,0 +1,110 @@
+/********************************************************************************
+ *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+/*
+ * File:   runtut8UnpackerRoot.cxx
+ * Author: winckler
+ *
+ * Created on January 15, 2015, 1:57 PM
+ */
+
+// FairRoot - FairMQ
+#include "FairMQLogger.h"
+
+// FairRoot - Base/MQ
+
+#include "FairMQUnpacker.h"
+
+// FairRoot - Tutorial 7
+//#include "tuto7tut8UnpackerFunctions.h"
+
+
+#include "FairTut8RawItem.h"
+#include "FairTut8Unpacker.h"
+
+//#include "FairMQLmdSource.h"
+//#include "boost/program_options.hpp"
+#include "FairMQProgOptions.h"
+
+ #include "runGenericDevices.h"
+// ////////////////////////////////////////////////////////////////////////
+
+
+
+
+int main(int argc, char** argv)
+{
+    try
+    {
+        namespace po = boost::program_options;
+        FairMQProgOptions config;
+
+        std::string filename;
+
+        // tut8Unpacker-specific commandline configuration
+        po::options_description tut8Unpacker_options("tut8Unpacker options");
+        tut8Unpacker_options.add_options()
+            ("output-file-name", po::value<std::string>(&filename), "Path to the output file")
+        ;
+
+
+        short type;
+        short subType;
+        short procId;
+        short subCrate;
+        short control;
+        std::string chanName;
+        // INI-FILE CONFIGURATION
+        po::options_description lmd_header_def("Lmd-header definition");
+        lmd_header_def.add_options()
+            ("LmdHeader.Tutorial8.chanName",    po::value<std::string>(&chanName),  "MQ-channel name for this sub-event")
+            ("LmdHeader.Tutorial8.type",        po::value<short>(&type),            "sub-event type")
+            ("LmdHeader.Tutorial8.subType",     po::value<short>(&subType),         "sub-event subType")
+            ("LmdHeader.Tutorial8.procId",      po::value<short>(&procId),          "sub-event procId")
+            ("LmdHeader.Tutorial8.subCrate",    po::value<short>(&subCrate),        "sub-event subCrate")
+            ("LmdHeader.Tutorial8.control",     po::value<short>(&control),         "sub-event control")
+        ;
+
+        config.AddToCmdLineOptions(tut8Unpacker_options);
+        config.AddToCfgFileOptions(lmd_header_def);
+
+        if (config.ParseAll(argc, argv, true))
+        {
+            return 1;
+        }
+
+        FairMQUnpacker<FairTut8Unpacker> unpacker;
+        // combination of sub-event header value = one special channel
+        // this channel MUST be defined in the json file for the MQ configuration
+        unpacker.AddSubEvtKey(type, subType, procId, subCrate, control, chanName);
+        runStateMachine(unpacker, config);
+
+
+
+    }
+    catch (std::exception& e)
+    {
+        LOG(ERROR)  << "Unhandled Exception reached the top of main: " 
+                    << e.what() << ", application will now exit";
+        return 1;
+    }
+
+    return 0;
+}
+
+
+
+
+
+
+
+
+
+
+///////////
+
+        

--- a/example/MQ/LmdSampler/run/runTut8Sink.cxx
+++ b/example/MQ/LmdSampler/run/runTut8Sink.cxx
@@ -1,0 +1,66 @@
+
+// FairRoot - FairMQ
+#include "GenericFileSink.h"
+
+// FairRoot - base/MQ
+
+#include "RootSerializer.h"
+#include "RootOutFileManager.h"
+
+// FairRoot - Tutorial7
+#include "tuto7FileSinkFunctions.h"
+#include "FairTut8RawItem.h"
+
+
+typedef GenericFileSink<RootDeSerializer, RootOutFileManager<FairTut8RawItem>>  TSink;
+
+
+int main(int argc, char** argv)
+{
+    try
+    {
+
+        namespace po = boost::program_options;
+        FairMQProgOptions config;
+
+        std::string filename;
+        std::string treename;
+        std::string branchname;
+        std::string hitname;
+        std::string fileoption;
+
+        po::options_description sink_options("File Sink options");
+        sink_options.add_options()
+            // TODO : make the semantic required for at least one source (and not both cfg & cmd)
+            //("input.file.name",         value<std::string>(&filename)->required(),                       "Path to the input file")
+            ("output-file-name",         po::value<std::string>(&filename),                                     "Path to the input file")
+            ("output-file-tree",         po::value<std::string>(&treename)->default_value("tut8tree"),          "Name of the output tree")
+            ("output-file-branch",       po::value<std::string>(&branchname)->default_value("FairTut8RawItem"), "Name of the output Branch")
+            ("output-file-option",       po::value<std::string>(&fileoption)->default_value("RECREATE"),        "Root file option : UPDATE, RECREATE etc.")
+            ("hit-classname",            po::value<std::string>(&hitname)->default_value("FairTut8RawItem"),    "Hit class name for initializing TClonesArray")
+        ;
+
+        config.AddToCmdLineOptions(sink_options);
+
+        if (config.ParseAll(argc, argv, true))
+        {
+            return 1;
+        }
+
+        TSink sink;
+        // call function member from storage policy
+        sink.SetFileProperties(filename, treename, branchname, hitname, fileoption, true);
+        // call function member from deserialization policy
+        sink.InitInputContainer(hitname);
+        runStateMachine(sink, config);
+
+    }
+    catch (std::exception& e)
+    {
+        LOG(ERROR)  << "Unhandled Exception reached the top of main: " 
+                    << e.what() << ", application will now exit";
+        return 1;
+    }
+
+    return 0;
+}

--- a/example/MQ/LmdSampler/unpacker/FairTut8Unpacker.cxx
+++ b/example/MQ/LmdSampler/unpacker/FairTut8Unpacker.cxx
@@ -1,0 +1,131 @@
+/********************************************************************************
+ *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+// ROOT headers
+#include "TClonesArray.h"
+
+// Fair headers
+//#include "FairRootManager.h"
+//#include "FairRunOnline.h"
+#include "FairMQLogger.h"
+
+// Land headers
+#include "FairTut8RawItem.h"
+#include "FairTut8Unpacker.h"
+
+// FairTut8Unpacker: Constructor
+FairTut8Unpacker::FairTut8Unpacker(Short_t type, Short_t subType, Short_t procId, Short_t subCrate, Short_t control)
+    : FairUnpack(type, subType, procId, subCrate, control)
+    , fRawData(new TClonesArray("FairTut8RawItem"))
+    , fNHits(0)
+    , fNHitsTotal(0)
+{
+}
+
+// Virtual FairTut8Unpacker: Public method
+FairTut8Unpacker::~FairTut8Unpacker()
+{
+    LOG(INFO) << "FairTut8Unpacker: Delete instance" ;
+    delete fRawData;
+}
+
+// Init: Public method
+Bool_t FairTut8Unpacker::Init()
+{
+    //Register();
+    return kTRUE;
+}
+
+// Register: Protected method
+void FairTut8Unpacker::Register()
+{
+    //  LOG(DEBUG) << "Registering" ;
+    /*LOG(INFO) << "FairTut8Unpacker : Registering..." ;
+    FairRootManager* fMan = FairRootManager::Instance();
+    if (!fMan)
+    {
+        return;
+    }
+    fMan->Register("Tut8RawItem", "Tut8", fRawData, kTRUE);*/
+}
+
+
+
+
+// DoUnpack: Public method
+Bool_t FairTut8Unpacker::DoUnpack(Int_t* data, Int_t size)
+{
+    LOG(DEBUG) << "FairTut8Unpacker : Unpacking... size = " << size ;
+
+    UInt_t l_i = 0;
+
+    Int_t n17 = 0;
+
+    while (l_i < size)
+    {
+        n17 = 0;
+
+        UInt_t* p1 = (UInt_t*)(data + l_i);
+        UInt_t l_sam_id = (p1[0] & 0xf0000000) >> 28; // identifies the sam
+        UInt_t l_gtb_id = (p1[0] & 0x0f000000) >> 24; // 0 or 1, identifies which of the 2 cables of the sam
+        UInt_t l_lec = (p1[0] & 0x00f00000) >> 20;
+        UInt_t l_da_siz = (p1[0] & 0x000001ff);
+
+        LOG(DEBUG) << "FairTut8Unpacker : SAM:" << l_sam_id << ",  GTB:" << l_gtb_id << ",  lec:" << l_lec
+                   << ",  size:" << l_da_siz ;
+
+        l_i += 1;
+
+        p1 = (UInt_t*)(data + l_i);
+
+        for (Int_t i1 = 0; i1 < l_da_siz; i1 += 2)
+        {
+            UInt_t tac_addr;
+            UInt_t tac_ch;
+            UInt_t cal;
+            UInt_t clock;
+            UInt_t tac_data;
+            UInt_t qdc_data;
+            tac_addr = (p1[i1] & 0xf8000000) >> 27;
+            tac_ch = (p1[i1] & 0x07c00000) >> 22;
+            cal = (p1[i1] & 0x003C0000) >> 18;
+            clock = 63 - ((p1[i1] & 0x0003f000) >> 12);
+            tac_data = 4095 - ((p1[i1] & 0x00000fff));
+            qdc_data = (p1[i1 + 1] & 0x00000fff);
+            l_i += 2;
+
+            if (16 == tac_ch)
+            {
+                n17 += 1;
+            }
+            LOG(DEBUG) << "FairTut8Unpacker : TAC ADDR IS " << tac_addr << ",  TAC CH IS " << tac_ch << ",  TAC Data IS "
+                       << tac_data << ",  QDC Data IS " << qdc_data ;
+            new ((*fRawData)[fNHits])
+                FairTut8RawItem(l_sam_id, l_gtb_id, tac_addr, tac_ch, cal, clock, tac_data, qdc_data);
+            fNHits++;
+        }
+
+        LOG(DEBUG) << "FairTut8Unpacker : n17=" << n17 ;
+    }
+
+    LOG(DEBUG) << "FairTut8Unpacker : Number of hits in LAND: " << fNHits ;
+    
+    fNHitsTotal += fNHits;
+    
+    return kTRUE;
+}
+
+// Reset: Public method
+void FairTut8Unpacker::Reset()
+{
+    LOG(DEBUG) << "FairTut8Unpacker : Clearing Data Structure" ;
+    fRawData->Clear();
+    fNHits = 0;
+}
+
+ClassImp(FairTut8Unpacker)

--- a/example/MQ/LmdSampler/unpacker/FairTut8Unpacker.h
+++ b/example/MQ/LmdSampler/unpacker/FairTut8Unpacker.h
@@ -1,0 +1,66 @@
+/********************************************************************************
+ *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+#ifndef FAIRTUT8UNPACKER_H
+#define FAIRTUT8UNPACKER_H
+
+#include "FairUnpack.h"
+
+class TClonesArray;
+
+/**
+ * An example unpacker of MBS data.
+ */
+class FairTut8Unpacker : public FairUnpack
+{
+  public:
+    /** Standard Constructor. Input - MBS parameters of the detector. */
+    FairTut8Unpacker(Short_t type = 94,
+                   Short_t subType = 9400,
+                   Short_t procId = 10,
+                   Short_t subCrate = 1,
+                   Short_t control = 3);
+
+    /** Destructor. */
+    virtual ~FairTut8Unpacker();
+
+    /** Initialization. Called once, before the event loop. */
+    virtual Bool_t Init();
+    
+    /** Process an MBS sub-event. */
+    virtual Bool_t DoUnpack(Int_t* data, Int_t size);
+    
+    /** Clear the output structures. */
+    virtual void Reset();
+
+    /** Method for controling the functionality. */
+    inline Int_t GetNHitsTotal()
+    {
+        return fNHitsTotal;
+    }
+
+    TClonesArray* GetOutputData()
+    {
+        return fRawData;
+    }
+
+  protected:
+    /** Register the output structures. */
+    virtual void Register();
+
+  private:
+    TClonesArray* fRawData; /**< Array of output raw items. */
+    Int_t fNHits;           /**< Number of raw items in current event. */
+    Int_t fNHitsTotal;      /**< Total number of raw items. */
+
+  public:
+    // Class definition
+    ClassDef(FairTut8Unpacker, 1)
+};
+
+#endif

--- a/example/MQ/datasource/README.md
+++ b/example/MQ/datasource/README.md
@@ -1,0 +1,1 @@
+output data directory

--- a/example/Tutorial7/CMakeLists.txt
+++ b/example/Tutorial7/CMakeLists.txt
@@ -27,6 +27,11 @@ set(INCLUDE_DIRECTORIES
     ${CMAKE_SOURCE_DIR}/example/Tutorial7/devices/policy/serialization
     ${CMAKE_SOURCE_DIR}/example/Tutorial7/devices/policy/task
     ${CMAKE_SOURCE_DIR}/example/Tutorial7/run/helper_functions
+    ${CMAKE_SOURCE_DIR}/MbsAPI
+
+    ${CMAKE_SOURCE_DIR}/example/Tutorial8
+    ${CMAKE_SOURCE_DIR}/example/Tutorial8/src
+    ${CMAKE_SOURCE_DIR}/example/Tutorial8/macro
 )
 
 Set(SYSTEM_INCLUDE_DIRECTORIES
@@ -39,6 +44,7 @@ include_directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
 
 set(SCRIPT_ARGS "\${\@:2}")
 configure_file( ${CMAKE_SOURCE_DIR}/example/Tutorial7/macro/startTuto7All.sh.in ${CMAKE_BINARY_DIR}/bin/startTuto7All.sh )
+configure_file( ${CMAKE_SOURCE_DIR}/example/Tutorial7/macro/startTuto7AllCRTP.sh.in ${CMAKE_BINARY_DIR}/bin/startTuto7AllCRTP.sh )
 configure_file( ${CMAKE_SOURCE_DIR}/example/Tutorial7/macro/startTuto7GenerateData.sh.in ${CMAKE_BINARY_DIR}/bin/startTuto7GenerateData.sh )
 configure_file( ${CMAKE_SOURCE_DIR}/example/Tutorial7/macro/startTuto7AllTuto3.sh.in ${CMAKE_BINARY_DIR}/bin/startTuto7AllTuto3.sh )
 configure_file( ${CMAKE_SOURCE_DIR}/example/Tutorial7/macro/startTuto7Sampler.sh.in ${CMAKE_BINARY_DIR}/bin/startTuto7Sampler.sh )
@@ -73,7 +79,7 @@ Set(LIBRARY_NAME Tutorial7)
 
 Set(DEPENDENCIES
     Base FairMQ BaseMQ FairTestDetector
-    boost_thread boost_system boost_serialization boost_program_options 
+    boost_thread boost_system boost_serialization boost_program_options Tutorial8
 )
 
 GENERATE_LIBRARY()
@@ -103,6 +109,10 @@ Set(Exe_Names
     tuto7FairTestDetectorSamplerBin
     tuto7FairTestDetectorProcessorBin
     tuto7FairTestDetectorFileSinkBin
+    tuto7SamplerCRTP
+    tuto7ProcessorCRTP
+    tuto7SinkCRTP
+    runLmdSourceTest
 )
 
 set(Exe_Source
@@ -130,6 +140,10 @@ set(Exe_Source
     run/FairTestDetector/runSamplerBinT7b.cxx
     run/FairTestDetector/runProcessorBinT7b.cxx
     run/FairTestDetector/runFileSinkBinT7b.cxx
+    run/runCrtpSamplerT7.cxx
+    run/runCrtpProcessorT7.cxx
+    run/runCrtpFileSinkT7.cxx
+    run/runLmdSourceTest.cxx
 )
 
 ############################################################

--- a/example/Tutorial7/CMakeLists.txt
+++ b/example/Tutorial7/CMakeLists.txt
@@ -14,6 +14,7 @@ set(INCLUDE_DIRECTORIES
     ${CMAKE_SOURCE_DIR}/fairmq/options
     ${CMAKE_SOURCE_DIR}/fairmq/tools
     ${CMAKE_SOURCE_DIR}/base/MQ
+    ${CMAKE_SOURCE_DIR}/base/MQ/devices
     ${CMAKE_SOURCE_DIR}/base/MQ/policies/Sampler
     ${CMAKE_SOURCE_DIR}/base/MQ/policies/Serialization
     ${CMAKE_SOURCE_DIR}/base/MQ/policies/Storage
@@ -27,11 +28,6 @@ set(INCLUDE_DIRECTORIES
     ${CMAKE_SOURCE_DIR}/example/Tutorial7/devices/policy/serialization
     ${CMAKE_SOURCE_DIR}/example/Tutorial7/devices/policy/task
     ${CMAKE_SOURCE_DIR}/example/Tutorial7/run/helper_functions
-    ${CMAKE_SOURCE_DIR}/MbsAPI
-
-    ${CMAKE_SOURCE_DIR}/example/Tutorial8
-    ${CMAKE_SOURCE_DIR}/example/Tutorial8/src
-    ${CMAKE_SOURCE_DIR}/example/Tutorial8/macro
 )
 
 Set(SYSTEM_INCLUDE_DIRECTORIES
@@ -79,7 +75,7 @@ Set(LIBRARY_NAME Tutorial7)
 
 Set(DEPENDENCIES
     Base FairMQ BaseMQ FairTestDetector
-    boost_thread boost_system boost_serialization boost_program_options Tutorial8
+    boost_thread boost_system boost_serialization boost_program_options
 )
 
 GENERATE_LIBRARY()
@@ -112,7 +108,6 @@ Set(Exe_Names
     tuto7SamplerCRTP
     tuto7ProcessorCRTP
     tuto7SinkCRTP
-    runLmdSourceTest
 )
 
 set(Exe_Source
@@ -143,7 +138,6 @@ set(Exe_Source
     run/runCrtpSamplerT7.cxx
     run/runCrtpProcessorT7.cxx
     run/runCrtpFileSinkT7.cxx
-    run/runLmdSourceTest.cxx
 )
 
 ############################################################

--- a/example/Tutorial7/README.md
+++ b/example/Tutorial7/README.md
@@ -6,10 +6,28 @@
 ### Generate input file
 Start the script startTuto7GenerateData.sh (in FairRoot/build/bin/) to generate and store random data. 
 A file Tuto7InputFile.root will be produce in the directory FairRoot/example/Tutorial7/macro/datasource.
+Use the help command line : 
+```bash
+./startTuto7GenerateData.sh --help 
+```
+to see the available command line options (the output file is already set in the startTuto7GenerateData.sh script).
+The data structure are basically digi with (x, y, z, t, t_err) as data members. These variables are normally distributed with defined mean and standard deviation. The mean of t is defined by the time index (from 0 to tmax) and the standard deviation is defined by t_err. By default tmax is set to 100. Use for example :
+
+```bash
+./startTuto7GenerateData.sh --tmax 1000
+```
+
+To increase the number of gaussian(x,y,z). For each time index, N event will be generated according to the gaussian(x,y,z) pdf. The number N also fluctuate according to gaussian(N,N_err). Use for example
+
+```bash
+./startTuto7GenerateData.sh --Nmean 1000 --Nsigma 10
+```
+
+to set the average number and standard deviation of digi per time index (pulse). For example on ubuntu 14.04.3 LTS and with gcc 4.8.4, the MyDigi class has a size of about 104 bytes (the serialized data members however have a size of 28 bytes). Therefore, with this setting, the approximated size of the generated file will be about Nmean x tmax x 104 bytes.
 
 ### Start the process chain
 Start the script startTuto7All.sh to use the Tuto7InputFile.root as data source. 
-The implemented serialization formats are boost, binary, Root (TMessage). 
+In this tutorial7 example, the implemented serialization formats are boost, binary, Root (TMessage). 
 To enable a specific format use e.g.
 
 ```bash
@@ -21,18 +39,3 @@ To enable a specific format use e.g.
 Alternatively you can start the script startTuto7AllTuto3.sh to use the testdigi.root from tutorial3 as data source.
 See tutorial 3 for more details.
 
-## Introduction
-The Tutorial 7 show how to use three generic devices, namely a generic sampler, processor and filesink.
-These three devices are policy based designed classes. These devices all inherit from FairMQDevice and from specific template parameters, namely :
-* The sampler inherit from 
- * a sampler policy (e.g a file reader) 
- * an output policy (serialize)
-* The processor inherit from 
- * an input policy (deserialize) 
- * an output policy (serialize)
- * a task policy (process data)
-* The filesink inherit from 
- * an input policy (deserialize)
- * a storage policy.
-
-Some policy examples (c.f. e.g. BoostSerializer.h) are available in Base/MQ.

--- a/example/Tutorial7/devices/policy/task/DigiToHitTaskCrtp.h
+++ b/example/Tutorial7/devices/policy/task/DigiToHitTaskCrtp.h
@@ -1,0 +1,103 @@
+/* 
+ * File:   DigiToHitTask.h
+ * Author: winckler
+ *
+ * Created on December 2, 2014, 10:44 AM
+ */
+
+#ifndef DIGITOHITTASK_H
+#define	DIGITOHITTASK_H
+
+// std
+#include <iostream>
+#include <string>
+#include <vector>
+#include <type_traits>
+
+// root
+#include "Rtypes.h"
+#include "TMath.h"
+
+// FairRoot
+#include "TVector3.h"
+
+// FairRoot - Tutorial7
+#include "BaseProcessorTaskPolicy.h"
+#include "FairHit.h"
+#include "MyDigi.h"
+#include "MyHit.h"
+
+
+//////////////// TClonesArray container version
+
+class DigiToHitTaskCrtp : public BaseProcessorTaskPolicy< DigiToHitTaskCrtp >
+{
+
+  public:
+    DigiToHitTaskCrtp() : BaseProcessorTaskPolicy< DigiToHitTaskCrtp >(),
+        fOutputContainer(nullptr), 
+        fTaskName(), 
+        fDetID(-1), 
+        fMCIndex(-1)
+    {}
+
+    virtual ~DigiToHitTaskCrtp()
+    {}
+
+    void InitTask(const std::string &ClassName)
+    {
+        InitContainer(ClassName.c_str());
+    }
+
+    void InitContainer(const char* ClassName)
+    {
+        fOutputContainer = new TClonesArray(ClassName);
+    }
+
+    void InitContainer(TClonesArray* array)
+    {
+        fOutputContainer = array;
+    }
+
+    void ExecuteTask(TClonesArray* inputdata)
+    {
+        fOutputContainer->Delete();
+        for(unsigned int idigi(0);idigi<inputdata->GetEntriesFast();idigi++)
+        {
+            TVector3 pos;
+            TVector3 dpos;
+            Double_t timestamp=0;
+            Double_t timestampErr=0;
+
+            MyDigi* digi = (MyDigi*)inputdata->At(idigi);
+            ProcessDigi(*digi, pos, dpos, timestamp, timestampErr);
+
+            MyHit* hit = new ((*fOutputContainer)[idigi]) MyHit(fDetID, fMCIndex, pos, dpos);
+            hit->SetTimeStamp(digi->GetTimeStamp());
+            hit->SetTimeStampError(digi->GetTimeStampError());
+        }
+    }
+
+    TClonesArray* GetOutputData()
+    {
+        return fOutputContainer;
+    }
+
+  protected:
+
+
+    inline void ProcessDigi(const MyDigi &Digi, TVector3 &pos, TVector3 &dpos, Double_t &t, Double_t &t_err)
+    {
+        pos.SetXYZ(Digi.GetX() + 0.5, Digi.GetY() + 0.5, Digi.GetZ() + 0.5);
+        dpos.SetXYZ(1 / TMath::Sqrt(12), 1 / TMath::Sqrt(12), 1 / TMath::Sqrt(12));
+        t = Digi.GetTimeStamp();
+        t_err = Digi.GetTimeStampError();
+    }
+
+    TClonesArray* fOutputContainer;
+    std::string fTaskName;
+    Int_t fDetID;
+    Int_t fMCIndex;
+};
+
+#endif /* DIGITOHITTASK_H */

--- a/example/Tutorial7/macro/startTuto7All.sh.in
+++ b/example/Tutorial7/macro/startTuto7All.sh.in
@@ -30,7 +30,9 @@ CONFIGFILE="@CMAKE_BINARY_DIR@/bin/config/tuto7Config.cfg"
 
 ########################## start SAMPLER
 SAMPLER="tuto7Sampler$dataFormat"
-SAMPLER+=" --id sampler1  -c $CONFIGFILE --register-task-sampler true"
+SAMPLER+=" --id sampler1  -c $CONFIGFILE"
+#uncomment if you like to test the task container of the generic sampler
+#SAMPLER+=" --register-task-sampler true"
 xterm +aw -geometry 120x27+0+0 -hold -e @CMAKE_BINARY_DIR@/bin/$SAMPLER &
 
 ########################## start SPLITTER

--- a/example/Tutorial7/macro/startTuto7AllCRTP.sh.in
+++ b/example/Tutorial7/macro/startTuto7AllCRTP.sh.in
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# dataFormat = Serialization format
+
+dataFormat="Bin"
+if [ "$1" = "bin" ]; then
+    echo "attempting to use pure binary data format"
+elif [ "$1" = "boost" ]; then
+    dataFormat="Boost"
+    echo "attempting to use Boost serialized data format"
+# TODO : protobuff implementation
+#elif [ "$1" = "proto" ]; then
+#    dataFormat="Proto"
+#    echo "attempting to use Google Protocol Buffers data format"
+elif [ "$1" = "root" ]; then
+    dataFormat="Root"
+    echo "attempting to use Root TMessage data format"
+else
+    echo "none or incorrect data formats provided."
+    #echo "(available data format options are: bin, boost, proto, root)"
+    echo "(available data format options are: bin, boost, root)"
+    echo "binary data format will be used."
+fi
+
+##########################
+# CONFIGFILE = ini/txt config file, which, in this example, 
+# contain path to json file for the MQDevice configuration (address, MQ methods, etc.), 
+# and other key-values specific to each device (input/output file names, branch, etc.)
+CONFIGFILE="@CMAKE_BINARY_DIR@/bin/config/tuto7Config.cfg"
+
+########################## start SAMPLER
+SAMPLER="tuto7SamplerCRTP"
+SAMPLER+=" --id sampler1  -c $CONFIGFILE --data-format $dataFormat"
+#uncomment if you like to test the task container of the generic sampler
+#SAMPLER+=" --register-task-sampler true"
+xterm -geometry 120x27+0+0 -hold -e @CMAKE_BINARY_DIR@/bin/$SAMPLER &
+
+########################## start SPLITTER
+SPLITTER="tuto7Splitter"
+SPLITTER+=" --id splitter1 --config $CONFIGFILE"
+xterm +aw -geometry 100x27+800+500 -hold -e @CMAKE_BINARY_DIR@/bin/$SPLITTER &
+
+########################## start PROCESSORs
+PROCESSOR1="tuto7ProcessorCRTP"
+PROCESSOR1+=" --id processor1 --config $CONFIGFILE --data-format $dataFormat"
+xterm +aw -geometry 100x27+800+0 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR1 &
+
+PROCESSOR2="tuto7ProcessorCRTP"
+PROCESSOR2+=" --id processor2 --config $CONFIGFILE --data-format $dataFormat"
+xterm +aw -geometry 100x27+800+0 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR2 &
+
+PROCESSOR3="tuto7ProcessorCRTP"
+PROCESSOR3+=" --id processor3 --config $CONFIGFILE --data-format $dataFormat"
+xterm +aw -geometry 100x27+800+0 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR3 &
+
+########################## start MERGER
+MERGER="tuto7Merger"
+MERGER+=" --id merger1 --config $CONFIGFILE"
+xterm +aw -geometry 100x27+800+500 -hold -e @CMAKE_BINARY_DIR@/bin/$MERGER &
+
+########################## start FILESINK
+FILESINK="tuto7SinkCRTP"
+FILESINK+=" --id sink1 --config $CONFIGFILE --data-format $dataFormat"
+FILESINK+=" --output.file.name @CMAKE_SOURCE_DIR@/example/Tutorial7/macro/datasource/Tuto7OutputFile$dataFormat.root"
+xterm +aw -geometry 120x27+0+500 -hold -e @CMAKE_BINARY_DIR@/bin/$FILESINK &
+
+

--- a/example/Tutorial7/macro/startTuto7GenerateData.sh.in
+++ b/example/Tutorial7/macro/startTuto7GenerateData.sh.in
@@ -1,8 +1,14 @@
 #!/bin/bash
 
-GENERATE="tuto7GenerateData"
-GENERATE+=" --input-file @CMAKE_SOURCE_DIR@/example/Tutorial7/macro/datasource/Tuto7InputFile.root"
-GENERATE+=" --tree T7SamplerTree --branch MyDigi --class-name MyDigi"
-GENERATE+=" --tmax 10000"
-GENERATE+=" --plot-data false"
+
+opt=""
+
+if [ "$#" -gt 0 ]; then
+        opt=" $*"
+fi
+
+GENERATE="tuto7GenerateData$opt"
+GENERATE+=" --output-file @CMAKE_SOURCE_DIR@/example/Tutorial7/macro/datasource/Tuto7InputFile.root"
+
+
 @CMAKE_BINARY_DIR@/bin/$GENERATE 

--- a/example/Tutorial7/options/tuto7Config.cfg.in
+++ b/example/Tutorial7/options/tuto7Config.cfg.in
@@ -26,7 +26,7 @@ config-json-file =@CMAKE_SOURCE_DIR@/example/Tutorial7/options/tuto7MQConfig.jso
 [input.file]
 
 name = @CMAKE_SOURCE_DIR@/example/Tutorial7/macro/datasource/Tuto7InputFile.root
-tree = T7SamplerTree
+tree = cbmsim
 branch = MyDigi
 
 
@@ -34,6 +34,6 @@ branch = MyDigi
 [output.file]
 
 name = @CMAKE_SOURCE_DIR@/example/Tutorial7/macro/datasource/Tuto7DefaultOutputFile.root"
-tree = T7SinkTree
+tree = cbmout
 branch = MyHit
 option = RECREATE

--- a/example/Tutorial7/run/helper_functions/tuto7FileSinkFunctions.h
+++ b/example/Tutorial7/run/helper_functions/tuto7FileSinkFunctions.h
@@ -58,5 +58,47 @@ inline int runFileSink(TGenSink& sink_,int argc, char** argv)
 }
 
 
+
+
+
+
+
+
+inline int InitConfig(FairMQProgOptions& config,int argc, char** argv)
+{
+    namespace po = boost::program_options;
+
+    po::options_description sink_options("File Sink options");
+    sink_options.add_options()
+        // TODO : make the semantic required for at least one source (and not both cfg & cmd)
+        //("input.file.name",         value<std::string>(&filename)->required(),                       "Path to the input file")
+        ("output.file.name",         po::value<std::string>(),                              "Path to the input file")
+        ("output.file.tree",         po::value<std::string>()->default_value("T7SinkTree"), "Name of the output tree")
+        ("output.file.branch",       po::value<std::string>()->default_value("MyHit"),      "Name of the output Branch")
+        ("output.file.option",       po::value<std::string>()->default_value("RECREATE"),   "Root file option : UPDATE, RECREATE etc.")
+        ("hit-classname",            po::value<std::string>()->default_value("MyHit"),      "Hit class name for initializing TClonesArray")
+        ("data-format",              po::value<std::string>()->default_value("Binary"),     "Data format (binary/boost/protobuf/tmessage)")
+    ;
+
+    config.AddToCmdLineOptions(sink_options);
+    config.AddToCfgFileOptions(sink_options, false);
+
+    if (config.ParseAll(argc, argv, true))
+    {
+        return 1;
+    }
+
+    return 0;
+}
+
+
+
+
+
+
+
+
+
+
 #endif	/* FILESINKFUNCTIONS_H */
 

--- a/example/Tutorial7/run/helper_functions/tuto7ProcessorFunctions.h
+++ b/example/Tutorial7/run/helper_functions/tuto7ProcessorFunctions.h
@@ -47,4 +47,25 @@ inline int runProcessor(TGenProcessor& processor_,int argc, char** argv)
     return 0;
 }
 
+inline int InitConfig(FairMQProgOptions& config, int argc, char** argv)
+{
+    namespace po = boost::program_options;
+    po::options_description processor_options("Processor options");
+    processor_options.add_options()
+        ("digi-classname", po::value<std::string>()->default_value("MyDigi"), "Digi class name for initializing TClonesArray")
+        ("hit-classname",  po::value<std::string>()->default_value("MyHit"),  "Hit class name for initializing TClonesArray")
+        ("data-format",    po::value<std::string>()->default_value("Binary"), "Data format (binary/boost/protobuf/tmessage)")
+    ;
+
+    config.AddToCmdLineOptions(processor_options);
+    config.AddToCfgFileOptions(processor_options,false);
+
+    if (config.ParseAll(argc, argv, true))
+    {
+        return 1;
+    }
+
+    return 0;
+}
+
 #endif /* PROCESSORFUNCTIONS_H */

--- a/example/Tutorial7/run/helper_functions/tuto7SamplerFunctions.h
+++ b/example/Tutorial7/run/helper_functions/tuto7SamplerFunctions.h
@@ -9,6 +9,8 @@
 #define SAMPLERFUNCTIONS_H
 
 #include "runGenericDevices.h"
+#include "SimpleTreeReader.h"
+#include "TClonesArray.h"
 
 // dummy function to illustrate the task container feature
 void myfuncHello() { LOG(INFO) << "Hello "; }
@@ -104,6 +106,34 @@ inline int InitSamplerSetting(TGenSampler& sampler_, FairMQProgOptions& config, 
     sampler_.SetProperty(TGenSampler::EventRate, eventRate);
     // call function member from sampler policy
     sampler_.SetFileProperties(filename, treename, branchname);
+
+    return 0;
+}
+
+
+
+inline int InitConfig(FairMQProgOptions& config, int argc, char** argv)
+{
+    namespace po = boost::program_options;
+
+    po::options_description sampler_options("Sampler options");
+    sampler_options.add_options()
+        ("event-rate",              po::value<int>()->default_value(0),                   "Event rate limit in maximum number of events per second")
+        // TODO : make the semantic required for at least one source (and not both cfg & cmd)
+        // ("input.file.name",         value<std::string>(&filename)->required(),                       "Path to the input file")
+        ("input.file.name",         po::value<std::string>(),                               "Path to the input file")
+        ("input.file.tree",         po::value<std::string>()->default_value("T7DataTree"),  "Name of the tree")
+        ("input.file.branch",       po::value<std::string>()->default_value("T7digidata"),"Name of the Branch")
+        ("data-format",             po::value<std::string>()->default_value("Binary"),                    "Data format (binary/boost/protobuf/tmessage)")
+    ;
+
+    config.AddToCmdLineOptions(sampler_options);
+    config.AddToCfgFileOptions(sampler_options, false);
+
+    if (config.ParseAll(argc, argv, true))
+    {
+        return 1;
+    }
 
     return 0;
 }

--- a/example/Tutorial7/run/runCrtpFileSinkT7.cxx
+++ b/example/Tutorial7/run/runCrtpFileSinkT7.cxx
@@ -1,0 +1,84 @@
+
+// FairRoot - FairMQ
+#include "GenericFileSink.h"
+
+// FairRoot - base/MQ
+#include "RootOutFileManager.h"
+#include "BoostSerializer.h"
+#include "RootSerializer.h"
+
+// FairRoot - Tutorial7
+#include "tuto7FileSinkFunctions.h"
+#include "MyHitSerializerCrtp.h"
+#include "MyHit.h"
+
+// Bin, Boost, Root suffixes = deserialization format
+// In this example all Sinks store the data into Root file using the policy RootOutFileManager<MyHit>
+typedef GenericFileSink<MyHitDeserializerCrtp_t, RootOutFileManager<MyHit>>                  TSinkBin;
+typedef GenericFileSink<BoostDeSerializer<MyHit,TClonesArray*>, RootOutFileManager<MyHit>>   TSinkBoost;
+typedef GenericFileSink<RootDeSerializer, RootOutFileManager<MyHit>>                         TSinkRoot;
+
+
+
+template<typename TSink>
+inline void runSink(FairMQProgOptions& config)
+{
+    std::string filename = config.GetValue<std::string>("output.file.name");
+    std::string treename = config.GetValue<std::string>("output.file.tree");
+    std::string branchname = config.GetValue<std::string>("output.file.branch");
+    std::string fileoption = config.GetValue<std::string>("output.file.option");
+    std::string hitname = config.GetValue<std::string>("hit-classname");
+
+    TSink sink;
+    // call function member from storage policy
+    sink.SetFileProperties(filename, treename, branchname, hitname, fileoption, true);
+    // call function member from deserialization policy
+    sink.InitInputContainer(hitname);
+    runStateMachine(sink, config);
+}
+
+template<>
+inline void runSink<TSinkBoost>(FairMQProgOptions& config)
+{
+    std::string filename = config.GetValue<std::string>("output.file.name");
+    std::string treename = config.GetValue<std::string>("output.file.tree");
+    std::string branchname = config.GetValue<std::string>("output.file.branch");
+    std::string fileoption = config.GetValue<std::string>("output.file.option");
+    std::string hitname = config.GetValue<std::string>("hit-classname");
+
+    TSinkBoost sink;
+    // call function member from storage policy
+    sink.SetFileProperties(filename, treename, branchname, hitname, fileoption, true);
+    // call function member from deserialization policy (required for "container = new TClonesArrays(...)" )
+    sink.InitInputContainer(hitname.c_str());
+    runStateMachine(sink, config);
+}
+
+
+int main(int argc, char** argv)
+{
+    try
+    {
+        FairMQProgOptions config;
+        InitConfig(config, argc, argv);
+
+        std::string format = config.GetValue<std::string>("data-format");
+
+        if (format == "Bin") { runSink<TSinkBin>(config); }
+            else if (format == "Boost") { runSink<TSinkBoost>(config); }
+            else if (format == "Root") { runSink<TSinkRoot>(config); }
+            else
+            {
+                LOG(ERROR) << "No valid data format provided. (--data-format binary|boost|tmessage). ";
+                return 1;
+            }
+    }
+    catch (std::exception& e)
+    {
+        LOG(ERROR)  << "Unhandled Exception reached the top of main: " 
+                    << e.what() << ", application will now exit";
+        return 1;
+    }
+
+    return 0;
+}

--- a/example/Tutorial7/run/runCrtpProcessorT7.cxx
+++ b/example/Tutorial7/run/runCrtpProcessorT7.cxx
@@ -1,0 +1,81 @@
+
+/// std
+#include <csignal>
+
+/// FairRoot - FairMQ - base/MQ
+#include "FairMQLogger.h"
+#include "GenericProcessor.h"
+#include "BoostSerializer.h"
+#include "RootSerializer.h"
+
+/// FairRoot - Tutorial7 
+#include "tuto7ProcessorFunctions.h"
+#include "MyDigiSerializerCrtp.h"
+#include "MyHitSerializerCrtp.h"
+#include "DigiToHitTaskCrtp.h"
+#include "MyDigi.h"
+#include "MyHit.h"
+
+// ////////////////////////////////////////////////////////////////////////
+
+typedef GenericProcessor<MyDigiDeserializerCrtp_t,MyHitSerializerCrtp_t,DigiToHitTaskCrtp>      TProcessorBin;
+typedef GenericProcessor<   
+                            BoostDeSerializer<MyDigi,TClonesArray*>,
+                            BoostSerializer<MyHit>,
+                            DigiToHitTaskCrtp
+                        >                                                                       TProcessorBoost;
+typedef GenericProcessor<RootDeSerializer,RootSerializer,DigiToHitTaskCrtp>                     TProcessorRoot;
+
+template<typename TProcessor>
+inline void runProcessor(FairMQProgOptions& config)
+{
+    std::string diginame=config.GetValue<std::string>("digi-classname");
+    std::string hitname=config.GetValue<std::string>("hit-classname");
+
+    TProcessor processor;
+    processor.InitInputContainer(diginame);
+    processor.InitTask(hitname);
+    runStateMachine(processor, config);
+}
+
+template<>
+inline void runProcessor<TProcessorBoost>(FairMQProgOptions& config)
+{
+    std::string diginame=config.GetValue<std::string>("digi-classname");
+    std::string hitname=config.GetValue<std::string>("hit-classname");
+
+    TProcessorBoost processor;
+    processor.InitInputContainer(diginame.c_str());
+    processor.InitTask(hitname);
+    runStateMachine(processor, config);
+}
+
+int main(int argc, char** argv)
+{
+    try
+    {
+        FairMQProgOptions config;
+        InitConfig(config, argc, argv);
+
+        std::string format = config.GetValue<std::string>("data-format");
+
+        if (format == "Bin") { runProcessor<TProcessorBin>(config); }
+            else if (format == "Boost") { runProcessor<TProcessorBoost>(config); }
+            else if (format == "Root") { runProcessor<TProcessorRoot>(config); }
+            else
+            {
+                LOG(ERROR) << "No valid data format provided. (--data-format binary|boost|tmessage). ";
+                return 1;
+            }
+
+
+    }
+    catch (std::exception& e)
+    {
+        LOG(ERROR)  << "Unhandled Exception reached the top of main: " 
+                    << e.what() << ", application will now exit";
+        return 1;
+    }
+
+    return 0;
+}

--- a/example/Tutorial7/run/runCrtpSamplerT7.cxx
+++ b/example/Tutorial7/run/runCrtpSamplerT7.cxx
@@ -19,8 +19,7 @@
 // FairRoot - Base/MQ
 // sampler policies
 
-#include "FairFileSource.h"
- #include "FairSourceMQInterface.h"
+ #include "FairMQFileSource.h"
 
 // FairRoot - Tutorial 7
 #include "tuto7SamplerFunctions.h"
@@ -42,12 +41,11 @@
 // ////////////////////////////////////////////////////////////////////////
 
 
-typedef FairSourceMQInterface<FairFileSource,TClonesArray>  TSourcePolicy;
 
 // build sampler type
-typedef GenericSampler<TSourcePolicy, MyDigiSerializerCrtp_t>   TSamplerBin;
-typedef GenericSampler<TSourcePolicy, BoostSerializer<MyDigi> > TSamplerBoost;
-typedef GenericSampler<TSourcePolicy, RootSerializer>           TSamplerTMessage;
+typedef GenericSampler<FairMQFileSource_t, MyDigiSerializerCrtp_t>   TSamplerBin;
+typedef GenericSampler<FairMQFileSource_t, BoostSerializer<MyDigi> > TSamplerBoost;
+typedef GenericSampler<FairMQFileSource_t, RootSerializer>           TSamplerTMessage;
 
 
 
@@ -64,18 +62,6 @@ inline void runSampler(FairMQProgOptions& config)
     sampler.SetProperty(TSampler::EventRate, eventRate);
     // call function member from sampler policy
     sampler.SetFileProperties(filename, branchname);
-//*
-    sampler.CustomInitSourceRunAna([=](FairFileSource** fSource, TClonesArray** fData, FairRunAna** fRunAna)
-            {
-                
-            *fRunAna = new FairRunAna();
-            *fSource = new FairFileSource(filename.c_str());
-            (*fSource)->Init();
-            (*fSource)->ActivateObject((TObject**)fData,branchname.c_str());
-            }
-        );
-
-        // */
 
     runStateMachine(sampler, config);
 }

--- a/example/Tutorial7/run/runCrtpSamplerT7.cxx
+++ b/example/Tutorial7/run/runCrtpSamplerT7.cxx
@@ -1,0 +1,113 @@
+/********************************************************************************
+ *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+/*
+ * File:   runSamplerRoot.cxx
+ * Author: winckler
+ *
+ * Created on January 15, 2015, 1:57 PM
+ */
+
+// FairRoot - FairMQ
+#include "FairMQLogger.h"
+#include "GenericSampler.h"
+
+// FairRoot - Base/MQ
+// sampler policies
+
+#include "FairFileSource.h"
+ #include "FairSourceMQInterface.h"
+
+// FairRoot - Tutorial 7
+#include "tuto7SamplerFunctions.h"
+#include "MyDigi.h"
+
+
+// FairRoot - Base/MQ
+// sampler & serialization policies
+#include "BoostSerializer.h"
+#include "RootSerializer.h"
+#include "MyDigiSerializerCrtp.h"
+// FairRoot - Tutorial 7
+#include "tuto7SamplerFunctions.h"
+#include "MyDigi.h"
+
+#include "FairRunAna.h"
+#include "TClonesArray.h"
+
+// ////////////////////////////////////////////////////////////////////////
+
+
+typedef FairSourceMQInterface<FairFileSource,TClonesArray>  TSourcePolicy;
+
+// build sampler type
+typedef GenericSampler<TSourcePolicy, MyDigiSerializerCrtp_t>   TSamplerBin;
+typedef GenericSampler<TSourcePolicy, BoostSerializer<MyDigi> > TSamplerBoost;
+typedef GenericSampler<TSourcePolicy, RootSerializer>           TSamplerTMessage;
+
+
+
+template<typename TSampler>
+inline void runSampler(FairMQProgOptions& config)
+{
+    int eventRate = config.GetValue<int>("event-rate");
+    std::string filename = config.GetValue<std::string>("input.file.name");
+    std::string branchname = config.GetValue<std::string>("input.file.branch");
+    
+
+    TSampler sampler;
+    /// configure sampler specific from parsed values
+    sampler.SetProperty(TSampler::EventRate, eventRate);
+    // call function member from sampler policy
+    sampler.SetFileProperties(filename, branchname);
+//*
+    sampler.CustomInitSourceRunAna([=](FairFileSource** fSource, TClonesArray** fData, FairRunAna** fRunAna)
+            {
+                
+            *fRunAna = new FairRunAna();
+            *fSource = new FairFileSource(filename.c_str());
+            (*fSource)->Init();
+            (*fSource)->ActivateObject((TObject**)fData,branchname.c_str());
+            }
+        );
+
+        // */
+
+    runStateMachine(sampler, config);
+}
+
+
+int main(int argc, char** argv)
+{
+    try
+    {
+        
+        FairMQProgOptions config;
+        InitConfig(config, argc, argv);
+
+        std::string format = config.GetValue<std::string>("data-format");
+
+        if (format == "Bin") { runSampler<TSamplerBin>(config); }
+            else if (format == "Boost") { runSampler<TSamplerBoost>(config); }
+            else if (format == "Root") { runSampler<TSamplerTMessage>(config); }
+            else
+            {
+                LOG(ERROR) << "No valid data format provided. (--data-format binary|boost|tmessage). ";
+                return 1;
+            }
+
+        
+    }
+    catch (std::exception& e)
+    {
+        LOG(ERROR)  << "Unhandled Exception reached the top of main: " 
+                    << e.what() << ", application will now exit";
+        return 1;
+    }
+
+    return 0;
+}

--- a/example/Tutorial7/run/runGenerateData.cxx
+++ b/example/Tutorial7/run/runGenerateData.cxx
@@ -67,44 +67,147 @@ typedef RootOutFileManager<TDigi> RootFileManager;
 int main(int argc, char** argv)
 {
 
-
-    string filename;
-    string treename;
-    string branchname;
-    string classname;
-    string fileoption;
-    bool useTCA;
-    bool plotdata;
-    unsigned int tmax;
-    double Nmean;
-    double Nsigma;
-    
-    namespace po = boost::program_options;
-    Tuto7DataGeneratorProgOptions config;
-
-    po::options_description desc("Data generator options");
-    desc.add_options()
-        ("output-file",     po::value<string>(&filename)->required(),                       "<   string   > : Path to the output root file of generated data")
-        ("tree",            po::value<string>(&treename)->default_value("T7SamplerTree"),   "<   string   > : Name of the tree")
-        ("branch",          po::value<string>(&branchname)->default_value("MyDigi"),        "<   string   > : Name of the Branch")
-        ("class-name",      po::value<string>(&classname)->default_value("MyDigi"),         "<   string   > : Name of the Payload class")
-        ("rootfile-option", po::value<string>(&fileoption)->default_value("RECREATE"),      "<   string   > : Root file option.")
-        ("use-TCA",         po::value<bool>(&useTCA)->default_value(true),                  "<    bool    > : Store data bunches in TClonesArray")
-        ("plot-data",       po::value<bool>(&plotdata)->default_value(false),               "<    bool    > : Plot generated data")
-        ("tmax",            po::value<unsigned int>(&tmax)->default_value(100),             "<unsigned int> : max time index=bunch number")
-        ("Nmean",           po::value<double>(&Nmean)->default_value(1595),                 "<unsigned int> : mean number of generated data / bunch")
-        ("Nsigma",          po::value<double>(&Nsigma)->default_value(25.98),               "<unsigned int> : std deviation of the number of generated data / bunch")
-        ;
-
-
-    config.AddToCmdLineOptions(desc);
-
     try
     {
+        string filename;
+        string treename;
+        string branchname;
+        string classname;
+        string fileoption;
+        bool useTCA;
+        bool plotdata;
+        unsigned int tmax;
+        double Nmean;
+        double Nsigma;
+        
+        namespace po = boost::program_options;
+        Tuto7DataGeneratorProgOptions config;
+
+        po::options_description desc("Data generator options");
+        desc.add_options()
+            ("output-file",     po::value<string>(&filename)->required(),                       "<   string   > : Path to the output root file of generated data")
+            ("tree",            po::value<string>(&treename)->default_value("T7SamplerTree"),   "<   string   > : Name of the tree")
+            ("branch",          po::value<string>(&branchname)->default_value("MyDigi"),        "<   string   > : Name of the Branch")
+            ("class-name",      po::value<string>(&classname)->default_value("MyDigi"),         "<   string   > : Name of the Payload class")
+            ("rootfile-option", po::value<string>(&fileoption)->default_value("RECREATE"),      "<   string   > : Root file option.")
+            ("use-TCA",         po::value<bool>(&useTCA)->default_value(true),                  "<    bool    > : Store data bunches in TClonesArray")
+            ("plot-data",       po::value<bool>(&plotdata)->default_value(false),               "<    bool    > : Plot generated data")
+            ("tmax",            po::value<unsigned int>(&tmax)->default_value(100),             "<unsigned int> : max time index=bunch number")
+            ("Nmean",           po::value<double>(&Nmean)->default_value(1595),                 "<unsigned int> : mean number of generated data / bunch")
+            ("Nsigma",          po::value<double>(&Nsigma)->default_value(25.98),               "<unsigned int> : std deviation of the number of generated data / bunch")
+            ;
+
+
+        config.AddToCmdLineOptions(desc);
+
+        
         if (config.ParseAll(argc, argv, true))
         {
             return 1;
         }
+
+
+        //----------------------------------------------
+        // Init output file manager 
+        RootFileManager* rootman = new RootFileManager();
+        rootman->SetFileProperties(filename, treename, branchname, classname,fileoption,useTCA);
+        rootman->InitOutputFile();
+        
+        //----------------------------------------------
+        // Init density function for the number of digi/ bunch
+        RdmVarParameters Nval(Nmean,Nsigma);
+        RooRealVar N("N","N",Nval.min,Nval.max);
+        RooGaussian Gauss_N("Gauss_N", "gaussian PDF", N, RooConst(Nval.mean), RooConst(Nval.sigma));// mean/sigma same as tutorial 3
+        
+        // Init density function for the (x,y,z,t,terr) random variables
+        PDFConfig pdfconfig;// default setting (i.e. default range, mean, standard deviation)
+        MultiVariatePDF* Model = new MultiVariatePDF(pdfconfig);
+        
+        //----------------------------------------------
+        // loop over t (= bunch index), generate data from pdf, fill digi and save to file
+        for(unsigned int t(0); t<tmax;t++)
+        {
+            
+            unsigned int NDigi=(unsigned int)Gauss_N.generate(N,1)->get(0)->getRealValue("N");
+            LOG(INFO)  <<"Bunch number "<<t+1<<"/"<<tmax 
+                       <<" ("<< 100.*(double)(t+1)/(double)tmax<<" %). Number of generated digi : "
+                       << NDigi<< " , payload = "<<NDigi*(3*sizeof(Int_t)+2*sizeof(Double_t))<<" bytes";
+
+            RooDataSet *simdataset = Model->GetGeneratedData(NDigi,t);
+            SaveDataToFile<TDigi,RootFileManager>(*rootman, simdataset);
+        }
+        delete Model;
+        delete rootman;
+        
+        //----------------------------------------------
+        // option : plot generated data
+        if(plotdata)
+        {
+            RootFileManager man;
+            man.SetFileProperties(filename, treename, branchname, 
+                                  classname,"READ",useTCA);
+            vector< vector<TDigi> > data=man.GetAllObj(filename, treename, branchname);
+
+            TH2D* histoxy = new TH2D("fxy","digi.fxy",100,pdfconfig.x.min,pdfconfig.x.max, 100,pdfconfig.y.min,pdfconfig.y.max);
+            TH1D* histox = new TH1D("fx","digi.fx",100,pdfconfig.x.min,pdfconfig.x.max);
+            TH1D* histoy = new TH1D("fy","digi.fy",100,pdfconfig.y.min,pdfconfig.y.max);
+            TH1D* histoz = new TH1D("fz","digi.fz",100,pdfconfig.z.min,pdfconfig.z.max);
+            TH1D* histot = new TH1D("ftimestamp","digi.ftimestamp",10*tmax, 0., (double)(tmax+1));
+            TH1D* histoterr = new TH1D("ftimestampErr","digi.ftimestampErr",100,pdfconfig.tErr.min,pdfconfig.tErr.max);
+            TH1D* histoN = new TH1D("f_N","Number of digi distribution",100,Nval.min,Nval.max);
+        
+            for(auto& p : data)
+            {
+                histoN->Fill((double)p.size());
+                for(auto& q : p)
+                {
+                    histox->Fill(q.GetX());
+                    histoy->Fill(q.GetY());
+                    histoxy->Fill(q.GetX(),q.GetY());
+                    histoz->Fill(q.GetZ());
+                    histot->Fill(q.GetTimeStamp());
+                    histoterr->Fill(q.GetTimeStampError());
+                }
+            }
+            
+            TApplication app("App", &argc, argv);
+            
+            TCanvas *T7Canvas = new  TCanvas("Tutorial7","Tutorial7",1000,800);
+            T7Canvas->Divide(4,2);
+            
+            T7Canvas->cd(1);
+            histox->Draw();
+            
+            T7Canvas->cd(2);
+            histoy->Draw();
+            
+            T7Canvas->cd(3);
+            histoxy->Draw("zcol");
+            
+            T7Canvas->cd(4);
+            histoz->Draw();
+            
+            T7Canvas->cd(5);
+            histot->Draw();
+            
+            T7Canvas->cd(6);
+            histoterr->Draw();
+            
+            T7Canvas->cd(7);
+            histoN->Draw();
+            
+            app.Run();
+            
+            
+            delete histox;
+            delete histoy;
+            delete histoz;
+            delete histoxy;
+            delete histot;
+            delete histoterr;
+            delete histoN;
+        }
+
     }
     catch (exception& e)
     {
@@ -112,108 +215,6 @@ int main(int argc, char** argv)
         return 1;
     }
     
-
-    //----------------------------------------------
-    // Init output file manager 
-    RootFileManager* rootman = new RootFileManager();
-    rootman->SetFileProperties(filename, treename, branchname, classname,fileoption,useTCA);
-    rootman->InitOutputFile();
-    
-    //----------------------------------------------
-    // Init density function for the number of digi/ bunch
-    RdmVarParameters Nval(Nmean,Nsigma);
-    RooRealVar N("N","N",Nval.min,Nval.max);
-    RooGaussian Gauss_N("Gauss_N", "gaussian PDF", N, RooConst(Nval.mean), RooConst(Nval.sigma));// mean/sigma same as tutorial 3
-    
-    // Init density function for the (x,y,z,t,terr) random variables
-    PDFConfig pdfconfig;// default setting (i.e. default range, mean, standard deviation)
-    MultiVariatePDF* Model = new MultiVariatePDF(pdfconfig);
-    
-    //----------------------------------------------
-    // loop over t (= bunch index), generate data from pdf, fill digi and save to file
-    for(unsigned int t(0); t<tmax;t++)
-    {
-        
-        unsigned int NDigi=(unsigned int)Gauss_N.generate(N,1)->get(0)->getRealValue("N");
-        LOG(INFO)  <<"Bunch number "<<t+1<<"/"<<tmax 
-                   <<" ("<< 100.*(double)(t+1)/(double)tmax<<" %). Number of generated digi : "
-                   << NDigi<< " , payload = "<<NDigi*(3*sizeof(Int_t)+2*sizeof(Double_t))<<" bytes";
-
-        RooDataSet *simdataset = Model->GetGeneratedData(NDigi,t);
-        SaveDataToFile<TDigi,RootFileManager>(*rootman, simdataset);
-    }
-    delete Model;
-    delete rootman;
-    
-    //----------------------------------------------
-    // option : plot generated data
-    if(plotdata)
-    {
-        RootFileManager man;
-        man.SetFileProperties(filename, treename, branchname, 
-                              classname,"READ",useTCA);
-        vector< vector<TDigi> > data=man.GetAllObj(filename, treename, branchname);
-
-        TH2D* histoxy = new TH2D("fxy","digi.fxy",100,pdfconfig.x.min,pdfconfig.x.max, 100,pdfconfig.y.min,pdfconfig.y.max);
-        TH1D* histox = new TH1D("fx","digi.fx",100,pdfconfig.x.min,pdfconfig.x.max);
-        TH1D* histoy = new TH1D("fy","digi.fy",100,pdfconfig.y.min,pdfconfig.y.max);
-        TH1D* histoz = new TH1D("fz","digi.fz",100,pdfconfig.z.min,pdfconfig.z.max);
-        TH1D* histot = new TH1D("ftimestamp","digi.ftimestamp",10*tmax, 0., (double)(tmax+1));
-        TH1D* histoterr = new TH1D("ftimestampErr","digi.ftimestampErr",100,pdfconfig.tErr.min,pdfconfig.tErr.max);
-        TH1D* histoN = new TH1D("f_N","Number of digi distribution",100,Nval.min,Nval.max);
-    
-        for(auto& p : data)
-        {
-            histoN->Fill((double)p.size());
-            for(auto& q : p)
-            {
-                histox->Fill(q.GetX());
-                histoy->Fill(q.GetY());
-                histoxy->Fill(q.GetX(),q.GetY());
-                histoz->Fill(q.GetZ());
-                histot->Fill(q.GetTimeStamp());
-                histoterr->Fill(q.GetTimeStampError());
-            }
-        }
-        
-        TApplication app("App", &argc, argv);
-        
-        TCanvas *T7Canvas = new  TCanvas("Tutorial7","Tutorial7",1000,800);
-        T7Canvas->Divide(4,2);
-        
-        T7Canvas->cd(1);
-        histox->Draw();
-        
-        T7Canvas->cd(2);
-        histoy->Draw();
-        
-        T7Canvas->cd(3);
-        histoxy->Draw("zcol");
-        
-        T7Canvas->cd(4);
-        histoz->Draw();
-        
-        T7Canvas->cd(5);
-        histot->Draw();
-        
-        T7Canvas->cd(6);
-        histoterr->Draw();
-        
-        T7Canvas->cd(7);
-        histoN->Draw();
-        
-        app.Run();
-        
-        
-        delete histox;
-        delete histoy;
-        delete histoz;
-        delete histoxy;
-        delete histot;
-        delete histoterr;
-        delete histoN;
-    }
-
     return 0;
    
 }

--- a/example/Tutorial7/run/runSamplerBinT7.cxx
+++ b/example/Tutorial7/run/runSamplerBinT7.cxx
@@ -45,13 +45,15 @@ int main(int argc, char** argv)
         FairMQProgOptions config;
         InitSamplerSetting(sampler, config, argc, argv);
 
-        sampler.RegisterTask([](TSampler* s, SamplerTasksMap& task_list) 
+        if( config.GetValue<bool>("register-task-sampler") )
         {
-            //task_list[2]=std::bind( &TSampler::template MultiPartTask<5>, s);
-            task_list[0] = std::bind(myFuncHello);
-            task_list[1] = std::bind(myFuncWorld);
-        });
-
+            sampler.RegisterTask([](TSampler* s, SamplerTasksMap& task_list) 
+            {
+                task_list[0] = std::bind(myFuncHello);
+                task_list[1] = std::bind(myFuncWorld);
+            });
+        }
+        
         runStateMachine(sampler, config);
     }
     catch (std::exception& e)

--- a/example/Tutorial7/run/runSamplerBoostT7.cxx
+++ b/example/Tutorial7/run/runSamplerBoostT7.cxx
@@ -54,8 +54,11 @@ int main(int argc, char** argv)
         FairMQProgOptions config;
         InitSamplerSetting(sampler, config, argc, argv);
 
-        AddTask(sampler, config, std::bind(&manager,std::placeholders::_1,std::placeholders::_2) );
-
+        if( config.GetValue<bool>("register-task-sampler") )
+        {
+            AddTask(sampler, config, std::bind(&manager,std::placeholders::_1,std::placeholders::_2) );
+        }
+        
         runStateMachine(sampler, config);
     }
     catch (std::exception& e)

--- a/example/Tutorial7/run/runSamplerRootT7.cxx
+++ b/example/Tutorial7/run/runSamplerRootT7.cxx
@@ -42,13 +42,15 @@ int main(int argc, char** argv)
         FairMQProgOptions config;
         InitSamplerSetting(sampler, config, argc, argv);
 
-        AddTask(sampler, config, [](TSampler* s, SamplerTasksMap& task_list) 
+        if( config.GetValue<bool>("register-task-sampler") )
         {
-            //task_list[2]=std::bind( &TSampler::template MultiPartTask<5>, s);
-            task_list[0] = std::bind(myFuncHello);
-            task_list[1] = std::bind(myFuncWorld);
-        });
-
+            AddTask(sampler, config, [](TSampler* s, SamplerTasksMap& task_list) 
+            {
+                //task_list[2]=std::bind( &TSampler::template MultiPartTask<5>, s);
+                task_list[0] = std::bind(myFuncHello);
+                task_list[1] = std::bind(myFuncWorld);
+            });
+        }
         runStateMachine(sampler, config);
     }
     catch (std::exception& e)

--- a/fairmq/CMakeLists.txt
+++ b/fairmq/CMakeLists.txt
@@ -143,6 +143,11 @@ Set(FAIRMQHEADERS
   devices/GenericSampler.tpl
   devices/GenericProcessor.h
   devices/GenericFileSink.h
+  devices/BaseDeserializationPolicy.h
+  devices/BaseSerializationPolicy.h
+  devices/BaseProcessorTaskPolicy.h
+  devices/BaseSinkPolicy.h
+  devices/BaseSourcePolicy.h
   tools/FairMQTools.h
 )
 Install(FILES ${FAIRMQHEADERS} DESTINATION include)

--- a/fairmq/devices/BaseDeserializationPolicy.h
+++ b/fairmq/devices/BaseDeserializationPolicy.h
@@ -1,0 +1,61 @@
+/* 
+ * File:   BaseDeserializationPolicy.h
+ * Author: winckler
+ *
+ * Created on October 14, 2015, 1:01 PM
+ */
+
+#ifndef BASEDESERIALIZATIONPOLICY_H
+#define	BASEDESERIALIZATIONPOLICY_H
+
+
+#include "FairMQMessage.h"
+
+// c++11 code
+#include <type_traits>
+
+
+
+//  CRTP base class
+template <typename TDerived >
+class BaseDeserializationPolicy
+{
+public:
+    BaseDeserializationPolicy() 
+    {}
+
+    virtual ~BaseDeserializationPolicy()
+    {}
+
+    template<typename C = TDerived>
+    auto DeserializeMsg(FairMQMessage* msg)-> decltype(static_cast<C*>(this)->DeserializeMsg(msg) )
+    {
+    	static_assert(std::is_same<C, TDerived>{}, "BaseDeserializationPolicy::DeserializeMsg hack broken");
+    	return static_cast<TDerived*>(this)->DeserializeMsg(msg);
+    }
+
+};
+
+
+/*
+// c++14 code
+//  CRTP base class
+template <typename TDerived >
+class BaseDeserializationPolicy
+{
+public:
+    BaseDeserializationPolicy() 
+    {}
+
+    virtual ~BaseDeserializationPolicy()
+    {}
+
+    auto DeSerializeMsg(FairMQMessage* msg)
+    {
+    	return static_cast<TDerived*>(this)->DeSerializeMsg(msg);
+    }
+
+};*/
+
+#endif	/* BASEDESERIALIZATIONPOLICY_H */
+

--- a/fairmq/devices/BaseProcessorTaskPolicy.h
+++ b/fairmq/devices/BaseProcessorTaskPolicy.h
@@ -1,0 +1,69 @@
+/* 
+ * File:   BaseProcessorTaskPolicy.h
+ * Author: winckler
+ *
+ * Created on October 14, 2015, 1:01 PM
+ */
+
+#ifndef BASEPROCESSORTASKPOLICY_H
+#define	BASEPROCESSORTASKPOLICY_H
+
+
+#include <type_traits>
+//  CRTP base class
+template <typename TDerived >
+class BaseProcessorTaskPolicy
+{
+public:
+    BaseProcessorTaskPolicy() 
+    {}
+
+    virtual ~BaseProcessorTaskPolicy()
+    {}
+
+    template<typename C = TDerived>
+    auto GetOutputData() -> decltype(static_cast<C*>(this)->GetOutputData() )
+    {
+    	static_assert(std::is_same<C, TDerived>{}, "BaseProcessorTaskPolicy::GetOutputData hack broken");
+    	return static_cast<TDerived*>(this)->GetOutputData();
+    }
+
+    template<typename CONTAINER_TYPE, typename C = TDerived>
+    auto ExecuteTask(CONTAINER_TYPE container) -> decltype( static_cast<C*>(this)->ExecuteTask(container) )
+    {
+    	static_assert(std::is_same<C, TDerived>{}, "BaseProcessorTaskPolicy::ExecuteTask hack broken");
+    	return static_cast<TDerived*>(this)->ExecuteTask(container);
+    }
+
+
+};
+
+ /*
+  
+// c++14 code only
+//  CRTP base class
+template <typename TDerived >
+class BaseProcessorTaskPolicy
+{
+public:
+    BaseProcessorTaskPolicy() 
+    {}
+
+    virtual ~BaseProcessorTaskPolicy()
+    {}
+
+    auto GetOutputData()
+    {
+    	return static_cast<TDerived*>(this)->GetOutputData();
+    }
+
+    template<typename CONTAINER_TYPE>
+    auto ExecuteTask(CONTAINER_TYPE container)
+    {
+    	return static_cast<TDerived*>(this)->ExecuteTask(container);
+    }
+
+};
+*/
+#endif	/* BASEPROCESSORTASKPOLICY_H */
+

--- a/fairmq/devices/BaseSerializationPolicy.h
+++ b/fairmq/devices/BaseSerializationPolicy.h
@@ -1,0 +1,68 @@
+/* 
+ * File:   BaseSerializationPolicy.h
+ * Author: winckler
+ *
+ * Created on October 14, 2015, 1:01 PM
+ */
+
+#ifndef BASESERIALIZATIONPOLICY_H
+#define	BASESERIALIZATIONPOLICY_H
+
+#include "FairMQMessage.h"
+
+#include <type_traits>
+//  CRTP base class
+template <typename TDerived >
+class BaseSerializationPolicy
+{
+public:
+    BaseSerializationPolicy() 
+    {}
+
+    virtual ~BaseSerializationPolicy()
+    {}
+
+    template<typename CONTAINER_TYPE, typename C = TDerived>
+    auto SerializeMsg(CONTAINER_TYPE container) -> decltype(static_cast<C*>(this)->SerializeMsg(container) )
+    {
+        static_assert(std::is_same<C, TDerived>{}, "BaseSerializationPolicy::SerializeMsg hack broken");
+        return static_cast<TDerived*>(this)->SerializeMsg(container);
+    }
+
+    template<typename C = TDerived>
+    auto SetMessage(FairMQMessage* msg)-> decltype(static_cast<C*>(this)->SetMessage(msg) )
+    {
+        static_assert(std::is_same<C, TDerived>{}, "BaseSerializationPolicy::SetMessage hack broken");
+        return static_cast<TDerived*>(this)->SetMessage(msg);
+    }
+
+};
+
+ /*
+//  CRTP base class
+// c++14 code
+template <typename TDerived >
+class BaseSerializationPolicy
+{
+public:
+    BaseSerializationPolicy() 
+    {}
+
+    virtual ~BaseSerializationPolicy()
+    {}
+
+    template<typename CONTAINER_TYPE>
+    auto SerializeMsg(CONTAINER_TYPE container)
+    {
+        return static_cast<TDerived*>(this)->SerializeMsg(container);
+    }
+
+    auto SetMessage(FairMQMessage* msg)
+    {
+        return static_cast<TDerived*>(this)->SetMessage(msg);
+    }
+
+};
+*/
+#endif	/* BASESERIALIZATIONPOLICY_H */
+

--- a/fairmq/devices/BaseSinkPolicy.h
+++ b/fairmq/devices/BaseSinkPolicy.h
@@ -1,0 +1,41 @@
+/* 
+ * File:   BaseSinkPolicy.h
+ * Author: winckler
+ *
+ * Created on October 14, 2015, 1:01 PM
+ */
+
+#ifndef BASESINKPOLICY_H
+#define	BASESINKPOLICY_H
+
+
+#include <type_traits>
+//  CRTP base class
+template <typename TDerived >
+class BaseSinkPolicy
+{
+public:
+    BaseSinkPolicy() 
+    {}
+
+    virtual ~BaseSinkPolicy()
+    {}
+
+    template<typename CONTAINER_TYPE, typename C = TDerived>
+    auto AddToFile(CONTAINER_TYPE container) -> decltype(static_cast<C*>(this)->AddToFile(container) )
+    {
+        static_assert(std::is_same<C, TDerived>{}, "BaseSinkPolicy::AddToFile hack broken");
+        return static_cast<TDerived*>(this)->AddToFile(container);
+    }
+
+    template<typename C = TDerived>
+    auto InitOutputFile() -> decltype(static_cast<C*>(this)->InitOutputFile() )
+    {
+        static_assert(std::is_same<C, TDerived>{}, "BaseSinkPolicy::InitOutputFile hack broken");
+        return static_cast<TDerived*>(this)->InitOutputFile();
+    }
+
+};
+
+#endif	/* BASESINKPOLICY_H */
+

--- a/fairmq/devices/BaseSourcePolicy.h
+++ b/fairmq/devices/BaseSourcePolicy.h
@@ -1,0 +1,91 @@
+/* 
+ * File:   BaseSourcePolicy.h
+ * Author: winckler
+ *
+ * Created on October 14, 2015, 1:01 PM
+ */
+
+#ifndef BASESOURCEPOLICY_H
+#define	BASESOURCEPOLICY_H
+
+#include <type_traits>
+// c++11 code
+//  CRTP base class
+template <typename TDerived >
+class BaseSourcePolicy
+{
+public:
+    BaseSourcePolicy() 
+    {}
+
+    virtual ~BaseSourcePolicy()
+    {}
+
+    template<typename C = TDerived>
+    auto InitSource()-> decltype(static_cast<C*>(this)->InitSource() )
+    {
+        static_assert(std::is_same<C, TDerived>{}, "BaseSourcePolicy::InitSource hack broken");
+        return static_cast<TDerived*>(this)->InitSource();
+    }
+
+    template<typename C = TDerived>
+    int64_t GetNumberOfEvent()//-> decltype(static_cast<C*>(this)->GetNumberOfEvent() )
+    {
+        static_assert(std::is_same<C, TDerived>{}, "BaseSourcePolicy::GetNumberOfEvent hack broken");
+        return static_cast<TDerived*>(this)->GetNumberOfEvent();
+    }
+
+    template<typename C = TDerived>
+    auto SetIndex(int64_t eventIdx)-> decltype(static_cast<C*>(this)->SetIndex(eventIdx) )
+    {
+        static_assert(std::is_same<C, TDerived>{}, "BaseSourcePolicy::SetIndex hack broken");
+        return static_cast<TDerived*>(this)->SetIndex(eventIdx);
+    }
+
+    template<typename C = TDerived>
+    //auto GetOutData()-> decltype(static_cast<C*>(this)->GetOutData() )
+    decltype(std::declval<C*>()->GetOutData() ) GetOutData()
+    {
+        static_assert(std::is_same<C, TDerived>{}, "BaseSourcePolicy::GetOutData hack broken");
+        return static_cast<TDerived*>(this)->GetOutData();
+    }
+
+};
+
+/*
+// c++14 code
+//  CRTP base class
+template <typename TDerived >
+class BaseSourcePolicy
+{
+public:
+    BaseSourcePolicy() 
+    {}
+
+    virtual ~BaseSourcePolicy()
+    {}
+
+    auto InitSource()
+    {
+        return static_cast<TDerived*>(this)->InitSource();
+    }
+
+    int64_t GetNumberOfEvent()
+    {
+        return static_cast<TDerived*>(this)->GetNumberOfEvent();
+    }
+
+    auto SetIndex(int64_t eventIdx)
+    {
+        return static_cast<TDerived*>(this)->SetIndex(int64_t eventIdx);
+    }
+
+    auto GetOutData()
+    {
+        return static_cast<TDerived*>(this)->GetOutData();
+    }
+
+};
+*/
+#endif	/* BASESOURCEPOLICY_H */
+

--- a/fairmq/devices/GenericFileSink.h
+++ b/fairmq/devices/GenericFileSink.h
@@ -28,7 +28,7 @@
  * 
  *  -------- INPUT POLICY --------
  *                deserialization_type::InitContainer(...)
- * CONTAINER_TYPE deserialization_type::DeSerializeMsg(FairMQMessage* msg)
+ * CONTAINER_TYPE deserialization_type::DeserializeMsg(FairMQMessage* msg)
  * 
  * 
  *  -------- OUTPUT POLICY --------
@@ -82,7 +82,7 @@ class GenericFileSink : public FairMQDevice, public T, public U
 
             if (inputChannel.Receive(msg) > 0)
             {
-                sink_type::AddToFile(deserialization_type::DeSerializeMsg(msg.get()));
+                sink_type::AddToFile(deserialization_type::DeserializeMsg(msg.get()));
                 receivedMsg++;
             }
         }

--- a/fairmq/devices/GenericFileSink.h
+++ b/fairmq/devices/GenericFileSink.h
@@ -27,24 +27,26 @@
  * Function to define in (parent) policy classes :
  * 
  *  -------- INPUT POLICY --------
- *                InputPolicy::InitContainer(...)
- * CONTAINER_TYPE InputPolicy::DeSerializeMsg(FairMQMessage* msg)
+ *                deserialization_type::InitContainer(...)
+ * CONTAINER_TYPE deserialization_type::DeSerializeMsg(FairMQMessage* msg)
  * 
  * 
  *  -------- OUTPUT POLICY --------
- *                OutputPolicy::AddToFile(CONTAINER_TYPE);
- *                OutputPolicy::InitOutputFile()
+ *                sink_type::AddToFile(CONTAINER_TYPE);
+ *                sink_type::InitOutputFile()
  **********************************************************************/
 
 #include "FairMQDevice.h"
 
-template <typename InputPolicy, typename OutputPolicy>
-class GenericFileSink : public FairMQDevice, public InputPolicy, public OutputPolicy
+template <typename T, typename U>
+class GenericFileSink : public FairMQDevice, public T, public U
 {
+    typedef T                        deserialization_type;
+    typedef U                                   sink_type;
   public:
     GenericFileSink()
-        : InputPolicy()
-        , OutputPolicy()
+        : deserialization_type()
+        , sink_type()
     {}
 
     virtual ~GenericFileSink()
@@ -58,13 +60,13 @@ class GenericFileSink : public FairMQDevice, public InputPolicy, public OutputPo
     template <typename... Args>
     void InitInputContainer(Args... args)
     {
-        InputPolicy::InitContainer(std::forward<Args>(args)...);
+        deserialization_type::InitContainer(std::forward<Args>(args)...);
     }
 
   protected:
     virtual void InitTask()
     {
-        OutputPolicy::InitOutputFile();
+        sink_type::InitOutputFile();
     }
 
     virtual void Run()
@@ -80,7 +82,7 @@ class GenericFileSink : public FairMQDevice, public InputPolicy, public OutputPo
 
             if (inputChannel.Receive(msg) > 0)
             {
-                OutputPolicy::AddToFile(InputPolicy::DeSerializeMsg(msg.get()));
+                sink_type::AddToFile(deserialization_type::DeSerializeMsg(msg.get()));
                 receivedMsg++;
             }
         }

--- a/fairmq/devices/GenericMerger.h
+++ b/fairmq/devices/GenericMerger.h
@@ -55,7 +55,7 @@ class GenericMerger : public FairMQDevice, public MergerPolicy, public InputPoli
                     received = fChannels.at("data-in").at(i).Receive(msg)
                     if (received > 0)
                     {
-                        MergerPolicy::Merge(InputPolicy::DeSerializeMsg(msg));
+                        MergerPolicy::Merge(InputPolicy::DeserializeMsg(msg));
                     }
                 }
 

--- a/fairmq/devices/GenericProcessor.h
+++ b/fairmq/devices/GenericProcessor.h
@@ -24,7 +24,7 @@
  * 
  *  -------- INPUT POLICY --------
  *                deserialization_type::InitContainer(...)
- * CONTAINER_TYPE deserialization_type::DeSerializeMsg(FairMQMessage* msg)
+ * CONTAINER_TYPE deserialization_type::DeserializeMsg(FairMQMessage* msg)
  *                deserialization_type::InitContainer(...)  // if GenericProcessor::InitInputContainer(...) is used
  * 
  * 
@@ -134,9 +134,9 @@ class GenericProcessor : public FairMQDevice, public T, public U, public V
 
             if (inputChannel.Receive(msg) > 0)
             {
-                // deserialization_type::DeSerializeMsg(msg) --> deserialize data of msg and fill output container
+                // deserialization_type::DeserializeMsg(msg) --> deserialize data of msg and fill output container
                 // proc_task_type::ExecuteTask( ... )   --> process output container
-                proc_task_type::ExecuteTask(deserialization_type::DeSerializeMsg(msg.get()));
+                proc_task_type::ExecuteTask(deserialization_type::DeserializeMsg(msg.get()));
 
                 // serialization_type::fMessage point to msg
                 serialization_type::SetMessage(msg.get());

--- a/fairmq/devices/GenericSampler.h
+++ b/fairmq/devices/GenericSampler.h
@@ -35,12 +35,11 @@
  * Function to define in (parent) policy classes :
  * 
  *  -------- INPUT POLICY (SAMPLER POLICY) --------
- *                source_type::InitSampler()                          // must be there to compile
+ *                source_type::InitSource()                          // must be there to compile
  *        int64_t source_type::GetNumberOfEvent()                     // must be there to compile
  *                source_type::SetIndex(int64_t eventIdx)             // must be there to compile
  * CONTAINER_TYPE source_type::GetOutData()                           // must be there to compile
  *                source_type::SetFileProperties(Args&... args)       // must be there to compile
- *                source_type::ExecuteTasks()                         // must be there to compile
  * 
  *           void BindSendPart(std::function<void(int)> callback)       // enabled if exists
  *           void BindGetSocketNumber(std::function<int()> callback)    // enabled if exists

--- a/fairmq/devices/GenericSampler.tpl
+++ b/fairmq/devices/GenericSampler.tpl
@@ -34,7 +34,7 @@ void base_GenericSampler<T,U,K,L>::InitTask()
     BindingGetSocketNumber();
     BindingGetCurrentIndex();
 
-    source_type::InitSampler();
+    source_type::InitSource();
     fNumEvents = source_type::GetNumberOfEvent();
 }
 

--- a/fairmq/devices/README.md
+++ b/fairmq/devices/README.md
@@ -56,14 +56,13 @@ The policies must have at least a couple of methods that will be called by the h
 ##### Input policy (Source)
 
 ``` C++
-				source_type::InitSampler(); 						// must be there to compile
+				source_type::InitSource(); 							// must be there to compile
 int64_t 		source_type::GetNumberOfEvent(); 					// must be there to compile
 
 				source_type::SetIndex(int64_t eventIdx);			// must be there to compile
 CONTAINER_TYPE  source_type::GetOutData(); 							// must be there to compile
 
 				source_type::SetFileProperties(Args&... args); 		// if called by the host, then must be there to compile
-				source_type::ExecuteTasks();						// must be there to compile
 
  void 			source_type::BindSendPart(std::function<void(int)> callback);		// enabled if exists
  void 			source_type::BindGetSocketNumber(std::function<int()> callback); 	// enabled if exists
@@ -122,6 +121,6 @@ void SetFileProperties(Args&... args)
 ```
 
 ### Generic Processor
-
+The function members required by the processor policies are :
 
 

--- a/fairmq/devices/README.md
+++ b/fairmq/devices/README.md
@@ -1,0 +1,85 @@
+
+
+## Introduction
+The Tutorial 7 show how to use three generic devices, namely a generic sampler, processor and filesink.
+These three devices are policy based designed classes. These devices all inherit from FairMQDevice and from specific template parameters, namely :
+* The sampler inherit from 
+ * a sampler policy (e.g a file reader) 
+ * an output policy (serialize)
+* The processor inherit from 
+ * an input policy (deserialize) 
+ * an output policy (serialize)
+ * a task policy (process data)
+* The filesink inherit from 
+ * an input policy (deserialize)
+ * a storage policy.
+
+Some policy examples (c.f. e.g. BoostSerializer.h) are available in FairRoot/Base/MQ. In this design the user only need to implement the policies, which are, depending on the devices, the serialization/deserialization tasks, the process tasks, the source and the sink implementations.
+The message queue implementation are provided by the host class, and do not need to be provided by the users.
+
+
+
+
+## Generic devices
+The generic devices are part of the FairMQ library, and can be found in the FairRoot/fairmq/devices directory. 
+These generic devices are called host classes and publicly inherit from template parameters called policies. 
+
+### Generic Sampler
+In the example of the GenericSampler.h, the beginning of the header look like :
+
+``` C++
+// in GenericSampler.h
+template <typename T, typename U, typename K, typename L>
+class base_GenericSampler : public FairMQDevice, public T, public U
+{
+    typedef T source_type;
+    typedef U serialization_type;
+    // etc...
+};
+```
+The host template class base_GenericSampler has four template parameters, i.e. T, U, K, L. The parameter T and U correspond to the source policy and serialization policy, respectively. 
+
+The template parameters K and L are used to define the key and function type of a task container (std::map<K,L>). For the moment, only L=std::function<void()> is supported by the base_GenericSampler host class. The task map mechanism is an experimental feature and might be replaced with boost::signal2. The users do not need to use directly the base_GenericSampler, and define the K and L parameter types. Instead an alias template, GenericSampler, that take two template parameters (source and serialization policies) is defined at the end of the implementation file (GenericSampler.tpl).
+
+``` C++
+// in GenericSampler.tpl
+// base_GenericSampler implementation ...
+
+// alias template for the policies. K and L types have default values.
+template<typename T, typename U>
+using GenericSampler = base_GenericSampler<T,U,int,std::function<void()>>;
+```
+
+#### Sampler policies
+
+The policies must have at least a couple of methods that will be called by the host class. For example all policies must have default constructor. In addition some functions are required and other are enabled only if the function signatures exist in the policy classes.
+##### Input policy (Source)
+
+``` C++
+				source_type::InitSampler() 						// must be there to compile
+int64_t 		source_type::GetNumberOfEvent() 				// must be there to compile
+
+				source_type::SetIndex(int64_t eventIdx)			// must be there to compile
+CONTAINER_TYPE  source_type::GetOutData() 						// must be there to compile
+
+				source_type::SetFileProperties(Args&... args) 	// if called then must be there to compile
+				source_type::ExecuteTasks()						// must be there to compile
+
+ void 			source_type::BindSendPart(std::function<void(int)> callback)		// enabled if exists
+ void 			source_type::BindGetSocketNumber(std::function<int()> callback) 	// enabled if exists
+ void 			source_type::BindGetCurrentIndex(std::function<int()> callback)		// enabled if exists
+```
+
+The function members above that have no returned type means that the returned types are not used and can be anything. 
+The CONTAINER_TYPE above must correspond to the input parameter of the serialization_type::SerializeMsg() function (see below).
+
+##### Output policy (Serialization)
+
+``` C++
+		serialization_type::SerializeMsg(CONTAINER_TYPE container)	// must be there to compile
+		serialization_type::SetMessage(FairMQMessage* msg) 			// must be there to compile
+```
+
+
+Examples of host class instantiation can be found in FairRoot/example/Tutorial7/run directory. For example
+

--- a/fairmq/logger/logger.h
+++ b/fairmq/logger/logger.h
@@ -26,7 +26,7 @@
 #include <boost/log/sources/global_logger_storage.hpp>
 #include <boost/log/expressions/attr_fwd.hpp>
 
-
+#include <boost/version.hpp>
 
 
 // WARNING : pragma commands to hide boost Wshadow warning
@@ -142,8 +142,15 @@ void init_log_formatter(const boost::log::record_view &view, boost::log::formatt
 // helper macros 
 
 // global macros (core). Level filters are set globally here, that is to all register sinks
+// add empty string if boost 1.59.0 (see : https://svn.boost.org/trac/boost/ticket/11549 )
+#if BOOST_VERSION == 105900
+#define LOG(severity) BOOST_LOG_SEV(global_logger::get(),custom_severity_level::severity) << ""
+#define MQLOG(severity) BOOST_LOG_SEV(global_logger::get(),custom_severity_level::severity) << ""
+#else
 #define LOG(severity) BOOST_LOG_SEV(global_logger::get(),custom_severity_level::severity)
 #define MQLOG(severity) BOOST_LOG_SEV(global_logger::get(),custom_severity_level::severity)
+#endif 
+
 #define SET_LOG_LEVEL(loglevel) boost::log::core::get()->set_filter(severity >= custom_severity_level::loglevel);
 #define SET_LOG_FILTER(op,loglevel)  set_global_log_level(log_op::op,custom_severity_level::loglevel)
 

--- a/fairmq/options/FairProgOptions.h
+++ b/fairmq/options/FairProgOptions.h
@@ -116,7 +116,7 @@ class FairProgOptions
 
     int ParseEnvironment(const std::function<std::string(std::string)>&);
 
-    virtual int ParseAll(const int argc, char** argv, bool allowUnregistered = false) = 0;
+    virtual int ParseAll(const int argc, char** argv, bool allowUnregistered = false) = 0;// TODO change return type to bool and propagate to executable
 
     virtual int PrintOptions();
     int PrintHelp() const;


### PR DESCRIPTION
- FairMQProgOptions to configure the data generator of tutorial7
- more documentation in tutorial7 and generic device
- CRTP base class for the generic device policies and example in tutorial7
- a new example of a MQ chain reading lmd file : LmdSampler - Unpacker - FileSink
- redefine LOG macro in case FairRoot is compiled with boost 1.59.0 
