### PR TITLE
Extend FairMQ multipart and messaging API

### DIFF
--- a/examples/MQ/1-sampler-sink/FairMQExample1Sampler.cxx
+++ b/examples/MQ/1-sampler-sink/FairMQExample1Sampler.cxx
@@ -39,11 +39,11 @@ void FairMQExample1Sampler::Run()
 
         string* text = new string(fText);
 
-        unique_ptr<FairMQMessage> msg(fTransportFactory->CreateMessage(const_cast<char*>(text->c_str()), text->length(), CustomCleanup, text));
+        unique_ptr<FairMQMessage> msg(NewMessage(const_cast<char*>(text->c_str()), text->length(), CustomCleanup, text));
 
         LOG(INFO) << "Sending \"" << fText << "\"";
 
-        fChannels.at("data-out").at(0).Send(msg);
+        Send(msg, "data");
     }
 }
 

--- a/examples/MQ/1-sampler-sink/FairMQExample1Sink.cxx
+++ b/examples/MQ/1-sampler-sink/FairMQExample1Sink.cxx
@@ -25,9 +25,9 @@ void FairMQExample1Sink::Run()
 {
     while (CheckCurrentState(RUNNING))
     {
-        unique_ptr<FairMQMessage> msg(fTransportFactory->CreateMessage());
+        unique_ptr<FairMQMessage> msg(NewMessage());
 
-        if (fChannels.at("data-in").at(0).Receive(msg) >= 0)
+        if (Receive(msg, "data") >= 0)
         {
             LOG(INFO) << "Received message: \""
                       << string(static_cast<char*>(msg->GetData()), msg->GetSize())

--- a/examples/MQ/1-sampler-sink/ex1-sampler-sink.json
+++ b/examples/MQ/1-sampler-sink/ex1-sampler-sink.json
@@ -6,7 +6,7 @@
             "id": "sampler1",
             "channel":
             {
-                "name": "data-out",
+                "name": "data",
                 "socket":
                 {
                     "type": "push",
@@ -24,7 +24,7 @@
             "id": "sink1",
             "channel":
             {
-                "name": "data-in",
+                "name": "data",
                 "socket":
                 {
                     "type": "pull",

--- a/examples/MQ/2-sampler-processor-sink/FairMQExample2Processor.cxx
+++ b/examples/MQ/2-sampler-processor-sink/FairMQExample2Processor.cxx
@@ -36,11 +36,11 @@ void FairMQExample2Processor::Run()
     while (CheckCurrentState(RUNNING))
     {
         // Create empty message to hold the input
-        unique_ptr<FairMQMessage> input(fTransportFactory->CreateMessage());
+        unique_ptr<FairMQMessage> input(NewMessage());
 
         // Receive the message (blocks until received or interrupted (e.g. by state change)). 
         // Returns size of the received message or -1 if interrupted.
-        if (fChannels.at("data-in").at(0).Receive(input) >= 0)
+        if (Receive(input, "data1") >= 0)
         {
             LOG(INFO) << "Received data, processing...";
 
@@ -49,10 +49,10 @@ void FairMQExample2Processor::Run()
             *text += " (modified by " + fId + ")";
 
             // Create output message
-            unique_ptr<FairMQMessage> msg(fTransportFactory->CreateMessage(const_cast<char*>(text->c_str()), text->length(), CustomCleanup, text));
+            unique_ptr<FairMQMessage> msg(NewMessage(const_cast<char*>(text->c_str()), text->length(), CustomCleanup, text));
 
             // Send out the output message
-            fChannels.at("data-out").at(0).Send(msg);
+            Send(msg, "data2");
         }
     }
 }

--- a/examples/MQ/2-sampler-processor-sink/FairMQExample2Sampler.cxx
+++ b/examples/MQ/2-sampler-processor-sink/FairMQExample2Sampler.cxx
@@ -39,11 +39,11 @@ void FairMQExample2Sampler::Run()
 
         string* text = new string(fText);
 
-        unique_ptr<FairMQMessage> msg(fTransportFactory->CreateMessage(const_cast<char*>(text->c_str()), text->length(), CustomCleanup, text));
+        unique_ptr<FairMQMessage> msg(NewMessage(const_cast<char*>(text->c_str()), text->length(), CustomCleanup, text));
 
         LOG(INFO) << "Sending \"" << fText << "\"";
 
-        fChannels.at("data-out").at(0).Send(msg);
+        Send(msg, "data1");
     }
 }
 

--- a/examples/MQ/2-sampler-processor-sink/FairMQExample2Sink.cxx
+++ b/examples/MQ/2-sampler-processor-sink/FairMQExample2Sink.cxx
@@ -28,9 +28,9 @@ void FairMQExample2Sink::Run()
 {
     while (CheckCurrentState(RUNNING))
     {
-        unique_ptr<FairMQMessage> msg(fTransportFactory->CreateMessage());
+        unique_ptr<FairMQMessage> msg(NewMessage());
 
-        if (fChannels.at("data-in").at(0).Receive(msg) >= 0)
+        if (Receive(msg, "data2") >= 0)
         {
             LOG(INFO) << "Received message: \""
                       << string(static_cast<char*>(msg->GetData()), msg->GetSize())

--- a/examples/MQ/2-sampler-processor-sink/ex2-sampler-processor-sink.json
+++ b/examples/MQ/2-sampler-processor-sink/ex2-sampler-processor-sink.json
@@ -6,7 +6,7 @@
             "id": "sampler1",
             "channel":
             {
-                "name": "data-out",
+                "name": "data1",
                 "socket":
                 {
                     "type": "push",
@@ -24,7 +24,7 @@
             "id": "processor1",
             "channel":
             {
-                "name": "data-in",
+                "name": "data1",
                 "socket":
                 {
                     "type": "pull",
@@ -37,7 +37,7 @@
             },
             "channel":
             {
-                "name": "data-out",
+                "name": "data2",
                 "socket":
                 {
                     "type": "push",
@@ -55,7 +55,7 @@
             "id": "processor2",
             "channel":
             {
-                "name": "data-in",
+                "name": "data1",
                 "socket":
                 {
                     "type": "pull",
@@ -68,7 +68,7 @@
             },
             "channel":
             {
-                "name": "data-out",
+                "name": "data2",
                 "socket":
                 {
                     "type": "push",
@@ -86,7 +86,7 @@
             "id": "sink1",
             "channel":
             {
-                "name": "data-in",
+                "name": "data2",
                 "socket":
                 {
                     "type": "pull",

--- a/examples/MQ/3-dds/FairMQExample3Processor.cxx
+++ b/examples/MQ/3-dds/FairMQExample3Processor.cxx
@@ -34,11 +34,11 @@ void FairMQExample3Processor::Run()
     while (CheckCurrentState(RUNNING))
     {
         // Create empty message to hold the input
-        unique_ptr<FairMQMessage> input(fTransportFactory->CreateMessage());
+        unique_ptr<FairMQMessage> input(NewMessage());
 
         // Receive the message (blocks until received or interrupted (e.g. by state change)). 
         // Returns size of the received message or -1 if interrupted.
-        if (fChannels.at("data-in").at(0).Receive(input) >= 0)
+        if (Receive(input, "data1") >= 0)
         {
             LOG(INFO) << "Received data, processing...";
 
@@ -47,10 +47,10 @@ void FairMQExample3Processor::Run()
             *text += " (modified by " + fId + ")";
 
             // Create output message
-            unique_ptr<FairMQMessage> msg(fTransportFactory->CreateMessage(const_cast<char*>(text->c_str()), text->length(), CustomCleanup, text));
+            unique_ptr<FairMQMessage> msg(NewMessage(const_cast<char*>(text->c_str()), text->length(), CustomCleanup, text));
 
             // Send out the output message
-            fChannels.at("data-out").at(0).Send(msg);
+            Send(msg, "data2");
         }
     }
 }

--- a/examples/MQ/3-dds/FairMQExample3Sampler.cxx
+++ b/examples/MQ/3-dds/FairMQExample3Sampler.cxx
@@ -37,11 +37,11 @@ void FairMQExample3Sampler::Run()
 
         string* text = new string("Data");
 
-        unique_ptr<FairMQMessage> msg(fTransportFactory->CreateMessage(const_cast<char*>(text->c_str()), text->length(), CustomCleanup, text));
+        unique_ptr<FairMQMessage> msg(NewMessage(const_cast<char*>(text->c_str()), text->length(), CustomCleanup, text));
 
         LOG(INFO) << "Sending \"Data\"";
 
-        fChannels.at("data-out").at(0).Send(msg);
+        Send(msg, "data1");
     }
 }
 

--- a/examples/MQ/3-dds/FairMQExample3Sink.cxx
+++ b/examples/MQ/3-dds/FairMQExample3Sink.cxx
@@ -28,9 +28,9 @@ void FairMQExample3Sink::Run()
 {
     while (CheckCurrentState(RUNNING))
     {
-        unique_ptr<FairMQMessage> msg(fTransportFactory->CreateMessage());
+        unique_ptr<FairMQMessage> msg(NewMessage());
 
-        if (fChannels.at("data-in").at(0).Receive(msg) >= 0)
+        if (Receive(msg, "data2") >= 0)
         {
             LOG(INFO) << "Received message: \""
                       << string(static_cast<char*>(msg->GetData()), msg->GetSize())

--- a/examples/MQ/3-dds/ex3-dds-hosts.cfg
+++ b/examples/MQ/3-dds/ex3-dds-hosts.cfg
@@ -3,6 +3,6 @@ echo "DBG: SSH ENV Script"
 #source setup.sh
 @bash_end@
 
-sampler, username@localhost, , /tmp/, 1
-processor, username@localhost, , /tmp/, 10
-sink, username@localhost, , /tmp/, 1
+sampler, orybalch@localhost, , /tmp/, 1
+processor, orybalch@localhost, , /tmp/, 10
+sink, orybalch@localhost, , /tmp/, 1

--- a/examples/MQ/3-dds/runExample3Processor.cxx
+++ b/examples/MQ/3-dds/runExample3Processor.cxx
@@ -55,12 +55,12 @@ int main(int argc, char** argv)
         // configure data output channel
         FairMQChannel dataInChannel("pull", "connect", "");
         dataInChannel.UpdateRateLogging(0);
-        processor.fChannels["data-in"].push_back(dataInChannel);
+        processor.fChannels["data1"].push_back(dataInChannel);
 
         // configure data output channel
         FairMQChannel dataOutChannel("push", "connect", "");
         dataOutChannel.UpdateRateLogging(0);
-        processor.fChannels["data-out"].push_back(dataOutChannel);
+        processor.fChannels["data2"].push_back(dataOutChannel);
 
         // Waiting for DDS properties
         dds::key_value::CKeyValue ddsKeyValue;
@@ -97,8 +97,8 @@ int main(int argc, char** argv)
             }
         }
 
-        processor.fChannels.at("data-in").at(0).UpdateAddress(samplerValues.begin()->second);
-        processor.fChannels.at("data-out").at(0).UpdateAddress(sinkValues.begin()->second);
+        processor.fChannels.at("data1").at(0).UpdateAddress(samplerValues.begin()->second);
+        processor.fChannels.at("data2").at(0).UpdateAddress(sinkValues.begin()->second);
 
         processor.ChangeState("INIT_DEVICE");
         processor.WaitForEndOfState("INIT_DEVICE");

--- a/examples/MQ/3-dds/runExample3Sampler.cxx
+++ b/examples/MQ/3-dds/runExample3Sampler.cxx
@@ -64,7 +64,7 @@ int main(int argc, char** argv)
         // configure data output channel
         FairMQChannel dataOutChannel("push", "bind", "");
         dataOutChannel.UpdateRateLogging(0);
-        sampler.fChannels["data-out"].push_back(dataOutChannel);
+        sampler.fChannels["data1"].push_back(dataOutChannel);
 
         // Get the IP of the current host and store it for binding.
         map<string,string> IPs;
@@ -85,7 +85,7 @@ int main(int argc, char** argv)
 
         // Configure the found host IP for the channel.
         // TCP port will be chosen randomly during the initialization (binding).
-        sampler.fChannels.at("data-out").at(0).UpdateAddress(initialOutputAddress);
+        sampler.fChannels.at("data1").at(0).UpdateAddress(initialOutputAddress);
 
         sampler.ChangeState("INIT_DEVICE");
         sampler.WaitForInitialValidation();
@@ -93,7 +93,7 @@ int main(int argc, char** argv)
         // Advertise the bound addresses via DDS property
         LOG(INFO) << "Giving sampler output address to DDS.";
         dds::key_value::CKeyValue ddsKeyValue;
-        ddsKeyValue.putValue("SamplerAddress", sampler.fChannels.at("data-out").at(0).GetAddress());
+        ddsKeyValue.putValue("SamplerAddress", sampler.fChannels.at("data1").at(0).GetAddress());
 
         sampler.WaitForEndOfState("INIT_DEVICE");
 

--- a/examples/MQ/3-dds/runExample3Sink.cxx
+++ b/examples/MQ/3-dds/runExample3Sink.cxx
@@ -64,7 +64,7 @@ int main(int argc, char** argv)
         // configure data output channel
         FairMQChannel dataInChannel("pull", "bind", "");
         dataInChannel.UpdateRateLogging(0);
-        sink.fChannels["data-in"].push_back(dataInChannel);
+        sink.fChannels["data2"].push_back(dataInChannel);
 
         // Get the IP of the current host and store it for binding.
         map<string,string> IPs;
@@ -85,7 +85,7 @@ int main(int argc, char** argv)
 
         // Configure the found host IP for the channel.
         // TCP port will be chosen randomly during the initialization (binding).
-        sink.fChannels.at("data-in").at(0).UpdateAddress(initialInputAddress);
+        sink.fChannels.at("data2").at(0).UpdateAddress(initialInputAddress);
 
         sink.ChangeState("INIT_DEVICE");
         sink.WaitForInitialValidation();
@@ -93,7 +93,7 @@ int main(int argc, char** argv)
         // Advertise the bound address via DDS property
         LOG(INFO) << "Giving sink input address to DDS.";
         dds::key_value::CKeyValue ddsKeyValue;
-        ddsKeyValue.putValue("SinkAddress", sink.fChannels.at("data-in").at(0).GetAddress());
+        ddsKeyValue.putValue("SinkAddress", sink.fChannels.at("data2").at(0).GetAddress());
 
         sink.WaitForEndOfState("INIT_DEVICE");
 

--- a/examples/MQ/4-copypush/FairMQExample4Sampler.cxx
+++ b/examples/MQ/4-copypush/FairMQExample4Sampler.cxx
@@ -34,23 +34,23 @@ void FairMQExample4Sampler::Run()
 
         uint64_t* number = new uint64_t(counter);
 
-        std::unique_ptr<FairMQMessage> msg(fTransportFactory->CreateMessage(number, sizeof(uint64_t)));
+        std::unique_ptr<FairMQMessage> msg(NewMessage(number, sizeof(uint64_t)));
 
         LOG(INFO) << "Sending \"" << counter << "\"";
 
-        if (fChannels.at("data-out").size() > 1)
+        if (fChannels.at("data").size() > 1)
         {
-            for (int i = 1; i < fChannels.at("data-out").size(); ++i)
+            for (int i = 1; i < fChannels.at("data").size(); ++i)
             {
-                std::unique_ptr<FairMQMessage> msgCopy(fTransportFactory->CreateMessage());
+                std::unique_ptr<FairMQMessage> msgCopy(NewMessage());
                 msgCopy->Copy(msg);
-                fChannels.at("data-out").at(i).Send(msgCopy);
+                Send(msgCopy, "data", i);
             }
-            fChannels.at("data-out").at(0).Send(msg);
+            Send(msg, "data");
         }
         else
         {
-            fChannels.at("data-out").at(0).Send(msg);
+            Send(msg, "data");
         }
 
         ++counter;

--- a/examples/MQ/4-copypush/FairMQExample4Sink.cxx
+++ b/examples/MQ/4-copypush/FairMQExample4Sink.cxx
@@ -28,9 +28,9 @@ void FairMQExample4Sink::Run()
 {
     while (CheckCurrentState(RUNNING))
     {
-        std::unique_ptr<FairMQMessage> msg(fTransportFactory->CreateMessage());
+        std::unique_ptr<FairMQMessage> msg(NewMessage());
 
-        if (fChannels.at("data-in").at(0).Receive(msg) >= 0)
+        if (Receive(msg, "data") >= 0)
         {
             LOG(INFO) << "Received message: \"" << *(static_cast<int*>(msg->GetData())) << "\"";
         }

--- a/examples/MQ/4-copypush/ex4-copypush.json
+++ b/examples/MQ/4-copypush/ex4-copypush.json
@@ -6,7 +6,7 @@
             "id": "sampler1",
             "channel":
             {
-                "name": "data-out",
+                "name": "data",
                 "socket":
                 {
                     "type": "push",
@@ -33,7 +33,7 @@
             "id": "sink1",
             "channel":
             {
-                "name": "data-in",
+                "name": "data",
                 "socket":
                 {
                     "type": "pull",
@@ -51,7 +51,7 @@
             "id": "sink2",
             "channel":
             {
-                "name": "data-in",
+                "name": "data",
                 "socket":
                 {
                     "type": "pull",

--- a/examples/MQ/5-req-rep/FairMQExample5Client.cxx
+++ b/examples/MQ/5-req-rep/FairMQExample5Client.cxx
@@ -42,14 +42,14 @@ void FairMQExample5Client::Run()
 
         string* text = new string(fText);
 
-        unique_ptr<FairMQMessage> request(fTransportFactory->CreateMessage(const_cast<char*>(text->c_str()), text->length(), CustomCleanup, text));
-        unique_ptr<FairMQMessage> reply(fTransportFactory->CreateMessage());
+        unique_ptr<FairMQMessage> request(NewMessage(const_cast<char*>(text->c_str()), text->length(), CustomCleanup, text));
+        unique_ptr<FairMQMessage> reply(NewMessage());
 
         LOG(INFO) << "Sending \"" << fText << "\" to server.";
 
-        if (fChannels.at("data").at(0).Send(request) > 0)
+        if (Send(request, "data") > 0)
         {
-            if (fChannels.at("data").at(0).Receive(reply) >= 0)
+            if (Receive(reply, "data") >= 0)
             {
                 LOG(INFO) << "Received reply from server: \"" << string(static_cast<char*>(reply->GetData()), reply->GetSize()) << "\"";
             }

--- a/examples/MQ/5-req-rep/FairMQExample5Server.cxx
+++ b/examples/MQ/5-req-rep/FairMQExample5Server.cxx
@@ -33,9 +33,9 @@ void FairMQExample5Server::Run()
 {
     while (CheckCurrentState(RUNNING))
     {
-        unique_ptr<FairMQMessage> request(fTransportFactory->CreateMessage());
+        unique_ptr<FairMQMessage> request(NewMessage());
 
-        if (fChannels.at("data").at(0).Receive(request) >= 0)
+        if (Receive(request, "data") >= 0)
         {
             LOG(INFO) << "Received request from client: \"" << string(static_cast<char*>(request->GetData()), request->GetSize()) << "\"";
 
@@ -43,9 +43,9 @@ void FairMQExample5Server::Run()
 
             LOG(INFO) << "Sending reply to client.";
 
-            unique_ptr<FairMQMessage> reply(fTransportFactory->CreateMessage(const_cast<char*>(text->c_str()), text->length(), CustomCleanup, text));
+            unique_ptr<FairMQMessage> reply(NewMessage(const_cast<char*>(text->c_str()), text->length(), CustomCleanup, text));
 
-            fChannels.at("data").at(0).Send(reply);
+            Send(reply, "data");
         }
     }
 }

--- a/examples/MQ/6-multiple-channels/FairMQExample6Broadcaster.cxx
+++ b/examples/MQ/6-multiple-channels/FairMQExample6Broadcaster.cxx
@@ -38,9 +38,9 @@ void FairMQExample6Broadcaster::Run()
         boost::this_thread::sleep(boost::posix_time::milliseconds(1000));
 
         string* text = new string("OK");
-        unique_ptr<FairMQMessage> msg(fTransportFactory->CreateMessage(const_cast<char*>(text->c_str()), text->length(), CustomCleanup, text));
-        LOG(INFO) << "Sending \"" << "OK" << "\"";
-        fChannels.at("broadcast-out").at(0).Send(msg);
+        unique_ptr<FairMQMessage> msg(NewMessage(const_cast<char*>(text->c_str()), text->length(), CustomCleanup, text));
+        LOG(INFO) << "Sending OK";
+        Send(msg, "broadcast");
     }
 }
 

--- a/examples/MQ/6-multiple-channels/FairMQExample6Sampler.cxx
+++ b/examples/MQ/6-multiple-channels/FairMQExample6Sampler.cxx
@@ -34,37 +34,37 @@ void FairMQExample6Sampler::CustomCleanup(void *data, void *object)
 
 void FairMQExample6Sampler::Run()
 {
-    std::unique_ptr<FairMQPoller> poller(fTransportFactory->CreatePoller(fChannels, { "data-out", "broadcast-in" }));
+    std::unique_ptr<FairMQPoller> poller(fTransportFactory->CreatePoller(fChannels, { "data", "broadcast" }));
 
     while (CheckCurrentState(RUNNING))
     {
         poller->Poll(-1);
 
-        if (poller->CheckInput("broadcast-in", 0))
+        if (poller->CheckInput("broadcast", 0))
         {
-            unique_ptr<FairMQMessage> msg(fTransportFactory->CreateMessage());
+            unique_ptr<FairMQMessage> msg(NewMessage());
 
-            if (fChannels.at("broadcast-in").at(0).Receive(msg) > 0)
+            if (Receive(msg, "broadcast") > 0)
             {
                 LOG(INFO) << "Received broadcast: \""
                           << string(static_cast<char*>(msg->GetData()), msg->GetSize())
                           << "\"";
             }
-        } // if (poller->CheckInput("broadcast-in", 0))
+        }
 
-        if (poller->CheckOutput("data-out", 0))
+        if (poller->CheckOutput("data", 0))
         {
             boost::this_thread::sleep(boost::posix_time::milliseconds(1000));
 
             string* text = new string(fText);
 
-            unique_ptr<FairMQMessage> msg(fTransportFactory->CreateMessage(const_cast<char*>(text->c_str()), text->length(), CustomCleanup, text));
+            unique_ptr<FairMQMessage> msg(NewMessage(const_cast<char*>(text->c_str()), text->length(), CustomCleanup, text));
 
             LOG(INFO) << "Sending \"" << fText << "\"";
 
-            fChannels.at("data-out").at(0).Send(msg);
-        } // if (poller->CheckOutput("data-out", 0))
-    } // while (CheckCurrentState(RUNNING))
+            Send(msg, "data");
+        }
+    }
 }
 
 FairMQExample6Sampler::~FairMQExample6Sampler()

--- a/examples/MQ/6-multiple-channels/FairMQExample6Sink.cxx
+++ b/examples/MQ/6-multiple-channels/FairMQExample6Sink.cxx
@@ -24,33 +24,29 @@ FairMQExample6Sink::FairMQExample6Sink()
 
 void FairMQExample6Sink::Run()
 {
-    std::unique_ptr<FairMQPoller> poller(fTransportFactory->CreatePoller(fChannels, { "data-in", "broadcast-in" }));
+    std::unique_ptr<FairMQPoller> poller(fTransportFactory->CreatePoller(fChannels, { "data", "broadcast" }));
 
     while (CheckCurrentState(RUNNING))
     {
         poller->Poll(-1);
 
-        if (poller->CheckInput("broadcast-in", 0))
+        if (poller->CheckInput("broadcast", 0))
         {
-            unique_ptr<FairMQMessage> msg(fTransportFactory->CreateMessage());
+            unique_ptr<FairMQMessage> msg(NewMessage());
 
-            if (fChannels.at("broadcast-in").at(0).Receive(msg) > 0)
+            if (Receive(msg, "broadcast") > 0)
             {
-                LOG(INFO) << "Received broadcast: \""
-                          << string(static_cast<char*>(msg->GetData()), msg->GetSize())
-                          << "\"";
+                LOG(INFO) << "Received broadcast: \"" << string(static_cast<char*>(msg->GetData()), msg->GetSize()) << "\"";
             }
         }
 
-        if (poller->CheckInput("data-in", 0))
+        if (poller->CheckInput("data", 0))
         {
-            unique_ptr<FairMQMessage> msg(fTransportFactory->CreateMessage());
+            unique_ptr<FairMQMessage> msg(NewMessage());
 
-            if (fChannels.at("data-in").at(0).Receive(msg) > 0)
+            if (Receive(msg, "data") > 0)
             {
-                LOG(INFO) << "Received message: \""
-                          << string(static_cast<char*>(msg->GetData()), msg->GetSize())
-                          << "\"";
+                LOG(INFO) << "Received message: \"" << string(static_cast<char*>(msg->GetData()), msg->GetSize()) << "\"";
             }
         }
     }

--- a/examples/MQ/6-multiple-channels/ex6-multiple-channels.json
+++ b/examples/MQ/6-multiple-channels/ex6-multiple-channels.json
@@ -6,7 +6,7 @@
             "id": "sampler1",
             "channel":
             {
-                "name": "data-out",
+                "name": "data",
                 "socket":
                 {
                     "type": "push",
@@ -19,7 +19,7 @@
             },
             "channel":
             {
-                "name": "broadcast-in",
+                "name": "broadcast",
                 "socket":
                 {
                     "type": "sub",
@@ -37,7 +37,7 @@
             "id": "sink1",
             "channel":
             {
-                "name": "data-in",
+                "name": "data",
                 "socket":
                 {
                     "type": "pull",
@@ -50,7 +50,7 @@
             },
             "channel":
             {
-                "name": "broadcast-in",
+                "name": "broadcast",
                 "socket":
                 {
                     "type": "sub",
@@ -68,7 +68,7 @@
             "id": "broadcaster1",
             "channel":
             {
-                "name": "broadcast-out",
+                "name": "broadcast",
                 "socket":
                 {
                     "type": "pub",

--- a/examples/MQ/7-parameters/FairMQExample7Client.cxx
+++ b/examples/MQ/7-parameters/FairMQExample7Client.cxx
@@ -62,12 +62,12 @@ void FairMQExample7Client::Run()
 
         LOG(INFO) << "Requesting parameter \"" << fParameterName << "\" for Run ID " << runId << ".";
 
-        unique_ptr<FairMQMessage> req(fTransportFactory->CreateMessage(const_cast<char*>(reqStr->c_str()), reqStr->length(), CustomCleanup, reqStr));
-        unique_ptr<FairMQMessage> rep(fTransportFactory->CreateMessage());
+        unique_ptr<FairMQMessage> req(NewMessage(const_cast<char*>(reqStr->c_str()), reqStr->length(), CustomCleanup, reqStr));
+        unique_ptr<FairMQMessage> rep(NewMessage());
 
-        if (fChannels.at("data").at(0).Send(req) > 0)
+        if (Send(req, "data") > 0)
         {
-            if (fChannels.at("data").at(0).Receive(rep) > 0)
+            if (Receive(rep, "data") > 0)
             {
                 FairMQExample7TMessage tmsg(rep->GetData(), rep->GetSize());
                 FairMQExample7ParOne* par = (FairMQExample7ParOne*)(tmsg.ReadObject(tmsg.GetClass()));

--- a/examples/MQ/8-multipart/FairMQExample8Sampler.cxx
+++ b/examples/MQ/8-multipart/FairMQExample8Sampler.cxx
@@ -39,17 +39,14 @@ void FairMQExample8Sampler::Run()
         // Set stopFlag to 1 for the first 4 messages, and to 0 for the 5th.
         counter < 5 ? header->stopFlag = 0 : header->stopFlag = 1;
 
-        // Create message part with the header.
-        unique_ptr<FairMQMessage> headerPart(fTransportFactory->CreateMessage(header, sizeof(Ex8Header)));
-        // Create message part with the body of 1000 bytes size.
-        unique_ptr<FairMQMessage> dataPart(fTransportFactory->CreateMessage(1000));
+        FairMQParts parts;
+        parts.AddPart(NewMessage(header, sizeof(Ex8Header)));
+        parts.AddPart(NewMessage(1000));
 
         LOG(INFO) << "Sending header with stopFlag: " << header->stopFlag;
+        LOG(INFO) << "Sending body of size: " << parts.At(1).GetSize();
 
-        // Schedule the header part for sending.
-        fChannels.at("data-out").at(0).SendPart(headerPart);
-        // Add body part (final part). `Send()` will send/queue all parts.
-        fChannels.at("data-out").at(0).Send(dataPart);
+        Send(parts, "data-out");
 
         // Go out of the sending loop if the stopFlag was sent.
         if (counter == 5)

--- a/examples/MQ/8-multipart/FairMQExample8Sink.cxx
+++ b/examples/MQ/8-multipart/FairMQExample8Sink.cxx
@@ -32,21 +32,18 @@ void FairMQExample8Sink::Run()
 {
     while (CheckCurrentState(RUNNING))
     {
-        unique_ptr<FairMQMessage> headerPart(fTransportFactory->CreateMessage());
-        unique_ptr<FairMQMessage> bodyPart(fTransportFactory->CreateMessage());
+        FairMQParts parts;
 
-        if (fChannels.at("data-in").at(0).Receive(headerPart) >= 0)
+        if (Receive(parts, "data-in") >= 0)
         {
-            if (fChannels.at("data-in").at(0).Receive(bodyPart) >= 0)
+            Ex8Header header;
+            header.stopFlag = (static_cast<Ex8Header*>(parts.At(0).GetData()))->stopFlag;
+            LOG(INFO) << "Received header with stopFlag: " << header.stopFlag;
+            LOG(INFO) << "Received body of size: " << parts.At(1).GetSize();
+            if (header.stopFlag == 1)
             {
-                Ex8Header header;
-                header.stopFlag = (static_cast<Ex8Header*>(headerPart->GetData()))->stopFlag;
-                LOG(INFO) << "Received header with stopFlag: " << header.stopFlag;
-                if (header.stopFlag == 1)
-                {
-                    LOG(INFO) << "Flag is 0, exiting Run()";
-                    break;
-                }
+                LOG(INFO) << "Flag is 0, exiting Run()";
+                break;
             }
         }
     }

--- a/fairmq/CMakeLists.txt
+++ b/fairmq/CMakeLists.txt
@@ -91,6 +91,7 @@ EndIf(NANOMSG_FOUND)
 # to copy src that are header-only files (e.g. c++ template) for FairRoot external installation
 # manual install (globbing add not recommended)
 Set(FAIRMQHEADERS
+  FairMQParts.h
   devices/GenericSampler.h
   devices/GenericSampler.tpl
   devices/GenericProcessor.h

--- a/fairmq/FairMQDevice.cxx
+++ b/fairmq/FairMQDevice.cxx
@@ -666,12 +666,6 @@ void FairMQDevice::InteractiveStateLoop()
     tcsetattr(STDIN_FILENO, TCSANOW, &t); // apply the new settings
 }
 
-inline void FairMQDevice::PrintInteractiveStateLoopHelp()
-{
-    LOG(INFO) << "Use keys to control the state machine:";
-    LOG(INFO) << "[h] help, [p] pause, [r] run, [s] stop, [t] reset task, [d] reset device, [q] end, [j] init task, [i] init device";
-}
-
 void FairMQDevice::Unblock()
 {
     FairMQMessage* cmd = fTransportFactory->CreateMessage();

--- a/fairmq/FairMQParts.h
+++ b/fairmq/FairMQParts.h
@@ -1,0 +1,52 @@
+/********************************************************************************
+ *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+#ifndef FAIRMQPARTS_H_
+#define FAIRMQPARTS_H_
+
+#include <vector>
+#include <memory> // unique_ptr
+
+#include "FairMQTransportFactory.h"
+#include "FairMQMessage.h"
+
+class FairMQParts
+{
+  public:
+    /// Default constructor
+    FairMQParts() {};
+    /// Copy Constructor
+    FairMQParts(const FairMQParts&) = delete;
+    /// Assignment operator
+    FairMQParts& operator=(const FairMQParts&) = delete;
+    /// Default destructor
+    ~FairMQParts() {};
+
+    /// Adds part (FairMQMessage) to the container
+    /// @param msg message pointer (for example created with NewMessage() method of FairMQDevice)
+    inline void AddPart(FairMQMessage* msg)
+    {
+        fParts.push_back(std::unique_ptr<FairMQMessage>(msg));
+    }
+
+    /// Get reference to part in the container at index (without bounds check)
+    /// @param index container index
+    inline FairMQMessage& operator[](const int index) { return *(fParts[index]); }
+
+    /// Get reference to part in the container at index (with bounds check)
+    /// @param index container index
+    inline FairMQMessage& At(const int index) { return *(fParts.at(index)); }
+
+    /// Get number of parts in the container
+    /// @return number of parts in the container
+    inline int Size() const { return fParts.size(); }
+
+    std::vector<std::unique_ptr<FairMQMessage>> fParts;
+};
+
+#endif /* FAIRMQPARTS_H_ */

--- a/fairmq/FairMQTransportFactory.h
+++ b/fairmq/FairMQTransportFactory.h
@@ -31,14 +31,14 @@ class FairMQTransportFactory
 {
   public:
     virtual FairMQMessage* CreateMessage() = 0;
-    virtual FairMQMessage* CreateMessage(size_t size) = 0;
-    virtual FairMQMessage* CreateMessage(void* data, size_t size, fairmq_free_fn *ffn = NULL, void* hint = NULL) = 0;
+    virtual FairMQMessage* CreateMessage(const size_t size) = 0;
+    virtual FairMQMessage* CreateMessage(void* data, const size_t size, fairmq_free_fn* ffn = NULL, void* hint = NULL) = 0;
 
-    virtual FairMQSocket* CreateSocket(const std::string& type, const std::string& name, int numIoThreads) = 0;
+    virtual FairMQSocket* CreateSocket(const std::string& type, const std::string& name, const int numIoThreads) = 0;
 
     virtual FairMQPoller* CreatePoller(const std::vector<FairMQChannel>& channels) = 0;
-    virtual FairMQPoller* CreatePoller(std::unordered_map<std::string, std::vector<FairMQChannel>>& channelsMap, std::initializer_list<std::string> channelList) = 0;
-    virtual FairMQPoller* CreatePoller(FairMQSocket& cmdSocket, FairMQSocket& dataSocket) = 0;
+    virtual FairMQPoller* CreatePoller(const std::unordered_map<std::string, std::vector<FairMQChannel>>& channelsMap, const std::initializer_list<std::string> channelList) = 0;
+    virtual FairMQPoller* CreatePoller(const FairMQSocket& cmdSocket, const FairMQSocket& dataSocket) = 0;
 
     virtual ~FairMQTransportFactory() {};
 };

--- a/fairmq/nanomsg/FairMQMessageNN.cxx
+++ b/fairmq/nanomsg/FairMQMessageNN.cxx
@@ -34,7 +34,7 @@ FairMQMessageNN::FairMQMessageNN()
     }
 }
 
-FairMQMessageNN::FairMQMessageNN(size_t size)
+FairMQMessageNN::FairMQMessageNN(const size_t size)
     : fMessage(NULL)
     , fSize(0)
     , fReceiving(false)
@@ -53,7 +53,7 @@ FairMQMessageNN::FairMQMessageNN(size_t size)
  * create FairMQMessage object only with size parameter and fill it with data.
  * possible TODO: make this zero copy (will should then be as efficient as ZeroMQ).
 */
-FairMQMessageNN::FairMQMessageNN(void* data, size_t size, fairmq_free_fn *ffn, void* hint)
+FairMQMessageNN::FairMQMessageNN(void* data, const size_t size, fairmq_free_fn *ffn, void* hint)
     : fMessage(NULL)
     , fSize(0)
     , fReceiving(false)
@@ -63,16 +63,19 @@ FairMQMessageNN::FairMQMessageNN(void* data, size_t size, fairmq_free_fn *ffn, v
     {
         LOG(ERROR) << "failed allocating message, reason: " << nn_strerror(errno);
     }
-    memcpy(fMessage, data, size);
-    fSize = size;
-
-    if (ffn)
-    {
-        ffn(data, hint);
-    }
     else
     {
-        if(data) free(data);
+        memcpy(fMessage, data, size);
+        fSize = size;
+
+        if (ffn)
+        {
+            ffn(data, hint);
+        }
+        else
+        {
+            if(data) free(data);
+        }
     }
 }
 
@@ -82,7 +85,7 @@ void FairMQMessageNN::Rebuild()
     fReceiving = false;
 }
 
-void FairMQMessageNN::Rebuild(size_t size)
+void FairMQMessageNN::Rebuild(const size_t size)
 {
     Clear();
     fMessage = nn_allocmsg(size, 0);
@@ -94,7 +97,7 @@ void FairMQMessageNN::Rebuild(size_t size)
     fReceiving = false;
 }
 
-void FairMQMessageNN::Rebuild(void* data, size_t size, fairmq_free_fn *ffn, void* hint)
+void FairMQMessageNN::Rebuild(void* data, const size_t size, fairmq_free_fn *ffn, void* hint)
 {
     Clear();
     fMessage = nn_allocmsg(size, 0);
@@ -102,17 +105,20 @@ void FairMQMessageNN::Rebuild(void* data, size_t size, fairmq_free_fn *ffn, void
     {
         LOG(ERROR) << "failed allocating message, reason: " << nn_strerror(errno);
     }
-    memcpy(fMessage, data, size);
-    fSize = size;
-    fReceiving = false;
-
-    if(ffn)
-    {
-        ffn(data, hint);
-    }
     else
     {
-        if(data) free(data);
+        memcpy(fMessage, data, size);
+        fSize = size;
+        fReceiving = false;
+
+        if(ffn)
+        {
+            ffn(data, hint);
+        }
+        else
+        {
+            if(data) free(data);
+        }
     }
 }
 
@@ -131,7 +137,7 @@ size_t FairMQMessageNN::GetSize()
     return fSize;
 }
 
-void FairMQMessageNN::SetMessage(void* data, size_t size)
+void FairMQMessageNN::SetMessage(void* data, const size_t size)
 {
     fMessage = data;
     fSize = size;
@@ -156,8 +162,11 @@ void FairMQMessageNN::Copy(FairMQMessage* msg)
     {
         LOG(ERROR) << "failed allocating message, reason: " << nn_strerror(errno);
     }
-    memcpy(fMessage, msg->GetMessage(), size);
-    fSize = size;
+    else
+    {
+        memcpy(fMessage, msg->GetMessage(), size);
+        fSize = size;
+    }
 }
 
 void FairMQMessageNN::Copy(const unique_ptr<FairMQMessage>& msg)
@@ -177,8 +186,11 @@ void FairMQMessageNN::Copy(const unique_ptr<FairMQMessage>& msg)
     {
         LOG(ERROR) << "failed allocating message, reason: " << nn_strerror(errno);
     }
-    memcpy(fMessage, msg->GetMessage(), size);
-    fSize = size;
+    else
+    {
+        memcpy(fMessage, msg->GetMessage(), size);
+        fSize = size;
+    }
 }
 
 inline void FairMQMessageNN::Clear()

--- a/fairmq/nanomsg/FairMQMessageNN.h
+++ b/fairmq/nanomsg/FairMQMessageNN.h
@@ -23,20 +23,20 @@ class FairMQMessageNN : public FairMQMessage
 {
   public:
     FairMQMessageNN();
-    FairMQMessageNN(size_t size);
-    FairMQMessageNN(void* data, size_t size, fairmq_free_fn *ffn = NULL, void* hint = NULL);
+    FairMQMessageNN(const size_t size);
+    FairMQMessageNN(void* data, const size_t size, fairmq_free_fn *ffn = NULL, void* hint = NULL);
     FairMQMessageNN(const FairMQMessageNN&) = delete;
     FairMQMessageNN operator=(const FairMQMessageNN&) = delete;
 
     virtual void Rebuild();
-    virtual void Rebuild(size_t size);
-    virtual void Rebuild(void* data, size_t size, fairmq_free_fn *ffn = NULL, void* hint = NULL);
+    virtual void Rebuild(const size_t size);
+    virtual void Rebuild(void* data, const size_t size, fairmq_free_fn *ffn = NULL, void* hint = NULL);
 
     virtual void* GetMessage();
     virtual void* GetData();
     virtual size_t GetSize();
 
-    virtual void SetMessage(void* data, size_t size);
+    virtual void SetMessage(void* data, const size_t size);
 
     virtual void CloseMessage() {};
     virtual void Copy(FairMQMessage* msg);

--- a/fairmq/nanomsg/FairMQPollerNN.cxx
+++ b/fairmq/nanomsg/FairMQPollerNN.cxx
@@ -59,7 +59,7 @@ FairMQPollerNN::FairMQPollerNN(const vector<FairMQChannel>& channels)
     }
 }
 
-FairMQPollerNN::FairMQPollerNN(unordered_map<string, vector<FairMQChannel>>& channelsMap, initializer_list<string> channelList)
+FairMQPollerNN::FairMQPollerNN(const unordered_map<string, vector<FairMQChannel>>& channelsMap, const initializer_list<string> channelList)
     : items()
     , fNumItems(0)
     , fOffsetMap()
@@ -118,7 +118,7 @@ FairMQPollerNN::FairMQPollerNN(unordered_map<string, vector<FairMQChannel>>& cha
     }
 }
 
-FairMQPollerNN::FairMQPollerNN(FairMQSocket& cmdSocket, FairMQSocket& dataSocket)
+FairMQPollerNN::FairMQPollerNN(const FairMQSocket& cmdSocket, const FairMQSocket& dataSocket)
     : items()
     , fNumItems(2)
     , fOffsetMap()

--- a/fairmq/nanomsg/FairMQPollerNN.h
+++ b/fairmq/nanomsg/FairMQPollerNN.h
@@ -32,7 +32,7 @@ class FairMQPollerNN : public FairMQPoller
 
   public:
     FairMQPollerNN(const std::vector<FairMQChannel>& channels);
-    FairMQPollerNN(std::unordered_map<std::string, std::vector<FairMQChannel>>& channelsMap, std::initializer_list<std::string> channelList);
+    FairMQPollerNN(const std::unordered_map<std::string, std::vector<FairMQChannel>>& channelsMap, const std::initializer_list<std::string> channelList);
     FairMQPollerNN(const FairMQPollerNN&) = delete;
     FairMQPollerNN operator=(const FairMQPollerNN&) = delete;
 
@@ -45,7 +45,7 @@ class FairMQPollerNN : public FairMQPoller
     virtual ~FairMQPollerNN();
 
   private:
-    FairMQPollerNN(FairMQSocket& cmdSocket, FairMQSocket& dataSocket);
+    FairMQPollerNN(const FairMQSocket& cmdSocket, const FairMQSocket& dataSocket);
 
     nn_pollfd* items;
     int fNumItems;

--- a/fairmq/nanomsg/FairMQSocketNN.cxx
+++ b/fairmq/nanomsg/FairMQSocketNN.cxx
@@ -20,7 +20,7 @@
 
 using namespace std;
 
-FairMQSocketNN::FairMQSocketNN(const string& type, const std::string& name, int numIoThreads)
+FairMQSocketNN::FairMQSocketNN(const string& type, const std::string& name, const int numIoThreads)
     : FairMQSocket(0, 0, NN_DONTWAIT)
     , fSocket(-1)
     , fId()

--- a/fairmq/nanomsg/FairMQSocketNN.h
+++ b/fairmq/nanomsg/FairMQSocketNN.h
@@ -26,7 +26,7 @@
 class FairMQSocketNN : public FairMQSocket
 {
   public:
-    FairMQSocketNN(const std::string& type, const std::string& name, int numIoThreads); // numIoThreads is not used in nanomsg.
+    FairMQSocketNN(const std::string& type, const std::string& name, const int numIoThreads); // numIoThreads is not used in nanomsg.
     FairMQSocketNN(const FairMQSocketNN&) = delete;
     FairMQSocketNN operator=(const FairMQSocketNN&) = delete;
 

--- a/fairmq/nanomsg/FairMQTransportFactoryNN.cxx
+++ b/fairmq/nanomsg/FairMQTransportFactoryNN.cxx
@@ -26,17 +26,17 @@ FairMQMessage* FairMQTransportFactoryNN::CreateMessage()
     return new FairMQMessageNN();
 }
 
-FairMQMessage* FairMQTransportFactoryNN::CreateMessage(size_t size)
+FairMQMessage* FairMQTransportFactoryNN::CreateMessage(const size_t size)
 {
     return new FairMQMessageNN(size);
 }
 
-FairMQMessage* FairMQTransportFactoryNN::CreateMessage(void* data, size_t size, fairmq_free_fn *ffn, void* hint)
+FairMQMessage* FairMQTransportFactoryNN::CreateMessage(void* data, const size_t size, fairmq_free_fn* ffn, void* hint)
 {
     return new FairMQMessageNN(data, size, ffn, hint);
 }
 
-FairMQSocket* FairMQTransportFactoryNN::CreateSocket(const string& type, const std::string& name, int numIoThreads)
+FairMQSocket* FairMQTransportFactoryNN::CreateSocket(const string& type, const std::string& name, const int numIoThreads)
 {
     return new FairMQSocketNN(type, name, numIoThreads);
 }
@@ -46,12 +46,12 @@ FairMQPoller* FairMQTransportFactoryNN::CreatePoller(const vector<FairMQChannel>
     return new FairMQPollerNN(channels);
 }
 
-FairMQPoller* FairMQTransportFactoryNN::CreatePoller(std::unordered_map<std::string, std::vector<FairMQChannel>>& channelsMap, std::initializer_list<std::string> channelList)
+FairMQPoller* FairMQTransportFactoryNN::CreatePoller(const std::unordered_map<std::string, std::vector<FairMQChannel>>& channelsMap, const std::initializer_list<std::string> channelList)
 {
     return new FairMQPollerNN(channelsMap, channelList);
 }
 
-FairMQPoller* FairMQTransportFactoryNN::CreatePoller(FairMQSocket& cmdSocket, FairMQSocket& dataSocket)
+FairMQPoller* FairMQTransportFactoryNN::CreatePoller(const FairMQSocket& cmdSocket, const FairMQSocket& dataSocket)
 {
     return new FairMQPollerNN(cmdSocket, dataSocket);
 }

--- a/fairmq/nanomsg/FairMQTransportFactoryNN.h
+++ b/fairmq/nanomsg/FairMQTransportFactoryNN.h
@@ -28,14 +28,14 @@ class FairMQTransportFactoryNN : public FairMQTransportFactory
     FairMQTransportFactoryNN();
 
     virtual FairMQMessage* CreateMessage();
-    virtual FairMQMessage* CreateMessage(size_t size);
-    virtual FairMQMessage* CreateMessage(void* data, size_t size, fairmq_free_fn *ffn = NULL, void* hint = NULL);
+    virtual FairMQMessage* CreateMessage(const size_t size);
+    virtual FairMQMessage* CreateMessage(void* data, const size_t size, fairmq_free_fn* ffn = NULL, void* hint = NULL);
 
-    virtual FairMQSocket* CreateSocket(const std::string& type, const std::string& name, int numIoThreads);
+    virtual FairMQSocket* CreateSocket(const std::string& type, const std::string& name, const int numIoThreads);
 
     virtual FairMQPoller* CreatePoller(const std::vector<FairMQChannel>& channels);
-    virtual FairMQPoller* CreatePoller(std::unordered_map<std::string, std::vector<FairMQChannel>>& channelsMap, std::initializer_list<std::string> channelList);
-    virtual FairMQPoller* CreatePoller(FairMQSocket& cmdSocket, FairMQSocket& dataSocket);
+    virtual FairMQPoller* CreatePoller(const std::unordered_map<std::string, std::vector<FairMQChannel>>& channelsMap, const std::initializer_list<std::string> channelList);
+    virtual FairMQPoller* CreatePoller(const FairMQSocket& cmdSocket, const FairMQSocket& dataSocket);
 
     virtual ~FairMQTransportFactoryNN() {};
 };

--- a/fairmq/options/FairMQProgOptions.cxx
+++ b/fairmq/options/FairMQProgOptions.cxx
@@ -101,7 +101,7 @@ int FairMQProgOptions::ParseAll(const int argc, char** argv, bool allowUnregiste
         {
             LOG(WARN) << p;
         }
-        LOG(WARN) << "No channels will be created (You can still fill these manually).";
+        LOG(WARN) << "No channels will be created (You can create them manually).";
         // return 1;
     }
 

--- a/fairmq/run/startBenchmark.sh.in
+++ b/fairmq/run/startBenchmark.sh.in
@@ -24,6 +24,8 @@ echo "Usage: startBenchmark [message size=1000000] [number of messages=0]"
 
 SAMPLER="bsampler"
 SAMPLER+=" --id bsampler1"
+#SAMPLER+=" --io-threads 2"
+#SAMPLER+=" --transport nanomsg"
 SAMPLER+=" --msg-size $msgSize"
 SAMPLER+=" --num-msgs $numMsgs"
 SAMPLER+=" --config-json-file @CMAKE_BINARY_DIR@/bin/config/benchmark.json"
@@ -31,6 +33,8 @@ xterm -geometry 80x23+0+0 -hold -e taskset 0x1 @CMAKE_BINARY_DIR@/bin/$SAMPLER &
 
 SINK="sink"
 SINK+=" --id sink1"
+#SINK+=" --io-threads 2"
+#SINK+=" --transport nanomsg"
 SINK+=" --num-msgs $numMsgs"
 SINK+=" --config-json-file @CMAKE_BINARY_DIR@/bin/config/benchmark.json"
 xterm -geometry 80x23+500+0 -hold -e taskset 0x2 @CMAKE_BINARY_DIR@/bin/$SINK &

--- a/fairmq/test/pub-sub/FairMQTestPub.cxx
+++ b/fairmq/test/pub-sub/FairMQTestPub.cxx
@@ -23,21 +23,21 @@ FairMQTestPub::FairMQTestPub()
 
 void FairMQTestPub::Run()
 {
-    std::unique_ptr<FairMQMessage> ready1Msg(fTransportFactory->CreateMessage());
-    int r1 = fChannels.at("control").at(0).Receive(ready1Msg);
-    std::unique_ptr<FairMQMessage> ready2Msg(fTransportFactory->CreateMessage());
-    int r2 = fChannels.at("control").at(0).Receive(ready2Msg);
+    std::unique_ptr<FairMQMessage> ready1Msg(NewMessage());
+    int r1 = Receive(ready1Msg, "control");
+    std::unique_ptr<FairMQMessage> ready2Msg(NewMessage());
+    int r2 = Receive(ready2Msg, "control");
 
     if (r1 >= 0 && r2 >= 0)
     {
-        std::unique_ptr<FairMQMessage> msg(fTransportFactory->CreateMessage());
-        fChannels.at("data").at(0).Send(msg);
+        std::unique_ptr<FairMQMessage> msg(NewMessage());
+        Send(msg, "data");
 
-        std::unique_ptr<FairMQMessage> ack1Msg(fTransportFactory->CreateMessage());
-        std::unique_ptr<FairMQMessage> ack2Msg(fTransportFactory->CreateMessage());
-        if (fChannels.at("control").at(0).Receive(ack1Msg) >= 0)
+        std::unique_ptr<FairMQMessage> ack1Msg(NewMessage());
+        std::unique_ptr<FairMQMessage> ack2Msg(NewMessage());
+        if (Receive(ack1Msg, "control") >= 0)
         {
-            if (fChannels.at("control").at(0).Receive(ack2Msg) >= 0)
+            if (Receive(ack2Msg, "control") >= 0)
             {
                 LOG(INFO) << "PUB-SUB test successfull";
             }

--- a/fairmq/test/pub-sub/FairMQTestSub.cxx
+++ b/fairmq/test/pub-sub/FairMQTestSub.cxx
@@ -23,14 +23,14 @@ FairMQTestSub::FairMQTestSub()
 
 void FairMQTestSub::Run()
 {
-    std::unique_ptr<FairMQMessage> readyMsg(fTransportFactory->CreateMessage());
-    fChannels.at("control").at(0).Send(readyMsg);
+    std::unique_ptr<FairMQMessage> readyMsg(NewMessage());
+    Send(readyMsg, "control");
 
-    std::unique_ptr<FairMQMessage> msg(fTransportFactory->CreateMessage());
-    if (fChannels.at("data").at(0).Receive(msg) >= 0)
+    std::unique_ptr<FairMQMessage> msg(NewMessage());
+    if (Receive(msg, "data") >= 0)
     {
-        std::unique_ptr<FairMQMessage> ackMsg(fTransportFactory->CreateMessage());
-        fChannels.at("control").at(0).Send(ackMsg);
+        std::unique_ptr<FairMQMessage> ackMsg(NewMessage());
+        Send(ackMsg, "control");
     }
     else
     {

--- a/fairmq/test/push-pull/FairMQTestPull.cxx
+++ b/fairmq/test/push-pull/FairMQTestPull.cxx
@@ -23,9 +23,9 @@ FairMQTestPull::FairMQTestPull()
 
 void FairMQTestPull::Run()
 {
-    std::unique_ptr<FairMQMessage> msg(fTransportFactory->CreateMessage());
+    std::unique_ptr<FairMQMessage> msg(NewMessage());
 
-    if (fChannels.at("data").at(0).Receive(msg) >= 0)
+    if (Receive(msg, "data") >= 0)
     {
         LOG(INFO) << "PUSH-PULL test successfull";
     }

--- a/fairmq/test/push-pull/FairMQTestPush.cxx
+++ b/fairmq/test/push-pull/FairMQTestPush.cxx
@@ -23,8 +23,8 @@ FairMQTestPush::FairMQTestPush()
 
 void FairMQTestPush::Run()
 {
-    std::unique_ptr<FairMQMessage> msg(fTransportFactory->CreateMessage());
-    fChannels.at("data").at(0).Send(msg);
+    std::unique_ptr<FairMQMessage> msg(NewMessage());
+    Send(msg, "data");
 }
 
 FairMQTestPush::~FairMQTestPush()

--- a/fairmq/test/req-rep/FairMQTestRep.cxx
+++ b/fairmq/test/req-rep/FairMQTestRep.cxx
@@ -23,11 +23,11 @@ FairMQTestRep::FairMQTestRep()
 
 void FairMQTestRep::Run()
 {
-    std::unique_ptr<FairMQMessage> request(fTransportFactory->CreateMessage());
-    if (fChannels.at("data").at(0).Receive(request) >= 0)
+    std::unique_ptr<FairMQMessage> request(NewMessage());
+    if (Receive(request, "data") >= 0)
     {
-        std::unique_ptr<FairMQMessage> reply(fTransportFactory->CreateMessage());
-        fChannels.at("data").at(0).Send(reply);
+        std::unique_ptr<FairMQMessage> reply(NewMessage());
+        Send(reply, "data");
     }
 }
 

--- a/fairmq/test/req-rep/FairMQTestReq.cxx
+++ b/fairmq/test/req-rep/FairMQTestReq.cxx
@@ -23,11 +23,11 @@ FairMQTestReq::FairMQTestReq()
 
 void FairMQTestReq::Run()
 {
-    std::unique_ptr<FairMQMessage> request(fTransportFactory->CreateMessage());
-    fChannels.at("data").at(0).Send(request);
+    std::unique_ptr<FairMQMessage> request(NewMessage());
+    Send(request, "data");
 
-    std::unique_ptr<FairMQMessage> reply(fTransportFactory->CreateMessage());
-    if (fChannels.at("data").at(0).Receive(reply) >= 0)
+    std::unique_ptr<FairMQMessage> reply(NewMessage());
+    if (Receive(reply, "data") >= 0)
     {
         LOG(INFO) << "REQ-REP test successfull";
     }

--- a/fairmq/test/runTransferTimeoutTest.cxx
+++ b/fairmq/test/runTransferTimeoutTest.cxx
@@ -56,11 +56,10 @@ class TransferTimeoutTester : public FairMQDevice
 
         if (getSndOK && getRcvOK)
         {
-            void* buffer = malloc(1000);
-            std::unique_ptr<FairMQMessage> msg1(fTransportFactory->CreateMessage(buffer, 1000));
-            std::unique_ptr<FairMQMessage> msg2(fTransportFactory->CreateMessage());
+            std::unique_ptr<FairMQMessage> msg1(NewMessage());
+            std::unique_ptr<FairMQMessage> msg2(NewMessage());
 
-            if (fChannels.at("data-out").at(0).Send(msg1) == -2)
+            if (Send(msg1, "data-out") == -2)
             {
                 LOG(INFO) << "send canceled";
                 sendCanceling = true;
@@ -70,7 +69,7 @@ class TransferTimeoutTester : public FairMQDevice
                 LOG(ERROR) << "send did not cancel";
             }
 
-            if (fChannels.at("data-in").at(0).Receive(msg2) == -2)
+            if (Receive(msg2, "data-in") == -2)
             {
                 LOG(INFO) << "receive canceled";
                 receiveCanceling = true;

--- a/fairmq/zeromq/FairMQMessageZMQ.cxx
+++ b/fairmq/zeromq/FairMQMessageZMQ.cxx
@@ -29,7 +29,7 @@ FairMQMessageZMQ::FairMQMessageZMQ()
     }
 }
 
-FairMQMessageZMQ::FairMQMessageZMQ(size_t size)
+FairMQMessageZMQ::FairMQMessageZMQ(const size_t size)
     : fMessage()
 {
     if (zmq_msg_init_size(&fMessage, size) != 0)
@@ -38,7 +38,7 @@ FairMQMessageZMQ::FairMQMessageZMQ(size_t size)
     }
 }
 
-FairMQMessageZMQ::FairMQMessageZMQ(void* data, size_t size, fairmq_free_fn *ffn, void* hint)
+FairMQMessageZMQ::FairMQMessageZMQ(void* data, const size_t size, fairmq_free_fn *ffn, void* hint)
     : fMessage()
 {
     if (zmq_msg_init_data(&fMessage, data, size, ffn ? ffn : &CleanUp, hint) != 0)
@@ -56,7 +56,7 @@ void FairMQMessageZMQ::Rebuild()
     }
 }
 
-void FairMQMessageZMQ::Rebuild(size_t size)
+void FairMQMessageZMQ::Rebuild(const size_t size)
 {
     CloseMessage();
     if (zmq_msg_init_size(&fMessage, size) != 0)
@@ -65,7 +65,7 @@ void FairMQMessageZMQ::Rebuild(size_t size)
     }
 }
 
-void FairMQMessageZMQ::Rebuild(void* data, size_t size, fairmq_free_fn *ffn, void* hint)
+void FairMQMessageZMQ::Rebuild(void* data, const size_t size, fairmq_free_fn *ffn, void* hint)
 {
     CloseMessage();
     if (zmq_msg_init_data(&fMessage, data, size, ffn ? ffn : &CleanUp, hint) != 0)
@@ -89,7 +89,7 @@ size_t FairMQMessageZMQ::GetSize()
     return zmq_msg_size(&fMessage);
 }
 
-void FairMQMessageZMQ::SetMessage(void*, size_t)
+void FairMQMessageZMQ::SetMessage(void*, const size_t)
 {
     // dummy method to comply with the interface. functionality not allowed in zeromq.
 }

--- a/fairmq/zeromq/FairMQMessageZMQ.h
+++ b/fairmq/zeromq/FairMQMessageZMQ.h
@@ -25,18 +25,18 @@ class FairMQMessageZMQ : public FairMQMessage
 {
   public:
     FairMQMessageZMQ();
-    FairMQMessageZMQ(size_t size);
-    FairMQMessageZMQ(void* data, size_t size, fairmq_free_fn *ffn = &CleanUp, void* hint = NULL);
+    FairMQMessageZMQ(const size_t size);
+    FairMQMessageZMQ(void* data, const size_t size, fairmq_free_fn *ffn = &CleanUp, void* hint = NULL);
 
     virtual void Rebuild();
-    virtual void Rebuild(size_t size);
-    virtual void Rebuild(void* data, size_t size, fairmq_free_fn *ffn = &CleanUp, void* hint = NULL);
+    virtual void Rebuild(const size_t size);
+    virtual void Rebuild(void* data, const size_t size, fairmq_free_fn *ffn = &CleanUp, void* hint = NULL);
 
     virtual void* GetMessage();
     virtual void* GetData();
     virtual size_t GetSize();
 
-    virtual void SetMessage(void* data, size_t size);
+    virtual void SetMessage(void* data, const size_t size);
 
     virtual void CloseMessage();
     virtual void Copy(FairMQMessage* msg);

--- a/fairmq/zeromq/FairMQPollerZMQ.cxx
+++ b/fairmq/zeromq/FairMQPollerZMQ.cxx
@@ -57,7 +57,7 @@ FairMQPollerZMQ::FairMQPollerZMQ(const vector<FairMQChannel>& channels)
     }
 }
 
-FairMQPollerZMQ::FairMQPollerZMQ(unordered_map<string, vector<FairMQChannel>>& channelsMap, initializer_list<string> channelList)
+FairMQPollerZMQ::FairMQPollerZMQ(const unordered_map<string, vector<FairMQChannel>>& channelsMap, const initializer_list<string> channelList)
     : items()
     , fNumItems(0)
     , fOffsetMap()
@@ -119,7 +119,7 @@ FairMQPollerZMQ::FairMQPollerZMQ(unordered_map<string, vector<FairMQChannel>>& c
     }
 }
 
-FairMQPollerZMQ::FairMQPollerZMQ(FairMQSocket& cmdSocket, FairMQSocket& dataSocket)
+FairMQPollerZMQ::FairMQPollerZMQ(const FairMQSocket& cmdSocket, const FairMQSocket& dataSocket)
     : items()
     , fNumItems(2)
     , fOffsetMap()
@@ -137,7 +137,7 @@ FairMQPollerZMQ::FairMQPollerZMQ(FairMQSocket& cmdSocket, FairMQSocket& dataSock
 
     int type = 0;
     size_t size = sizeof(type);
-    zmq_getsockopt (dataSocket.GetSocket(), ZMQ_TYPE, &type, &size);
+    zmq_getsockopt(dataSocket.GetSocket(), ZMQ_TYPE, &type, &size);
 
     if (type == ZMQ_REQ || type == ZMQ_REP || type == ZMQ_PAIR || type == ZMQ_DEALER || type == ZMQ_ROUTER)
     {

--- a/fairmq/zeromq/FairMQPollerZMQ.h
+++ b/fairmq/zeromq/FairMQPollerZMQ.h
@@ -32,7 +32,7 @@ class FairMQPollerZMQ : public FairMQPoller
 
   public:
     FairMQPollerZMQ(const std::vector<FairMQChannel>& channels);
-    FairMQPollerZMQ(std::unordered_map<std::string, std::vector<FairMQChannel>>& channelsMap, std::initializer_list<std::string> channelList);
+    FairMQPollerZMQ(const std::unordered_map<std::string, std::vector<FairMQChannel>>& channelsMap, const std::initializer_list<std::string> channelList);
     FairMQPollerZMQ(const FairMQPollerZMQ&) = delete;
     FairMQPollerZMQ operator=(const FairMQPollerZMQ&) = delete;
 
@@ -45,7 +45,7 @@ class FairMQPollerZMQ : public FairMQPoller
     virtual ~FairMQPollerZMQ();
 
   private:
-    FairMQPollerZMQ(FairMQSocket& cmdSocket, FairMQSocket& dataSocket);
+    FairMQPollerZMQ(const FairMQSocket& cmdSocket, const FairMQSocket& dataSocket);
 
     zmq_pollitem_t* items;
     int fNumItems;

--- a/fairmq/zeromq/FairMQSocketZMQ.cxx
+++ b/fairmq/zeromq/FairMQSocketZMQ.cxx
@@ -24,7 +24,7 @@ using namespace std;
 // Context to hold the ZeroMQ sockets
 boost::shared_ptr<FairMQContextZMQ> FairMQSocketZMQ::fContext = boost::shared_ptr<FairMQContextZMQ>(new FairMQContextZMQ(1));
 
-FairMQSocketZMQ::FairMQSocketZMQ(const string& type, const string& name, int numIoThreads)
+FairMQSocketZMQ::FairMQSocketZMQ(const string& type, const string& name, const int numIoThreads)
     : FairMQSocket(ZMQ_SNDMORE, ZMQ_RCVMORE, ZMQ_DONTWAIT)
     , fSocket(NULL)
     , fId()

--- a/fairmq/zeromq/FairMQSocketZMQ.h
+++ b/fairmq/zeromq/FairMQSocketZMQ.h
@@ -23,7 +23,7 @@
 class FairMQSocketZMQ : public FairMQSocket
 {
   public:
-    FairMQSocketZMQ(const std::string& type, const std::string& name, int numIoThreads);
+    FairMQSocketZMQ(const std::string& type, const std::string& name, const int numIoThreads);
     FairMQSocketZMQ(const FairMQSocketZMQ&) = delete;
     FairMQSocketZMQ operator=(const FairMQSocketZMQ&) = delete;
 

--- a/fairmq/zeromq/FairMQTransportFactoryZMQ.cxx
+++ b/fairmq/zeromq/FairMQTransportFactoryZMQ.cxx
@@ -30,17 +30,17 @@ FairMQMessage* FairMQTransportFactoryZMQ::CreateMessage()
     return new FairMQMessageZMQ();
 }
 
-FairMQMessage* FairMQTransportFactoryZMQ::CreateMessage(size_t size)
+FairMQMessage* FairMQTransportFactoryZMQ::CreateMessage(const size_t size)
 {
     return new FairMQMessageZMQ(size);
 }
 
-FairMQMessage* FairMQTransportFactoryZMQ::CreateMessage(void* data, size_t size, fairmq_free_fn *ffn, void* hint)
+FairMQMessage* FairMQTransportFactoryZMQ::CreateMessage(void* data, const size_t size, fairmq_free_fn* ffn, void* hint)
 {
     return new FairMQMessageZMQ(data, size, ffn, hint);
 }
 
-FairMQSocket* FairMQTransportFactoryZMQ::CreateSocket(const string& type, const std::string& name, int numIoThreads)
+FairMQSocket* FairMQTransportFactoryZMQ::CreateSocket(const string& type, const std::string& name, const int numIoThreads)
 {
     return new FairMQSocketZMQ(type, name, numIoThreads);
 }
@@ -50,12 +50,12 @@ FairMQPoller* FairMQTransportFactoryZMQ::CreatePoller(const vector<FairMQChannel
     return new FairMQPollerZMQ(channels);
 }
 
-FairMQPoller* FairMQTransportFactoryZMQ::CreatePoller(std::unordered_map<std::string, std::vector<FairMQChannel>>& channelsMap, std::initializer_list<std::string> channelList)
+FairMQPoller* FairMQTransportFactoryZMQ::CreatePoller(const std::unordered_map<std::string, std::vector<FairMQChannel>>& channelsMap, const std::initializer_list<std::string> channelList)
 {
     return new FairMQPollerZMQ(channelsMap, channelList);
 }
 
-FairMQPoller* FairMQTransportFactoryZMQ::CreatePoller(FairMQSocket& cmdSocket, FairMQSocket& dataSocket)
+FairMQPoller* FairMQTransportFactoryZMQ::CreatePoller(const FairMQSocket& cmdSocket, const FairMQSocket& dataSocket)
 {
     return new FairMQPollerZMQ(cmdSocket, dataSocket);
 }

--- a/fairmq/zeromq/FairMQTransportFactoryZMQ.h
+++ b/fairmq/zeromq/FairMQTransportFactoryZMQ.h
@@ -29,14 +29,14 @@ class FairMQTransportFactoryZMQ : public FairMQTransportFactory
     FairMQTransportFactoryZMQ();
 
     virtual FairMQMessage* CreateMessage();
-    virtual FairMQMessage* CreateMessage(size_t size);
-    virtual FairMQMessage* CreateMessage(void* data, size_t size, fairmq_free_fn *ffn = NULL, void* hint = NULL);
+    virtual FairMQMessage* CreateMessage(const size_t size);
+    virtual FairMQMessage* CreateMessage(void* data, const size_t size, fairmq_free_fn* ffn = NULL, void* hint = NULL);
 
-    virtual FairMQSocket* CreateSocket(const std::string& type, const std::string& name, int numIoThreads);
+    virtual FairMQSocket* CreateSocket(const std::string& type, const std::string& name, const int numIoThreads);
 
     virtual FairMQPoller* CreatePoller(const std::vector<FairMQChannel>& channels);
-    virtual FairMQPoller* CreatePoller(std::unordered_map<std::string, std::vector<FairMQChannel>>& channelsMap, std::initializer_list<std::string> channelList);
-    virtual FairMQPoller* CreatePoller(FairMQSocket& cmdSocket, FairMQSocket& dataSocket);
+    virtual FairMQPoller* CreatePoller(const std::unordered_map<std::string, std::vector<FairMQChannel>>& channelsMap, const std::initializer_list<std::string> channelList);
+    virtual FairMQPoller* CreatePoller(const FairMQSocket& cmdSocket, const FairMQSocket& dataSocket);
 
     virtual ~FairMQTransportFactoryZMQ() {};
 };


### PR DESCRIPTION
 - Extend the multipart API to allow sending vectors of messages or helper
   thin wrapper `FairMQParts`. See example in examples/MQ/8-multipart.

 - `NewMessage()` can be used in devices instead of
   `fTransportFactory->CreateMessage()`.
   Possible arguments remain unchanged (no args, size or data+size).

 - `Send()`/`Receive()` methods can be used in devices instead of
   `fChannels.at("chan").at(i).Send()`/`Receive()`:
   `Send(msg, "chan", i = 0)`, `Receive(msg, "chan", i = 0)`.

 - Use the new methods in MQ examples and tests.