### PR TITLE
Simplify handling of send/receive timeouts

### DIFF
--- a/fairmq/FairMQChannel.cxx
+++ b/fairmq/FairMQChannel.cxx
@@ -583,60 +583,62 @@ int FairMQChannel::Receive(FairMQMessage* msg, const int flags) const
     }
 }
 
-bool FairMQChannel::SetSendTimeout(const int timeout)
+void FairMQChannel::SetSendTimeout(const int timeout)
 {
-    if (fSocket)
-    {
-        if (fSocket->SetSendTimeout(timeout, fAddress, fMethod))
-        {
+    // if (fSocket)
+    // {
+    //     if (fSocket->SetSendTimeout(timeout, fAddress, fMethod))
+    //     {
             fSndTimeoutInMs = timeout;
-            return true;
-        }
-    }
+    //         return true;
+    //     }
+    // }
 
-    LOG(ERROR) << "SetSendTimeout() failed - socket is not initialized!";
-    return false;
+    // LOG(ERROR) << "SetSendTimeout() failed - socket is not initialized!";
+    // return false;
 }
 
 int FairMQChannel::GetSendTimeout() const
 {
-    if (fSocket)
-    {
-        return fSocket->GetSendTimeout();
-    }
-    else
-    {
-        LOG(ERROR) << "GetSendTimeout() failed - socket is not initialized!";
-        return -1;
-    }
+    return fSndTimeoutInMs;
+    // if (fSocket)
+    // {
+    //     return fSocket->GetSendTimeout();
+    // }
+    // else
+    // {
+    //     LOG(ERROR) << "GetSendTimeout() failed - socket is not initialized!";
+    //     return -1;
+    // }
 }
 
-bool FairMQChannel::SetReceiveTimeout(const int timeout)
+void FairMQChannel::SetReceiveTimeout(const int timeout)
 {
-    if (fSocket)
-    {
-        if (fSocket->SetReceiveTimeout(timeout, fAddress, fMethod))
-        {
+    // if (fSocket)
+    // {
+    //     if (fSocket->SetReceiveTimeout(timeout, fAddress, fMethod))
+    //     {
             fRcvTimeoutInMs = timeout;
-            return true;
-        }
-    }
+    //         return true;
+    //     }
+    // }
 
-    LOG(ERROR) << "SetReceiveTimeout() failed - socket is not initialized!";
-    return false;
+    // LOG(ERROR) << "SetReceiveTimeout() failed - socket is not initialized!";
+    // return false;
 }
 
 int FairMQChannel::GetReceiveTimeout() const
 {
-    if (fSocket)
-    {
-        return fSocket->GetReceiveTimeout();
-    }
-    else
-    {
-        LOG(ERROR) << "GetReceiveTimeout() failed - socket is not initialized!";
-        return -1;
-    }
+    return fRcvTimeoutInMs;
+    // if (fSocket)
+    // {
+    //     return fSocket->GetReceiveTimeout();
+    // }
+    // else
+    // {
+    //     LOG(ERROR) << "GetReceiveTimeout() failed - socket is not initialized!";
+    //     return -1;
+    // }
 }
 
 bool FairMQChannel::ExpectsAnotherPart() const

--- a/fairmq/FairMQChannel.h
+++ b/fairmq/FairMQChannel.h
@@ -161,8 +161,7 @@ class FairMQChannel
 
     /// Sets a timeout on the (blocking) Send method
     /// @param timeout timeout value in milliseconds
-    /// @return true if operation was successfull, otherwise false.
-    bool SetSendTimeout(const int timeout);
+    void SetSendTimeout(const int timeout);
 
     /// Gets the current value of the timeout on the (blocking) Send method
     /// @return Timeout value in milliseconds. -1 for no timeout.
@@ -170,8 +169,7 @@ class FairMQChannel
 
     /// Sets a timeout on the (blocking) Receive method
     /// @param timeout timeout value in milliseconds
-    /// @return true if operation was successfull, otherwise false.
-    bool SetReceiveTimeout(const int timeout);
+    void SetReceiveTimeout(const int timeout);
 
     /// Gets the current value of the timeout on the (blocking) Receive method
     /// @return Timeout value in milliseconds. -1 for no timeout.

--- a/fairmq/test/runTransferTimeoutTest.cxx
+++ b/fairmq/test/runTransferTimeoutTest.cxx
@@ -37,47 +37,27 @@ class TransferTimeoutTester : public FairMQDevice
         bool sendCanceling = false;
         bool receiveCanceling = false;
 
-        if (fChannels.at("data-out").at(0).SetSendTimeout(1000))
+        fChannels.at("data-out").at(0).SetSendTimeout(1000);
+        fChannels.at("data-in").at(0).SetReceiveTimeout(1000);
+
+        if (fChannels.at("data-out").at(0).GetSendTimeout() == 1000)
         {
-            setSndOK = true;
-            LOG(INFO) << "set send timeout OK";
+            getSndOK = true;
+            LOG(INFO) << "get send timeout OK: " << fChannels.at("data-out").at(0).GetSendTimeout();
         }
         else
         {
-            LOG(ERROR) << "set send timeout failed";
+            LOG(ERROR) << "get send timeout failed";
         }
 
-        if (fChannels.at("data-in").at(0).SetReceiveTimeout(1000))
+        if (fChannels.at("data-in").at(0).GetReceiveTimeout() == 1000)
         {
-            setRcvOK = true;
-            LOG(INFO) << "set receive timeout OK";
+            getRcvOK = true;
+            LOG(INFO) << "get receive timeout OK: " << fChannels.at("data-in").at(0).GetReceiveTimeout();
         }
         else
         {
-            LOG(ERROR) << "set receive timeout failed";
-        }
-
-        if (setSndOK && setRcvOK)
-        {
-            if (fChannels.at("data-out").at(0).GetSendTimeout() == 1000)
-            {
-                getSndOK = true;
-                LOG(INFO) << "get send timeout OK: " << fChannels.at("data-out").at(0).GetSendTimeout();
-            }
-            else
-            {
-                LOG(ERROR) << "get send timeout failed";
-            }
-
-            if (fChannels.at("data-in").at(0).GetReceiveTimeout() == 1000)
-            {
-                getRcvOK = true;
-                LOG(INFO) << "get receive timeout OK: " << fChannels.at("data-in").at(0).GetReceiveTimeout();
-            }
-            else
-            {
-                LOG(ERROR) << "get receive timeout failed";
-            }
+            LOG(ERROR) << "get receive timeout failed";
         }
 
         if (getSndOK && getRcvOK)


### PR DESCRIPTION
This will fix the occasional fail of the tests, caused by the reconnections necessary when setting timeout values via zeromq. Now the timeouts can be set directly on the Send/receive calls of FairMQChannel.