### PR TITLE
Allocate dynamic size flatbuffers structure on the heap

### DIFF
--- a/examples/advanced/Tutorial3/MQ/processorTask/FairTestDetectorMQRecoTaskFlatBuffers.tpl
+++ b/examples/advanced/Tutorial3/MQ/processorTask/FairTestDetectorMQRecoTaskFlatBuffers.tpl
@@ -44,7 +44,7 @@ void FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TestD
     fRecoTask->Exec(opt);
 
     flatbuffers::FlatBufferBuilder* builder = new flatbuffers::FlatBufferBuilder();
-    flatbuffers::Offset<TestDetectorFlat::Hit> hits[numEntries];
+    flatbuffers::Offset<TestDetectorFlat::Hit>* hits = new flatbuffers::Offset<TestDetectorFlat::Hit>[numEntries];
 
     // unsigned char *inv_buf = nullptr;
     // auto bigBuffer = builder->CreateUninitializedVector<unsigned char>(sizeof(*fBigBuffer), &inv_buf);
@@ -75,6 +75,8 @@ void FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TestD
     auto mloc = CreateHitPayload(*builder, hvector); // hits:[Hit]
     // auto mloc = CreateHitPayload(*builder, hvector, bigBuffer); // hits:[Hit], bigBuffer:[ubyte]
     FinishHitPayloadBuffer(*builder, mloc);
+
+    delete [] hits;
 
     fPayload->Rebuild(builder->GetBufferPointer(), builder->GetSize(), free_builder, builder);
 }

--- a/examples/advanced/Tutorial3/MQ/samplerTask/FairTestDetectorDigiLoaderFlatBuffers.tpl
+++ b/examples/advanced/Tutorial3/MQ/samplerTask/FairTestDetectorDigiLoaderFlatBuffers.tpl
@@ -19,7 +19,7 @@ void FairTestDetectorDigiLoader<FairTestDetectorDigi, TestDetectorFlat::DigiPayl
     int nDigis = fInput->GetEntriesFast();
 
     flatbuffers::FlatBufferBuilder* builder = new flatbuffers::FlatBufferBuilder();
-    flatbuffers::Offset<TestDetectorFlat::Digi> digis[nDigis];
+    flatbuffers::Offset<TestDetectorFlat::Digi>* digis = new flatbuffers::Offset<TestDetectorFlat::Digi>[nDigis];
 
     // Write some data to check it on the receiver side
     // (*fBigBuffer)[7] = 'c';
@@ -51,6 +51,8 @@ void FairTestDetectorDigiLoader<FairTestDetectorDigi, TestDetectorFlat::DigiPayl
     auto mloc = CreateDigiPayload(*builder, dvector); // digis:[Digi]
     // auto mloc = CreateDigiPayload(*builder, dvector, bigBuffer); // digis:[Digi], bigBuffer:[ubyte]
     FinishDigiPayloadBuffer(*builder, mloc);
+
+    delete [] digis;
 
     fOutput = fTransportFactory->CreateMessage(builder->GetBufferPointer(), builder->GetSize(), free_builder, builder);
 }

--- a/fairmq/FairMQMessage.h
+++ b/fairmq/FairMQMessage.h
@@ -24,8 +24,8 @@ class FairMQMessage
 {
   public:
     virtual void Rebuild() = 0;
-    virtual void Rebuild(size_t size) = 0;
-    virtual void Rebuild(void* data, size_t size, fairmq_free_fn *ffn = NULL, void* hint = NULL) = 0;
+    virtual void Rebuild(const size_t size) = 0;
+    virtual void Rebuild(void* data, const size_t size, fairmq_free_fn *ffn = NULL, void* hint = NULL) = 0;
 
     virtual void* GetMessage() = 0;
     virtual void* GetData() = 0;

--- a/fairmq/devices/FairMQMerger.cxx
+++ b/fairmq/devices/FairMQMerger.cxx
@@ -54,7 +54,7 @@ void FairMQMerger::Run()
             if (poller->CheckInput(i))
             {
                 // Try receiving the data.
-                if (dataInChannels[i]->Receive(msg) > 0)
+                if (dataInChannels[i]->Receive(msg) >= 0)
                 {
                     // If data was received, send it to output.
                     if (dataOutChannel.Send(msg) < 0)

--- a/fairmq/devices/FairMQSplitter.cxx
+++ b/fairmq/devices/FairMQSplitter.cxx
@@ -44,7 +44,7 @@ void FairMQSplitter::Run()
     {
         std::unique_ptr<FairMQMessage> msg(fTransportFactory->CreateMessage());
 
-        if (dataInChannel.Receive(msg) > 0)
+        if (dataInChannel.Receive(msg) >= 0)
         {
             dataOutChannels[direction]->Send(msg);
             ++direction;


### PR DESCRIPTION
+ Allocate dynamic size flatbuffers structure on the heap.
+ Merger, Splitter: remove debug output when handling empty messages.