### PR TITLE
Fixing memory leak by deleting temporary FairEventHeader in FairRootM…

### DIFF
--- a/base/steer/FairRootManager.cxx
+++ b/base/steer/FairRootManager.cxx
@@ -559,6 +559,7 @@ Int_t  FairRootManager::ReadEvent(Int_t i)
   FairEventHeader* tempEH = new FairEventHeader();
   fSource->FillEventHeader(tempEH);
   fCurrentTime = tempEH->GetEventTime();
+  tempEH->Delete();
 
   LOG(DEBUG) << "--Event number --- "
 	     << fCurrentEntryNo << " with time ---- " 


### PR DESCRIPTION
…anager::ReadEvent()