### PR TITLE
Redmine issue #65

### DIFF
--- a/base/source/FairFileSource.cxx
+++ b/base/source/FairFileSource.cxx
@@ -751,6 +751,8 @@ void FairFileSource::SetBeamTime(Double_t beamTime, Double_t gapTime)
 //_____________________________________________________________________________
 void FairFileSource::SetEventTime()
 {
+  //Check if the time for the current entry is already set
+  if(fTimeforEntryNo==fCurrentEntryNo) return;
   LOG(DEBUG) << "Set event time for Entry = "
 	     << fTimeforEntryNo << " , where the current entry is "
 	     << fCurrentEntryNo << " and eventTime is "


### PR DESCRIPTION
Bug in event time: Add a check for the event time so that it will not be set twice for the same entry
https://fairroot-redmine.gsi.de/issues/65

