### PR TITLE
PixelDetector example does depend on common/mcstack which does depend…

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,8 +2,8 @@
  ################################################################################
  #    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    #
  #                                                                              #
- #              This software is distributed under the terms of the             # 
- #         GNU Lesser General Public Licence version 3 (LGPL) version 3,        #  
+ #              This software is distributed under the terms of the             #
+ #         GNU Lesser General Public Licence version 3 (LGPL) version 3,        #
  #                  copied verbatim in the file "LICENSE"                       #
  ################################################################################
 If(GEANT3_FOUND)
@@ -21,6 +21,7 @@ If(GEANT3_FOUND)
   If(Boost_FOUND AND POS_C++11 AND ZMQ_FOUND)
     add_subdirectory(MQ/7-parameters)
     add_subdirectory(MQ/GenericDevices)
+    add_subdirectory(MQ/9-PixelDetector)
   EndIf()
   add_subdirectory (simulation/rutherford)
 EndIf()
@@ -36,7 +37,6 @@ If(Boost_FOUND AND POS_C++11 AND ZMQ_FOUND)
   add_subdirectory(MQ/6-multiple-channels)
   add_subdirectory(MQ/8-multipart)
   add_subdirectory(MQ/LmdSampler)
-  add_subdirectory(MQ/9-PixelDetector)
 EndIf()
 
 add_subdirectory(advanced/Tutorial8)


### PR DESCRIPTION
… on Geant3...

Thus moved the add_directory to within the If(GEANT3_FOUND) part.

Otherwise my FairRoot build w/o Geant3 was failing with : 

[ 97%] Built target runTut8Sink
[ 97%] Linking CXX executable ../../../bin/runTut8MQUnpacker
[ 97%] Linking CXX shared library ../../../../lib/libPixel.so
ld: library not found for -lMCStack
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [lib/libPixel.15.11.0.so] Error 1
make[1]: *** [examples/MQ/9-PixelDetector/src/CMakeFiles/Pixel.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 97%] Built target runTut8MQUnpacker