### PR TITLE
Fix warnings and Tutorial 3 issues

### DIFF
--- a/base/MQ/devices/FairMQLmdSampler.cxx
+++ b/base/MQ/devices/FairMQLmdSampler.cxx
@@ -12,12 +12,12 @@
  * Created on October 27, 2015, 2:07 PM
  */
 
+#include <stdexcept>
 
 #include "FairMQLogger.h"
 #include "FairMQLmdSampler.h"
-#include <stdexcept>
 
-FairMQLmdSampler::FairMQLmdSampler() : 
+FairMQLmdSampler::FairMQLmdSampler() :
     fCurrentFile(0),
     fNEvent(0),
     fCurrentEvent(0),
@@ -29,11 +29,12 @@ FairMQLmdSampler::FairMQLmdSampler() :
     fxSubEvent(nullptr),
     fxInfoHeader(nullptr),
     stop(false),
-    fMsgCounter(0)
+    fMsgCounter(0),
+    fSubEventChanMap()
 {
 }
 
-FairMQLmdSampler::~FairMQLmdSampler() 
+FairMQLmdSampler::~FairMQLmdSampler()
 {
 }
 

--- a/base/MQ/devices/FairMQLmdSampler.h
+++ b/base/MQ/devices/FairMQLmdSampler.h
@@ -32,35 +32,34 @@ extern "C"
 #include <tuple>
 #include <map>
 
-
 namespace fs = boost::filesystem;
-
 
 class FairMQLmdSampler : public FairMQDevice
 {
-    typedef fs::path         path;
+    typedef fs::path path;
 
-public:
-
+  public:
     FairMQLmdSampler();
+    FairMQLmdSampler(const FairMQLmdSampler&) = delete;
+    FairMQLmdSampler operator=(const FairMQLmdSampler&) = delete;
+
     virtual ~FairMQLmdSampler();
 
     void AddSubEvtKey(short type, short subType, short procid, short subCrate, short control, const std::string& channelName);
     void AddDir(const std::string& dir);
     void AddFile(const std::string& fileName);
 
-protected:
-
+  protected:
     void InitTask();
     void Run();
     int ReadEvent();
     bool OpenNextFile(const std::string& fileName);
-    
+
     void Close();
-private:
-     ////////////////////// data members
+
+  private:
     int fCurrentFile;
-    int fNEvent;    
+    int fNEvent;
     int fCurrentEvent;
     std::vector<std::string> fFileNames;
     s_evt_channel* fxInputChannel;
@@ -72,7 +71,7 @@ private:
     bool stop;
     int fMsgCounter;
     typedef std::tuple<short,short,short,short,short> SubEvtKey;
-    std::map<SubEvtKey,std::string > fSubEventChanMap;
+    std::map<SubEvtKey, std::string> fSubEventChanMap;
 };
 
 #endif  /* !FAIRMQLMDSAMPLER_H */

--- a/base/MQ/devices/FairMQProcessor.cxx
+++ b/base/MQ/devices/FairMQProcessor.cxx
@@ -46,6 +46,9 @@ void FairMQProcessor::Run()
     int receivedMsgs = 0;
     int sentMsgs = 0;
 
+    // int inSize = 0;
+    // int outSize = 0;
+
     // store the channel references to avoid traversing the map on every loop iteration
     FairMQChannel& dataInChannel = fChannels.at("data-in").at(0);
     FairMQChannel& dataOutChannel = fChannels.at("data-out").at(0);
@@ -54,12 +57,13 @@ void FairMQProcessor::Run()
     {
         fProcessorTask->SetPayload(fTransportFactory->CreateMessage());
 
-        ++receivedMsgs;
-
         if (dataInChannel.Receive(fProcessorTask->GetPayload()) > 0)
         {
+            ++receivedMsgs;
+            // inSize += fProcessorTask->GetPayload()->GetSize();
             fProcessorTask->Exec();
 
+            // outSize += fProcessorTask->GetPayload()->GetSize();
             dataOutChannel.Send(fProcessorTask->GetPayload());
             sentMsgs++;
         }
@@ -67,6 +71,7 @@ void FairMQProcessor::Run()
         fProcessorTask->GetPayload()->CloseMessage();
     }
 
+    // LOG(INFO) << "Input size (" << receivedMsgs << "): " << inSize << ". Output size (" << sentMsgs << "): " << outSize;
     LOG(INFO) << "Received " << receivedMsgs << " and sent " << sentMsgs << " messages!";
 }
 

--- a/base/MQ/devices/FairMQProcessor.cxx
+++ b/base/MQ/devices/FairMQProcessor.cxx
@@ -68,7 +68,7 @@ void FairMQProcessor::Run()
             sentMsgs++;
         }
 
-        fProcessorTask->GetPayload()->CloseMessage();
+        fProcessorTask->ClearPayload();
     }
 
     // LOG(INFO) << "Input size (" << receivedMsgs << "): " << inSize << ". Output size (" << sentMsgs << "): " << outSize;

--- a/base/MQ/devices/FairMQProcessor.h
+++ b/base/MQ/devices/FairMQProcessor.h
@@ -18,14 +18,15 @@
 #include "FairMQDevice.h"
 #include "FairMQProcessorTask.h"
 
-
 class FairMQProcessor : public FairMQDevice
 {
   public:
     FairMQProcessor();
+    FairMQProcessor(const FairMQProcessor&) = delete;
+    FairMQProcessor operator=(const FairMQProcessor&) = delete;
     virtual ~FairMQProcessor();
-    void SetTask(FairMQProcessorTask* task);
 
+    void SetTask(FairMQProcessorTask* task);
     void SendPart();
     bool ReceivePart();
 
@@ -35,10 +36,6 @@ class FairMQProcessor : public FairMQDevice
 
   private:
     FairMQProcessorTask* fProcessorTask;
-
-    /// Copy Constructor
-    FairMQProcessor(const FairMQProcessor&);
-    FairMQProcessor operator=(const FairMQProcessor&);
 };
 
 #endif /* FAIRMQPROCESSOR_H_ */

--- a/base/MQ/devices/FairMQSampler.h
+++ b/base/MQ/devices/FairMQSampler.h
@@ -57,13 +57,12 @@ class FairMQSampler : public FairMQDevice
         ParFile,
         Branch,
         EventRate,
+        ChainInput,
         Last
     };
 
     FairMQSampler();
     virtual ~FairMQSampler();
-
-    void ResetEventCounter();
 
     virtual void SetProperty(const int key, const std::string& value);
     virtual std::string GetProperty(const int key, const std::string& default_ = "");
@@ -73,6 +72,8 @@ class FairMQSampler : public FairMQDevice
     virtual std::string GetPropertyDescription(const int key);
     virtual void ListProperties();
 
+    void ListenForAcks();
+
     /**
      * Sends the currently available output of the Sampler Task as part of a multipart message
      * and reinitializes the message to be filled with the next part.
@@ -80,8 +81,6 @@ class FairMQSampler : public FairMQDevice
      * The final message part must be sent with normal Send method.
      */
     void SendPart();
-
-    void SetContinuous(bool flag);
 
   protected:
     virtual void InitTask();
@@ -93,9 +92,9 @@ class FairMQSampler : public FairMQDevice
     std::string fParFile;
     std::string fBranch; // The name of the sub-detector branch to stream the digis from.
     int fNumEvents;
+    int fChainInput;
     int fEventRate;
     int fEventCounter;
-    bool fContinuous;
 
   private:
     /// Copy Constructor

--- a/base/MQ/devices/FairMQSampler.h
+++ b/base/MQ/devices/FairMQSampler.h
@@ -31,6 +31,7 @@
 #include "FairRuntimeDb.h"
 #include "FairRunAna.h"
 #include "FairTask.h"
+#include "FairFileSource.h"
 
 #include "FairMQDevice.h"
 #include "FairMQSamplerTask.h"
@@ -91,6 +92,7 @@ class FairMQSampler : public FairMQDevice
 
     FairRunAna *fFairRunAna;
     FairMQSamplerTask *fSamplerTask;
+    boost::timer::auto_cpu_timer* fTimer;
     std::string fInputFile; // Filename of a root file containing the simulated digis.
     std::string fParFile;
     std::string fBranch; // The name of the sub-detector branch to stream the digis from.

--- a/base/MQ/devices/FairMQSampler.h
+++ b/base/MQ/devices/FairMQSampler.h
@@ -62,6 +62,9 @@ class FairMQSampler : public FairMQDevice
     };
 
     FairMQSampler();
+    FairMQSampler(const FairMQSampler&) = delete;
+    FairMQSampler operator=(const FairMQSampler&) = delete;
+
     virtual ~FairMQSampler();
 
     virtual void SetProperty(const int key, const std::string& value);
@@ -95,11 +98,6 @@ class FairMQSampler : public FairMQDevice
     int fChainInput;
     int fEventRate;
     int fEventCounter;
-
-  private:
-    /// Copy Constructor
-    FairMQSampler(const FairMQSampler&);
-    FairMQSampler operator=(const FairMQSampler&);
 };
 
 // Template implementation is in FairMQSampler.tpl :

--- a/base/MQ/devices/FairMQSampler.tpl
+++ b/base/MQ/devices/FairMQSampler.tpl
@@ -20,9 +20,9 @@ FairMQSampler<Loader>::FairMQSampler()
     , fParFile()
     , fBranch()
     , fNumEvents(0)
+    , fChainInput(0)
     , fEventRate(1)
     , fEventCounter(0)
-    , fContinuous(false)
 {
 }
 
@@ -39,7 +39,8 @@ FairMQSampler<Loader>::~FairMQSampler()
 template <typename Loader>
 void FairMQSampler<Loader>::InitTask()
 {
-    LOG(INFO) << "Starting task initialization";
+    LOG(INFO) << "Initializing Task...";
+
     fSamplerTask->SetBranch(fBranch);
     fSamplerTask->SetTransport(fTransportFactory);
 
@@ -47,9 +48,10 @@ void FairMQSampler<Loader>::InitTask()
     fSamplerTask->SetSendPart(boost::bind(&FairMQSampler::SendPart, this));
 
     fFairRunAna->SetInputFile(TString(fInputFile));
-    // This loop can be used to duplicate input file to get more data. The output will still be a single file.
-    for (int i = 0; i < 10; ++i) {
-      fFairRunAna->AddFile(fInputFile);
+    // Adds the same file to the input. The output will still be a single file.
+    for (int i = 0; i < fChainInput; ++i)
+    {
+        fFairRunAna->AddFile(fInputFile);
     }
 
     TString output = fInputFile;
@@ -68,51 +70,67 @@ void FairMQSampler<Loader>::InitTask()
     // fFairRunAna->Run(0, 0);
     FairRootManager *ioman = FairRootManager::Instance();
     fNumEvents = int((ioman->GetInChain())->GetEntries());
-    LOG(INFO) << "Finished task initialization";
+
+    LOG(INFO) << "Task initialized.";
 }
 
 template <typename Loader>
 void FairMQSampler<Loader>::Run()
 {
-    // boost::thread resetEventCounter(boost::bind(&FairMQSampler::ResetEventCounter, this));
+    boost::thread ackListener(boost::bind(&FairMQSampler::ListenForAcks, this));
 
     int sentMsgs = 0;
-
-    boost::timer::auto_cpu_timer timer;
 
     LOG(INFO) << "Number of events to process: " << fNumEvents;
 
     // store the channel references to avoid traversing the map on every loop iteration
     FairMQChannel& dataOutChannel = fChannels.at("data-out").at(0);
 
-    do
+    for (Long64_t eventNr = 0; eventNr < fNumEvents; ++eventNr)
     {
-        for (Long64_t eventNr = 0; eventNr < fNumEvents; ++eventNr)
+        fSamplerTask->SetEventIndex(eventNr);
+        fFairRunAna->RunMQ(eventNr);
+
+        dataOutChannel.Send(fSamplerTask->GetOutput());
+        ++sentMsgs;
+
+        fSamplerTask->GetOutput()->CloseMessage();
+
+        if (!CheckCurrentState(RUNNING))
         {
-            fSamplerTask->SetEventIndex(eventNr);
-            fFairRunAna->RunMQ(eventNr);
-
-            dataOutChannel.Send(fSamplerTask->GetOutput());
-            ++sentMsgs;
-
-            fSamplerTask->GetOutput()->CloseMessage();
-
-            // Optional event rate limiting
-            // --fEventCounter;
-            // while (fEventCounter == 0) {
-            //   boost::this_thread::sleep(boost::posix_time::milliseconds(1));
-            // }
-
-            if (!CheckCurrentState(RUNNING))
-            {
-                break;
-            }
+            break;
         }
-    } while (CheckCurrentState(RUNNING) && fContinuous);
+    }
+
+    try
+    {
+        ackListener.join();
+    }
+    catch(boost::thread_resource_error& e)
+    {
+        LOG(ERROR) << e.what();
+        exit(EXIT_FAILURE);
+    }
+}
+
+template <typename Loader>
+void FairMQSampler<Loader>::ListenForAcks()
+{
+    boost::timer::auto_cpu_timer timer;
+
+    for (Long64_t eventNr = 0; eventNr < fNumEvents; ++eventNr)
+    {
+        std::unique_ptr<FairMQMessage> ack(fTransportFactory->CreateMessage());
+        fChannels.at("ack-in").at(0).Receive(ack);
+
+        if (!CheckCurrentState(RUNNING))
+        {
+            break;
+        }
+    }
 
     boost::timer::cpu_times const elapsedTime(timer.elapsed());
-    LOG(INFO) << "Sent everything in:\n" << boost::timer::format(elapsedTime, 2);
-    LOG(INFO) << "Sent " << sentMsgs << " messages!";
+    LOG(INFO) << "Acknowledged " << fNumEvents << " messages in:\n" << boost::timer::format(elapsedTime, 2);
 }
 
 template <typename Loader>
@@ -120,31 +138,6 @@ void FairMQSampler<Loader>::SendPart()
 {
     fChannels.at("data-out").at(0).Send(fSamplerTask->GetOutput(), "snd-more");
     fSamplerTask->GetOutput()->CloseMessage();
-}
-
-template <typename Loader>
-void FairMQSampler<Loader>::SetContinuous(bool flag)
-{
-    fContinuous = flag;
-}
-
-template <typename Loader>
-void FairMQSampler<Loader>::ResetEventCounter()
-{
-    while (true)
-    {
-        try
-        {
-            fEventCounter = fEventRate / 100;
-            boost::this_thread::sleep(boost::posix_time::milliseconds(10));
-        }
-        catch (boost::thread_interrupted &)
-        {
-            LOG(DEBUG) << "resetEventCounter interrupted";
-            break;
-        }
-    }
-    LOG(DEBUG) << ">>>>>>> stopping resetEventCounter <<<<<<<";
 }
 
 template <typename Loader>
@@ -191,6 +184,9 @@ void FairMQSampler<Loader>::SetProperty(const int key, const int value)
         case EventRate:
             fEventRate = value;
             break;
+        case ChainInput:
+            fChainInput = value;
+            break;
         default:
             FairMQDevice::SetProperty(key, value);
             break;
@@ -204,6 +200,8 @@ int FairMQSampler<Loader>::GetProperty(const int key, const int default_/*= 0*/)
     {
         case EventRate:
             return fEventRate;
+        case ChainInput:
+            return fChainInput;
         default:
             return FairMQDevice::GetProperty(key, default_);
     }

--- a/base/MQ/devices/FairMQUnpacker.h
+++ b/base/MQ/devices/FairMQUnpacker.h
@@ -24,40 +24,43 @@
 #include <tuple>
 #include <map>
 
-
-template<typename U, typename T=RootSerializer>
+template<typename U, typename T = RootSerializer>
 class FairMQUnpacker : public FairMQDevice, public T
 {
     typedef U unpacker_type;
     typedef T serialization_type;
 
-public:
-
+  public:
     FairMQUnpacker() : serialization_type(),
-        fSubEventChanMap(), 
-        fUnpacker(nullptr), 
+        fSubEventChanMap(),
+        fUnpacker(nullptr),
         fInputChannelName()
     {
-
     }
+    /// Copy Constructor
+    FairMQUnpacker(const FairMQUnpacker&) = delete;
+    FairMQUnpacker operator=(const FairMQUnpacker&) = delete;
+
     virtual ~FairMQUnpacker()
     {
-        if(fUnpacker)
+        if (fUnpacker)
+        {
             delete fUnpacker;
+        }
     }
 
     void AddSubEvtKey(short type, short subType, short procid, short subCrate, short control, const std::string& channelName)
     {
-        if(fSubEventChanMap.size()>0)
+        if (fSubEventChanMap.size() > 0)
         {
-            LOG(ERROR)<<"Only one input channel allowed for this device";
+            LOG(ERROR) << "Only one input channel allowed for this device";
         }
         else
         {
              SubEvtKey key(type, subType, procid, subCrate, control);
              fInputChannelName=channelName;
 
-            if(!fSubEventChanMap.count(fInputChannelName))
+            if (!fSubEventChanMap.count(fInputChannelName))
                 fSubEventChanMap[fInputChannelName] = key;
             else
             {
@@ -79,19 +82,17 @@ public:
         }
     }
 
-protected:
-
+  protected:
     void InitTask()
     {
         // check if subevt map is configured
-        if(fInputChannelName.empty() || fSubEventChanMap.size()==0)
+        if (fInputChannelName.empty() || fSubEventChanMap.size()==0)
         {
             throw std::runtime_error(std::string("Sub-event map not configured.") );
         }
 
-
         // check if given channel exist
-        if(!fChannels.count(fInputChannelName))
+        if (!fChannels.count(fInputChannelName))
         {
             throw std::runtime_error(std::string("MQ-channel name '")+fInputChannelName+ "' does not exist. Check the MQ-channel configuration");
         }
@@ -104,12 +105,10 @@ protected:
         std::tie (setype,sesubtype,seprocid,sesubcrate,secontrol) = fSubEventChanMap.at(fInputChannelName);
         fUnpacker = new unpacker_type(setype,sesubtype,seprocid,sesubcrate,secontrol);
         //fUnpacker->Init(); // a priori not needed -> only required for Registering in FairRootManager
-
     }
 
     void Run()
     {
-
         const FairMQChannel& inputChannel = fChannels.at(fInputChannelName).at(0);
         const FairMQChannel& outputChannel = fChannels.at("data-out").at(0);
 
@@ -119,16 +118,16 @@ protected:
             std::unique_ptr<FairMQMessage> msgSize(fTransportFactory->CreateMessage());
             std::unique_ptr<FairMQMessage> msg(fTransportFactory->CreateMessage());
 
-            if(inputChannel.Receive(msgSize)>=0)
-                if(inputChannel.Receive(msg)>=0)
+            if (inputChannel.Receive(msgSize) >= 0)
+                if (inputChannel.Receive(msg) >= 0)
                 {
                     int dataSize=*(static_cast<int*>(msgSize->GetData()));
                     int* subEvt_ptr = static_cast<int*>(msg->GetData());
 
                     LOG(TRACE)<<"array size = "<<dataSize;
-                    if(dataSize>0)
+                    if (dataSize>0)
                         LOG(TRACE)<<"first element in array = "<<*subEvt_ptr;
-                    
+
                     fUnpacker->DoUnpack(subEvt_ptr,dataSize);
 
                     serialization_type::SetMessage(msg.get());
@@ -138,16 +137,11 @@ protected:
         }
     }
 
-
-     ////////////////////// data members
-
     typedef std::tuple<short,short,short,short,short> SubEvtKey;
     std::map<std::string, SubEvtKey> fSubEventChanMap;
 
     unpacker_type* fUnpacker;
     std::string fInputChannelName;
-
 };
 
 #endif  /* !FAIRMQUNPACKER_H */
-

--- a/base/MQ/policies/Sampler/FairSourceMQInterface.h
+++ b/base/MQ/policies/Sampler/FairSourceMQInterface.h
@@ -19,89 +19,98 @@
 #include <type_traits>
 #include <functional>
 
-
 template<typename T, typename U>
 using enable_if_match = typename std::enable_if<std::is_same<T,U>::value,int>::type;
 
-
 template<typename FairSourceType, typename DataType>
-class FairSourceMQInterface : public BaseSourcePolicy< FairSourceMQInterface<FairSourceType, DataType> >
+class FairSourceMQInterface : public BaseSourcePolicy<FairSourceMQInterface<FairSourceType, DataType>>
 {
-	typedef DataType* DataType_ptr;
-	typedef FairSourceMQInterface<FairSourceType,DataType> this_type;
-public:
-	FairSourceMQInterface() : 
-			BaseSourcePolicy<FairSourceMQInterface<FairSourceType, DataType>>(), 
-			fSource(nullptr), 
-			fData(nullptr), 
-			fIndex(0),
-			fMaxIndex(-1),
-			fSourceName(),
-			fBranchName(),
-			fRunAna(nullptr)
-	{
-	}
+    typedef DataType* DataType_ptr;
+    typedef FairSourceMQInterface<FairSourceType,DataType> this_type;
 
-	virtual ~FairSourceMQInterface() 
-	{
-		if(fData)
-			delete fData;
-		fData=nullptr;
-		if(fSource)
-			delete fSource;
-		fSource=nullptr;
-		if(fRunAna)
-			delete fRunAna;
-		fRunAna=nullptr;
-	}
+  public:
+    FairSourceMQInterface() :
+        BaseSourcePolicy<FairSourceMQInterface<FairSourceType, DataType>>(),
+        fSource(nullptr),
+        fData(nullptr),
+        fIndex(0),
+        fMaxIndex(-1),
+        fClassName(),
+        fSourceName(),
+        fBranchName(),
+        fRunAna(nullptr)
+    {
+    }
 
-	//______________________________________________________________________________
-	int64_t GetNumberOfEvent()
-	{
-		return fMaxIndex;
-	}
+    FairSourceMQInterface(const FairSourceMQInterface&) = delete;
+    FairSourceMQInterface operator=(const FairSourceMQInterface&) = delete;
 
-	void SetFileProperties(const std::string &filename, const std::string &branchname)
+    virtual ~FairSourceMQInterface()
+    {
+        if (fData)
+        {
+            delete fData;
+        }
+        fData = nullptr;
+
+        if (fSource)
+        {
+            delete fSource;
+        }
+        fSource = nullptr;
+
+        if (fRunAna)
+        {
+            delete fRunAna;
+        }
+        fRunAna = nullptr;
+    }
+
+    int64_t GetNumberOfEvent()
+    {
+        return fMaxIndex;
+    }
+
+    void SetFileProperties(const std::string &filename, const std::string &branchname)
     {
         fSourceName = filename;
         fBranchName = branchname;
     }
 
 
-	//______________________________________________________________________________
-	// FairFileSource
+    //______________________________________________________________________________
+    // FairFileSource
 
-	template <typename T = FairSourceType, enable_if_match<T, FairFileSource> = 0>
-	void InitSource()
-	{
-		fRunAna = new FairRunAna();
-		fSource = new FairSourceType(fSourceName.c_str());
-		fSource->Init();
-		fSource->ActivateObject((TObject**)&fData,fBranchName.c_str());
-		fMaxIndex = fSource->CheckMaxEventNo();
-	}
+    template <typename T = FairSourceType, enable_if_match<T, FairFileSource> = 0>
+    void InitSource()
+    {
+        fRunAna = new FairRunAna();
+        fSource = new FairSourceType(fSourceName.c_str());
+        fSource->Init();
+        fSource->ActivateObject((TObject**)&fData,fBranchName.c_str());
+        fMaxIndex = fSource->CheckMaxEventNo();
+    }
 
-	template <typename T = FairSourceType, enable_if_match<T, FairFileSource> = 0>
-	void SetIndex(int64_t eventIdx)
-	{
-		fIndex=eventIdx;
-	}
+    template <typename T = FairSourceType, enable_if_match<T, FairFileSource> = 0>
+    void SetIndex(int64_t eventIdx)
+    {
+        fIndex = eventIdx;
+    }
 
-	template <typename T = FairSourceType, enable_if_match<T, FairFileSource> = 0>
- 	DataType_ptr GetOutData()
- 	{
-		fSource->ReadEvent(fIndex);
-		return fData;
- 	}
+    template <typename T = FairSourceType, enable_if_match<T, FairFileSource> = 0>
+    DataType_ptr GetOutData()
+    {
+        fSource->ReadEvent(fIndex);
+        return fData;
+    }
 
-protected:
-
- 	FairSourceType* fSource;
- 	DataType_ptr fData;
- 	int64_t fIndex;
- 	int64_t fMaxIndex;
- 	std::string fClassName;
- 	std::string fBranchName;
- 	std::string fSourceName;
- 	FairRunAna* fRunAna;
+  protected:
+    FairSourceType* fSource;
+    DataType_ptr fData;
+    int64_t fIndex;
+    int64_t fMaxIndex;
+    std::string fClassName;
+    std::string fBranchName;
+    std::string fSourceName;
+    FairRunAna* fRunAna;
 };

--- a/base/MQ/policies/Sampler/SimpleTreeReader.h
+++ b/base/MQ/policies/Sampler/SimpleTreeReader.h
@@ -27,12 +27,13 @@
 #include "FairMQMessage.h"
 
 template <typename DataType>
-class base_SimpleTreeReader 
+class base_SimpleTreeReader
 {
-protected:
+  protected:
     typedef DataType* DataType_ptr;
     typedef DataType& DataType_ref;
-public:
+
+  public:
     base_SimpleTreeReader()
         : fDataBranch(nullptr)
         , fFileName()
@@ -42,7 +43,13 @@ public:
         , fTree(nullptr)
         , fIndex(0)
         , fIndexMax(0)
+        , SendHeader()
+        , GetSocketNumber()
+        , GetCurrentIndex()
     {}
+
+    base_SimpleTreeReader(const base_SimpleTreeReader&) = delete;
+    base_SimpleTreeReader operator=(const base_SimpleTreeReader&) = delete;
 
     virtual ~base_SimpleTreeReader()
     {
@@ -69,52 +76,45 @@ public:
             fTree = (TTree*)fInputFile->Get(fTreeName.c_str());
             if (fTree)
             {
-                fTree->SetBranchAddress(fBranchName.c_str(),&fDataBranch);
-                fIndexMax=fTree->GetEntries();
+                fTree->SetBranchAddress(fBranchName.c_str(), &fDataBranch);
+                fIndexMax = fTree->GetEntries();
             }
             else
             {
-                LOG(ERROR)<<"Could not find tree "<<fTreeName;
+                LOG(ERROR) << "Could not find tree " << fTreeName;
             }
         }
         else
         {
-            LOG(ERROR)<<"Could not open file "<<fFileName<<" in SimpleTreeReader::InitSource()";
+            LOG(ERROR) << "Could not open file " << fFileName << " in SimpleTreeReader::InitSource()";
         }
         
     }
-    
-    
-    
-    
 
     void SendMultiPart()
     {
         SendHeader(0);// callback that does the zmq multipart AND increment the current index (Event number) in generic sampler
-
     }
-    
-    
-    
+
     /// ///////////////////////////////////////////////////////////////////////////////////////
     void SetIndex(int64_t Event)
     {
         fIndex = Event;
     }
-    
+
     /// ///////////////////////////////////////////////////////////////////////////////////////
     DataType_ptr GetOutData()
     {
         return GetOutData(fIndex);
     }
-    
+
     /// ///////////////////////////////////////////////////////////////////////////////////////
     DataType_ptr GetOutData(int64_t Event)
     {
         fTree->GetEntry(Event);
         return fDataBranch;
     }
-    
+
     /// ///////////////////////////////////////////////////////////////////////////////////////
     int64_t GetNumberOfEvent()
     {
@@ -123,16 +123,16 @@ public:
         else 
             return 0;
     }
-    
+
     /// ///////////////////////////////////////////////////////////////////////////////////////
     template<typename T>
     std::vector< std::vector<T> > GetDataVector()
     {
-        std::vector<std::vector<T> > Allobj;
+        std::vector<std::vector<T>> Allobj;
         std::vector<T> TempObj;
         if (std::is_same<DataType,TClonesArray>::value)
         {
-            for (int64_t i(0);i<fTree->GetEntries() ;i++)
+            for (int64_t i = 0; i < fTree->GetEntries(); i++)
             {
                 TempObj.clear();
                 fTree->GetEntry(i);
@@ -148,11 +148,11 @@ public:
         }
         else
         {
-            for (int64_t i(0);i<fTree->GetEntries() ;i++)
+            for (int64_t i = 0; i < fTree->GetEntries(); i++)
             {
                 TempObj.clear();
                 fTree->GetEntry(i);
-                T Data_i=*fDataBranch;
+                T Data_i = *fDataBranch;
                 TempObj.push_back(Data_i);
                 Allobj.push_back(TempObj);
             }
@@ -160,27 +160,26 @@ public:
         return Allobj;
     }
 
-    
     /// ///////////////////////////////////////////////////////////////////////////////////////
     // provides a callback to the Sampler.
     void BindSendHeader(std::function<void(int)> callback)
     {
         SendHeader = callback;
     }
-    
+
     /// ///////////////////////////////////////////////////////////////////////////////////////
     void BindGetSocketNumber(std::function<int()> callback)
     {
         GetSocketNumber = callback;
     }
-    
+
     /// ///////////////////////////////////////////////////////////////////////////////////////
     void BindGetCurrentIndex(std::function<int()> callback)
     {
         GetCurrentIndex = callback;
     }
-    
-private:
+
+  private:
     /// ///////////////////////////////////////////////////////////////////////////////////////
     std::function<void(int)> SendHeader;  // function pointer for the Sampler callback.
     std::function<int()> GetSocketNumber; // function pointer for the Sampler callback.
@@ -199,5 +198,4 @@ private:
 template<typename T>
 using SimpleTreeReader = base_SimpleTreeReader<T>;
 
-#endif	/* SIMPLEROOTSAMPLER_H */
-
+#endif /* SIMPLEROOTSAMPLER_H */

--- a/base/MQ/policies/Serialization/BinaryBaseClassSerializer.h
+++ b/base/MQ/policies/Serialization/BinaryBaseClassSerializer.h
@@ -7,7 +7,7 @@
 
 
 #ifndef BINARYBASECLASSSERIALIZER_H
-#define	BINARYBASECLASSSERIALIZER_H
+#define BINARYBASECLASSSERIALIZER_H
 
 #include <iostream>
 #include "FairMQMessage.h"
@@ -15,12 +15,15 @@
 template <typename TPayload>
 class BinaryBaseClassSerializer
 {
-public:
+  public:
     BinaryBaseClassSerializer()
         : fPayload(nullptr)
         , fMessage(nullptr)
         , fNumInput(0)
     {}
+
+    BinaryBaseClassSerializer(const BinaryBaseClassSerializer&) = delete;
+    BinaryBaseClassSerializer operator=(const BinaryBaseClassSerializer&) = delete;
 
     virtual ~BinaryBaseClassSerializer()
     {}
@@ -45,7 +48,7 @@ public:
         return fMessage;
     }
 
-protected:
+  protected:
     TPayload* fPayload;
     FairMQMessage* fMessage;
     int fNumInput;

--- a/base/MQ/policies/Serialization/BoostSerializer.h
+++ b/base/MQ/policies/Serialization/BoostSerializer.h
@@ -72,8 +72,12 @@ class BoostSerializer : public BaseSerializationPolicy<BoostSerializer<DataType,
     BoostSerializer() :
         BaseSerializationPolicy<BoostSerializer<DataType,BoostArchiveOut>>(),
         fMessage(nullptr),
-        fTransport(nullptr)
+        fTransport(nullptr),
+        fDataVector()
     {}
+
+    BoostSerializer(const BoostSerializer&) = delete;
+    BoostSerializer operator=(const BoostSerializer&) = delete;
 
     ~BoostSerializer()
     {}
@@ -145,7 +149,6 @@ class BoostSerializer : public BaseSerializationPolicy<BoostSerializer<DataType,
         // fMessage = fTransport->CreateMessage(size);
         fMessage->Rebuild(size);
         std::memcpy(fMessage->GetData(), buffer.str().c_str(), size);
-
     }
 
     /// --------------------------------------------------------
@@ -226,7 +229,7 @@ class BoostSerializer : public BaseSerializationPolicy<BoostSerializer<DataType,
     }
 
   protected:
-    virtual void SetTransport(FairMQTransportFactory* transport)
+    void SetTransport(FairMQTransportFactory* transport)
     {
         fTransport = transport;
     }
@@ -260,10 +263,15 @@ class BoostDeSerializer : public BaseSerializationPolicy<BoostDeSerializer<DataT
     BoostDeSerializer() :
         BaseSerializationPolicy<BoostDeSerializer<DataType,TContainer,BoostArchiveIn>>(),
         fMessage(nullptr),
-        fTransport(nullptr)
+        fTransport(nullptr),
+        fDataContainer(),
+        fDataVector()
     {
         DefaultContainerInit();
     }
+
+    BoostDeSerializer(const BoostDeSerializer&) = delete;
+    BoostDeSerializer operator=(const BoostDeSerializer&) = delete;
 
     ~BoostDeSerializer()
     {
@@ -316,7 +324,7 @@ class BoostDeSerializer : public BaseSerializationPolicy<BoostDeSerializer<DataT
 
     /// --------------------------------------------------------
     /// FairMQMessage*  -------->  std::vector<DataType>& 
-    template <typename T = TContainer, enable_if_match<T, std::vector<DataType> > = 0>
+    template <typename T = TContainer, enable_if_match<T, std::vector<DataType>> = 0>
     T& DeserializeMsg(FairMQMessage* msg)
     {
         DoDeSerialization(msg);
@@ -409,10 +417,8 @@ class BoostDeSerializer : public BaseSerializationPolicy<BoostDeSerializer<DataT
     {
     }
 
-
   protected:
-
-    virtual void SetTransport(FairMQTransportFactory* transport)
+    void SetTransport(FairMQTransportFactory* transport)
     {
         fTransport = transport;
     }

--- a/base/MQ/policies/Serialization/NoInputMethod.h
+++ b/base/MQ/policies/Serialization/NoInputMethod.h
@@ -10,7 +10,7 @@
 
 #include "FairMQMessage.h"
 
-class NoInputMethod 
+class NoInputMethod
 {
   public:
     NoInputMethod()

--- a/base/MQ/policies/Serialization/RootSerializer.h
+++ b/base/MQ/policies/Serialization/RootSerializer.h
@@ -27,9 +27,8 @@ class FairTMessage : public TMessage
     }
 };
 
-
 // helper function to clean up the object holding the data after it is transported.
-void free_tmessage (void *data, void *hint)
+void free_tmessage(void *data, void *hint)
 {
     delete (TMessage*)hint;
 }
@@ -44,6 +43,9 @@ class RootSerializer
         , fNumInput(0)
     {}
 
+    RootSerializer(const RootSerializer&) = delete;
+    RootSerializer operator=(const RootSerializer&) = delete;
+
     ~RootSerializer()
     {}
 
@@ -51,7 +53,7 @@ class RootSerializer
     {
         fContainer = new TClonesArray(ClassName.c_str());
     }
-    
+
     void InitContainer(TClonesArray* array)
     {
         fContainer = array;
@@ -60,7 +62,7 @@ class RootSerializer
     ////////////////////////////////////////////////////////////////////////////////////////
     // serialize
 
-    virtual void DoSerialization(TClonesArray* array)
+    void DoSerialization(TClonesArray* array)
     {
         TMessage* tm = new TMessage(kMESS_OBJECT);
         tm->WriteObject(array);
@@ -100,6 +102,9 @@ class RootDeSerializer
         , fNumInput(0)
     {}
 
+    RootDeSerializer(const RootDeSerializer&) = delete;
+    RootDeSerializer operator=(const RootDeSerializer&) = delete;
+
     ~RootDeSerializer()
     {}
 
@@ -116,7 +121,7 @@ class RootDeSerializer
     ////////////////////////////////////////////////////////////////////////////////////////
     // deserialize
 
-    virtual void DoDeSerialization(FairMQMessage* msg)
+    void DoDeSerialization(FairMQMessage* msg)
     {
         FairTMessage tm(msg->GetData(), msg->GetSize());
         fContainer  = (TClonesArray*)(tm.ReadObject(tm.GetClass()));

--- a/base/MQ/policies/Storage/BinaryOutFileManager.h
+++ b/base/MQ/policies/Storage/BinaryOutFileManager.h
@@ -48,68 +48,62 @@ template <typename TPayload, typename TStoragePolicy=TriviallyCopyableDataSaver<
 class BinaryOutFileManager : public TStoragePolicy
 {
     //CHECK_FUN(TStoragePolicy, Write)
-public:
+  public:
     //enum { kPolicyMember = sizeof(&TStoragePolicy::Write) > 0 };
 
     using TStoragePolicy::Write;
     using TStoragePolicy::Read;
-    
+
     BinaryOutFileManager() : TStoragePolicy(), fFileName("test.dat") {;}
     virtual ~BinaryOutFileManager()
     {
         fOutfile.close();
     }
-    
+
     std::string GetPolicyID()
     {
         std::string str(GET_POLICY_ID(TStoragePolicy));
         return str;
     }
-    
+
     void SetFileProperties(const std::string &filename)
     {
         fFileName=filename;
     }
-    
+
     void AddToFile(FairMQMessage* msg)
     {
         Write(fOutfile,msg);
     }
-    
-    
+
     void AddToFile(TPayload* ObjArr, long size)
     {
         AppendObjArray<TPayload>(fOutfile,ObjArr,size);
     }
-    
+
     template<typename T>
     void AppendObjArray(std::ofstream& outfile, T* ObjArr, long size)
     {
         Write(outfile,ObjArr,size);
     }
-    
-    
+
     std::vector<std::vector<TPayload> > GetAllObj(const std::string &filename)
     {
         std::ifstream infile;
         infile = std::ifstream(filename);
         std::vector<std::vector<TPayload> > vect=Read(infile);
-        
+
         return vect;
     }
-    
+
     virtual void InitOutputFile()
     {
         fOutfile = std::ofstream(fFileName, std::ios::out | std::ios::binary | std::ios::app);
     }
-    
-protected:
 
+  protected:
     std::string fFileName;
     std::ofstream fOutfile;
-    
 };
 
-
-#endif	/* BINARYOUTFILEMANAGER_H */
-
+#endif /* BINARYOUTFILEMANAGER_H */

--- a/base/MQ/policies/Storage/BoostDataSaver.h
+++ b/base/MQ/policies/Storage/BoostDataSaver.h
@@ -28,31 +28,30 @@ typedef boost::archive::binary_iarchive TBoostIn;
 typedef boost::archive::binary_oarchive TBoostOut;
 
 template <typename TPayload, typename TArchiveIn=TBoostIn, typename TArchiveOut=TBoostOut>
-class BoostDataSaver 
+class BoostDataSaver
 {
-public:
-    
+  public:
     typedef std::vector<TPayload> TObjArray;
     typedef std::vector<TObjArray> TObjArrContainer;
-    
+
     BoostDataSaver() {}
     virtual ~BoostDataSaver() {}
-    
+
     virtual void InitOutputFile(){}
-    
+
     void Write(std::ofstream& outfile, TPayload* ObjArr, long sizeArr=1)
     {
         TObjArray DataVector(ObjArr, ObjArr +sizeArr);
         TArchiveOut OutArchive(outfile);
         OutArchive << DataVector;
     }
-    
+
     void Write(std::ofstream& outfile, TObjArray DataVector)
     {
         TArchiveOut OutArchive(outfile);
         OutArchive << DataVector;
     }
-    
+
     void Write(std::ofstream& outfile, FairMQMessage* msg)
     {
         //std::string msgStr(static_cast<char*>(msg->GetData()), msg->GetSize());
@@ -73,7 +72,7 @@ public:
         TArchiveOut OutArchive(outfile);
         OutArchive << objarr;
     }
-    
+
     TObjArrContainer Read(std::ifstream& infile)
     {
         TObjArrContainer DataContainer;
@@ -86,10 +85,6 @@ public:
         }
         return DataContainer;
     }
-    
-    
 };
 
-
-#endif	/* BOOSTDATASAVER_H */
-
+#endif /* BOOSTDATASAVER_H */

--- a/base/MQ/policies/Storage/RootOutFileManager.h
+++ b/base/MQ/policies/Storage/RootOutFileManager.h
@@ -32,35 +32,38 @@
 template <typename DataType>
 class RootOutFileManager : public BaseSinkPolicy<RootOutFileManager<DataType>>
 {
-public:
+  public:
     RootOutFileManager();
     RootOutFileManager(const std::string &filename, const std::string &treename, 
                      const std::string &branchname, const std::string &Classname, const std::string &FileOption);
+
+    RootOutFileManager(const RootOutFileManager&) = delete;
+    RootOutFileManager operator=(const RootOutFileManager&) = delete;
+
     virtual ~RootOutFileManager();
-    
+
     void SetRootFileProperties(const std::string &filename, const std::string &treename, 
                            const std::string &branchname, const std::string &Classname="", 
                            const std::string &FileOption="RECREATE", bool UseClonesArray=false, bool flowmode=true);
-    
+
     void SetFileProperties(const std::string &filename, const std::string &treename, 
                            const std::string &branchname, const std::string &Classname="", 
                            const std::string &FileOption="RECREATE", bool UseClonesArray=false, bool flowmode=true);
-    
+
     void AddToFile(std::vector<DataType>& InputData);
     void AddToFile(DataType* ObjArr, long size);
     void AddToFile(TClonesArray* InputData);
     void AddToFile(FairMQMessage* msg);
     void InitOutputFile();
     void InitTCA(const std::string &classname);
-    std::vector<std::vector<DataType> > GetAllObj(const std::string &filename, 
-                                                  const std::string &treename, 
+    std::vector<std::vector<DataType> > GetAllObj(const std::string &filename,
+                                                  const std::string &treename,
                                                   const std::string &branchname
-                                                  );    
-    
-protected:
+                                                  );
 
+  protected:
     virtual void Init();
-    
+
     std::string fFileName;
     std::string fTreeName;
     std::string fBranchName;
@@ -69,7 +72,7 @@ protected:
     bool fUseClonesArray;
     bool fFlowMode;
     bool fWrite;
-    
+
     TFile* fOutFile;
     TTree* fTree;
     TClonesArray* fOutput;
@@ -77,10 +80,6 @@ protected:
     TFolder* fFolder;
 };
 
-
 #include "RootOutFileManager.tpl"
 
-
-
-#endif	/* ROOTOUTFILEMANAGER_H */
-
+#endif /* ROOTOUTFILEMANAGER_H */

--- a/base/MQ/policies/Storage/TriviallyCopyableDataSaver.h
+++ b/base/MQ/policies/Storage/TriviallyCopyableDataSaver.h
@@ -84,8 +84,7 @@ class TriviallyCopyableDataSaver
             MQLOG(ERROR) << "(de)serialization of object is not supported (Object must be a 'trivially copyable' data class).";
         }
     }
-    
-    
+
     template<typename T>
     void ReadArr(std::ifstream& infile, T* ObjArr, long posArr = 0)
     {
@@ -186,4 +185,4 @@ class TriviallyCopyableDataSaver
     }
 };
 
-#endif	/* TRIVIALLYCOPYABLEDATASAVER_H */
+#endif /* TRIVIALLYCOPYABLEDATASAVER_H */

--- a/base/MQ/tasks/FairMQProcessorTask.cxx
+++ b/base/MQ/tasks/FairMQProcessorTask.cxx
@@ -16,7 +16,7 @@
 
 
 FairMQProcessorTask::FairMQProcessorTask()
-    : fPayload(NULL)
+    : fPayload(nullptr)
     , SendPart()
     , ReceivePart()
 {
@@ -57,4 +57,9 @@ void FairMQProcessorTask::SetPayload(FairMQMessage* msg)
     {
         LOG(ERROR) << "FairMQMessage uninitialized or bad format";
     }
+}
+
+void FairMQProcessorTask::ClearPayload()
+{
+    delete fPayload;
 }

--- a/base/MQ/tasks/FairMQProcessorTask.h
+++ b/base/MQ/tasks/FairMQProcessorTask.h
@@ -29,6 +29,9 @@ class FairMQProcessorTask : public FairTask
 {
   public:
     FairMQProcessorTask();
+    FairMQProcessorTask(const FairMQProcessorTask&) = delete;
+    FairMQProcessorTask operator=(const FairMQProcessorTask&) = delete;
+
     virtual ~FairMQProcessorTask();
 
     virtual void Exec(Option_t* opt = "0");
@@ -43,11 +46,6 @@ class FairMQProcessorTask : public FairTask
     FairMQMessage* fPayload;
     boost::function<void()> SendPart; // function pointer for the Processor callback.
     boost::function<bool()> ReceivePart; // function pointer for the Processor callback.
-
-  private:
-    /// Copy Constructor
-    FairMQProcessorTask(const FairMQProcessorTask&);
-    FairMQProcessorTask operator=(const FairMQProcessorTask&);
 };
 
 #endif /* FAIRMQPROCESSORTASK_H_ */

--- a/base/MQ/tasks/FairMQProcessorTask.h
+++ b/base/MQ/tasks/FairMQProcessorTask.h
@@ -24,7 +24,6 @@
 #include "FairMQMessage.h"
 #include "FairMQTransportFactory.h"
 
-
 class FairMQProcessorTask : public FairTask
 {
   public:
@@ -39,8 +38,9 @@ class FairMQProcessorTask : public FairTask
     void SetSendPart(boost::function<void()>); // provides a callback to the Processor.
     void SetReceivePart(boost::function<bool()>); // provides a callback to the Processor.
 
-    FairMQMessage* GetPayload();
     void SetPayload(FairMQMessage* msg);
+    FairMQMessage* GetPayload();
+    void ClearPayload();
 
   protected:
     FairMQMessage* fPayload;

--- a/base/MQ/tasks/FairMQSamplerTask.cxx
+++ b/base/MQ/tasks/FairMQSamplerTask.cxx
@@ -18,38 +18,37 @@ using namespace std;
 
 FairMQSamplerTask::FairMQSamplerTask()
     : FairTask("Abstract base task used for loading a branch from a root file into memory")
-    , fInput(NULL)
     , fBranch()
-    , fOutput(NULL)
-    , fTransportFactory(NULL)
+    , fInput(nullptr)
+    , fOutput(nullptr)
+    , fTransportFactory(nullptr)
     , fEventIndex(0)
     , SendPart()
-    , fEvtHeader(NULL)
+    , fEvtHeader(nullptr)
 {
 }
 
 FairMQSamplerTask::FairMQSamplerTask(const Text_t* name, int iVerbose)
     : FairTask(name, iVerbose)
-    , fInput(NULL)
     , fBranch()
-    , fOutput(NULL)
-    , fTransportFactory(NULL)
+    , fInput(nullptr)
+    , fOutput(nullptr)
+    , fTransportFactory(nullptr)
     , fEventIndex(0)
     , SendPart()
-    , fEvtHeader(NULL)
+    , fEvtHeader(nullptr)
 {
 }
 
 FairMQSamplerTask::~FairMQSamplerTask()
 {
     delete fInput;
-    // fOutput->CloseMessage();
 }
 
 InitStatus FairMQSamplerTask::Init()
 {
     FairRootManager* ioman = FairRootManager::Instance();
-    fEvtHeader = (FairEventHeader *)ioman->GetObject("EventHeader.");
+    fEvtHeader = (FairEventHeader*)ioman->GetObject("EventHeader.");
     fInput = (TClonesArray*) ioman->GetObject(fBranch.c_str());
 
     return kSUCCESS;
@@ -78,6 +77,11 @@ void FairMQSamplerTask::SetEventIndex(Long64_t EventIndex)
 FairMQMessage* FairMQSamplerTask::GetOutput()
 {
     return fOutput;
+}
+
+void FairMQSamplerTask::ClearOutput()
+{
+    delete fOutput;
 }
 
 void FairMQSamplerTask::SetTransport(FairMQTransportFactory* factory)

--- a/base/MQ/tasks/FairMQSamplerTask.h
+++ b/base/MQ/tasks/FairMQSamplerTask.h
@@ -32,6 +32,8 @@ class FairMQSamplerTask : public FairTask
   public:
     FairMQSamplerTask();
     FairMQSamplerTask(const Text_t *name, int iVerbose = 1);
+    FairMQSamplerTask(const FairMQSamplerTask&) = delete;
+    FairMQSamplerTask operator=(const FairMQSamplerTask&) = delete;
 
     virtual ~FairMQSamplerTask();
 
@@ -51,11 +53,6 @@ class FairMQSamplerTask : public FairTask
     Long64_t fEventIndex;
     boost::function<void()> SendPart; // function pointer for the Sampler callback.
     FairEventHeader *fEvtHeader;
-
-  private:
-    /// Copy Constructor
-    FairMQSamplerTask(const FairMQSamplerTask&);
-    FairMQSamplerTask operator=(const FairMQSamplerTask&);
 };
 
 #endif /* FAIRMQSAMPLERTASK_H_ */

--- a/base/MQ/tasks/FairMQSamplerTask.h
+++ b/base/MQ/tasks/FairMQSamplerTask.h
@@ -39,20 +39,23 @@ class FairMQSamplerTask : public FairTask
 
     virtual InitStatus Init();
     virtual void Exec(Option_t *opt);
+
     void SetSendPart(boost::function<void()>); // provides a callback to the Sampler.
     void SetEventIndex(Long64_t EventIndex);
     void SetBranch(std::string branch);
-    FairMQMessage *GetOutput();
+
+    FairMQMessage* GetOutput();
+    void ClearOutput();
     void SetTransport(FairMQTransportFactory *factory);
 
   protected:
-    TClonesArray *fInput;
     std::string fBranch;
-    FairMQMessage *fOutput;
-    FairMQTransportFactory *fTransportFactory;
+    TClonesArray* fInput;
+    FairMQMessage* fOutput;
+    FairMQTransportFactory* fTransportFactory;
     Long64_t fEventIndex;
     boost::function<void()> SendPart; // function pointer for the Sampler callback.
-    FairEventHeader *fEvtHeader;
+    FairEventHeader* fEvtHeader;
 };
 
 #endif /* FAIRMQSAMPLERTASK_H_ */

--- a/examples/MQ/3-dds/CMakeLists.txt
+++ b/examples/MQ/3-dds/CMakeLists.txt
@@ -76,10 +76,10 @@ GENERATE_LIBRARY()
 
 Set(Exe_Names
   ${Exe_Names}
-  ex3-sampler-dds
-  ex3-processor-dds
-  ex3-sink-dds
-  ex3-dds-command-ui
+  ex3-sampler
+  ex3-processor
+  ex3-sink
+  ex3-command-ui
 )
 
 Set(Exe_Source

--- a/examples/MQ/3-dds/ex3-dds-topology.xml
+++ b/examples/MQ/3-dds/ex3-dds-topology.xml
@@ -1,7 +1,7 @@
 <topology id="ExampleDDS">
 
-    <property id="SamplerOutputAddress" />
-    <property id="SinkInputAddress" />
+    <property id="SamplerAddress" />
+    <property id="SinkAddress" />
 
     <declrequirement id="SamplerWorker">
         <hostPattern type="wnname" value="sampler"/>
@@ -16,27 +16,27 @@
     </declrequirement>
 
     <decltask id="Sampler">
-        <exe reachable="true">@CMAKE_BINARY_DIR@/bin/ex3-sampler-dds --id sampler0 --log-color-format false</exe>
+        <exe reachable="true">@CMAKE_BINARY_DIR@/bin/ex3-sampler --id sampler0 --log-color false</exe>
         <requirement>SamplerWorker</requirement>
         <properties>
-            <id access="write">SamplerOutputAddress</id>
+            <id access="write">SamplerAddress</id>
         </properties>
     </decltask>
 
     <decltask id="Processor">
-        <exe reachable="true">@CMAKE_BINARY_DIR@/bin/ex3-processor-dds --id processor%taskIndex% --log-color-format false</exe>
+        <exe reachable="true">@CMAKE_BINARY_DIR@/bin/ex3-processor --id processor%taskIndex% --log-color false</exe>
         <requirement>ProcessorWorker</requirement>
         <properties>
-            <id access="read">SamplerOutputAddress</id>
-            <id access="read">SinkInputAddress</id>
+            <id access="read">SamplerAddress</id>
+            <id access="read">SinkAddress</id>
         </properties>
     </decltask>
 
     <decltask id="Sink">
-        <exe reachable="true">@CMAKE_BINARY_DIR@/bin/ex3-sink-dds --id sink0 --log-color-format false</exe>
+        <exe reachable="true">@CMAKE_BINARY_DIR@/bin/ex3-sink --id sink0 --log-color false</exe>
         <requirement>SinkWorker</requirement>
         <properties>
-            <id access="write">SinkInputAddress</id>
+            <id access="write">SinkAddress</id>
         </properties>
     </decltask>
 

--- a/examples/MQ/3-dds/runExample3Processor.cxx
+++ b/examples/MQ/3-dds/runExample3Processor.cxx
@@ -84,12 +84,12 @@ int main(int argc, char** argv)
 
             LOG(INFO) << "Subscribing and waiting for sampler output address.";
             ddsKeyValue.subscribe([&keyCondition](const string& /*_key*/, const string& /*_value*/) { keyCondition.notify_all(); });
-            ddsKeyValue.getValues("SamplerOutputAddress", &samplerValues);
+            ddsKeyValue.getValues("SamplerAddress", &samplerValues);
             while (samplerValues.empty())
             {
                 unique_lock<mutex> lock(keyMutex);
                 keyCondition.wait_until(lock, chrono::system_clock::now() + chrono::milliseconds(1000));
-                ddsKeyValue.getValues("SamplerOutputAddress", &samplerValues);
+                ddsKeyValue.getValues("SamplerAddress", &samplerValues);
             }
         }
         // Sink properties
@@ -100,12 +100,12 @@ int main(int argc, char** argv)
 
             LOG(INFO) << "Subscribing and waiting for sink input address.";
             ddsKeyValue.subscribe([&keyCondition](const string& /*_key*/, const string& /*_value*/) { keyCondition.notify_all(); });
-            ddsKeyValue.getValues("SinkInputAddress", &sinkValues);
+            ddsKeyValue.getValues("SinkAddress", &sinkValues);
             while (sinkValues.empty())
             {
                 unique_lock<mutex> lock(keyMutex);
                 keyCondition.wait_until(lock, chrono::system_clock::now() + chrono::milliseconds(1000));
-                ddsKeyValue.getValues("SinkInputAddress", &sinkValues);
+                ddsKeyValue.getValues("SinkAddress", &sinkValues);
             }
         }
 
@@ -123,7 +123,7 @@ int main(int argc, char** argv)
         // Subscribe on custom commands
         ddsCustomCmd.subscribeCmd([&](const string& command, const string& condition, uint64_t senderId)
         {
-            LOG(INFO) << "Received custom command: " << command << " condition: " << condition << " senderId: " << senderId;
+            LOG(INFO) << "Received custom command: " << command;
             if (command == "check-state")
             {
                 ddsCustomCmd.sendCmd(id + ": " + processor.GetCurrentStateName(), to_string(senderId));

--- a/examples/MQ/3-dds/runExample3Sampler.cxx
+++ b/examples/MQ/3-dds/runExample3Sampler.cxx
@@ -105,7 +105,7 @@ int main(int argc, char** argv)
         // Advertise the bound addresses via DDS property
         LOG(INFO) << "Giving sampler output address to DDS.";
         dds::key_value::CKeyValue ddsKeyValue;
-        ddsKeyValue.putValue("SamplerOutputAddress", sampler.fChannels.at("data-out").at(0).GetAddress());
+        ddsKeyValue.putValue("SamplerAddress", sampler.fChannels.at("data-out").at(0).GetAddress());
 
         sampler.WaitForEndOfState("INIT_DEVICE");
 
@@ -117,7 +117,7 @@ int main(int argc, char** argv)
         // Subscribe on custom commands
         ddsCustomCmd.subscribeCmd([&](const string& command, const string& condition, uint64_t senderId)
         {
-            LOG(INFO) << "Received custom command: " << command << " condition: " << condition << " senderId: " << senderId;
+            LOG(INFO) << "Received custom command: " << command;
             if (command == "check-state")
             {
                 ddsCustomCmd.sendCmd(id + ": " + sampler.GetCurrentStateName(), to_string(senderId));

--- a/examples/MQ/3-dds/runExample3Sink.cxx
+++ b/examples/MQ/3-dds/runExample3Sink.cxx
@@ -105,7 +105,7 @@ int main(int argc, char** argv)
         // Advertise the bound address via DDS property
         LOG(INFO) << "Giving sink input address to DDS.";
         dds::key_value::CKeyValue ddsKeyValue;
-        ddsKeyValue.putValue("SinkInputAddress", sink.fChannels.at("data-in").at(0).GetAddress());
+        ddsKeyValue.putValue("SinkAddress", sink.fChannels.at("data-in").at(0).GetAddress());
 
         sink.WaitForEndOfState("INIT_DEVICE");
 
@@ -117,7 +117,7 @@ int main(int argc, char** argv)
         // Subscribe on custom commands
         ddsCustomCmd.subscribeCmd([&](const string& command, const string& condition, uint64_t senderId)
         {
-            LOG(INFO) << "Received custom command: " << command << " condition: " << condition << " senderId: " << senderId;
+            LOG(INFO) << "Received custom command: " << command;
             if (command == "check-state")
             {
                 ddsCustomCmd.sendCmd(id + ": " + sink.GetCurrentStateName(), to_string(senderId));

--- a/examples/MQ/GenericDevices/data_generator/RooDataGenerator.h
+++ b/examples/MQ/GenericDevices/data_generator/RooDataGenerator.h
@@ -23,18 +23,13 @@
 #include "RooArgSet.h"
 #include "RooRandom.h"
 
-
-
 #include "FairProgOptions.h"
 
-
-
-using namespace RooFit ;
+using namespace RooFit;
 
 class Tuto7DataGeneratorProgOptions : public FairProgOptions
 {
-
-public:
+  public:
     Tuto7DataGeneratorProgOptions(): FairProgOptions()
     {
         AddToCmdLineOptions(fGenericDesc);
@@ -42,7 +37,6 @@ public:
     virtual ~Tuto7DataGeneratorProgOptions(){}
     virtual int ParseAll(const int argc, char** argv, bool allowUnregistered = false)
     {
-
         // parse command line options
         if (ParseCmdLine(argc, argv, fCmdLineOptions, fVarMap, allowUnregistered))
         {
@@ -77,12 +71,12 @@ public:
         //SET_LOG_LEVEL(DEBUG);
         if (fSeverityMap.count(verbose))
         {
-            set_global_log_level(log_op::operation::GREATER_EQ_THAN,fSeverityMap.at(verbose));
+            set_global_log_level(log_op::operation::GREATER_EQ_THAN, fSeverityMap.at(verbose));
         }
         else
         {
             LOG(ERROR)<<" verbosity level '"<<verbose<<"' unknown, it will be set to DEBUG";
-            set_global_log_level(log_op::operation::GREATER_EQ_THAN,fSeverityMap.at("DEBUG"));
+            set_global_log_level(log_op::operation::GREATER_EQ_THAN, fSeverityMap.at("DEBUG"));
         }
 
         PrintOptions();
@@ -92,18 +86,20 @@ public:
 
 struct RdmVarParameters
 {
-    RdmVarParameters(double Min, double Max, double  Mean, double Sigma) :
+    RdmVarParameters(double Min, double Max, double Mean, double Sigma) :
         min(Min),
         max(Max),
         mean(Mean),
         sigma(Sigma)
     {}
-    RdmVarParameters(double  Mean, double Sigma) :
-        min(Mean-6*Sigma),
-        max(Mean+6*Sigma),
+
+    RdmVarParameters(double Mean, double Sigma) :
+        min(Mean - 6 * Sigma),
+        max(Mean + 6 * Sigma),
         mean(Mean),
         sigma(Sigma)
     {}
+
     double min;
     double max;
     double mean;
@@ -112,18 +108,18 @@ struct RdmVarParameters
 
 struct PDFConfig
 {
-    PDFConfig() : 
-        x(-10,3), 
-        y(10,2), 
-        z(0,0.5), 
-        tErr(0.005,0.001)
+    PDFConfig() :
+        x(-10,3),
+        y(10,2),
+        z(0,0.5),
+        tErr(0.005, 0.001)
     {}
-    void Set(const RdmVarParameters& X,const RdmVarParameters& Y,const RdmVarParameters& Z,const RdmVarParameters& Terr)
+    void Set(const RdmVarParameters& X, const RdmVarParameters& Y, const RdmVarParameters& Z, const RdmVarParameters& Terr)
     {
-        x=X;
-        y=Y;
-        z=Z;
-        tErr=Terr;
+        x = X;
+        y = Y;
+        z = Z;
+        tErr = Terr;
     }
     RdmVarParameters x;
     RdmVarParameters y;
@@ -133,129 +129,124 @@ struct PDFConfig
 
 class MultiVariatePDF
 {
-    public:
-        MultiVariatePDF(unsigned int t_start=0) :
-            fOpt(),
-            fModel(nullptr),
-            fDataSet(nullptr),
-            x(nullptr),
-            y(nullptr),
-            z(nullptr),
-            t(nullptr),
-            tErr(nullptr),
-            mean_t(nullptr),
-            sigma_t(nullptr),
-            Gauss_x(nullptr),  
-            Gauss_y(nullptr), 
-            Gauss_z(nullptr),
-            Gauss_t(nullptr),
-            Gauss_tErr(nullptr)
-        {
-                Init(t_start);
-        }
-        MultiVariatePDF(const PDFConfig & opt, unsigned int t_start=0) :
-            fOpt(opt),
-            fModel(nullptr),
-            fDataSet(nullptr),
-            x(nullptr),
-            y(nullptr),
-            z(nullptr),
-            t(nullptr),
-            tErr(nullptr),
-            mean_t(nullptr),
-            sigma_t(nullptr),
-            Gauss_x(nullptr),  
-            Gauss_y(nullptr), 
-            Gauss_z(nullptr),
-            Gauss_t(nullptr),
-            Gauss_tErr(nullptr)
-        {
-            Init(t_start);
-        }
-        
-        ~MultiVariatePDF()
-        {
-            delete x;
-            delete y;
-            delete z;
-            delete t;
-            delete tErr;
-            delete mean_t;
-            delete sigma_t;
-            
-            delete Gauss_x;
-            delete Gauss_y;
-            delete Gauss_z;
-            delete Gauss_t;
-            delete Gauss_tErr;
-            delete fModel;
-        }
-        
-        RooDataSet* GetGeneratedData(unsigned int N, unsigned int t_i)
-        {
-            
-            t->setRange((double)t_i,(double)(t_i+1));
-            mean_t->setVal((double)t_i+0.5);
-            fDataSet = fModel->generate(RooArgSet(*x,*y,*z,*t,*tErr),N);
-            return fDataSet;
-            
-        }
-    private:
-        
-        PDFConfig fOpt;
-        RooProdPdf* fModel;
-        RooDataSet* fDataSet;
-        
-        RooRealVar *x;
-        RooRealVar *y;
-        RooRealVar *z;
-        RooRealVar *t;
-        RooRealVar *tErr;
+  public:
+    MultiVariatePDF(unsigned int t_start = 0) :
+        fOpt(),
+        fModel(nullptr),
+        fDataSet(nullptr),
+        x(nullptr),
+        y(nullptr),
+        z(nullptr),
+        t(nullptr),
+        tErr(nullptr),
+        mean_t(nullptr),
+        sigma_t(nullptr),
+        Gauss_x(nullptr),
+        Gauss_y(nullptr),
+        Gauss_z(nullptr),
+        Gauss_t(nullptr),
+        Gauss_tErr(nullptr)
+    {
+        Init(t_start);
+    }
 
-        RooRealVar *mean_t;
-        RooRealVar *sigma_t;
+    MultiVariatePDF(const PDFConfig & opt, unsigned int t_start = 0) :
+        fOpt(opt),
+        fModel(nullptr),
+        fDataSet(nullptr),
+        x(nullptr),
+        y(nullptr),
+        z(nullptr),
+        t(nullptr),
+        tErr(nullptr),
+        mean_t(nullptr),
+        sigma_t(nullptr),
+        Gauss_x(nullptr),
+        Gauss_y(nullptr),
+        Gauss_z(nullptr),
+        Gauss_t(nullptr),
+        Gauss_tErr(nullptr)
+    {
+        Init(t_start);
+    }
 
-        RooGaussian *Gauss_x;  
-        RooGaussian *Gauss_y; 
-        RooGaussian *Gauss_z;
-        RooGaussian *Gauss_t;
-        RooGaussian *Gauss_tErr;
-        
-        
-        void Init(double t_start)
-        {
-            RooMsgService::instance().setGlobalKillBelow(ERROR);
-            TDatime* time = new TDatime();
-            int seed=time->GetTime();
-            delete time;
-            RooRandom::randomGenerator()->SetSeed(seed);
-            
-            double tmin=(double)t_start;
-            double tmax=(double)(t_start+1);
-            
-            x = new RooRealVar("x","x",fOpt.x.min,fOpt.x.max);
-            y = new RooRealVar("y","y",fOpt.y.min,fOpt.y.max) ;
-            z = new RooRealVar("z","z",fOpt.z.min,fOpt.z.max) ;
-            t = new RooRealVar("t","t",tmin,tmax);
-            tErr = new RooRealVar("tErr","tErr",fOpt.tErr.min,fOpt.tErr.max);
-            
-            mean_t = new RooRealVar("mu_t","mean of t-distribution",(tmin+tmax)/2) ;
-            sigma_t = new RooRealVar("sigma_t","width of t-distribution",0.1) ;
-            
-            Gauss_x = new RooGaussian(   "Gauss_x"   , "gaussian PDF", *x   , RooConst(fOpt.x.mean),   RooConst(fOpt.x.sigma));  
-            Gauss_y = new RooGaussian(   "Gauss_y"   , "gaussian PDF", *y   , RooConst(fOpt.y.mean) ,  RooConst(fOpt.y.sigma)); 
-            Gauss_z = new RooGaussian(   "Gauss_z"   , "gaussian PDF", *z   , RooConst(fOpt.z.mean)  , RooConst(fOpt.z.sigma));
-            Gauss_t = new RooGaussian(   "Gauss_t"   , "gaussian PDF", *t   , *mean_t       , *sigma_t) ;
-            Gauss_tErr=new RooGaussian("Gauss_tErr", "gaussian PDF", *tErr, RooConst((tErr->getMin()+tErr->getMax())/2), RooConst(fOpt.tErr.sigma)) ;            
+    MultiVariatePDF(const MultiVariatePDF&) = delete;
+    MultiVariatePDF operator=(const MultiVariatePDF&) = delete;
 
-            fModel = new RooProdPdf("Gauss_xyzt_ter","Gauss_x*Gauss_y*Gauss_z*Gauss_t*Gauss_tErr",RooArgList(*Gauss_x,*Gauss_y,*Gauss_z,*Gauss_t,*Gauss_tErr));
-            
-        }
-        
+    ~MultiVariatePDF()
+    {
+        delete x;
+        delete y;
+        delete z;
+        delete t;
+        delete tErr;
+        delete mean_t;
+        delete sigma_t;
+
+        delete Gauss_x;
+        delete Gauss_y;
+        delete Gauss_z;
+        delete Gauss_t;
+        delete Gauss_tErr;
+        delete fModel;
+    }
+
+    RooDataSet* GetGeneratedData(unsigned int N, unsigned int t_i)
+    {
+        t->setRange((double)t_i, (double)(t_i + 1));
+        mean_t->setVal((double)t_i + 0.5);
+        fDataSet = fModel->generate(RooArgSet(*x, *y, *z, *t, *tErr), N);
+        return fDataSet;
+    }
+
+  private:
+    PDFConfig fOpt;
+    RooProdPdf* fModel;
+    RooDataSet* fDataSet;
+
+    RooRealVar *x;
+    RooRealVar *y;
+    RooRealVar *z;
+    RooRealVar *t;
+    RooRealVar *tErr;
+
+    RooRealVar *mean_t;
+    RooRealVar *sigma_t;
+
+    RooGaussian *Gauss_x;
+    RooGaussian *Gauss_y;
+    RooGaussian *Gauss_z;
+    RooGaussian *Gauss_t;
+    RooGaussian *Gauss_tErr;
+
+    void Init(double t_start)
+    {
+        RooMsgService::instance().setGlobalKillBelow(ERROR);
+        TDatime* time = new TDatime();
+        int seed = time->GetTime();
+        delete time;
+        RooRandom::randomGenerator()->SetSeed(seed);
+
+        double tmin = (double)t_start;
+        double tmax = (double)(t_start + 1);
+
+        x = new RooRealVar("x", "x", fOpt.x.min, fOpt.x.max);
+        y = new RooRealVar("y", "y", fOpt.y.min, fOpt.y.max) ;
+        z = new RooRealVar("z", "z", fOpt.z.min, fOpt.z.max) ;
+        t = new RooRealVar("t", "t", tmin, tmax);
+        tErr = new RooRealVar("tErr", "tErr", fOpt.tErr.min, fOpt.tErr.max);
+
+        mean_t = new RooRealVar("mu_t", "mean of t-distribution", (tmin + tmax) / 2) ;
+        sigma_t = new RooRealVar("sigma_t", "width of t-distribution", 0.1) ;
+
+        Gauss_x = new RooGaussian("Gauss_x", "gaussian PDF", *x, RooConst(fOpt.x.mean), RooConst(fOpt.x.sigma));
+        Gauss_y = new RooGaussian("Gauss_y", "gaussian PDF", *y, RooConst(fOpt.y.mean), RooConst(fOpt.y.sigma));
+        Gauss_z = new RooGaussian("Gauss_z", "gaussian PDF", *z, RooConst(fOpt.z.mean), RooConst(fOpt.z.sigma));
+        Gauss_t = new RooGaussian("Gauss_t", "gaussian PDF", *t, *mean_t, *sigma_t);
+        Gauss_tErr = new RooGaussian("Gauss_tErr", "gaussian PDF", *tErr, RooConst((tErr->getMin() + tErr->getMax()) / 2), RooConst(fOpt.tErr.sigma));
+
+        fModel = new RooProdPdf("Gauss_xyzt_ter", "Gauss_x*Gauss_y*Gauss_z*Gauss_t*Gauss_tErr", RooArgList(*Gauss_x, *Gauss_y, *Gauss_z, *Gauss_t, *Gauss_tErr));
+    }
 };
 
-
-
-
-#endif	/* ROODATAGENERATOR_H */
-
+#endif /* ROODATAGENERATOR_H */

--- a/examples/MQ/GenericDevices/data_generator/RooDataGenerator.h
+++ b/examples/MQ/GenericDevices/data_generator/RooDataGenerator.h
@@ -68,10 +68,12 @@ public:
         }
 
         // set log level before printing (default is 0 = DEBUG level)
-        std::string verbose=GetValue<std::string>("verbose");
-        bool color_format=GetValue<bool>("log-color-format");
-        if(!color_format)
+        std::string verbose = GetValue<std::string>("verbose");
+        bool color = GetValue<bool>("log-color");
+        if (!color)
+        {
             reinit_logger(false);
+        }
         //SET_LOG_LEVEL(DEBUG);
         if (fSeverityMap.count(verbose))
         {

--- a/examples/MQ/GenericDevices/devices/policy/serialization/MyDigiSerializer.h
+++ b/examples/MQ/GenericDevices/devices/policy/serialization/MyDigiSerializer.h
@@ -23,7 +23,6 @@
 #include "MyDigi.h"
 #include "MyPodData.h"
 
-
 // FairRoot - Tutorial3
 #include "FairTestDetectorDigi.h"
 #include "FairTestDetectorPayload.h"
@@ -31,19 +30,18 @@
 template <typename PodType,typename DigiType>
 class MyDigiSerializer : public BaseSerializationPolicy < MyDigiSerializer<PodType,DigiType> >
 {
-public: 
-    
-    
-    MyDigiSerializer() :  
+  public:
+    MyDigiSerializer() :
           fPayload(nullptr)
         , fMessage(nullptr)
         , fNumInput(0)
-
     {}
+
+    MyDigiSerializer(const MyDigiSerializer&) = delete;
+    MyDigiSerializer operator=(const MyDigiSerializer&) = delete;
 
     virtual ~MyDigiSerializer()
     {}
-    
 
     void SetMessage(FairMQMessage* msg)
     {
@@ -54,7 +52,7 @@ public:
     {
         return fMessage;
     }
-    
+
     FairMQMessage* SerializeMsg(TClonesArray* array)
     {
         int nDigis = array->GetEntriesFast();
@@ -82,9 +80,8 @@ public:
 
         return fMessage;
     }
-    
-protected:
 
+  protected:
     PodType* fPayload;
     FairMQMessage* fMessage;
     int fNumInput;
@@ -95,22 +92,24 @@ protected:
 template <typename PodType,typename DigiType>
 class MyDigiDeserializer : public BaseDeserializationPolicy < MyDigiDeserializer<PodType,DigiType> >
 {
-public: 
-    
-    MyDigiDeserializer() : 
-          fContainer(nullptr) 
+  public:
+    MyDigiDeserializer()
+        : fContainer(nullptr)
         , fPayload(nullptr)
         , fMessage(nullptr)
         , fNumInput(0)
     {}
 
+    MyDigiDeserializer(const MyDigiDeserializer&) = delete;
+    MyDigiDeserializer operator=(const MyDigiDeserializer&) = delete;
+
     virtual ~MyDigiDeserializer()
-    { 
-        if(fContainer) 
-            delete fContainer; 
+    {
+        if(fContainer)
+            delete fContainer;
         fContainer=nullptr;
     }
-    
+
     TClonesArray* DeserializeMsg(FairMQMessage* msg)
     {
         int inputSize = msg->GetSize();
@@ -135,28 +134,23 @@ public:
         }
         return fContainer;
     }
-    
-    
+
     void InitContainer(const std::string &ClassName)
     {
         fContainer = new TClonesArray(ClassName.c_str());
     }
-    
+
     void InitContainer(TClonesArray* array)
     {
         fContainer = array;
     }
-    
-    protected:
-    
+
+  protected:
     TClonesArray* fContainer;
     PodType* fPayload;
     FairMQMessage* fMessage;
     int fNumInput;
-    
 };
-
-
 
 // for tuto 7 data
 typedef MyDigiSerializer<MyPodData::Digi,MyDigi>        MyDigiSerializer_t;
@@ -166,4 +160,4 @@ typedef MyDigiSerializer<TestDetectorPayload::Digi,FairTestDetectorDigi>    Tuto
 typedef MyDigiDeserializer<TestDetectorPayload::Digi,FairTestDetectorDigi>  Tuto3DigiDeSerializer_t;
 
 
-#endif  /* MYDIGISERIALIZERCRTP_H */
+#endif /* MYDIGISERIALIZERCRTP_H */

--- a/examples/MQ/GenericDevices/devices/policy/serialization/MyHitSerializer.h
+++ b/examples/MQ/GenericDevices/devices/policy/serialization/MyHitSerializer.h
@@ -39,13 +39,16 @@
 template <typename PodType, typename HitType>
 class MyHitSerializer : public BaseSerializationPolicy<MyHitSerializer<PodType,HitType> >
 {
-public:
-    
+  public:
     MyHitSerializer() : BaseSerializationPolicy<MyHitSerializer<PodType,HitType> >(),
         fPayload(nullptr),
         fMessage(nullptr),
         fNumInput(0)
     {}
+
+    MyHitSerializer(const MyHitSerializer&) = delete;
+    MyHitSerializer operator=(const MyHitSerializer&) = delete;
+
     virtual ~MyHitSerializer(){}
 
     void SetMessage(FairMQMessage* msg)
@@ -57,7 +60,7 @@ public:
     {
         return fMessage;
     }
-   
+
     FairMQMessage* SerializeMsg(TClonesArray* array)
     {
         int numOutput = array->GetEntriesFast();
@@ -82,9 +85,8 @@ public:
         }
         return fMessage;
     }
-    
-protected:
 
+  protected:
     PodType* fPayload;
     FairMQMessage* fMessage;
     int fNumInput;
@@ -96,27 +98,28 @@ protected:
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // deserialize
-    
 
 template <typename PodType, typename HitType>
 class MyHitDeserializer : public BaseDeserializationPolicy<MyHitDeserializer<PodType,HitType> >
 {
-public:
-    
-    MyHitDeserializer() : BaseDeserializationPolicy<MyHitDeserializer<PodType,HitType> >(), 
+  public:
+    MyHitDeserializer() : BaseDeserializationPolicy<MyHitDeserializer<PodType,HitType>>(),
         fContainer(nullptr),
         fPayload(nullptr),
         fMessage(nullptr),
         fNumInput(0)
     {}
 
-    virtual ~MyHitDeserializer() 
-    { 
-        if(fContainer) 
-            delete fContainer; 
+    MyHitDeserializer(const MyHitDeserializer&) = delete;
+    MyHitDeserializer operator=(const MyHitDeserializer&) = delete;
+
+    virtual ~MyHitDeserializer()
+    {
+        if(fContainer)
+            delete fContainer;
         fContainer=nullptr;
     }
-    
+
     TClonesArray* DeserializeMsg(FairMQMessage* msg)
     {
         int inputSize = msg->GetSize();
@@ -142,19 +145,18 @@ public:
         }
         return fContainer;
     }
-    
+
     void InitContainer(const std::string &ClassName)
     {
         fContainer = new TClonesArray(ClassName.c_str());
     }
-    
+
     void InitContainer(TClonesArray* array)
     {
         fContainer = array;
     }
-    
-protected:
-    
+
+  protected:
     TClonesArray* fContainer;
     PodType* fPayload;
     FairMQMessage* fMessage;
@@ -170,5 +172,5 @@ typedef MyHitSerializer<TestDetectorPayload::Hit,FairTestDetectorHit>   Tuto3Hit
 typedef MyHitDeserializer<TestDetectorPayload::Hit,FairTestDetectorHit> Tuto3HitDeserializer_t;
 
 
-#endif	/* MYHITSERIALIZERCRTP_H */
+#endif /* MYHITSERIALIZERCRTP_H */
 

--- a/examples/MQ/GenericDevices/devices/policy/task/DigiToHitTask.h
+++ b/examples/MQ/GenericDevices/devices/policy/task/DigiToHitTask.h
@@ -35,13 +35,17 @@ class DigiToHitTask_base : public BaseProcessorTaskPolicy< DigiToHitTask_base<T,
 {
     typedef T Digi_type;
     typedef U Hit_type;
+
   public:
     DigiToHitTask_base() : BaseProcessorTaskPolicy< DigiToHitTask_base<T,U> >(),
-        fOutputContainer(nullptr), 
-        fTaskName(), 
-        fDetID(-1), 
+        fOutputContainer(nullptr),
+        fTaskName(),
+        fDetID(-1),
         fMCIndex(-1)
     {}
+
+    DigiToHitTask_base(const DigiToHitTask_base&) = delete;
+    DigiToHitTask_base operator=(const DigiToHitTask_base&) = delete;
 
     virtual ~DigiToHitTask_base()
     {}

--- a/examples/MQ/GenericDevices/test/startGenericMQTutoTestBin.sh.in
+++ b/examples/MQ/GenericDevices/test/startGenericMQTutoTestBin.sh.in
@@ -13,7 +13,7 @@ VERBOSITY="INFO"
 ########################## start dummy data generator
 GENERATE="genericMQTutoGenerateData"
 GENERATE+=" --output-file $INPUTFILE"
-GENERATE+=" --tree cbmsim --log-color-format false"
+GENERATE+=" --tree cbmsim --log-color false"
 @CMAKE_BINARY_DIR@/bin/$GENERATE &
 GENERATE_PID=$!
 wait $GENERATE_PID
@@ -21,19 +21,19 @@ wait $GENERATE_PID
 ########################## start SAMPLER
 SAMPLER="genericMQTutoSamplerTest"
 SAMPLER+=" --id sampler1  -c $CONFIGFILE --config-json-file $JSONFILE --verbose $VERBOSITY --data-format $dataFormat"
-SAMPLER+=" --input.file.name $INPUTFILE --log-color-format false"
+SAMPLER+=" --input.file.name $INPUTFILE --log-color false"
 @CMAKE_BINARY_DIR@/bin/$SAMPLER &
 SAMPLER_PID=$!
 
 ########################## start PROCESSOR
 PROCESSOR1="genericMQTutoProcessorTest"
-PROCESSOR1+=" --id processor1 --config $CONFIGFILE --config-json-file $JSONFILE --verbose $VERBOSITY --data-format $dataFormat --log-color-format false"
+PROCESSOR1+=" --id processor1 --config $CONFIGFILE --config-json-file $JSONFILE --verbose $VERBOSITY --data-format $dataFormat --log-color false"
 @CMAKE_BINARY_DIR@/bin/$PROCESSOR1 &
 PROCESSOR1_PID=$!
 
 ########################## start FILESINK
 FILESINK="genericMQTutoSinkTest"
-FILESINK+=" --id sink1 --config $CONFIGFILE --config-json-file $JSONFILE --verbose $VERBOSITY --data-format $dataFormat --log-color-format false"
+FILESINK+=" --id sink1 --config $CONFIGFILE --config-json-file $JSONFILE --verbose $VERBOSITY --data-format $dataFormat --log-color false"
 FILESINK+=" --output.file.name @CMAKE_BINARY_DIR@/examples/MQ/GenericDevices/data_io/GenericMQTutoOutputFile$dataFormat.root"
 @CMAKE_BINARY_DIR@/bin/$FILESINK &
 FILESINK_PID=$!

--- a/examples/MQ/GenericDevices/test/startGenericMQTutoTestBoost.sh.in
+++ b/examples/MQ/GenericDevices/test/startGenericMQTutoTestBoost.sh.in
@@ -12,7 +12,7 @@ VERBOSITY="INFO"
 ########################## start dummy data generator
 GENERATE="genericMQTutoGenerateData"
 GENERATE+=" --output-file $INPUTFILE"
-GENERATE+=" --tree cbmsim --log-color-format false"
+GENERATE+=" --tree cbmsim --log-color false"
 @CMAKE_BINARY_DIR@/bin/$GENERATE &
 GENERATE_PID=$!
 wait $GENERATE_PID
@@ -20,19 +20,19 @@ wait $GENERATE_PID
 ########################## start SAMPLER
 SAMPLER="genericMQTutoSamplerTest"
 SAMPLER+=" --id sampler1  -c $CONFIGFILE --config-json-file $JSONFILE --verbose $VERBOSITY --data-format $dataFormat"
-SAMPLER+=" --input.file.name $INPUTFILE --log-color-format false"
+SAMPLER+=" --input.file.name $INPUTFILE --log-color false"
 @CMAKE_BINARY_DIR@/bin/$SAMPLER &
 SAMPLER_PID=$!
 
 ########################## start PROCESSOR
 PROCESSOR1="genericMQTutoProcessorTest"
-PROCESSOR1+=" --id processor1 --config $CONFIGFILE --config-json-file $JSONFILE --verbose $VERBOSITY --data-format $dataFormat --log-color-format false"
+PROCESSOR1+=" --id processor1 --config $CONFIGFILE --config-json-file $JSONFILE --verbose $VERBOSITY --data-format $dataFormat --log-color false"
 @CMAKE_BINARY_DIR@/bin/$PROCESSOR1 &
 PROCESSOR1_PID=$!
 
 ########################## start FILESINK
 FILESINK="genericMQTutoSinkTest"
-FILESINK+=" --id sink1 --config $CONFIGFILE --config-json-file $JSONFILE --verbose $VERBOSITY --data-format $dataFormat --log-color-format false"
+FILESINK+=" --id sink1 --config $CONFIGFILE --config-json-file $JSONFILE --verbose $VERBOSITY --data-format $dataFormat --log-color false"
 FILESINK+=" --output.file.name @CMAKE_BINARY_DIR@/examples/MQ/GenericDevices/data_io/GenericMQTutoOutputFile$dataFormat.root"
 @CMAKE_BINARY_DIR@/bin/$FILESINK &
 FILESINK_PID=$!

--- a/examples/MQ/GenericDevices/test/startGenericMQTutoTestRoot.sh.in
+++ b/examples/MQ/GenericDevices/test/startGenericMQTutoTestRoot.sh.in
@@ -12,7 +12,7 @@ VERBOSITY="INFO"
 ########################## start dummy data generator
 GENERATE="genericMQTutoGenerateData"
 GENERATE+=" --output-file $INPUTFILE"
-GENERATE+=" --tree cbmsim --log-color-format false"
+GENERATE+=" --tree cbmsim --log-color false"
 @CMAKE_BINARY_DIR@/bin/$GENERATE &
 GENERATE_PID=$!
 wait $GENERATE_PID
@@ -20,19 +20,19 @@ wait $GENERATE_PID
 ########################## start SAMPLER
 SAMPLER="genericMQTutoSamplerTest"
 SAMPLER+=" --id sampler1  -c $CONFIGFILE --config-json-file $JSONFILE --verbose $VERBOSITY --data-format $dataFormat"
-SAMPLER+=" --input.file.name $INPUTFILE --log-color-format false"
+SAMPLER+=" --input.file.name $INPUTFILE --log-color false"
 @CMAKE_BINARY_DIR@/bin/$SAMPLER &
 SAMPLER_PID=$!
 
 ########################## start PROCESSOR
 PROCESSOR1="genericMQTutoProcessorTest"
-PROCESSOR1+=" --id processor1 --config $CONFIGFILE --config-json-file $JSONFILE --verbose $VERBOSITY --data-format $dataFormat --log-color-format false"
+PROCESSOR1+=" --id processor1 --config $CONFIGFILE --config-json-file $JSONFILE --verbose $VERBOSITY --data-format $dataFormat --log-color false"
 @CMAKE_BINARY_DIR@/bin/$PROCESSOR1 &
 PROCESSOR1_PID=$!
 
 ########################## start FILESINK
 FILESINK="genericMQTutoSinkTest"
-FILESINK+=" --id sink1 --config $CONFIGFILE --config-json-file $JSONFILE --verbose $VERBOSITY --data-format $dataFormat --log-color-format false"
+FILESINK+=" --id sink1 --config $CONFIGFILE --config-json-file $JSONFILE --verbose $VERBOSITY --data-format $dataFormat --log-color false"
 FILESINK+=" --output.file.name @CMAKE_BINARY_DIR@/examples/MQ/GenericDevices/data_io/GenericMQTutoOutputFile$dataFormat.root"
 @CMAKE_BINARY_DIR@/bin/$FILESINK &
 FILESINK_PID=$!

--- a/examples/MQ/LmdSampler/unpacker/FairTut8Unpacker.h
+++ b/examples/MQ/LmdSampler/unpacker/FairTut8Unpacker.h
@@ -31,10 +31,10 @@ class FairTut8Unpacker : public FairUnpack
 
     /** Initialization. Called once, before the event loop. */
     virtual Bool_t Init();
-    
+
     /** Process an MBS sub-event. */
     virtual Bool_t DoUnpack(Int_t* data, Int_t size);
-    
+
     /** Clear the output structures. */
     virtual void Reset();
 
@@ -57,6 +57,10 @@ class FairTut8Unpacker : public FairUnpack
     TClonesArray* fRawData; /**< Array of output raw items. */
     Int_t fNHits;           /**< Number of raw items in current event. */
     Int_t fNHitsTotal;      /**< Total number of raw items. */
+
+    /// Copy Constructor
+    FairTut8Unpacker(const FairTut8Unpacker&);
+    FairTut8Unpacker operator=(const FairTut8Unpacker&);
 
   public:
     // Class definition

--- a/examples/advanced/Tutorial3/MQ/fileSink/FairTestDetectorFileSink.h
+++ b/examples/advanced/Tutorial3/MQ/fileSink/FairTestDetectorFileSink.h
@@ -56,9 +56,9 @@ class FairTestDetectorFileSink : public FairMQDevice
 {
   public:
     FairTestDetectorFileSink()
-        : fOutFile(NULL)
-        , fTree(NULL)
-        , fOutput(NULL)
+        : fOutput(nullptr)
+        , fOutFile(nullptr)
+        , fTree(nullptr)
         , fHitVector()
         , fHasBoostSerialization(false)
     {
@@ -76,6 +76,8 @@ class FairTestDetectorFileSink : public FairMQDevice
             }
         }
     }
+    FairTestDetectorFileSink(const FairTestDetectorFileSink&) = delete;
+    FairTestDetectorFileSink operator=(const FairTestDetectorFileSink&) = delete;
 
     virtual ~FairTestDetectorFileSink()
     {
@@ -85,6 +87,11 @@ class FairTestDetectorFileSink : public FairMQDevice
         {
             fHitVector.clear();
         }
+        if (fOutput)
+        {
+            delete fOutput;
+        }
+        delete fOutFile;
     }
 
     virtual void InitOutputFile(TString defaultId = "100")
@@ -108,19 +115,15 @@ class FairTestDetectorFileSink : public FairMQDevice
     virtual void Run();
 
   private:
+    TClonesArray* fOutput;
     TFile* fOutFile;
     TTree* fTree;
-    TClonesArray* fOutput;
 
 #ifndef __CINT__ // for BOOST serialization
     friend class boost::serialization::access;
     vector<TIn> fHitVector;
     bool fHasBoostSerialization;
 #endif // for BOOST serialization
-
-    /// Copy Constructor
-    FairTestDetectorFileSink(const FairTestDetectorFileSink&);
-    FairTestDetectorFileSink operator=(const FairTestDetectorFileSink&);
 };
 
 // Template implementation of Run() in FairTestDetectorFileSink.tpl :

--- a/examples/advanced/Tutorial3/MQ/fileSink/FairTestDetectorFileSinkBin.tpl
+++ b/examples/advanced/Tutorial3/MQ/fileSink/FairTestDetectorFileSinkBin.tpl
@@ -40,6 +40,9 @@ void FairTestDetectorFileSink<FairTestDetectorHit, TestDetectorPayload::Hit>::Ru
                 LOG(ERROR) << "FairTestDetectorFileSink::Run(): No Output array!";
             }
 
+            std::unique_ptr<FairMQMessage> ack(fTransportFactory->CreateMessage());
+            fChannels.at("ack-out").at(0).Send(ack);
+
             fTree->Fill();
         }
 

--- a/examples/advanced/Tutorial3/MQ/fileSink/FairTestDetectorFileSinkBoost.tpl
+++ b/examples/advanced/Tutorial3/MQ/fileSink/FairTestDetectorFileSinkBoost.tpl
@@ -50,6 +50,9 @@ void FairTestDetectorFileSink<TIn, TPayloadIn>::Run()
                     LOG(ERROR) << "FairTestDetectorFileSink::Run(): No Output array!";
                 }
 
+                std::unique_ptr<FairMQMessage> ack(fTransportFactory->CreateMessage());
+                fChannels.at("ack-out").at(0).Send(ack);
+
                 fTree->Fill();
             }
 

--- a/examples/advanced/Tutorial3/MQ/fileSink/FairTestDetectorFileSinkProtobuf.tpl
+++ b/examples/advanced/Tutorial3/MQ/fileSink/FairTestDetectorFileSinkProtobuf.tpl
@@ -45,6 +45,9 @@ void FairTestDetectorFileSink<FairTestDetectorHit, TestDetectorProto::HitPayload
                 LOG(ERROR) << "FairTestDetectorFileSink::Run(): No Output array!";
             }
 
+            std::unique_ptr<FairMQMessage> ack(fTransportFactory->CreateMessage());
+            fChannels.at("ack-out").at(0).Send(ack);
+
             fTree->Fill();
         }
 

--- a/examples/advanced/Tutorial3/MQ/fileSink/FairTestDetectorFileSinkTMessage.tpl
+++ b/examples/advanced/Tutorial3/MQ/fileSink/FairTestDetectorFileSinkTMessage.tpl
@@ -42,6 +42,9 @@ void FairTestDetectorFileSink<FairTestDetectorHit, TMessage>::Run()
                 LOG(ERROR) << "FairTestDetectorFileSink::Run(): No Output array!";
             }
 
+            std::unique_ptr<FairMQMessage> ack(fTransportFactory->CreateMessage());
+            fChannels.at("ack-out").at(0).Send(ack);
+
             fTree->Fill();
 
             delete fOutput;

--- a/examples/advanced/Tutorial3/MQ/processorTask/FairTestDetectorMQRecoTask.h
+++ b/examples/advanced/Tutorial3/MQ/processorTask/FairTestDetectorMQRecoTask.h
@@ -47,7 +47,7 @@ class FairTestDetectorMQRecoTask : public FairMQProcessorTask
   public:
     /** Default constructor **/
     FairTestDetectorMQRecoTask()
-        : fRecoTask(NULL)
+        : fRecoTask(nullptr)
         , fDigiVector()
         , fHitVector()
         , fHasBoostSerialization(false)
@@ -79,7 +79,7 @@ class FairTestDetectorMQRecoTask : public FairMQProcessorTask
     }
 
     FairTestDetectorMQRecoTask(Int_t verbose)
-        : fRecoTask(NULL)
+        : fRecoTask(nullptr)
         , fDigiVector()
         , fHitVector()
         , fHasBoostSerialization(false)
@@ -129,12 +129,22 @@ class FairTestDetectorMQRecoTask : public FairMQProcessorTask
             fHasBoostSerialization = true;
         }
     }
+    FairTestDetectorMQRecoTask(const FairTestDetectorMQRecoTask&) = delete;
+    FairTestDetectorMQRecoTask operator=(const FairTestDetectorMQRecoTask&) = delete;
 
     /** Destructor **/
     virtual ~FairTestDetectorMQRecoTask()
     {
-        fRecoTask->fDigiArray->Delete();
-        fRecoTask->fHitArray->Delete();
+        if (fRecoTask->fDigiArray)
+        {
+            fRecoTask->fDigiArray->Delete();
+            delete fRecoTask->fDigiArray;
+        }
+        if (fRecoTask->fHitArray)
+        {
+            fRecoTask->fHitArray->Delete();
+            delete fRecoTask->fHitArray;
+        }
         delete fRecoTask;
         if (fDigiVector.size() > 0)
         {
@@ -175,10 +185,6 @@ class FairTestDetectorMQRecoTask : public FairMQProcessorTask
     vector<TIn> fDigiVector;
     vector<TOut> fHitVector;
 #endif // for BOOST serialization
-
-    /// Copy Constructor
-    FairTestDetectorMQRecoTask(const FairTestDetectorMQRecoTask&);
-    FairTestDetectorMQRecoTask operator=(const FairTestDetectorMQRecoTask&);
 };
 
 // Template implementation of exec in FairTestDetectorMQRecoTask.tpl :

--- a/examples/advanced/Tutorial3/MQ/run/runTestDetectorFileSink.cxx
+++ b/examples/advanced/Tutorial3/MQ/run/runTestDetectorFileSink.cxx
@@ -143,7 +143,7 @@ void runFileSink(const DeviceOptions_t& options)
     filesink.ChangeState("INIT_TASK");
     filesink.WaitForEndOfState("INIT_TASK");
 
-    filesink.InitOutputFile(options.id);
+    filesink.InitOutputFile(options.id + options.dataFormat);
 
     filesink.ChangeState("RUN");
     filesink.InteractiveStateLoop();

--- a/examples/advanced/Tutorial3/MQ/run/runTestDetectorSampler.cxx
+++ b/examples/advanced/Tutorial3/MQ/run/runTestDetectorSampler.cxx
@@ -43,7 +43,7 @@ using TSamplerTMessage = FairMQSampler<FairTestDetectorDigiLoader<FairTestDetect
 typedef struct DeviceOptions
 {
     DeviceOptions() :
-        id(), ioThreads(0), dataFormat(), inputFile(), parameterFile(), branch(), eventRate(0),
+        id(), ioThreads(0), dataFormat(), inputFile(), parameterFile(), branch(), eventRate(0), chainInput(0),
         outputSocketType(), outputBufSize(0), outputMethod(), outputAddress(),
         ackSocketType(), ackBufSize(0), ackMethod(), ackAddress() {}
 

--- a/examples/advanced/Tutorial3/MQ/run/runTestDetectorSampler.cxx
+++ b/examples/advanced/Tutorial3/MQ/run/runTestDetectorSampler.cxx
@@ -17,7 +17,6 @@
 #include "boost/program_options.hpp"
 
 #include "FairMQLogger.h"
-#include "FairMQSampler.h"
 
 #ifdef NANOMSG
 #include "nanomsg/FairMQTransportFactoryNN.h"
@@ -25,23 +24,8 @@
 #include "zeromq/FairMQTransportFactoryZMQ.h"
 #endif
 
+#include "FairMQSampler.h"
 #include "FairTestDetectorDigiLoader.h"
-
-// data format for the task
-#include "FairTestDetectorDigi.h"
-
-// binary data format
-#include "FairTestDetectorPayload.h"
-
-// boost data format
-#include <boost/archive/text_oarchive.hpp>
-#include <boost/archive/binary_oarchive.hpp>
-
-// Google Protocol Buffers data format
-#include "FairTestDetectorPayload.pb.h"
-
-// TMessage data format
-#include "TMessage.h"
 
 using namespace std;
 
@@ -51,7 +35,8 @@ using TBoostTextPayloadOut = boost::archive::text_oarchive;  // boost text forma
 using TProtoDigiPayload = TestDetectorProto::DigiPayload; // protobuf payload
 
 using TSamplerBin = FairMQSampler<FairTestDetectorDigiLoader<FairTestDetectorDigi, TPayloadOut>>;
-using TSamplerBoost = FairMQSampler<FairTestDetectorDigiLoader<FairTestDetectorDigi, TBoostBinPayloadOut>>;
+using TSamplerBoostBin = FairMQSampler<FairTestDetectorDigiLoader<FairTestDetectorDigi, TBoostBinPayloadOut>>;
+using TSamplerBoostText = FairMQSampler<FairTestDetectorDigiLoader<FairTestDetectorDigi, TBoostTextPayloadOut>>;
 using TSamplerProtobuf = FairMQSampler<FairTestDetectorDigiLoader<FairTestDetectorDigi, TProtoDigiPayload>>;
 using TSamplerTMessage = FairMQSampler<FairTestDetectorDigiLoader<FairTestDetectorDigi, TMessage>>;
 
@@ -59,7 +44,8 @@ typedef struct DeviceOptions
 {
     DeviceOptions() :
         id(), ioThreads(0), dataFormat(), inputFile(), parameterFile(), branch(), eventRate(0),
-        outputSocketType(), outputBufSize(0), outputMethod(), outputAddress() {}
+        outputSocketType(), outputBufSize(0), outputMethod(), outputAddress(),
+        ackSocketType(), ackBufSize(0), ackMethod(), ackAddress() {}
 
     string id;
     int ioThreads;
@@ -68,31 +54,41 @@ typedef struct DeviceOptions
     string parameterFile;
     string branch;
     int eventRate;
+    int chainInput;
     string outputSocketType;
     int outputBufSize;
     string outputMethod;
     string outputAddress;
+    string ackSocketType;
+    int ackBufSize;
+    string ackMethod;
+    string ackAddress;
 } DeviceOptions_t;
 
 inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
 {
     if (_options == NULL)
-        throw std::runtime_error("Internal error: options' container is empty.");
+        throw runtime_error("Internal error: options' container is empty.");
 
     namespace bpo = boost::program_options;
     bpo::options_description desc("Options");
     desc.add_options()
         ("id", bpo::value<string>()->required(), "Device ID")
         ("io-threads", bpo::value<int>()->default_value(1), "Number of I/O threads")
-        ("data-format", bpo::value<string>()->default_value("binary"), "Data format (binary/boost/protobuf/tmessage)")
+        ("data-format", bpo::value<string>()->default_value("binary"), "Data format (binary/boost/boost-text/protobuf/tmessage)")
         ("input-file", bpo::value<string>()->required(), "Path to the input file")
         ("parameter-file", bpo::value<string>()->required(), "path to the parameter file")
         ("branch", bpo::value<string>()->default_value("FairTestDetectorDigi"), "Name of the Branch")
         ("event-rate", bpo::value<int>()->default_value(0), "Event rate limit in maximum number of events per second")
+        ("chain-input", bpo::value<int>()->default_value(0), "Chain input file more than once (default)")
         ("output-socket-type", bpo::value<string>()->required(), "Output socket type: pub/push")
         ("output-buff-size", bpo::value<int>()->required(), "Output buffer size in number of messages (ZeroMQ)/bytes(nanomsg)")
         ("output-method", bpo::value<string>()->required(), "Output method: bind/connect")
         ("output-address", bpo::value<string>()->required(), "Output address, e.g.: \"tcp://*:5555\"")
+        ("ack-socket-type", bpo::value<string>()->default_value("pull"), "ack socket type: pub/push")
+        ("ack-buff-size", bpo::value<int>()->default_value(1000), "ack buffer size in number of messages (ZeroMQ)/bytes(nanomsg)")
+        ("ack-method", bpo::value<string>()->default_value("bind"), "ack method: bind/connect")
+        ("ack-address", bpo::value<string>()->required(), "ack address, e.g.: \"tcp://*:5555\"")
         ("help", "Print help messages");
 
     bpo::variables_map vm;
@@ -113,10 +109,15 @@ inline bool parse_cmd_line(int _argc, char* _argv[], DeviceOptions* _options)
     if (vm.count("parameter-file"))     { _options->parameterFile    = vm["parameter-file"].as<string>(); }
     if (vm.count("branch"))             { _options->branch           = vm["branch"].as<string>(); }
     if (vm.count("event-rate"))         { _options->eventRate        = vm["event-rate"].as<int>(); }
+    if (vm.count("chain-input"))        { _options->chainInput       = vm["chain-input"].as<int>(); }
     if (vm.count("output-socket-type")) { _options->outputSocketType = vm["output-socket-type"].as<string>(); }
     if (vm.count("output-buff-size"))   { _options->outputBufSize    = vm["output-buff-size"].as<int>(); }
     if (vm.count("output-method"))      { _options->outputMethod     = vm["output-method"].as<string>(); }
     if (vm.count("output-address"))     { _options->outputAddress    = vm["output-address"].as<string>(); }
+    if (vm.count("ack-socket-type"))    { _options->ackSocketType    = vm["ack-socket-type"].as<string>(); }
+    if (vm.count("ack-buff-size"))      { _options->ackBufSize       = vm["ack-buff-size"].as<int>(); }
+    if (vm.count("ack-method"))         { _options->ackMethod        = vm["ack-method"].as<string>(); }
+    if (vm.count("ack-address"))        { _options->ackAddress       = vm["ack-address"].as<string>(); }
 
     return true;
 }
@@ -135,18 +136,26 @@ void runSampler(const DeviceOptions_t& options)
 
     sampler.SetTransport(transportFactory);
 
-    FairMQChannel channel(options.outputSocketType, options.outputMethod, options.outputAddress);
-    channel.UpdateSndBufSize(options.outputBufSize);
-    channel.UpdateRcvBufSize(options.outputBufSize);
-    channel.UpdateRateLogging(1);
+    FairMQChannel outputChannel(options.outputSocketType, options.outputMethod, options.outputAddress);
+    outputChannel.UpdateSndBufSize(options.outputBufSize);
+    outputChannel.UpdateRcvBufSize(options.outputBufSize);
+    outputChannel.UpdateRateLogging(1);
 
-    sampler.fChannels["data-out"].push_back(channel);
+    sampler.fChannels["data-out"].push_back(outputChannel);
+
+    FairMQChannel ackChannel(options.ackSocketType, options.ackMethod, options.ackAddress);
+    ackChannel.UpdateSndBufSize(options.ackBufSize);
+    ackChannel.UpdateRcvBufSize(options.ackBufSize);
+    ackChannel.UpdateRateLogging(0);
+
+    sampler.fChannels["ack-in"].push_back(ackChannel);
 
     sampler.SetProperty(T::Id, options.id);
     sampler.SetProperty(T::InputFile, options.inputFile);
     sampler.SetProperty(T::ParFile, options.parameterFile);
     sampler.SetProperty(T::Branch, options.branch);
     sampler.SetProperty(T::EventRate, options.eventRate);
+    sampler.SetProperty(T::ChainInput, options.chainInput);
     sampler.SetProperty(T::NumIoThreads, options.ioThreads);
 
     sampler.ChangeState("INIT_DEVICE");
@@ -176,12 +185,13 @@ int main(int argc, char** argv)
     LOG(INFO) << "PID: " << getpid();
 
     if (options.dataFormat == "binary") { runSampler<TSamplerBin>(options); }
-    else if (options.dataFormat == "boost") { runSampler<TSamplerBoost>(options); }
+    else if (options.dataFormat == "boost") { runSampler<TSamplerBoostBin>(options); }
+    else if (options.dataFormat == "boost-text") { runSampler<TSamplerBoostText>(options); }
     else if (options.dataFormat == "protobuf") { runSampler<TSamplerProtobuf>(options); }
     else if (options.dataFormat == "tmessage") { runSampler<TSamplerTMessage>(options); }
     else
     {
-        LOG(ERROR) << "No valid data format provided. (--data-format binary|boost|protobuf|tmessage). ";
+        LOG(ERROR) << "No valid data format provided. (--data-format binary|boost|boost-text|protobuf|tmessage). ";
         return 1;
     }
 

--- a/examples/advanced/Tutorial3/MQ/run/startAll.sh.in
+++ b/examples/advanced/Tutorial3/MQ/run/startAll.sh.in
@@ -14,6 +14,9 @@ if [ "$1" = "binary" ]; then
 elif [ "$1" = "boost" ]; then
     dataFormat="boost"
     echo "attempting to use Boost serialized data format"
+elif [ "$1" = "boost-text" ]; then
+    dataFormat="boost-text"
+    echo "attempting to use Boost serialized data format"
 elif [ "$1" = "protobuf" ]; then
     dataFormat="protobuf"
     echo "attempting to use Google Protocol Buffers data format"
@@ -22,16 +25,18 @@ elif [ "$1" = "tmessage" ]; then
     echo "attempting to use Root TMessage data format"
 else
     echo "none or incorrect data formats provided."
-    echo "(available data format options are: binary, boost, protobuf, tmessage)"
+    echo "(available data format options are: binary, boost, boost-text, protobuf, tmessage)"
     echo "binary data format will be used."
 fi
 
 SAMPLER="testDetectorSampler"
 SAMPLER+=" --id 101"
 SAMPLER+=" --data-format $dataFormat"
+SAMPLER+=" --chain-input 99"
 SAMPLER+=" --input-file @CMAKE_SOURCE_DIR@/examples/advanced/Tutorial3/macro/data/testdigi_$mcEngine.root"
 SAMPLER+=" --parameter-file @CMAKE_SOURCE_DIR@/examples/advanced/Tutorial3/macro/data/testparams_$mcEngine.root"
 SAMPLER+=" --output-socket-type push --output-buff-size $buffSize --output-method connect --output-address tcp://localhost:5565"
+SAMPLER+=" --ack-address tcp://*:5999"
 xterm -geometry 80x23+0+0 -hold -e @CMAKE_BINARY_DIR@/bin/$SAMPLER &
 
 SPLITTER="splitter"
@@ -77,4 +82,5 @@ FILESINK="testDetectorFileSink"
 FILESINK+=" --id 701"
 FILESINK+=" --data-format $dataFormat"
 FILESINK+=" --input-socket-type pull --input-buff-size $buffSize --input-method connect --input-address tcp://localhost:5572"
+FILESINK+=" --ack-address tcp://localhost:5999"
 xterm -geometry 80x23+1000+350 -hold -e @CMAKE_BINARY_DIR@/bin/$FILESINK &

--- a/examples/advanced/Tutorial3/MQ/run/startAllProxy.sh.in
+++ b/examples/advanced/Tutorial3/MQ/run/startAllProxy.sh.in
@@ -14,6 +14,9 @@ if [ "$1" = "binary" ]; then
 elif [ "$1" = "boost" ]; then
     dataFormat="boost"
     echo "attempting to use Boost serialized data format"
+elif [ "$1" = "boost-text" ]; then
+    dataFormat="boost-text"
+    echo "attempting to use Boost serialized data format"
 elif [ "$1" = "protobuf" ]; then
     dataFormat="protobuf"
     echo "attempting to use Google Protocol Buffers data format"
@@ -22,16 +25,18 @@ elif [ "$1" = "tmessage" ]; then
     echo "attempting to use Root TMessage data format"
 else
     echo "none or incorrect data formats provided."
-    echo "(available data format options are: binary, boost, protobuf, tmessage)"
+    echo "(available data format options are: binary, boost, boost-text, protobuf, tmessage)"
     echo "binary data format will be used."
 fi
 
 SAMPLER="testDetectorSampler"
 SAMPLER+=" --id SAMPLER1"
 SAMPLER+=" --data-format $dataFormat"
+SAMPLER+=" --chain-input 99"
 SAMPLER+=" --input-file @CMAKE_SOURCE_DIR@/examples/advanced/Tutorial3/macro/data/testdigi_$mcEngine.root"
 SAMPLER+=" --parameter-file @CMAKE_SOURCE_DIR@/examples/advanced/Tutorial3/macro/data/testparams_$mcEngine.root"
 SAMPLER+=" --output-socket-type push --output-buff-size $buffSize --output-method connect --output-address tcp://localhost:5565"
+SAMPLER+=" --ack-address tcp://*:5999"
 xterm -geometry 80x23+0+0 -hold -e @CMAKE_BINARY_DIR@/bin/$SAMPLER &
 
 PROXY1="proxy"
@@ -71,4 +76,5 @@ FILESINK="testDetectorFileSink"
 FILESINK+=" --id FILESINK1"
 FILESINK+=" --data-format $dataFormat"
 FILESINK+=" --input-socket-type pull --input-buff-size $buffSize --input-method connect --input-address tcp://localhost:5570"
+FILESINK+=" --ack-address tcp://localhost:5999"
 xterm -geometry 80x23+1000+350 -hold -e @CMAKE_BINARY_DIR@/bin/$FILESINK &

--- a/examples/advanced/Tutorial3/MQ/run/startExtraProcessor.sh.in
+++ b/examples/advanced/Tutorial3/MQ/run/startExtraProcessor.sh.in
@@ -12,6 +12,9 @@ if [ "$1" = "binary" ]; then
 elif [ "$1" = "boost" ]; then
     dataFormat="boost"
     echo "attempting to use Boost serialized data format"
+elif [ "$1" = "boost-text" ]; then
+    dataFormat="boost-text"
+    echo "attempting to use Boost serialized data format"
 elif [ "$1" = "protobuf" ]; then
     dataFormat="protobuf"
     echo "attempting to use Google Protocol Buffers data format"
@@ -20,7 +23,7 @@ elif [ "$1" = "tmessage" ]; then
     echo "attempting to use Root TMessage data format"
 else
     echo "none or incorrect data formats provided."
-    echo "(available data format options are: binary, boost, protobuf, tmessage)"
+    echo "(available data format options are: binary, boost, boost-text, protobuf, tmessage)"
     echo "binary data format will be used."
 fi
 

--- a/examples/advanced/Tutorial3/MQ/run/startPushPull.sh.in
+++ b/examples/advanced/Tutorial3/MQ/run/startPushPull.sh.in
@@ -14,6 +14,9 @@ if [ "$1" = "binary" ]; then
 elif [ "$1" = "boost" ]; then
     dataFormat="boost"
     echo "attempting to use Boost serialized data format"
+elif [ "$1" = "boost-text" ]; then
+    dataFormat="boost-text"
+    echo "attempting to use Boost serialized data format"
 elif [ "$1" = "protobuf" ]; then
     dataFormat="protobuf"
     echo "attempting to use Google Protocol Buffers data format"
@@ -22,16 +25,18 @@ elif [ "$1" = "tmessage" ]; then
     echo "attempting to use Root TMessage data format"
 else
     echo "none or incorrect data formats provided."
-    echo "(available data format options are: binary, boost, protobuf, tmessage)"
+    echo "(available data format options are: binary, boost, boost-text, protobuf, tmessage)"
     echo "binary data format will be used."
 fi
 
 SAMPLER="testDetectorSampler"
 SAMPLER+=" --id 101"
 SAMPLER+=" --data-format $dataFormat"
+SAMPLER+=" --chain-input 99"
 SAMPLER+=" --input-file @CMAKE_SOURCE_DIR@/examples/advanced/Tutorial3/macro/data/testdigi_$mcEngine.root"
 SAMPLER+=" --parameter-file @CMAKE_SOURCE_DIR@/examples/advanced/Tutorial3/macro/data/testparams_$mcEngine.root"
 SAMPLER+=" --output-socket-type push --output-buff-size $buffSize --output-method bind --output-address tcp://*:5566"
+SAMPLER+=" --ack-address tcp://*:5999"
 xterm -geometry 80x23+0+0 -hold -e @CMAKE_BINARY_DIR@/bin/$SAMPLER &
 
 PROCESSOR1="testDetectorProcessor"
@@ -52,4 +57,5 @@ FILESINK="testDetectorFileSink"
 FILESINK+=" --id 401"
 FILESINK+=" --data-format $dataFormat"
 FILESINK+=" --input-socket-type pull --input-buff-size $buffSize --input-method bind --input-address tcp://*:5567"
+FILESINK+=" --ack-address tcp://localhost:5999"
 xterm -geometry 80x23+1000+0 -hold -e @CMAKE_BINARY_DIR@/bin/$FILESINK &

--- a/examples/advanced/Tutorial3/MQ/run/startThree.sh.in
+++ b/examples/advanced/Tutorial3/MQ/run/startThree.sh.in
@@ -14,6 +14,9 @@ if [ "$1" = "binary" ]; then
 elif [ "$1" = "boost" ]; then
     dataFormat="boost"
     echo "attempting to use Boost serialized data format"
+elif [ "$1" = "boost-text" ]; then
+    dataFormat="boost-text"
+    echo "attempting to use Boost serialized data format"
 elif [ "$1" = "protobuf" ]; then
     dataFormat="protobuf"
     echo "attempting to use Google Protocol Buffers data format"
@@ -22,16 +25,18 @@ elif [ "$1" = "tmessage" ]; then
     echo "attempting to use Root TMessage data format"
 else
     echo "none or incorrect data formats provided."
-    echo "(available data format options are: binary, boost, protobuf, tmessage)"
+    echo "(available data format options are: binary, boost, boost-text, protobuf, tmessage)"
     echo "binary data format will be used."
 fi
 
 SAMPLER="testDetectorSampler"
 SAMPLER+=" --id 101"
 SAMPLER+=" --data-format $dataFormat"
+SAMPLER+=" --chain-input 99"
 SAMPLER+=" --input-file @CMAKE_SOURCE_DIR@/examples/advanced/Tutorial3/macro/data/testdigi_$mcEngine.root"
 SAMPLER+=" --parameter-file @CMAKE_SOURCE_DIR@/examples/advanced/Tutorial3/macro/data/testparams_$mcEngine.root"
 SAMPLER+=" --output-socket-type push --output-buff-size $buffSize --output-method bind --output-address tcp://*:5565"
+SAMPLER+=" --ack-address tcp://*:5999"
 xterm -geometry 80x23+0+0 -hold -e @CMAKE_BINARY_DIR@/bin/$SAMPLER &
 
 PROCESSOR="testDetectorProcessor"
@@ -45,4 +50,5 @@ FILESINK="testDetectorFileSink"
 FILESINK+=" --id 301"
 FILESINK+=" --data-format $dataFormat"
 FILESINK+=" --input-socket-type pull --input-buff-size $buffSize --input-method bind --input-address tcp://*:5570"
+FILESINK+=" --ack-address tcp://localhost:5999"
 xterm -geometry 80x23+1000+0 -hold -e @CMAKE_BINARY_DIR@/bin/$FILESINK &

--- a/fairmq/FairMQChannel.cxx
+++ b/fairmq/FairMQChannel.cxx
@@ -63,6 +63,47 @@ FairMQChannel::FairMQChannel(const string& type, const string& method, const str
 {
 }
 
+FairMQChannel::FairMQChannel(const FairMQChannel& chan)
+    : fType(chan.fType)
+    , fMethod(chan.fMethod)
+    , fAddress(chan.fAddress)
+    , fSndBufSize(chan.fSndBufSize)
+    , fRcvBufSize(chan.fRcvBufSize)
+    , fRateLogging(chan.fRateLogging)
+    , fSocket(nullptr)
+    , fChannelName(chan.fChannelName)
+    , fIsValid(false)
+    , fPoller(nullptr)
+    , fCmdSocket(nullptr)
+    , fTransportFactory(nullptr)
+    , fNoBlockFlag(chan.fNoBlockFlag)
+    , fSndMoreFlag(chan.fSndMoreFlag)
+    , fSndTimeoutInMs(chan.fSndTimeoutInMs)
+    , fRcvTimeoutInMs(chan.fRcvTimeoutInMs)
+{}
+
+FairMQChannel& FairMQChannel::operator=(const FairMQChannel& chan)
+{
+    fType = chan.fType;
+    fMethod = chan.fMethod;
+    fAddress = chan.fAddress;
+    fSndBufSize = chan.fSndBufSize;
+    fRcvBufSize = chan.fRcvBufSize;
+    fRateLogging = chan.fRateLogging;
+    fSocket = nullptr;
+    fChannelName = chan.fChannelName;
+    fIsValid = false;
+    fPoller = nullptr;
+    fCmdSocket = nullptr;
+    fTransportFactory = nullptr;
+    fNoBlockFlag = chan.fNoBlockFlag;
+    fSndMoreFlag = chan.fSndMoreFlag;
+    fSndTimeoutInMs = chan.fSndTimeoutInMs;
+    fRcvTimeoutInMs = chan.fRcvTimeoutInMs;
+
+    return *this;
+}
+
 string FairMQChannel::GetType() const
 {
     try

--- a/fairmq/FairMQChannel.h
+++ b/fairmq/FairMQChannel.h
@@ -41,6 +41,12 @@ class FairMQChannel
     /// @param address Network address to bind/connect to (e.g. "tcp://127.0.0.1:5555" or "ipc://abc")
     FairMQChannel(const std::string& type, const std::string& method, const std::string& address);
 
+    /// Copy Constructor
+    FairMQChannel(const FairMQChannel&);
+
+    /// Assignment operator
+    FairMQChannel& operator=(const FairMQChannel&);
+
     /// Default destructor
     virtual ~FairMQChannel();
 

--- a/fairmq/FairMQDevice.h
+++ b/fairmq/FairMQDevice.h
@@ -45,6 +45,10 @@ class FairMQDevice : public FairMQStateMachine, public FairMQConfigurable
 
     /// Default constructor
     FairMQDevice();
+    /// Copy constructor (disabled)
+    FairMQDevice(const FairMQDevice&) = delete;
+    /// Assignment operator (disabled)
+    FairMQDevice operator=(const FairMQDevice&) = delete;
     /// Default destructor
     virtual ~FairMQDevice();
 
@@ -173,10 +177,6 @@ class FairMQDevice : public FairMQStateMachine, public FairMQConfigurable
     /// Signal handler
     void SignalHandler(int signal);
     bool fCatchingSignals;
-
-    /// Copy Constructor
-    FairMQDevice(const FairMQDevice&);
-    FairMQDevice operator=(const FairMQDevice&);
 };
 
 #endif /* FAIRMQDEVICE_H_ */

--- a/fairmq/FairMQStateMachine.h
+++ b/fairmq/FairMQStateMachine.h
@@ -57,6 +57,15 @@ struct internal_IDLE         { std::string name() const { return "internal_IDLE"
 struct END                   { std::string name() const { return "END"; } };
 struct ERROR_FOUND           { std::string name() const { return "ERROR_FOUND"; } };
 
+// deactivate the warning for non-virtual destructor thrown in the boost library
+#if defined(__clang__)
+_Pragma("clang diagnostic push")
+_Pragma("clang diagnostic ignored \"-Wnon-virtual-dtor\"")
+#elif defined(__GNUC__) || defined(__GNUG__)
+_Pragma("GCC diagnostic push")
+_Pragma("GCC diagnostic ignored \"-Wnon-virtual-dtor\"")
+#endif
+
 // defining the boost MSM state machine
 struct FairMQFSM_ : public msm::front::state_machine_def<FairMQFSM_>
 {
@@ -458,6 +467,13 @@ struct FairMQFSM_ : public msm::front::state_machine_def<FairMQFSM_>
   protected:
     std::atomic<State> fState;
 };
+
+// reactivate the warning for non-virtual destructor
+#if defined(__clang__)
+_Pragma("clang diagnostic pop")
+#elif defined(__GNUC__) || defined(__GNUG__)
+_Pragma("GCC diagnostic pop")
+#endif
 
 typedef msm::back::state_machine<FairMQFSM_> FairMQFSM;
 } // namespace FairMQFSM

--- a/fairmq/devices/BaseDeserializationPolicy.h
+++ b/fairmq/devices/BaseDeserializationPolicy.h
@@ -6,34 +6,28 @@
  */
 
 #ifndef BASEDESERIALIZATIONPOLICY_H
-#define	BASEDESERIALIZATIONPOLICY_H
-
+#define BASEDESERIALIZATIONPOLICY_H
 
 #include "FairMQMessage.h"
 
 // c++11 code
 #include <type_traits>
 
-
-
 //  CRTP base class
 template <typename TDerived >
 class BaseDeserializationPolicy
 {
-public:
-    BaseDeserializationPolicy() 
-    {}
+  public:
+    BaseDeserializationPolicy() {}
 
-    virtual ~BaseDeserializationPolicy()
-    {}
+    virtual ~BaseDeserializationPolicy() {}
 
     template<typename C = TDerived>
-    auto DeserializeMsg(FairMQMessage* msg)-> decltype(static_cast<C*>(this)->DeserializeMsg(msg) )
+    auto DeserializeMsg(FairMQMessage* msg)-> decltype(static_cast<C*>(this)->DeserializeMsg(msg))
     {
-    	static_assert(std::is_same<C, TDerived>{}, "BaseDeserializationPolicy::DeserializeMsg hack broken");
-    	return static_cast<TDerived*>(this)->DeserializeMsg(msg);
+        static_assert(std::is_same<C, TDerived>{}, "BaseDeserializationPolicy::DeserializeMsg hack broken");
+        return static_cast<TDerived*>(this)->DeserializeMsg(msg);
     }
-
 };
 
 
@@ -57,5 +51,4 @@ public:
 
 };*/
 
-#endif	/* BASEDESERIALIZATIONPOLICY_H */
-
+#endif /* BASEDESERIALIZATIONPOLICY_H */

--- a/fairmq/devices/BaseProcessorTaskPolicy.h
+++ b/fairmq/devices/BaseProcessorTaskPolicy.h
@@ -6,7 +6,7 @@
  */
 
 #ifndef BASEPROCESSORTASKPOLICY_H
-#define	BASEPROCESSORTASKPOLICY_H
+#define BASEPROCESSORTASKPOLICY_H
 
 
 #include <type_traits>
@@ -14,31 +14,27 @@
 template <typename TDerived >
 class BaseProcessorTaskPolicy
 {
-public:
-    BaseProcessorTaskPolicy() 
-    {}
+  public:
+    BaseProcessorTaskPolicy() {}
 
-    virtual ~BaseProcessorTaskPolicy()
-    {}
+    virtual ~BaseProcessorTaskPolicy() {}
 
     template<typename C = TDerived>
-    auto GetOutputData() -> decltype(static_cast<C*>(this)->GetOutputData() )
+    auto GetOutputData() -> decltype(static_cast<C*>(this)->GetOutputData())
     {
-    	static_assert(std::is_same<C, TDerived>{}, "BaseProcessorTaskPolicy::GetOutputData hack broken");
-    	return static_cast<TDerived*>(this)->GetOutputData();
+        static_assert(std::is_same<C, TDerived>{}, "BaseProcessorTaskPolicy::GetOutputData hack broken");
+        return static_cast<TDerived*>(this)->GetOutputData();
     }
 
     template<typename CONTAINER_TYPE, typename C = TDerived>
-    auto ExecuteTask(CONTAINER_TYPE container) -> decltype( static_cast<C*>(this)->ExecuteTask(container) )
+    auto ExecuteTask(CONTAINER_TYPE container) -> decltype( static_cast<C*>(this)->ExecuteTask(container))
     {
-    	static_assert(std::is_same<C, TDerived>{}, "BaseProcessorTaskPolicy::ExecuteTask hack broken");
-    	return static_cast<TDerived*>(this)->ExecuteTask(container);
+        static_assert(std::is_same<C, TDerived>{}, "BaseProcessorTaskPolicy::ExecuteTask hack broken");
+        return static_cast<TDerived*>(this)->ExecuteTask(container);
     }
-
-
 };
 
- /*
+/*
   
 // c++14 code only
 //  CRTP base class
@@ -65,5 +61,5 @@ public:
 
 };
 */
-#endif	/* BASEPROCESSORTASKPOLICY_H */
 
+#endif /* BASEPROCESSORTASKPOLICY_H */

--- a/fairmq/devices/BaseSerializationPolicy.h
+++ b/fairmq/devices/BaseSerializationPolicy.h
@@ -6,7 +6,7 @@
  */
 
 #ifndef BASESERIALIZATIONPOLICY_H
-#define	BASESERIALIZATIONPOLICY_H
+#define BASESERIALIZATIONPOLICY_H
 
 #include "FairMQMessage.h"
 
@@ -15,12 +15,10 @@
 template <typename TDerived >
 class BaseSerializationPolicy
 {
-public:
-    BaseSerializationPolicy() 
-    {}
+  public:
+    BaseSerializationPolicy() {}
 
-    virtual ~BaseSerializationPolicy()
-    {}
+    virtual ~BaseSerializationPolicy() {}
 
     template<typename CONTAINER_TYPE, typename C = TDerived>
     auto SerializeMsg(CONTAINER_TYPE container) -> decltype(static_cast<C*>(this)->SerializeMsg(container) )
@@ -35,10 +33,9 @@ public:
         static_assert(std::is_same<C, TDerived>{}, "BaseSerializationPolicy::SetMessage hack broken");
         return static_cast<TDerived*>(this)->SetMessage(msg);
     }
-
 };
 
- /*
+/*
 //  CRTP base class
 // c++14 code
 template <typename TDerived >
@@ -64,5 +61,5 @@ public:
 
 };
 */
-#endif	/* BASESERIALIZATIONPOLICY_H */
 
+#endif /* BASESERIALIZATIONPOLICY_H */

--- a/fairmq/devices/BaseSinkPolicy.h
+++ b/fairmq/devices/BaseSinkPolicy.h
@@ -6,20 +6,18 @@
  */
 
 #ifndef BASESINKPOLICY_H
-#define	BASESINKPOLICY_H
-
+#define BASESINKPOLICY_H
 
 #include <type_traits>
+
 //  CRTP base class
 template <typename TDerived >
 class BaseSinkPolicy
 {
-public:
-    BaseSinkPolicy() 
-    {}
+  public:
+    BaseSinkPolicy() {}
 
-    virtual ~BaseSinkPolicy()
-    {}
+    virtual ~BaseSinkPolicy() {}
 
     template<typename CONTAINER_TYPE, typename C = TDerived>
     auto AddToFile(CONTAINER_TYPE container) -> decltype(static_cast<C*>(this)->AddToFile(container) )
@@ -34,8 +32,6 @@ public:
         static_assert(std::is_same<C, TDerived>{}, "BaseSinkPolicy::InitOutputFile hack broken");
         return static_cast<TDerived*>(this)->InitOutputFile();
     }
-
 };
 
-#endif	/* BASESINKPOLICY_H */
-
+#endif /* BASESINKPOLICY_H */

--- a/fairmq/devices/BaseSourcePolicy.h
+++ b/fairmq/devices/BaseSourcePolicy.h
@@ -6,20 +6,19 @@
  */
 
 #ifndef BASESOURCEPOLICY_H
-#define	BASESOURCEPOLICY_H
+#define BASESOURCEPOLICY_H
 
 #include <type_traits>
+
 // c++11 code
 //  CRTP base class
 template <typename TDerived >
 class BaseSourcePolicy
 {
-public:
-    BaseSourcePolicy() 
-    {}
+  public:
+    BaseSourcePolicy() {}
 
-    virtual ~BaseSourcePolicy()
-    {}
+    virtual ~BaseSourcePolicy() {}
 
     template<typename C = TDerived>
     auto InitSource()-> decltype(static_cast<C*>(this)->InitSource() )
@@ -49,7 +48,6 @@ public:
         static_assert(std::is_same<C, TDerived>{}, "BaseSourcePolicy::GetOutData hack broken");
         return static_cast<TDerived*>(this)->GetOutData();
     }
-
 };
 
 /*
@@ -87,5 +85,5 @@ public:
 
 };
 */
-#endif	/* BASESOURCEPOLICY_H */
 
+#endif /* BASESOURCEPOLICY_H */

--- a/fairmq/devices/GenericMerger.h
+++ b/fairmq/devices/GenericMerger.h
@@ -6,7 +6,7 @@
  */
 
 #ifndef GENERICMERGER_H
-#define	GENERICMERGER_H
+#define GENERICMERGER_H
 
 
 #include <boost/thread.hpp>
@@ -72,4 +72,3 @@ class GenericMerger : public FairMQDevice, public MergerPolicy, public InputPoli
 };
 
 #endif /* GENERICMERGER_H */
-

--- a/fairmq/devices/GenericSampler.tpl
+++ b/fairmq/devices/GenericSampler.tpl
@@ -13,6 +13,7 @@ base_GenericSampler<T,U,K,L>::base_GenericSampler()
   , fEventRate(1)
   , fEventCounter(0)
   , fContinuous(false)
+  , fTaskList()
 {
 }
 

--- a/fairmq/nanomsg/FairMQMessageNN.h
+++ b/fairmq/nanomsg/FairMQMessageNN.h
@@ -25,6 +25,8 @@ class FairMQMessageNN : public FairMQMessage
     FairMQMessageNN();
     FairMQMessageNN(size_t size);
     FairMQMessageNN(void* data, size_t size, fairmq_free_fn *ffn = NULL, void* hint = NULL);
+    FairMQMessageNN(const FairMQMessageNN&) = delete;
+    FairMQMessageNN operator=(const FairMQMessageNN&) = delete;
 
     virtual void Rebuild();
     virtual void Rebuild(size_t size);
@@ -50,10 +52,6 @@ class FairMQMessageNN : public FairMQMessage
     bool fReceiving;
 
     void Clear();
-
-    /// Copy Constructor
-    FairMQMessageNN(const FairMQMessageNN&);
-    FairMQMessageNN operator=(const FairMQMessageNN&);
 };
 
 #endif /* FAIRMQMESSAGENN_H_ */

--- a/fairmq/nanomsg/FairMQPollerNN.h
+++ b/fairmq/nanomsg/FairMQPollerNN.h
@@ -33,6 +33,8 @@ class FairMQPollerNN : public FairMQPoller
   public:
     FairMQPollerNN(const std::vector<FairMQChannel>& channels);
     FairMQPollerNN(std::unordered_map<std::string, std::vector<FairMQChannel>>& channelsMap, std::initializer_list<std::string> channelList);
+    FairMQPollerNN(const FairMQPollerNN&) = delete;
+    FairMQPollerNN operator=(const FairMQPollerNN&) = delete;
 
     virtual void Poll(const int timeout);
     virtual bool CheckInput(const int index);
@@ -49,10 +51,6 @@ class FairMQPollerNN : public FairMQPoller
     int fNumItems;
 
     std::unordered_map<std::string, int> fOffsetMap;
-
-    /// Copy Constructor
-    FairMQPollerNN(const FairMQPollerNN&);
-    FairMQPollerNN operator=(const FairMQPollerNN&);
 };
 
 #endif /* FAIRMQPOLLERNN_H_ */

--- a/fairmq/nanomsg/FairMQSocketNN.h
+++ b/fairmq/nanomsg/FairMQSocketNN.h
@@ -27,6 +27,8 @@ class FairMQSocketNN : public FairMQSocket
 {
   public:
     FairMQSocketNN(const std::string& type, const std::string& name, int numIoThreads); // numIoThreads is not used in nanomsg.
+    FairMQSocketNN(const FairMQSocketNN&) = delete;
+    FairMQSocketNN operator=(const FairMQSocketNN&) = delete;
 
     virtual std::string GetId();
 
@@ -67,10 +69,6 @@ class FairMQSocketNN : public FairMQSocket
     unsigned long fBytesRx;
     unsigned long fMessagesTx;
     unsigned long fMessagesRx;
-
-    /// Copy Constructor
-    FairMQSocketNN(const FairMQSocketNN&);
-    FairMQSocketNN operator=(const FairMQSocketNN&);
 };
 
 #endif /* FAIRMQSOCKETNN_H_ */

--- a/fairmq/options/FairMQParser.cxx
+++ b/fairmq/options/FairMQParser.cxx
@@ -15,24 +15,7 @@
 #include "FairMQParser.h"
 #include "FairMQLogger.h"
 #include <boost/property_tree/xml_parser.hpp>
-
-// WARNING : pragma commands to hide boost (1.54.0) warning
-// TODO : remove these pragma commands when boost will fix this issue in future release
-#if defined(__clang__)
-    _Pragma("clang diagnostic push") 
-    _Pragma("clang diagnostic ignored \"-Wshadow\"") 
-    #include <boost/property_tree/json_parser.hpp> 
-    _Pragma("clang diagnostic pop")
-#elif defined(__GNUC__) || defined(__GNUG__)
-    _Pragma("GCC diagnostic push")
-    _Pragma("GCC diagnostic ignored \"-Wshadow\"")
-    #include <boost/property_tree/json_parser.hpp> 
-    _Pragma("GCC diagnostic pop")
-#endif
-
-
-
-
+#include <boost/property_tree/json_parser.hpp>
 
 using namespace std;
 

--- a/fairmq/options/FairMQProgOptions.cxx
+++ b/fairmq/options/FairMQProgOptions.cxx
@@ -60,19 +60,21 @@ int FairMQProgOptions::ParseAll(const int argc, char** argv, bool allowUnregiste
     }
 
     // set log level before printing (default is 0 = DEBUG level)
-    std::string verbose=GetValue<std::string>("verbose");
-    bool color_format=GetValue<bool>("log-color-format");
-    if(!color_format)
+    std::string verbose = GetValue<std::string>("verbose");
+    bool color = GetValue<bool>("log-color");
+    if (!color)
+    {
         reinit_logger(false);
+    }
     //SET_LOG_LEVEL(DEBUG);
     if (fSeverityMap.count(verbose))
     {
-        set_global_log_level(log_op::operation::GREATER_EQ_THAN,fSeverityMap.at(verbose));
+        set_global_log_level(log_op::operation::GREATER_EQ_THAN, fSeverityMap.at(verbose));
     }
     else
     {
-        LOG(ERROR)<<" verbosity level '"<<verbose<<"' unknown, it will be set to DEBUG";
-        set_global_log_level(log_op::operation::GREATER_EQ_THAN,fSeverityMap.at("DEBUG"));
+        LOG(ERROR) << " verbosity level '" << verbose << "' unknown, it will be set to DEBUG";
+        set_global_log_level(log_op::operation::GREATER_EQ_THAN, fSeverityMap.at("DEBUG"));
     }
 
     PrintOptions();

--- a/fairmq/options/FairProgOptions.cxx
+++ b/fairmq/options/FairProgOptions.cxx
@@ -42,7 +42,7 @@ FairProgOptions::FairProgOptions() :
                                                                     "  STATE \n"
                                                                     "  NOLOG"
             )
-        ("log-color-format", po::value<bool>()->default_value(true), "logger color format : true or false")
+        ("log-color", po::value<bool>()->default_value(true), "logger color: true or false")
         ;
 
     fSeverityMap["TRACE"]              = fairmq::severity_level::TRACE;

--- a/fairmq/options/FairProgOptions.cxx
+++ b/fairmq/options/FairProgOptions.cxx
@@ -18,15 +18,19 @@ using namespace std;
 
 /// //////////////////////////////////////////////////////////////////////////////////////////////////////
 /// Constructor
-FairProgOptions::FairProgOptions() : 
+FairProgOptions::FairProgOptions() :
                         fGenericDesc("Generic options description"),
                         fConfigDesc("Configuration options description"),
                         fHiddenDesc("Hidden options description"),
-                        fEnvironmentDesc("Environment Variables"),
+                        fEnvironmentDesc("Environment variables"),
                         fCmdLineOptions("Command line options"),
                         fConfigFileOptions("Configuration file options"),
                         fVisibleOptions("Visible options"),
-                        fVerboseLvl("INFO"), fUseConfigFile(false), fConfigFile()
+                        fVerboseLvl("INFO"),
+                        fUseConfigFile(false),
+                        fConfigFile(),
+                        fVarMap(),
+                        fSeverityMap()
 {
     // define generic options
     fGenericDesc.add_options()
@@ -141,7 +145,7 @@ int FairProgOptions::ParseCmdLine(const int argc, char** argv, const po::options
 
 int FairProgOptions::ParseCmdLine(const int argc, char** argv, const po::options_description& desc, bool allowUnregistered)
 {
-    return ParseCmdLine(argc,argv,desc,fVarMap,allowUnregistered);
+    return ParseCmdLine(argc, argv, desc, fVarMap, allowUnregistered);
 }
 
 int FairProgOptions::ParseCfgFile(ifstream& ifs, const po::options_description& desc, po::variables_map& varmap, bool allowUnregistered)

--- a/fairmq/options/FairProgOptions.h
+++ b/fairmq/options/FairProgOptions.h
@@ -96,13 +96,13 @@ class FairProgOptions
 
     // convert value to string that corresponds to the key
     std::string GetStringValue(const std::string& key);
-    
-    const po::variables_map& GetVarMap() const {return fVarMap;}
-    
+
+    const po::variables_map& GetVarMap() const { return fVarMap; }
+
     // boost prog options parsers
     int ParseCmdLine(const int argc, char** argv, const po::options_description& desc, po::variables_map& varmap, bool allowUnregistered = false);
     int ParseCmdLine(const int argc, char** argv, const po::options_description& desc, bool allowUnregistered = false);
-    
+
     int ParseCfgFile(const std::string& filename, const po::options_description& desc, po::variables_map& varmap, bool allowUnregistered = false);
     int ParseCfgFile(const std::string& filename, const po::options_description& desc, bool allowUnregistered = false);
     int ParseCfgFile(std::ifstream& ifs, const po::options_description& desc, po::variables_map& varmap, bool allowUnregistered = false);

--- a/fairmq/options/FairProgOptionsHelper.h
+++ b/fairmq/options/FairProgOptionsHelper.h
@@ -25,8 +25,6 @@
 #include <iterator>
 #include <tuple>
 
-
-
 template<class T>
 std::ostream& operator<<(std::ostream& os, const std::vector<T>& v)
 {
@@ -36,9 +34,8 @@ std::ostream& operator<<(std::ostream& os, const std::vector<T>& v)
 
 namespace fairmq
 {
-    
     namespace po = boost::program_options;
-    
+
     //_____________________________________________________________________________________________________________________________
 
     template<typename T>
@@ -108,6 +105,7 @@ namespace fairmq
             return std::string("empty value");
         }
     };
+
 //_____________________________________________________________________________________________________________________________
 
     // policy to convert variable value content into a tuple with value, type, defaulted, empty information

--- a/fairmq/test/runTransferTimeoutTest.cxx
+++ b/fairmq/test/runTransferTimeoutTest.cxx
@@ -62,7 +62,7 @@ class TransferTimeoutTester : public FairMQDevice
 
         if (getSndOK && getRcvOK)
         {
-            void* buffer = operator new[](1000);
+            void* buffer = malloc(1000);
             std::unique_ptr<FairMQMessage> msg1(fTransportFactory->CreateMessage(buffer, 1000));
             std::unique_ptr<FairMQMessage> msg2(fTransportFactory->CreateMessage());
 

--- a/fairmq/tools/runSimpleMQStateMachine.h
+++ b/fairmq/tools/runSimpleMQStateMachine.h
@@ -28,8 +28,6 @@
 #include "FairMQParser.h"
 #include "FairMQProgOptions.h"
 
-
-
 // template function that take any device, 
 // and run a simple MQ state machine configured from a JSON file
 template<typename TMQDevice>
@@ -114,6 +112,4 @@ inline int runNonInteractiveStateMachine(TMQDevice& device, FairMQProgOptions& c
     return 0;
 }
 
-
 #endif /* RUNSIMPLEMQSTATEMACHINE_H */
-

--- a/fairmq/zeromq/FairMQContextZMQ.h
+++ b/fairmq/zeromq/FairMQContextZMQ.h
@@ -20,6 +20,8 @@ class FairMQContextZMQ
   public:
     /// Constructor
     FairMQContextZMQ(int numIoThreads);
+    FairMQContextZMQ(const FairMQContextZMQ&) = delete;
+    FairMQContextZMQ operator=(const FairMQContextZMQ&) = delete;
 
     virtual ~FairMQContextZMQ();
     void* GetContext();
@@ -27,10 +29,6 @@ class FairMQContextZMQ
 
   private:
     void* fContext;
-
-    /// Copy Constructor
-    FairMQContextZMQ(const FairMQContextZMQ&);
-    FairMQContextZMQ operator=(const FairMQContextZMQ&);
 };
 
 #endif /* FAIRMQCONTEXTZMQ_H_ */

--- a/fairmq/zeromq/FairMQPollerZMQ.h
+++ b/fairmq/zeromq/FairMQPollerZMQ.h
@@ -33,6 +33,8 @@ class FairMQPollerZMQ : public FairMQPoller
   public:
     FairMQPollerZMQ(const std::vector<FairMQChannel>& channels);
     FairMQPollerZMQ(std::unordered_map<std::string, std::vector<FairMQChannel>>& channelsMap, std::initializer_list<std::string> channelList);
+    FairMQPollerZMQ(const FairMQPollerZMQ&) = delete;
+    FairMQPollerZMQ operator=(const FairMQPollerZMQ&) = delete;
 
     virtual void Poll(const int timeout);
     virtual bool CheckInput(const int index);
@@ -49,10 +51,6 @@ class FairMQPollerZMQ : public FairMQPoller
     int fNumItems;
 
     std::unordered_map<std::string,int> fOffsetMap;
-
-    /// Copy Constructor
-    FairMQPollerZMQ(const FairMQPollerZMQ&);
-    FairMQPollerZMQ operator=(const FairMQPollerZMQ&);
 };
 
 #endif /* FAIRMQPOLLERZMQ_H_ */

--- a/fairmq/zeromq/FairMQSocketZMQ.h
+++ b/fairmq/zeromq/FairMQSocketZMQ.h
@@ -24,6 +24,8 @@ class FairMQSocketZMQ : public FairMQSocket
 {
   public:
     FairMQSocketZMQ(const std::string& type, const std::string& name, int numIoThreads);
+    FairMQSocketZMQ(const FairMQSocketZMQ&) = delete;
+    FairMQSocketZMQ operator=(const FairMQSocketZMQ&) = delete;
 
     virtual std::string GetId();
 
@@ -66,10 +68,6 @@ class FairMQSocketZMQ : public FairMQSocket
     unsigned long fMessagesRx;
 
     static boost::shared_ptr<FairMQContextZMQ> fContext;
-
-    /// Copy Constructor
-    FairMQSocketZMQ(const FairMQSocketZMQ&);
-    FairMQSocketZMQ operator=(const FairMQSocketZMQ&);
 };
 
 #endif /* FAIRMQSOCKETZMQ_H_ */

--- a/parmq/ParameterMQServer.h
+++ b/parmq/ParameterMQServer.h
@@ -36,6 +36,8 @@ class ParameterMQServer : public FairMQDevice
     };
 
     ParameterMQServer();
+    ParameterMQServer(const ParameterMQServer&) = delete;
+    ParameterMQServer operator=(const ParameterMQServer&) = delete;
     virtual ~ParameterMQServer();
 
     virtual void Run();


### PR DESCRIPTION
- Add acknowledgement channel to Tutorial 3 to measure performance of the serialization libraries.
- Rename `--log-color-format` cmd option to `--log-color`.
- Fix Weffc++ warnings (missing copy constructors and assignment operators).
- Hide the warning from FairMQStateMachine.h where it is produced by boost and/or is intended.
- Fix small memory leaks in Processor and Sink of Tutorial 3.
- Use FairFileSource for FairMQSampler of Tutorial 3.
- Some code cleanup.