### PR TITLE
Update Tutorial 3 to include unused members in the transfer

### DIFF
--- a/examples/advanced/Tutorial3/MQ/fileSink/FairTestDetectorFileSinkMsgpack.tpl
+++ b/examples/advanced/Tutorial3/MQ/fileSink/FairTestDetectorFileSinkMsgpack.tpl
@@ -26,7 +26,7 @@ void FairTestDetectorFileSink<FairTestDetectorHit, MsgPack>::Run()
 
             // deserialize
 
-            std::vector<msgpack::type::tuple<int, double, double, double, double, double, double>> hits;
+            std::vector<msgpack::type::tuple<int, int, double, double, double, double, double, double>> hits;
 
             msgpack::unpacked unpackedHits;
             // msgpack::unpacked unpackedBigBuffer;
@@ -51,9 +51,9 @@ void FairTestDetectorFileSink<FairTestDetectorHit, MsgPack>::Run()
 
             for (int i = 0; i < numEntries; ++i)
             {
-                TVector3 pos(std::get<1>(hits.at(i)), std::get<2>(hits.at(i)), std::get<3>(hits.at(i)));
-                TVector3 dpos(std::get<4>(hits.at(i)), std::get<5>(hits.at(i)), std::get<6>(hits.at(i)));
-                new ((*fOutput)[i]) FairTestDetectorHit(std::get<0>(hits.at(i)), 0, pos, dpos);
+                TVector3 pos(std::get<2>(hits.at(i)), std::get<3>(hits.at(i)), std::get<4>(hits.at(i)));
+                TVector3 dpos(std::get<5>(hits.at(i)), std::get<6>(hits.at(i)), std::get<7>(hits.at(i)));
+                new ((*fOutput)[i]) FairTestDetectorHit(std::get<0>(hits.at(i)), std::get<1>(hits.at(i)), pos, dpos);
             }
 
             if (fOutput->IsEmpty())
@@ -91,7 +91,7 @@ void FairTestDetectorFileSink<FairTestDetectorHit, MsgPack>::Run()
 //             msgpack::unpack(&pmsg, static_cast<char*>(msg->GetData()), msg->GetSize());
 //             msgpack::object hitsObj = pmsg.get();
 
-//             std::vector<msgpack::type::tuple<int, double, double, double, double, double, double>> hits;
+//             std::vector<msgpack::type::tuple<int, int, double, double, double, double, double, double>> hits;
 //             hitsObj.convert(&hits);
 
 //             int numEntries = hits.size();
@@ -100,9 +100,9 @@ void FairTestDetectorFileSink<FairTestDetectorHit, MsgPack>::Run()
 
 //             for (int i = 0; i < numEntries; ++i)
 //             {
-//                 TVector3 pos(std::get<1>(hits.at(i)), std::get<2>(hits.at(i)), std::get<3>(hits.at(i)));
-//                 TVector3 dpos(std::get<4>(hits.at(i)), std::get<5>(hits.at(i)), std::get<6>(hits.at(i)));
-//                 new ((*fOutput)[i]) FairTestDetectorHit(std::get<0>(hits.at(i)), 0, pos, dpos);
+//                 TVector3 pos(std::get<2>(hits.at(i)), std::get<3>(hits.at(i)), std::get<4>(hits.at(i)));
+//                 TVector3 dpos(std::get<5>(hits.at(i)), std::get<6>(hits.at(i)), std::get<7>(hits.at(i)));
+//                 new ((*fOutput)[i]) FairTestDetectorHit(std::get<0>(hits.at(i)), std::get<1>(hits.at(i)), pos, dpos);
 //             }
 
 //             if (fOutput->IsEmpty())
@@ -150,11 +150,11 @@ void FairTestDetectorFileSink<FairTestDetectorHit, MsgPack>::Run()
 //             while (pac.next(&umsg))
 //             {
 //                 msgpack::object hitObj = umsg.get();
-//                 msgpack::type::tuple<int, double, double, double, double, double, double> hit;
+//                 msgpack::type::tuple<int, int, double, double, double, double, double, double> hit;
 //                 hitObj.convert(&hit);
-//                 TVector3 pos(std::get<1>(hit), std::get<2>(hit), std::get<3>(hit));
-//                 TVector3 dpos(std::get<4>(hit), std::get<5>(hit), std::get<6>(hit));
-//                 new ((*fOutput)[numEntries]) FairTestDetectorHit(std::get<0>(hit), 0, pos, dpos);
+//                 TVector3 pos(std::get<2>(hits.at(i)), std::get<3>(hits.at(i)), std::get<4>(hits.at(i)));
+//                 TVector3 dpos(std::get<5>(hits.at(i)), std::get<6>(hits.at(i)), std::get<7>(hits.at(i)));
+//                 new ((*fOutput)[i]) FairTestDetectorHit(std::get<0>(hits.at(i)), std::get<1>(hits.at(i)), pos, dpos);
 //                 numEntries++;
 //             }
 

--- a/examples/advanced/Tutorial3/MQ/processorTask/FairTestDetectorMQRecoTaskBin.tpl
+++ b/examples/advanced/Tutorial3/MQ/processorTask/FairTestDetectorMQRecoTaskBin.tpl
@@ -34,6 +34,7 @@ void FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TestD
     for (int i = 0; i < numEntries; ++i)
     {
         new ((*fRecoTask->fDigiArray)[i]) FairTestDetectorDigi(input[i].fX, input[i].fY, input[i].fZ, input[i].fTimeStamp);
+        static_cast<FairTestDetectorDigi*>(((*fRecoTask->fDigiArray)[i]))->SetTimeStampError(input[i].fTimeStampError);
     }
 
     if (!fRecoTask->fDigiArray)
@@ -59,6 +60,7 @@ void FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TestD
             FairTestDetectorHit* hit = (FairTestDetectorHit*)fRecoTask->fHitArray->At(i);
 
             output[i].detID = hit->GetDetectorID();
+            output[i].mcindex = hit->GetRefIndex();
             output[i].posX = hit->GetX();
             output[i].posY = hit->GetY();
             output[i].posZ = hit->GetZ();

--- a/examples/advanced/Tutorial3/MQ/processorTask/FairTestDetectorMQRecoTaskFlatBuffers.tpl
+++ b/examples/advanced/Tutorial3/MQ/processorTask/FairTestDetectorMQRecoTaskFlatBuffers.tpl
@@ -32,6 +32,7 @@ void FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TestD
     for (auto it = digis->begin(); it != digis->end(); ++it)
     {
         new ((*fRecoTask->fDigiArray)[it - digis->begin()]) FairTestDetectorDigi((*it)->x(), (*it)->y(), (*it)->z(), (*it)->timestamp());
+        static_cast<FairTestDetectorDigi*>(((*fRecoTask->fDigiArray)[it - digis->begin()]))->SetTimeStampError((*it)->timestampError());
         // LOG(INFO) << (*it)->x() << " " << (*it)->y() << " " << (*it)->z() << " " << (*it)->timestamp() << " " << (*it)->timestampError();
     }
 
@@ -59,6 +60,7 @@ void FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TestD
         // LOG(WARN) << " " << hit->GetDetectorID() << " " << hit->GetX() << " " << hit->GetY() << " " << hit->GetZ() << " " << hit->GetDx() << " " << hit->GetDy() << " " << hit->GetDz();
         HitBuilder hb(*builder);
         hb.add_detID(hit->GetDetectorID()); // detID:int
+        hb.add_mcIndex(hit->GetRefIndex()); // GetRefIndex:int
         hb.add_x(hit->GetX()); // x:double
         hb.add_y(hit->GetY()); // y:double
         hb.add_z(hit->GetZ()); // z:double

--- a/examples/advanced/Tutorial3/MQ/processorTask/FairTestDetectorMQRecoTaskMsgpack.tpl
+++ b/examples/advanced/Tutorial3/MQ/processorTask/FairTestDetectorMQRecoTaskMsgpack.tpl
@@ -12,7 +12,7 @@
 
 // Types to be used as template parameters.
 struct MsgPack {};
-// struct MsgPackRef { msgpack::vrefbuffer vbuf; std::vector<msgpack::type::tuple<int, double, double, double, double, double, double>> hits; };
+// struct MsgPackRef { msgpack::vrefbuffer vbuf; std::vector<msgpack::type::tuple<int, int, double, double, double, double, double, double>> hits; };
 // struct MsgPackStream {};
 
 void free_sbuffer(void *data, void *hint)
@@ -25,7 +25,7 @@ void FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, MsgPa
 {
     // deserialize
 
-    std::vector<msgpack::type::tuple<int, int, int, double>> digis;
+    std::vector<msgpack::type::tuple<int, int, int, double, double>> digis;
 
     msgpack::unpacked unpackedDigis;
     // msgpack::unpacked unpackedBigBuffer;
@@ -51,6 +51,7 @@ void FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, MsgPa
     for (int i = 0; i < numEntries; ++i)
     {
         new ((*fRecoTask->fDigiArray)[i]) FairTestDetectorDigi(std::get<0>(digis.at(i)), std::get<1>(digis.at(i)), std::get<2>(digis.at(i)), std::get<3>(digis.at(i)));
+        static_cast<FairTestDetectorDigi*>(((*fRecoTask->fDigiArray)[i]))->SetTimeStampError(std::get<4>(digis.at(i)));
     }
 
     if (!fRecoTask->fDigiArray)
@@ -67,12 +68,12 @@ void FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, MsgPa
     msgpack::sbuffer* sbuf = new msgpack::sbuffer();
     msgpack::packer<msgpack::sbuffer> packer(sbuf);
 
-    std::vector<msgpack::type::tuple<int, double, double, double, double, double, double>> hits;
+    std::vector<msgpack::type::tuple<int, int, double, double, double, double, double, double>> hits;
 
     for (int i = 0; i < numEntries; ++i)
     {
         FairTestDetectorHit* hit = static_cast<FairTestDetectorHit*>(fRecoTask->fHitArray->At(i));
-        hits.push_back(std::make_tuple(hit->GetDetectorID(), hit->GetX(), hit->GetY(), hit->GetZ(), hit->GetDx(), hit->GetDy(), hit->GetDz()));
+        hits.push_back(std::make_tuple(hit->GetDetectorID(), hit->GetRefIndex(), hit->GetX(), hit->GetY(), hit->GetZ(), hit->GetDx(), hit->GetDy(), hit->GetDz()));
     }
 
     packer.pack(hits);
@@ -95,7 +96,7 @@ void FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, MsgPa
 //     msgpack::unpack(&msg, static_cast<char*>(fPayload->GetData()), fPayload->GetSize());
 //     msgpack::object digisObj = msg.get();
 
-//     std::vector<msgpack::type::tuple<int, int, int, double>> digis;
+//     std::vector<msgpack::type::tuple<int, int, int, double, double>> digis;
 //     digisObj.convert(&digis);
 
 //     int numEntries = digis.size();
@@ -144,7 +145,7 @@ void FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, MsgPa
 //     while (pac.next(&msg))
 //     {
 //         msgpack::object digiObj = msg.get();
-//         msgpack::type::tuple<int, int, int, double> digi;
+//         msgpack::type::tuple<int, int, int, double, double> digi;
 //         digiObj.convert(&digi);
 //         new ((*fRecoTask->fDigiArray)[numEntries]) FairTestDetectorDigi(std::get<0>(digi), std::get<1>(digi), std::get<2>(digi), std::get<3>(digi));
 //         numEntries++;

--- a/examples/advanced/Tutorial3/MQ/processorTask/FairTestDetectorMQRecoTaskProtobuf.tpl
+++ b/examples/advanced/Tutorial3/MQ/processorTask/FairTestDetectorMQRecoTaskProtobuf.tpl
@@ -35,6 +35,7 @@ void FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TestD
     {
         const TestDetectorProto::Digi& digi = dp.digi(i);
         new ((*fRecoTask->fDigiArray)[i]) FairTestDetectorDigi(digi.fx(), digi.fy(), digi.fz(), digi.ftimestamp());
+        static_cast<FairTestDetectorDigi*>(((*fRecoTask->fDigiArray)[i]))->SetTimeStampError(digi.ftimestamperror());
     }
 
     if (!fRecoTask->fDigiArray)
@@ -55,6 +56,7 @@ void FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TestD
         }
         TestDetectorProto::Hit* h = hp.add_hit();
         h->set_detid(hit->GetDetectorID());
+        h->set_mcindex(hit->GetRefIndex());
         h->set_posx(hit->GetX());
         h->set_posy(hit->GetY());
         h->set_posz(hit->GetZ());

--- a/examples/advanced/Tutorial3/MQ/samplerTask/FairTestDetectorDigiLoaderBin.tpl
+++ b/examples/advanced/Tutorial3/MQ/samplerTask/FairTestDetectorDigiLoaderBin.tpl
@@ -47,5 +47,6 @@ void FairTestDetectorDigiLoader<FairTestDetectorDigi, TestDetectorPayload::Digi>
         digiPayload[i].fY = digi->GetY();
         digiPayload[i].fZ = digi->GetZ();
         digiPayload[i].fTimeStamp = digi->GetTimeStamp();
+        digiPayload[i].fTimeStampError = digi->GetTimeStampError();
     }
 }

--- a/examples/advanced/Tutorial3/MQ/samplerTask/FairTestDetectorDigiLoaderMsgpack.tpl
+++ b/examples/advanced/Tutorial3/MQ/samplerTask/FairTestDetectorDigiLoaderMsgpack.tpl
@@ -12,7 +12,7 @@
 
 // Types to be used as template parameters.
 struct MsgPack {};
-// struct MsgPackRef { msgpack::vrefbuffer vbuf; std::vector<msgpack::type::tuple<int, int, int, double>> digis; };
+// struct MsgPackRef { msgpack::vrefbuffer vbuf; std::vector<msgpack::type::tuple<int, int, int, double, double>> digis; };
 // struct MsgPackStream {};
 
 void free_sbuffer(void *data, void *hint)
@@ -28,12 +28,12 @@ void FairTestDetectorDigiLoader<FairTestDetectorDigi, MsgPack>::Exec(Option_t* o
     msgpack::sbuffer* sbuf = new msgpack::sbuffer();
     msgpack::packer<msgpack::sbuffer> packer(sbuf);
 
-    std::vector<msgpack::type::tuple<int, int, int, double>> digis;
+    std::vector<msgpack::type::tuple<int, int, int, double, double>> digis;
 
     for (int i = 0; i < nDigis; ++i)
     {
         FairTestDetectorDigi* digi = static_cast<FairTestDetectorDigi*>(fInput->At(i));
-        digis.push_back(std::make_tuple(digi->GetX(), digi->GetY(), digi->GetZ(), digi->GetTimeStamp()));
+        digis.push_back(std::make_tuple(digi->GetX(), digi->GetY(), digi->GetZ(), digi->GetTimeStamp(), digi->GetTimeStampError()));
     }
 
     // Write some data to check it on the receiver side

--- a/examples/advanced/Tutorial3/MQ/samplerTask/FairTestDetectorDigiLoaderProtobuf.tpl
+++ b/examples/advanced/Tutorial3/MQ/samplerTask/FairTestDetectorDigiLoaderProtobuf.tpl
@@ -38,6 +38,7 @@ void FairTestDetectorDigiLoader<FairTestDetectorDigi, TestDetectorProto::DigiPay
         d->set_fy(digi->GetY());
         d->set_fz(digi->GetZ());
         d->set_ftimestamp(digi->GetTimeStamp());
+        d->set_ftimestamperror(digi->GetTimeStampError());
     }
 
     // dp.set_bigbuffer(fBigBuffer->data(), sizeof(*fBigBuffer));


### PR DESCRIPTION
Some serialization methods skipped unused class member, which produced slightly unfair comparison.
Now fixed.