### PR TITLE
Added possibility to merge proof output files.

### DIFF
--- a/base/steer/FairAnaSelector.h
+++ b/base/steer/FairAnaSelector.h
@@ -32,6 +32,7 @@ class TFile;
 class TList;
 class TObject;
 class TProofOutputFile;
+class TString;
 
 class FairAnaSelector : public TSelector
 {
@@ -41,7 +42,8 @@ class FairAnaSelector : public TSelector
     TTree*                fChain;   //!pointer to the analyzed TTree or TChain
     FairRunAnaProof*      fRunAna;
 
- FairAnaSelector(TTree* /*tree*/ =0) : fProofFile(0), fFile(0), fChain(0), fRunAna(NULL), fLogger(FairLogger::GetLogger()), fProofSource(0) { }
+    FairAnaSelector(TTree* /*tree*/ =0) : fProofFile(0), fFile(0), fChain(0), fRunAna(NULL), fLogger(FairLogger::GetLogger()), fProofSource(0), fCurrentDirectory("") { }
+
     virtual ~FairAnaSelector() { }
     virtual Int_t   Version() const {
       return 1;
@@ -83,6 +85,8 @@ class FairAnaSelector : public TSelector
     FairAnaSelector operator=(const FairAnaSelector&);
 
     FairFileSource* fProofSource;
+
+    TString fCurrentDirectory;
 
     ClassDef(FairAnaSelector,0);
 };

--- a/base/steer/FairRun.h
+++ b/base/steer/FairRun.h
@@ -63,11 +63,11 @@ class FairRun : public TNamed
     /**
      * Set the output file name for analysis or simulation
     */
-    void        SetOutputFile(const char* fname);
+    virtual void    SetOutputFile(const char* fname);
     /**
      * Set the output file for analysis or simulation
     */
-    void        SetOutputFile(TFile* f);
+    virtual void    SetOutputFile(TFile* f);
     /**
      *       Set the experiment dependent run header
      *       for each run

--- a/base/steer/FairRunAnaProof.cxx
+++ b/base/steer/FairRunAnaProof.cxx
@@ -346,8 +346,13 @@ void FairRunAnaProof::RunOneEvent(Long64_t entry)
 //_____________________________________________________________________________
 void FairRunAnaProof::RunOnProof(Int_t NStart,Int_t NStop)
 {
-//  FairAnaSelector* proofSelector = new FairAnaSelector();
-
+  fProofOutputStatus.ToLower();
+  if ( !fProofOutputStatus.Contains("copy") && !fProofOutputStatus.Contains("merge") ) {
+    LOG(WARNING) << "FairRunAnaProof::RunOnProof. Do not know how to create output \"" << fProofOutputStatus.Data() << "\"." << FairLogger::endl;
+    LOG(WARNING) << "FairRunAnaProof::RunOnProof. Please use SetProofOutputStatus to either \"copy\" or \"merge\"." << FairLogger::endl;
+    LOG(WARNING) << "FairRunAnaProof::RunOnProof. For the current run using the \"merge\" setting." << FairLogger::endl;
+    fProofOutputStatus = "merge";
+  }
 
 //  TChain* inChain = (TChain*)fRootManager->GetInChain();
   TChain* inChain = (TChain*)fProofFileSource->GetInChain();
@@ -362,8 +367,7 @@ void FairRunAnaProof::RunOnProof(Int_t NStart,Int_t NStop)
 
   TString outDir = (fOutputDirectory.Length()>1?fOutputDirectory.Data():gSystem->WorkingDirectory());
 
-  TString outFile = fRootManager->GetOutFile()->GetName();
-  fRootManager->CloseOutFile();
+  TString outFile = Form("%s",fOutname);
 
   fProof->AddInput(fTask);
 
@@ -401,6 +405,25 @@ void FairRunAnaProof::RunOnProof(Int_t NStart,Int_t NStop)
   LOG(INFO) << "FairRunAnaProof::RunOnProof(): inChain->Process DONE" << FairLogger::endl;
 
   return;
+}
+//_____________________________________________________________________________
+
+//_____________________________________________________________________________
+void FairRunAnaProof::SetOutputFile(const char* fname)
+{
+  fOutname=fname;
+}
+//_____________________________________________________________________________
+
+//_____________________________________________________________________________
+void FairRunAnaProof::SetOutputFile(TFile* f)
+{
+  if (! fRootManager) return;
+
+  fOutname=f->GetName();
+  fRootManager->OpenOutFile(f);
+  fOutFile = f;
+
 }
 //_____________________________________________________________________________
 

--- a/base/steer/FairRunAnaProof.h
+++ b/base/steer/FairRunAnaProof.h
@@ -35,6 +35,15 @@ class FairRunAnaProof : public FairRunAna
     /** Init containers executed on PROOF, which is part of Init when running locally*/
     void        InitContainers();
 
+    /**
+     * Set the output file name for analysis or simulation
+    */
+    virtual void    SetOutputFile(const char* fname);
+    /**
+     * Set the output file for analysis or simulation
+    */
+    virtual void    SetOutputFile(TFile* f);
+
     /**Run from event number NStart to event number NStop */
     void        Run(Int_t NStart=0 ,Int_t NStop=0);
     /**Run for one event, used on PROOF nodes*/
@@ -64,7 +73,7 @@ class FairRunAnaProof : public FairRunAna
     void SetOutputDirectory(TString dirName) {
       fOutputDirectory = dirName;
     }
-    /** Set PROOF output status, possibilities: "copy","merge","dataset"*/
+    /** Set PROOF output status, possibilities: "copy","merge"*/
     void SetProofOutputStatus(TString outStat) {
       fProofOutputStatus = outStat;
     }
@@ -72,7 +81,7 @@ class FairRunAnaProof : public FairRunAna
     virtual void   SetSource(FairSource* tempSource);
 
   protected:
-    static FairRunAnaProof*                      fRAPInstance;
+    static FairRunAnaProof*                 fRAPInstance;
 
     /** PROOF **/
     TProof*                                 fProof;

--- a/examples/advanced/Tutorial3/macro/run_DiReLo.C
+++ b/examples/advanced/Tutorial3/macro/run_DiReLo.C
@@ -86,7 +86,6 @@ void run_DiReLo(Int_t nofFiles, TString mcEngine="TGeant3" )
 
   cout << endl << endl;
   cout << "Output file is "    << outFile << endl;
-  //  cout << "Parameter file is " << parFile << endl;
   cout << "Real time " << rtime << " s, CPU time " << ctime
        << "s" << endl << endl;
   cout << "Macro finished successfully." << endl;

--- a/examples/advanced/Tutorial3/macro/run_DiRePr.C
+++ b/examples/advanced/Tutorial3/macro/run_DiRePr.C
@@ -46,7 +46,6 @@ void run_DiRePr(Int_t nofFiles, TString mcEngine="TGeant3" )
 
   cout << "PAR LIST CREATED" << endl;
   parInput1->open(fnamelist);       
-  //  parInput1->open(parFile.Data());
 
   rtdb->setFirstInput(parInput1);
   
@@ -85,7 +84,6 @@ void run_DiRePr(Int_t nofFiles, TString mcEngine="TGeant3" )
 
   cout << endl << endl;
   cout << "Output file is "    << outFile << endl;
-  //  cout << "Parameter file is " << parFile << endl;
   cout << "Real time " << rtime << " s, CPU time " << ctime
        << "s" << endl << endl;
   cout << "Macro finished successfully." << endl;

--- a/parbase/FairParRootFileIo.cxx
+++ b/parbase/FairParRootFileIo.cxx
@@ -197,7 +197,7 @@ Bool_t FairParRootFileIo::open(const TList* fnamelist, Option_t* option,
       newParFileName = string->GetString();
       newParFileName.Replace(newParFileName.Last('/')+1,
                              newParFileName.Length(),"");
-      newParFileName = Form("%sallParams_%d_%d.root",
+      newParFileName = Form("%sallParams_%d_%06d.root",
                             newParFileName.Data(),
                             currentDate.GetDate(),
                             currentDate.GetTime());


### PR DESCRIPTION
The event order in the output merged file is not restored.

- FairRun - virtualized the SetOutputFile functions
- FairRunAnaProof:
  * SetOutputFile does not open the file
  * checking for the outputFileOption, only two possible: merge or copy
- FairAnaSelector:
  * added functionality to merge output files
  * copy option will copy the outputs of different workers to one directory
- FairParRootFileIo: changed the merged parameter file name (%d to %06d for the time)
- Fixed the advanced example 3 macros.