### PR TITLE
Fix warnings in base and datamatch directories.

### DIFF
--- a/base/event/FairEventBuilder.h
+++ b/base/event/FairEventBuilder.h
@@ -77,7 +77,7 @@ class FairEventBuilder : public FairWriteoutBuffer
 
     virtual Bool_t Init() = 0;
 
-    virtual void Print() = 0;
+    virtual void Print(Option_t *option="") const = 0;
 
     /** Finish at the end of each event **/
     virtual void Finish();

--- a/base/event/FairLink.cxx
+++ b/base/event/FairLink.cxx
@@ -69,7 +69,7 @@ FairLink::FairLink(Int_t file, Int_t entry, TString branchName, Int_t index, Flo
 {
 }
 
-void FairLink::Print(std::ostream& out) const
+void FairLink::PrintLinkInfo(std::ostream& out) const
 {
   out << "(" << GetFile() << "/" << GetEntry() << "/";
   out << GetType() << "/" << GetIndex() << "/" << GetWeight() << ")";

--- a/base/event/FairLink.h
+++ b/base/event/FairLink.h
@@ -56,7 +56,7 @@ class FairLink : public TObject
     void SetWeight(Float_t weight) {fWeight = weight;}
     void AddWeight(Float_t weight) {fWeight += weight;}
 
-    virtual void Print(std::ostream& out = std::cout) const;
+    virtual void PrintLinkInfo(std::ostream& out = std::cout) const;
 
     virtual bool operator==(const FairLink& link) const {
       if ((fFile == link.GetFile() || link.GetFile() == -1) && (fEntry == link.GetEntry() || link.GetEntry() == -1) && fType == link.GetType() && fIndex == link.GetIndex()) {
@@ -95,7 +95,7 @@ class FairLink : public TObject
     }
 
     friend std::ostream& operator<< (std::ostream& out, const FairLink& link) {
-      link.Print(out);
+      link.PrintLinkInfo(out);
       return out;
     }
 

--- a/base/event/FairMultiLinkedData.cxx
+++ b/base/event/FairMultiLinkedData.cxx
@@ -28,6 +28,7 @@ ClassImp(FairMultiLinkedData);
 FairMultiLinkedData::FairMultiLinkedData()
   :TObject(),
    fLinks(),
+   fEntryNr(),
    fPersistanceCheck(kTRUE),
    fInsertHistory(kTRUE),
    fVerbose(0),
@@ -39,6 +40,7 @@ FairMultiLinkedData::FairMultiLinkedData()
 FairMultiLinkedData::FairMultiLinkedData(std::set<FairLink> links, Bool_t persistanceCheck)
   :TObject(),
    fLinks(links),
+   fEntryNr(),
    fPersistanceCheck(persistanceCheck),
    fInsertHistory(kTRUE),
    fVerbose(0),
@@ -49,6 +51,7 @@ FairMultiLinkedData::FairMultiLinkedData(std::set<FairLink> links, Bool_t persis
 FairMultiLinkedData::FairMultiLinkedData(TString dataType, std::vector<Int_t> links, Int_t fileId, Int_t evtId, Bool_t persistanceCheck, Bool_t bypass, Float_t mult)
   :TObject(),
    fLinks(),
+   fEntryNr(),
    fPersistanceCheck(persistanceCheck),
    fInsertHistory(kTRUE),
    fVerbose(0),
@@ -62,6 +65,7 @@ FairMultiLinkedData::FairMultiLinkedData(TString dataType, std::vector<Int_t> li
 FairMultiLinkedData::FairMultiLinkedData(Int_t dataType, std::vector<Int_t> links, Int_t fileId, Int_t evtId, Bool_t persistanceCheck, Bool_t bypass, Float_t mult)
   :TObject(),
    fLinks(),
+   fEntryNr(),
    fPersistanceCheck(persistanceCheck),
    fInsertHistory(kTRUE),
    fVerbose(0),

--- a/base/event/FairMultiLinkedData.h
+++ b/base/event/FairMultiLinkedData.h
@@ -80,11 +80,11 @@ class FairMultiLinkedData : public  TObject
     virtual void ResetLinks() {fLinks.clear();}                                    ///< Clears fLinks
 
 
-    std::ostream& Print(std::ostream& out = std::cout) const
+    std::ostream& PrintLinkInfo(std::ostream& out = std::cout) const
     {
       out << GetEntryNr() << " -> [";
       for (Int_t i = 0; i < GetNLinks(); i++) {
-        GetLink(i).Print(out);
+        GetLink(i).PrintLinkInfo(out);
         out << " ";
       }
       out << "]";
@@ -92,7 +92,7 @@ class FairMultiLinkedData : public  TObject
     }                                                     ///< Output
 
     friend std::ostream& operator<< (std::ostream& out, const FairMultiLinkedData& data) {
-      data.Print(out);
+      data.PrintLinkInfo(out);
       return out;
     }                                                     ///< Output
 

--- a/base/event/FairMultiLinkedData_Interface.cxx
+++ b/base/event/FairMultiLinkedData_Interface.cxx
@@ -17,32 +17,32 @@
 ClassImp(FairMultiLinkedData_Interface);
 
 FairMultiLinkedData_Interface::FairMultiLinkedData_Interface()
-  :TObject(), fLink(0), fVerbose(0), fInsertHistory(kTRUE)
+  :TObject(), fVerbose(0), fInsertHistory(kTRUE), fLink(NULL)
 {
 }
 
 FairMultiLinkedData_Interface::FairMultiLinkedData_Interface(FairMultiLinkedData& links, Bool_t persistanceCheck)
-  :TObject(), fLink(0), fVerbose(0), fInsertHistory(kTRUE)
+  :TObject(), fVerbose(0), fInsertHistory(kTRUE), fLink(NULL)
 {
 	SetLinks(links);
 }
 
 FairMultiLinkedData_Interface::FairMultiLinkedData_Interface(TString dataType, std::vector<Int_t> links, Int_t fileId, Int_t evtId, Bool_t persistanceCheck, Bool_t bypass, Float_t mult)
-  :TObject(), fLink(0), fVerbose(0), fInsertHistory(kTRUE)
+  :TObject(), fVerbose(0), fInsertHistory(kTRUE), fLink(NULL)
 {
 	FairMultiLinkedData data(dataType, links, fileId, evtId, persistanceCheck, bypass, mult);
 	SetLinks(data);
 }
 
 FairMultiLinkedData_Interface::FairMultiLinkedData_Interface( Int_t dataType, std::vector<Int_t> links, Int_t fileId, Int_t evtId, Bool_t persistanceCheck, Bool_t bypass, Float_t mult)
-  :TObject(), fLink(0), fVerbose(0), fInsertHistory(kTRUE)
+  :TObject(), fVerbose(0), fInsertHistory(kTRUE), fLink(NULL)
 {
 	FairMultiLinkedData data(dataType, links, fileId, evtId, persistanceCheck, bypass, mult);
 	SetLinks(data);
 }
 
 FairMultiLinkedData_Interface::FairMultiLinkedData_Interface(const FairMultiLinkedData_Interface& toCopy)
-  :TObject(), fLink(0), fVerbose(0), fInsertHistory(kTRUE)
+  :TObject(), fVerbose(0), fInsertHistory(kTRUE), fLink(NULL)
 {
 	if (toCopy.GetPointerToLinks() != 0){
 		SetInsertHistory(kFALSE);

--- a/base/event/FairMultiLinkedData_Interface.h
+++ b/base/event/FairMultiLinkedData_Interface.h
@@ -63,15 +63,15 @@ class FairMultiLinkedData_Interface : public  TObject
     virtual void ResetLinks();
 
 
-    std::ostream& Print(std::ostream& out = std::cout) const {
+    std::ostream& PrintLinkInfo(std::ostream& out = std::cout) const {
 
 		if (GetPointerToLinks() != 0)
-			GetPointerToLinks()->Print(out);
+			GetPointerToLinks()->PrintLinkInfo(out);
 		return out;
     }                                                     ///< Output
 
     friend std::ostream& operator<< (std::ostream& out, FairMultiLinkedData_Interface& data) {
-      data.Print(out);
+      data.PrintLinkInfo(out);
       return out;
     }                                                     ///< Output
 

--- a/base/event/FairTimeStamp.cxx
+++ b/base/event/FairTimeStamp.cxx
@@ -39,10 +39,10 @@ FairTimeStamp::~FairTimeStamp()
 
 // -------------------------------------------------------------------------
 
-std::ostream& FairTimeStamp::Print(std::ostream& out) const
+std::ostream& FairTimeStamp::PrintTimeInfo(std::ostream& out) const
 {
   out << "EntryNr of Data: " << fEntryNr << " TimeStamp: " << GetTimeStamp() << " +/- " << GetTimeStampError() << std::endl;
-  FairMultiLinkedData_Interface::Print(out);
+  FairMultiLinkedData_Interface::PrintLinkInfo(out);
 
   return out;
 }

--- a/base/event/FairTimeStamp.h
+++ b/base/event/FairTimeStamp.h
@@ -61,7 +61,7 @@ class FairTimeStamp : public FairMultiLinkedData_Interface
     }
 
 
-    virtual std::ostream& Print(std::ostream& out = std::cout) const;
+    virtual std::ostream& PrintTimeInfo(std::ostream& out = std::cout) const;
     virtual Bool_t IsSortable() const { return kTRUE;};
 
 
@@ -70,7 +70,7 @@ class FairTimeStamp : public FairMultiLinkedData_Interface
     }
 
     friend std::ostream& operator<< (std::ostream& out, const FairTimeStamp& link) {
-      link.Print(out);
+      link.PrintTimeInfo(out);
       return out;
     }
 

--- a/base/sim/FairModule.cxx
+++ b/base/sim/FairModule.cxx
@@ -482,7 +482,7 @@ void FairModule::ReAssignMediaId()
     TList* media = gGeoManager->GetListOfMedia();
     // Loop over new media which are not in GeoBase and shift the ID
     TGeoMedium* med;
-    TGeoMedium* med2;
+//    TGeoMedium* med2;
     for(Int_t i = geoBuilder->GetNMedia(); i < media->GetEntries(); i++)
     {
         med = (TGeoMedium*) media->At(i);

--- a/base/source/FairMbsStreamSource.cxx
+++ b/base/source/FairMbsStreamSource.cxx
@@ -89,7 +89,7 @@ Bool_t FairMbsStreamSource::ConnectToServer()
 }
 
 
-Int_t FairMbsStreamSource::ReadEvent()
+Int_t FairMbsStreamSource::ReadEvent(UInt_t)
 {
   void* evtptr = &fxEvent;
   void* buffptr = &fxBuffer;

--- a/base/source/FairMbsStreamSource.h
+++ b/base/source/FairMbsStreamSource.h
@@ -30,7 +30,7 @@ class FairMbsStreamSource : public FairMbsSource
     virtual ~FairMbsStreamSource();
 
     virtual Bool_t Init();
-    virtual Int_t ReadEvent();
+    virtual Int_t ReadEvent(UInt_t=0);
     virtual void Close();
 
     const char* GetServerName() const {return fServerName.Data();};

--- a/base/source/FairMixedSource.cxx
+++ b/base/source/FairMixedSource.cxx
@@ -36,25 +36,22 @@ using std::set;
 
 FairMixedSource::FairMixedSource(TFile *f, const char* Title, UInt_t identifier)
   :FairSource(),
+   fRootManager(0),
    fInputTitle(Title),
    fRootFile(f),
-   fRootManager(0),
    fListFolder(new TObjArray(16)),
    fRtdb(FairRuntimeDb::instance()),
    fCbmout(0),
    fCbmroot(0),
    fSourceIdentifier(0),
-   fActualSignalIdentifier(0),
-   fNoOfSignals(0),
-   fSignalChainList(NULL),
-   fBackgroundChain(NULL),
-   fSignalTypeList(),
+   fNoOfEntries(-1),
+   IsInitialized(kFALSE),
     fMCHeader(0),
     fEvtHeader(0),
     fOutHeader(0),
     fFileHeader(0),
-    fEvtHeaderIsNew(kFALSE),
    fEventTimeInMCHeader(kTRUE),
+    fEvtHeaderIsNew(kFALSE),
     fCurrentEntryNo(0),
     fTimeforEntryNo(0),
     fNoOfBGEntries(0),
@@ -62,15 +59,18 @@ FairMixedSource::FairMixedSource(TFile *f, const char* Title, UInt_t identifier)
     fEventTimeMin(0.),
     fEventTimeMax(0.),
     fEventTime(0.),
-    fEventMeanTime(0.),
   fBeamTime(-1.),
   fGapTime(-1.),
+    fEventMeanTime(0.),
     fTimeProb(0),
    fSignalBGN(),
    fSBRatiobyN(kFALSE),
   fSBRatiobyT(kFALSE),
-  fNoOfEntries(-1),
-  IsInitialized(kFALSE)
+   fActualSignalIdentifier(0),
+   fNoOfSignals(0),
+   fSignalChainList(NULL),
+   fBackgroundChain(NULL),
+   fSignalTypeList()
 {
    if (fRootFile->IsZombie()) {
      LOG(FATAL) << "Error opening the Input file" << FairLogger::endl;
@@ -82,25 +82,22 @@ FairMixedSource::FairMixedSource(TFile *f, const char* Title, UInt_t identifier)
 }
 FairMixedSource::FairMixedSource(const TString* RootFileName, const char* Title, UInt_t identifier)
 :FairSource(),
+ fRootManager(0),
  fInputTitle(Title),
  fRootFile(0),
- fRootManager(0),
  fListFolder(new TObjArray(16)),
  fRtdb(FairRuntimeDb::instance()),
  fCbmout(0),
  fCbmroot(0),
  fSourceIdentifier(0),
-    fActualSignalIdentifier(0),
-    fNoOfSignals(0),
-    fSignalChainList(NULL),
-    fBackgroundChain(NULL),
-    fSignalTypeList(),
+ fNoOfEntries(-1),
+ IsInitialized(kFALSE),
     fMCHeader(0),
     fEvtHeader(0),
     fOutHeader(0),
     fFileHeader(0),
-    fEvtHeaderIsNew(kFALSE),
    fEventTimeInMCHeader(kTRUE),
+    fEvtHeaderIsNew(kFALSE),
     fCurrentEntryNo(0),
     fTimeforEntryNo(0),
     fNoOfBGEntries(0),
@@ -108,15 +105,18 @@ FairMixedSource::FairMixedSource(const TString* RootFileName, const char* Title,
     fEventTimeMin(0.),
     fEventTimeMax(0.),
     fEventTime(0.),
-    fEventMeanTime(0.),
   fBeamTime(-1.),
   fGapTime(-1.),
+    fEventMeanTime(0.),
     fTimeProb(0),
    fSignalBGN(),
    fSBRatiobyN(kFALSE),
   fSBRatiobyT(kFALSE),
- fNoOfEntries(-1),
- IsInitialized(kFALSE)
+    fActualSignalIdentifier(0),
+    fNoOfSignals(0),
+    fSignalChainList(NULL),
+    fBackgroundChain(NULL),
+    fSignalTypeList()
 {
   fRootFile = new TFile(RootFileName->Data());
   if (fRootFile->IsZombie()) {
@@ -128,25 +128,22 @@ FairMixedSource::FairMixedSource(const TString* RootFileName, const char* Title,
 
 FairMixedSource::FairMixedSource(const TString RootFileName, const Int_t signalId, const char* Title, UInt_t identifier) 
   :FairSource(), 
+   fRootManager(0),
    fInputTitle(Title),
    fRootFile(0),
-   fRootManager(0),
    fListFolder(new TObjArray(16)),
    fRtdb(FairRuntimeDb::instance()),
    fCbmout(0),
    fCbmroot(0),
    fSourceIdentifier(0),
-   fActualSignalIdentifier(0),
-   fNoOfSignals(0),
-   fSignalChainList(NULL),
-   fBackgroundChain(NULL),
-  fSignalTypeList(),
+   fNoOfEntries(-1),
+   IsInitialized(kFALSE),
     fMCHeader(0),
     fEvtHeader(0),
   fOutHeader(0),
     fFileHeader(0),
-    fEvtHeaderIsNew(kFALSE),
    fEventTimeInMCHeader(kTRUE),
+    fEvtHeaderIsNew(kFALSE),
     fCurrentEntryNo(0),
     fTimeforEntryNo(0),
     fNoOfBGEntries(0),
@@ -154,15 +151,18 @@ FairMixedSource::FairMixedSource(const TString RootFileName, const Int_t signalI
     fEventTimeMin(0.),
     fEventTimeMax(0.),
     fEventTime(0.),
-    fEventMeanTime(0.),
   fBeamTime(-1.),
   fGapTime(-1.),
+    fEventMeanTime(0.),
     fTimeProb(0),
    fSignalBGN(),
    fSBRatiobyN(kFALSE),
   fSBRatiobyT(kFALSE),
-  fNoOfEntries(-1),
-  IsInitialized(kFALSE) 
+   fActualSignalIdentifier(0),
+   fNoOfSignals(0),
+   fSignalChainList(NULL),
+   fBackgroundChain(NULL),
+  fSignalTypeList()
 {
     fRootFile = new TFile(RootFileName.Data());
 
@@ -459,7 +459,7 @@ void FairMixedSource::SetSignalFile(TString name, UInt_t identifier )
     } else {
       TChain* CurrentChain=fSignalTypeList[identifier];
       CurrentChain->AddFile(name.Data());
-      TObjArray* fileElements=CurrentChain->GetListOfFiles();
+//      TObjArray* fileElements=CurrentChain->GetListOfFiles();
     }
 
   }
@@ -512,7 +512,7 @@ void FairMixedSource::AddBackgroundFile(TString name)
   } else {
     if(fBackgroundChain!=0) {
       fBackgroundChain->AddFile(name.Data());
-      TObjArray* fileElements=fBackgroundChain->GetListOfFiles();
+//      TObjArray* fileElements=fBackgroundChain->GetListOfFiles();
     } else {
       LOG(FATAL) << "Use SetBackGroundFile first, then add files to background" << FairLogger::endl;
     }

--- a/base/source/FairRemoteSource.cxx
+++ b/base/source/FairRemoteSource.cxx
@@ -64,7 +64,7 @@ Bool_t FairRemoteSource::Init()
 }
 
 
-Int_t FairRemoteSource::ReadEvent()
+Int_t FairRemoteSource::ReadEvent(UInt_t)
 {
   usleep(10000);
   fREvent = fBuffer->RevGet(fSocket, 0, 0);

--- a/base/source/FairRemoteSource.h
+++ b/base/source/FairRemoteSource.h
@@ -30,7 +30,7 @@ class FairRemoteSource : public FairMbsSource
     virtual ~FairRemoteSource();
 
     virtual Bool_t Init();
-    virtual Int_t ReadEvent();
+    virtual Int_t ReadEvent(UInt_t=0);
     virtual void Close();
 
     inline const char* GetNode() const { return fNode; }

--- a/base/steer/FairAnaSelector.h
+++ b/base/steer/FairAnaSelector.h
@@ -41,7 +41,7 @@ class FairAnaSelector : public TSelector
     TTree*                fChain;   //!pointer to the analyzed TTree or TChain
     FairRunAnaProof*      fRunAna;
 
- FairAnaSelector(TTree* /*tree*/ =0) : fLogger(FairLogger::GetLogger()), fProofFile(0), fFile(0), fChain(0), fRunAna(NULL), fProofSource(0) { }
+ FairAnaSelector(TTree* /*tree*/ =0) : fProofFile(0), fFile(0), fChain(0), fRunAna(NULL), fLogger(FairLogger::GetLogger()), fProofSource(0) { }
     virtual ~FairAnaSelector() { }
     virtual Int_t   Version() const {
       return 1;

--- a/base/steer/FairRunAnaProof.cxx
+++ b/base/steer/FairRunAnaProof.cxx
@@ -52,11 +52,11 @@ FairRunAnaProof::FairRunAnaProof(const char* proofName)
   :FairRunAna(),
    fProof(NULL),
    fRunOnProofWorker(kFALSE),
-   fProofFileSource(0),
    fProofServerName(proofName),
    fProofParName("$VMCWORKDIR/gconfig/libFairRoot.par"),
    fOutputDirectory(""),
-   fProofOutputStatus("copy")
+   fProofOutputStatus("copy"),
+   fProofFileSource(0)
 {
   if ( strcmp(proofName,"RunOnProofWorker") == 0 ) {
     fRunOnProofWorker = kTRUE;

--- a/datamatch/FairMCEntry.h
+++ b/datamatch/FairMCEntry.h
@@ -53,12 +53,12 @@ class FairMCEntry : public FairMultiLinkedData
 
     virtual ~FairMCEntry();
 
-    virtual void Print(std::ostream& out) {
+    virtual void PrintInfo(std::ostream& out) {
       out << *this;
     }
 
     friend std::ostream& operator<< (std::ostream& out, const FairMCEntry& link) {
-      ((FairMultiLinkedData)link).Print(out);
+      ((FairMultiLinkedData)link).PrintLinkInfo(out);
       return out;
     }
 

--- a/datamatch/FairMCMatch.cxx
+++ b/datamatch/FairMCMatch.cxx
@@ -301,7 +301,7 @@ void FairMCMatch::GetNextStage(FairMultiLinkedData& startStage, Int_t stopStage)
       tempStage = GetEntry(startStage.GetLink(i));
       if (fVerbose > 0) {
         std::cout << "TempStage Start";
-        startStage.GetLink(i).Print();
+        startStage.GetLink(i).PrintLinkInfo();
         std::cout << " --> " << tempStage << std::endl;
       }
       if (tempStage.GetNLinks() == 0) {

--- a/datamatch/FairMCMatch.h
+++ b/datamatch/FairMCMatch.h
@@ -102,12 +102,12 @@ class FairMCMatch: public TNamed
 
     bool IsTypeInList(Int_t type);
 
-    void Print(std::ostream& out = std::cout) {out << *this;}
+    void PrintInfo(std::ostream& out = std::cout) {out << *this;}
 
     friend std::ostream& operator<< (std::ostream& out, const FairMCMatch& match) {
       for (int i = 0; i < match.GetNMCStages(); i++) {
         if (match.GetMCStage(i)->GetLoaded() == kTRUE) {
-          match.GetMCStage(i)->Print(out);
+          match.GetMCStage(i)->PrintInfo(out);
           out << std::endl;
         }
       }

--- a/datamatch/FairMCMatchLoaderTask.cxx
+++ b/datamatch/FairMCMatchLoaderTask.cxx
@@ -23,9 +23,9 @@
 // -----   Default constructor   -------------------------------------------
 FairMCMatchLoaderTask::FairMCMatchLoaderTask()
   : FairTask("Creates FairMCMatch"),
+    fMCMatch(NULL),
     fMCLink(NULL),
-    fEventNr(0),
-    fMCMatch(NULL)
+    fEventNr(0)
 {
 }
 // -------------------------------------------------------------------------

--- a/datamatch/FairMCObject.h
+++ b/datamatch/FairMCObject.h
@@ -35,18 +35,21 @@ class FairMCObject: public TObject
     FairMCObject(Int_t type)
       : TObject(),
         fStage(),
-        fStageId(type) {
-    }
+        fStageId(type)
+        {
+        }	
     FairMCObject(const FairMCObject& obj)
       : TObject(obj),
-        fStageId(obj.GetStageId()),
-        fStage(obj.GetEntryVector()) {
-    }
+        fStage(obj.GetEntryVector()), 
+        fStageId(obj.GetStageId())
+        {
+        }
     FairMCObject(Int_t type, std::vector<FairMCEntry> stage)
       : TObject(),
         fStage(stage),
-        fStageId(type) {
-    }
+        fStageId(type) 
+        {
+        }
 
     FairMCObject& operator=(const FairMCObject& from) {
       if (this == &from) { return *this; }
@@ -98,7 +101,7 @@ class FairMCObject: public TObject
 
     virtual void ClearEntries() {fStage.clear();}
 
-    virtual void Print(std::ostream& out = std::cout) {out << *this;}
+    virtual void PrintInfo(std::ostream& out = std::cout) {out << *this;}
 
     /*
         void operator=(const FairMCObject& obj) {
@@ -112,7 +115,7 @@ class FairMCObject: public TObject
       for (int i = 0; i < stages.size(); i++) {
         if (stages[i].GetNLinks() > 0) {
           out << i << ": ";
-          stages[i].Print(out);
+          stages[i].PrintInfo(out);
           out << std::endl;
         }
       }

--- a/datamatch/FairMCResult.h
+++ b/datamatch/FairMCResult.h
@@ -56,11 +56,11 @@ class FairMCResult: public FairMCObject
     Int_t GetStartType(void) const {return fStartType;}
     Int_t GetStopType(void) const {return fStopType;}
 
-    virtual void Print(std::ostream& out = std::cout) { out << *this;}
+    virtual void PrintInfo(std::ostream& out = std::cout) { out << *this;}
 
     friend std::ostream& operator<< (std::ostream& out, const FairMCResult& result) {
       out << "MC Link from: " << result.GetStartType() << " to "  << result.GetStopType() << ":" << std::endl;
-      ((FairMCObject)result).Print(out);
+      ((FairMCObject)result).PrintInfo(out);
       return out;
     }
 

--- a/datamatch/FairMCStage.cxx
+++ b/datamatch/FairMCStage.cxx
@@ -18,8 +18,8 @@ ClassImp(FairMCStage);
 
 FairMCStage::FairMCStage()
   : FairMCObject(),
-    fFileName(""),
     fBranchName(""),
+    fFileName(""),
     fWeight(1.0),
     fLoaded(kFALSE),
     fFill(kFALSE)
@@ -32,8 +32,8 @@ FairMCStage::~FairMCStage()
 
 FairMCStage::FairMCStage(Int_t id, std::string fileName, std::string branchName, Double_t weight)
   : FairMCObject(id),
-    fFileName(fileName),
     fBranchName(branchName),
+    fFileName(fileName),
     fWeight(weight),
     fLoaded(kFALSE),
     fFill(kFALSE)

--- a/datamatch/FairMCStage.h
+++ b/datamatch/FairMCStage.h
@@ -73,11 +73,11 @@ class FairMCStage: public FairMCObject
       fLoaded = kFALSE;
     }
 
-    virtual void Print(std::ostream& out) {out << *this;}
+    virtual void PrintInfo(std::ostream& out) {out << *this;}
 
     friend std::ostream& operator<< (std::ostream& out, const FairMCStage& stage) {
       out << stage.GetStageId() << ": " << stage.GetBranchName() << " // " <<  stage.GetFileName() << std::endl; //" with weight: " << stage.GetWeight() << std::endl;
-      ((FairMCObject)stage).Print(out);
+      ((FairMCObject)stage).PrintInfo(out);
       return out;
     }
 


### PR DESCRIPTION
Rename Print() function in FairLinks, FairTimeStamp, FairMultilinkedData_Interface and FairMultilinkedData .