### PR TITLE
Change compiler flags. Allow to use ctest launchers.

### DIFF
--- a/FairBase_test.cmake
+++ b/FairBase_test.cmake
@@ -18,27 +18,29 @@ Set(CTEST_UPDATE_COMMAND "${CTEST_GIT_COMMAND}")
 Set(BUILD_COMMAND "make")
 Set(CTEST_BUILD_COMMAND "${BUILD_COMMAND} -j$ENV{number_of_processors}")
 
-Set(EXTRA_FLAGS $ENV{EXTRA_FLAGS})
-
 String(TOUPPER $ENV{ctest_model} _Model)
-
 Set(configure_options "-DCMAKE_BUILD_TYPE=${_Model}")
+
+Set(USE_LAUNCHERS $ENV{USE_LAUNCHERS})
+If(USE_LAUNCHERS)
+  Set(CTEST_USE_LAUNCHERS 1)
+  Set(configure_options "${configure_options};-DCTEST_USE_LAUNCHERS=${CTEST_USE_LAUNCHERS}")
+EndIf()
+
+Set(EXTRA_FLAGS $ENV{EXTRA_FLAGS})
 If(EXTRA_FLAGS)
   Set(configure_options "${configure_options};${EXTRA_FLAGS}") 
 EndIf()
 
 If($ENV{ctest_model} MATCHES Nightly OR $ENV{ctest_model} MATCHES Profile)
 
-   Find_Program(GCOV_COMMAND gcov)
-   If(GCOV_COMMAND)
-     Message("Found GCOV: ${GCOV_COMMAND}")
-     Set(CTEST_COVERAGE_COMMAND ${GCOV_COMMAND})
-   EndIf(GCOV_COMMAND)
- 
-#   String(TOUPPER $ENV{ctest_model} _Model)
-   Set(ENV{ctest_model} Nightly)
+  Find_Program(GCOV_COMMAND gcov)
+  If(GCOV_COMMAND)
+    Message("Found GCOV: ${GCOV_COMMAND}")
+    Set(CTEST_COVERAGE_COMMAND ${GCOV_COMMAND})
+  EndIf(GCOV_COMMAND)
 
-#  Set(CTEST_CONFIGURE_COMMAND " \"${CMAKE_EXECUTABLE_NAME}\" \"-DCMAKE_BUILD_TYPE=${_Model}\" \"-G${CTEST_CMAKE_GENERATOR}\" \"${EXTRA_FLAGS}\" \"${CTEST_SOURCE_DIRECTORY}\" ")
+  Set(ENV{ctest_model} Nightly)
 
   CTEST_EMPTY_BINARY_DIRECTORY(${CTEST_BINARY_DIRECTORY})
 
@@ -47,21 +49,39 @@ EndIf()
 Configure_File(${CTEST_SOURCE_DIRECTORY}/CTestCustom.cmake
                ${CTEST_BINARY_DIRECTORY}/CTestCustom.cmake
               )
+
+# Copy CTestConfig.cmake to build directory.
+# When building with launchers send the results to the alternative cdash server.
+File(READ ${CTEST_SOURCE_DIRECTORY}/CTestConfig.cmake f0 )
+If(USE_LAUNCHERS)
+  String(REGEX REPLACE "cdash.gsi.de" "lxwww53.gsi.de" f1 "${f0}" )
+  String(REGEX REPLACE "https" "http" f2 "${f1}" )
+  File(WRITE ${CTEST_BINARY_DIRECTORY}/CTestConfig.cmake "${f2}")
+Else()
+  File(WRITE ${CTEST_BINARY_DIRECTORY}/CTestConfig.cmake "${f0}")
+EndIf()
+
 Ctest_Read_Custom_Files("${CTEST_BINARY_DIRECTORY}")
 
 Ctest_Start($ENV{ctest_model})
+
 If(NOT $ENV{ctest_model} MATCHES Experimental)
   Ctest_Update(SOURCE "${CTEST_SOURCE_DIRECTORY}")
 EndIf()
+
 Ctest_Configure(BUILD "${CTEST_BINARY_DIRECTORY}"
                 OPTIONS "${configure_options}"
                )
+
 Ctest_Build(BUILD "${CTEST_BINARY_DIRECTORY}")
+
 Ctest_Test(BUILD "${CTEST_BINARY_DIRECTORY}" 
            PARALLEL_LEVEL $ENV{number_of_processors}
           )
+
 If(GCOV_COMMAND)
   Ctest_Coverage(BUILD "${CTEST_BINARY_DIRECTORY}")
 EndIf()
+
 Ctest_Submit()
  

--- a/cmake/modules/CheckCompiler.cmake
+++ b/cmake/modules/CheckCompiler.cmake
@@ -190,11 +190,11 @@ if (CMAKE_SYSTEM_NAME MATCHES Darwin)
 
       # Select flags.
       set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -Wshadow ")
-      set(CMAKE_CXX_FLAGS_NIGHTLY        "-O2 -g -Wshadow -Weffc++")
+      set(CMAKE_CXX_FLAGS_NIGHTLY        "-O2 -g -Wshadow -Weffc++ -Wall -Wextra")
       set(CMAKE_CXX_FLAGS_RELEASE        "-O2 -Wshadow ")
       set(CMAKE_CXX_FLAGS_DEBUG          "-g -O2 -Wshadow  -fno-inline")
       set(CMAKE_CXX_FLAGS_DEBUGFULL      "-g3 -fno-inline -Wnon-virtual-dtor -Wno-long-long -ansi -Wundef -Wcast-align -Wchar-subscripts -Wall -W -Wpointer-arith -Wformat-security -fno-exceptions -fno-check-new -fno-common")
-      set(CMAKE_CXX_FLAGS_PROFILE        "-g3 -fno-inline -ftest-coverage -fprofile-arcs")
+      set(CMAKE_CXX_FLAGS_PROFILE        "-g3 -fno-inline -ftest-coverage -fprofile-arcs -Wall -Wextra")
       set(CMAKE_C_FLAGS_RELWITHDEBINFO   "-O2 -g")
       set(CMAKE_C_FLAGS_RELEASE          "-O2")
       set(CMAKE_C_FLAGS_DEBUG            "-g -O2  -fno-inline")

--- a/cmake/scripts/generate_dictionary_root.sh.in
+++ b/cmake/scripts/generate_dictionary_root.sh.in
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This macro is used to generate the ROOT dictionaries
+# To use the ctest launchers one needs some environment variables which
+# are only present when running CMake. To have the same environment at
+# the time the dictionary is build this script is used which is build
+# at the time cmake runs.
+
+# Setup the needed environment
+export LD_LIBRARY_PATH=@MY_LD_LIBRARY_PATH@
+export DYLD_LIBRARY_PATH=@MY_LD_LIBRARY_PATH@
+export ROOTSYS=@ROOTSYS@
+
+@ROOT_CINT_EXECUTABLE@ -f @Int_DICTIONARY@ @EXTRA_DICT_PARAMETERS_STR@ -c  @Int_DEF_STR@ @Int_INC_STR@ @Int_HDRS_STR@ @Int_LINKDEF@


### PR DESCRIPTION
Switch on Wall and Wextra compiler warnings when running build type 'Nightly' or 'Profile' on Mac OSX.

Allow to switch on ctest_launchers for compilation. In this case the output of each compilation unit is send as one packet
to the cdash server even if one uses a parallel build. The cdash server then show all data together and not mixed in one
long list.

Don't run rootcint directly when generating the dictionary. Instead create a shell script when running cmake which is
executed to generate the dictionary. This two step procedure is needed because with cteat_launchers the needed environment
variables are not present when generating the dictionary but only when running cmake.

Switch to alternative CDash server (lxwww53) when building with ctest_launchers.
When the environment varibale USE_LAUNCHERS is set, switch on building with launchers and use alternative cdash server.