### PR TITLE
Boost fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,14 +157,14 @@ Message("-- Looking for Boost ...")
 # for boost.
 Unset(Boost_INCLUDE_DIR CACHE)
 Unset(Boost_LIBRARY_DIRS CACHE)
-find_package(Boost 1.41 COMPONENTS thread system timer program_options random filesystem chrono exception regex)
+find_package(Boost 1.59 COMPONENTS thread system timer program_options random filesystem chrono exception regex)
 If (Boost_FOUND)
   Set(Boost_Avail 1)
   Set(LD_LIBRARY_PATH ${LD_LIBRARY_PATH} ${Boost_LIBRARY_DIR})
 Else (Boost_FOUND)
   Set(Boost_Avail 0)
 EndIf (Boost_FOUND)
-
+message("Hello ${_boost_MULTITHREADED}")
 # Set the library version in the main CMakeLists.txt
 SET(FAIRROOT_MAJOR_VERSION 15)
 SET(FAIRROOT_MINOR_VERSION 11)

--- a/base/MQ/CMakeLists.txt
+++ b/base/MQ/CMakeLists.txt
@@ -66,7 +66,7 @@ set(DEPENDENCIES
   ParBase
   FairTools
   GeoBase
-  boost_thread
+  boost_thread${_boost_MULTITHREADED}
   boost_timer
   boost_system
   boost_filesystem

--- a/cmake/modules/FindFairRoot.cmake
+++ b/cmake/modules/FindFairRoot.cmake
@@ -45,7 +45,7 @@ FIND_PATH(FAIRROOT_CMAKEMOD_DIR NAMES CMakeLists.txt  PATHS
 set(FAIRMQ_DEPENDENCIES
   boost_log
   boost_log_setup
-  boost_thread
+  boost_thread${_boost_MULTITHREADED}
   boost_filesystem
   boost_system
   boost_date_time

--- a/examples/MQ/GenericDevices/CMakeLists.txt
+++ b/examples/MQ/GenericDevices/CMakeLists.txt
@@ -95,7 +95,7 @@ Set(DEPENDENCIES
     FairMQ 
     BaseMQ 
     FairTestDetector
-    boost_thread 
+    boost_thread${_boost_MULTITHREADED} 
     boost_system 
     boost_serialization 
     boost_program_options

--- a/examples/MQ/LmdSampler/CMakeLists.txt
+++ b/examples/MQ/LmdSampler/CMakeLists.txt
@@ -96,7 +96,7 @@ ForEach(_file RANGE 0 ${_length})
     Set(DEPENDENCIES
         FairMQ 
         BaseMQ 
-        boost_thread 
+        boost_thread${_boost_MULTITHREADED} 
         boost_system 
         boost_serialization 
         boost_program_options 

--- a/examples/advanced/Tutorial3/CMakeLists.txt
+++ b/examples/advanced/Tutorial3/CMakeLists.txt
@@ -116,7 +116,7 @@ Set(LIBRARY_NAME FairTestDetector)
 
 If (Boost_FOUND AND POS_C++11 AND ZMQ_FOUND)
   Set(DEPENDENCIES
-    Base MCStack FairMQ BaseMQ boost_thread boost_system boost_serialization boost_program_options)
+    Base MCStack FairMQ BaseMQ boost_thread${_boost_MULTITHREADED} boost_system boost_serialization boost_program_options)
   If(PROTOBUF_FOUND)
     Set(DEPENDENCIES
       ${DEPENDENCIES}

--- a/fairmq/CMakeLists.txt
+++ b/fairmq/CMakeLists.txt
@@ -109,7 +109,7 @@ Install(FILES ${FAIRMQHEADERS} DESTINATION include)
 Set(DEPENDENCIES
   ${DEPENDENCIES}
   ${ZMQ_LIBRARY_SHARED}
-  boost_thread
+  boost_thread${_boost_MULTITHREADED}
   fairmq_logger
   boost_timer
   boost_system

--- a/fairmq/logger/CMakeLists.txt
+++ b/fairmq/logger/CMakeLists.txt
@@ -26,9 +26,9 @@ set(SRCS logger.cxx)
 set(LIBRARY_NAME fairmq_logger)
 
 set(DEPENDENCIES
-    boost_log
-    boost_log_setup
-    boost_thread
+    boost_log${_boost_MULTITHREADED}
+    boost_log_setup${_boost_MULTITHREADED}
+    boost_thread${_boost_MULTITHREADED}
     boost_date_time
     boost_filesystem
     boost_system

--- a/parmq/CMakeLists.txt
+++ b/parmq/CMakeLists.txt
@@ -45,7 +45,7 @@ Set(DEPENDENCIES
   Base
   ParBase
   FairMQ
-  boost_thread
+  boost_thread${_boost_MULTITHREADED}
   boost_program_options
 )
 


### PR DESCRIPTION
Sometimes boost libraries have a -mt (as in multithreading) appended to
their name. This is particularly the case on my mac, using homebrew.
With the attached I managed to get it compile fine.