### PR TITLE
Create lib directory in build structure

### DIFF
--- a/cmake/modules/ROOTMacros.cmake
+++ b/cmake/modules/ROOTMacros.cmake
@@ -92,13 +92,15 @@ Macro(ROOT_GENERATE_DICTIONARY_NEW)
     set_source_files_properties(${OUTPUT_FILES} PROPERTIES GENERATED TRUE)
     If (CMAKE_SYSTEM_NAME MATCHES Linux)
       add_custom_command(OUTPUT  ${OUTPUT_FILES}
-                         COMMAND LD_LIBRARY_PATH=${ROOT_LIBRARY_DIR}:${_intel_lib_dirs}:$ENV{LD_LIBRARY_PATH} ROOTSYS=${ROOTSYS} ${ROOT_CINT_EXECUTABLE} -f ${Int_DICTIONARY} ${EXTRA_DICT_PARAMETERS} -c  ${Int_DEF} ${Int_INC} ${Int_HDRS} ${Int_LINKDEF}
+                         COMMAND ${CMAKE_COMMAND} -E make_directory ${LIBRARY_OUTPUT_PATH}
+			 COMMAND LD_LIBRARY_PATH=${ROOT_LIBRARY_DIR}:${_intel_lib_dirs}:$ENV{LD_LIBRARY_PATH} ROOTSYS=${ROOTSYS} ${ROOT_CINT_EXECUTABLE} -f ${Int_DICTIONARY} ${EXTRA_DICT_PARAMETERS} -c  ${Int_DEF} ${Int_INC} ${Int_HDRS} ${Int_LINKDEF}
                          COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/${Int_PCMFILE} ${LIBRARY_OUTPUT_PATH}/${Int_PCMFILE} 
                          DEPENDS ${Int_HDRS} ${Int_LINKDEF}
                          )
     Else (CMAKE_SYSTEM_NAME MATCHES Linux)
       If (CMAKE_SYSTEM_NAME MATCHES Darwin)
         add_custom_command(OUTPUT  ${OUTPUT_FILES}
+                           COMMAND ${CMAKE_COMMAND} -E make_directory ${LIBRARY_OUTPUT_PATH}
                            COMMAND DYLD_LIBRARY_PATH=${ROOT_LIBRARY_DIR}:$ENV{DYLD_LIBRARY_PATH} ROOTSYS=${ROOTSYS} ${ROOT_CINT_EXECUTABLE} -f ${Int_DICTIONARY} ${EXTRA_DICT_PARAMETERS} -c  ${Int_DEF} ${Int_INC} ${Int_HDRS} ${Int_LINKDEF}
                            COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/${Int_PCMFILE} ${LIBRARY_OUTPUT_PATH}/${Int_PCMFILE} 
                            DEPENDS ${Int_HDRS} ${Int_LINKDEF}


### PR DESCRIPTION
In some cases (e.g. clion ide on linux) the lib directory in the build structure is not created before creating the rootmap.
To avoid problems, make sure to create a directory "lib" beforehand.