### PR TITLE
Reimplement missing function.

### DIFF
--- a/base/steer/FairRootManager.h
+++ b/base/steer/FairRootManager.h
@@ -207,6 +207,7 @@ class FairRootManager : public TObject
     
     /** These methods have been moved to the FairFileSource */
     void   SetSource(FairSource* tempSource) { fSource = tempSource; }    
+    FairSource* GetSource() { return fSource;}
     Bool_t InitSource();
     
     void                SetListOfFolders(TObjArray* ta){ fListFolder=ta; }

--- a/base/steer/FairRunOnline.h
+++ b/base/steer/FairRunOnline.h
@@ -61,6 +61,9 @@ class FairRunOnline : public FairRun
     void        SetAutoFinish(Bool_t val) { fAutomaticFinish = val; }
     /** Set the source which should be used **/
     void        SetSource(FairSource* source) { fRootManager->SetSource(source); }
+    /** Return pointer to source **/
+    FairSource*  GetSource() { return fRootManager->GetSource(); }
+
 
     /** Initialization of parameter container is set to static, i.e: the run id is
      *  is not checked anymore after initialization


### PR DESCRIPTION
Reimplement GetSource in FairRunOnline. This function is needed by the CBM experiment and was probably removed when moving the source from FairRunOnline to FairRootManager.