### PR TITLE
examples/advanced: add Go-based examples

### DIFF
--- a/examples/advanced/GoTutorial/README.md
+++ b/examples/advanced/GoTutorial/README.md
@@ -1,0 +1,9 @@
+# GoTutorial
+
+`GoTutorial` shows how one can mix and mash devices written in `C++` and devices written in `Go`, exchanging data over `nanomsg`.
+
+- `go-sink` is a sink, written in `Go`
+- `go-processor` is a processor, written in `Go`
+
+They are meant to be used with the `C++` devices shown in `MQ/1-sampler-sink` and `MQ/2-sampler-processor-sink`.
+

--- a/examples/advanced/GoTutorial/go-processor/README.md
+++ b/examples/advanced/GoTutorial/go-processor/README.md
@@ -1,0 +1,167 @@
+# go-processor
+
+`go-processor` is a simple `Go` based program using `nanomsg` as a transport facility.
+It replicates the basic example from [FairRootMQ example 2](https://github.com/FairRootGroup/FairRoot/tree/master/examples/MQ/2-sampler-processor-sink).
+
+## Build
+
+```sh
+$> cd go-processor
+$> go build
+```
+
+## Usage
+
+- First, you need to run the `C++` `FairRootMQ` `sampler` program:
+
+```sh
+$> ex2-sampler --id sampler1 \
+  --transport nanomsg \
+  --config-json-file /opt/alice/src/fair-root/examples/MQ/2-sampler-processor-sink/ex2-sampler-processor-sink.json --transport nanomsg
+[17:04:43][STATE] Entering FairMQ state machine
+[17:04:43][INFO] ***************************************************************************************************************************************************
+[17:04:43][INFO] **********************************************************     Program options found     **********************************************************
+[17:04:43][INFO] ***************************************************************************************************************************************************
+[17:04:43][INFO] config-json-file = /opt/alice/src/fair-root/examples/MQ/2-sampler-processor-sink/ex2-sampler-processor-sink.json  [Type=string]  [provided value] *
+[17:04:43][INFO] id               = sampler1                                                                                       [Type=string]  [provided value] *
+[17:04:43][INFO] io-threads       = 1                                                                                              [Type=int]     [default value]  *
+[17:04:43][INFO] log-color        = 1                                                                                              [Type=bool]    [default value]  *
+[17:04:43][INFO] text             = Hello                                                                                          [Type=string]  [default value]  *
+[17:04:43][INFO] transport        = nanomsg                                                                                        [Type=string]  [provided value] *
+[17:04:43][INFO] verbose          = DEBUG                                                                                          [Type=string]  [default value]  *
+[17:04:43][INFO] ***************************************************************************************************************************************************
+[17:04:43][DEBUG] Found device id 'sampler1' in JSON input
+[17:04:43][DEBUG] Found device id 'processor1' in JSON input
+[17:04:43][DEBUG] Found device id 'processor2' in JSON input
+[17:04:43][DEBUG] Found device id 'sink1' in JSON input
+[17:04:43][DEBUG] [node = device]   id = sampler1
+[17:04:43][DEBUG] 	 [node = channel]   name = data1
+[17:04:43][DEBUG] 	 	 [node = socket]   socket index = 1
+[17:04:43][DEBUG] 	 	 	 type        = push
+[17:04:43][DEBUG] 	 	 	 method      = bind
+[17:04:43][DEBUG] 	 	 	 address     = tcp://*:5555
+[17:04:43][DEBUG] 	 	 	 sndBufSize  = 1000
+[17:04:43][DEBUG] 	 	 	 rcvBufSize  = 1000
+[17:04:43][DEBUG] 	 	 	 rateLogging = 0
+[17:04:43][DEBUG] ---- Channel-keys found are :
+[17:04:43][DEBUG] data1
+[17:04:43][INFO] PID: 168
+[17:04:43][INFO] Using nanomsg library
+[17:04:43][STATE] Entering INITIALIZING DEVICE state
+[17:04:43][INFO] created socket sampler1.device-commands.pub
+[17:04:43][INFO] bind socket sampler1.device-commands.pub on inproc://commands
+[17:04:43][DEBUG] Validating channel "data1[0]"... VALID
+[17:04:43][DEBUG] Initializing channel data1[0] (push)
+[17:04:43][INFO] created socket sampler1.data1[0].push
+[17:04:43][DEBUG] Binding channel data1[0] on tcp://*:5555
+[17:04:43][INFO] bind socket sampler1.data1[0].push on tcp://*:5555
+[17:04:43][INFO] created socket internal.device-commands.sub
+[17:04:43][INFO] connect socket internal.device-commands.sub to inproc://commands
+[17:04:44][STATE] Entering DEVICE READY state
+[17:04:44][STATE] Entering INITIALIZING TASK state
+[17:04:44][STATE] Entering READY state
+[17:04:44][STATE] Entering RUNNING state
+[17:04:44][INFO] DEVICE: Running...
+[17:04:44][INFO] Use keys to control the state machine:
+[17:04:44][INFO] [h] help, [p] pause, [r] run, [s] stop, [t] reset task, [d] reset device, [q] end, [j] init task, [i] init device
+[17:04:45][INFO] Sending "Hello"
+[17:04:54][INFO] Sending "Hello"
+[17:04:55][INFO] Sending "Hello"
+[17:04:56][INFO] Sending "Hello"
+[...]
+[17:06:07][INFO] Sending "Hello"
+[17:06:08][INFO] Sending "Hello"
+q
+[17:06:08][INFO] [q] end
+[17:06:08][STATE] Entering EXITING state
+[17:06:09][INFO] Sending "Hello"
+[17:06:09][DEBUG] unblocked
+[17:06:09][DEBUG] Closing sockets...
+[17:06:09][DEBUG] Closed all sockets!
+[17:06:09][STATE] Exiting FairMQ state machine
+```
+
+- Then, in another terminal:
+
+```sh
+$> go-processor
+2016/03/11 17:04:53 dialing tcp://localhost:5555 ...
+2016/03/11 17:04:53 dialing tcp://localhost:5555 ... [done]
+2016/03/11 17:04:53 dialing tcp://localhost:5556 ...
+2016/03/11 17:04:53 dialing tcp://localhost:5556 ... [done]
+2016/03/11 17:04:53 recv: Hello
+2016/03/11 17:04:54 recv: Hello
+2016/03/11 17:04:55 recv: Hello
+2016/03/11 17:04:56 recv: Hello
+[...]
+2016/03/11 17:06:07 recv: Hello
+2016/03/11 17:06:08 recv: Hello
+^C
+```
+
+- And, in yet another terminal:
+
+```sh
+$> ex2-sink --id sink1 --config-json-file /opt/alice/src/fair-root/examples/MQ/2-sampler-processor-sink/ex2-sampler-processor-sink.json --transport nanomsg
+[17:05:56][STATE] Entering FairMQ state machine
+[17:05:56][INFO] ***************************************************************************************************************************************************
+[17:05:56][INFO] **********************************************************     Program options found     **********************************************************
+[17:05:56][INFO] ***************************************************************************************************************************************************
+[17:05:56][INFO] config-json-file = /opt/alice/src/fair-root/examples/MQ/2-sampler-processor-sink/ex2-sampler-processor-sink.json  [Type=string]  [provided value] *
+[17:05:56][INFO] id               = sink1                                                                                          [Type=string]  [provided value] *
+[17:05:56][INFO] io-threads       = 1                                                                                              [Type=int]     [default value]  *
+[17:05:56][INFO] log-color        = 1                                                                                              [Type=bool]    [default value]  *
+[17:05:56][INFO] transport        = nanomsg                                                                                        [Type=string]  [provided value] *
+[17:05:56][INFO] verbose          = DEBUG                                                                                          [Type=string]  [default value]  *
+[17:05:56][INFO] ***************************************************************************************************************************************************
+[17:05:56][DEBUG] Found device id 'sampler1' in JSON input
+[17:05:56][DEBUG] Found device id 'processor1' in JSON input
+[17:05:56][DEBUG] Found device id 'processor2' in JSON input
+[17:05:56][DEBUG] Found device id 'sink1' in JSON input
+[17:05:56][DEBUG] [node = device]   id = sink1
+[17:05:56][DEBUG] 	 [node = channel]   name = data2
+[17:05:56][DEBUG] 	 	 [node = socket]   socket index = 1
+[17:05:56][DEBUG] 	 	 	 type        = pull
+[17:05:56][DEBUG] 	 	 	 method      = bind
+[17:05:56][DEBUG] 	 	 	 address     = tcp://*:5556
+[17:05:56][DEBUG] 	 	 	 sndBufSize  = 1000
+[17:05:56][DEBUG] 	 	 	 rcvBufSize  = 1000
+[17:05:56][DEBUG] 	 	 	 rateLogging = 0
+[17:05:56][DEBUG] ---- Channel-keys found are :
+[17:05:56][DEBUG] data2
+[17:05:56][INFO] PID: 219
+[17:05:56][INFO] Using nanomsg library
+[17:05:56][STATE] Entering INITIALIZING DEVICE state
+[17:05:56][INFO] created socket sink1.device-commands.pub
+[17:05:56][INFO] bind socket sink1.device-commands.pub on inproc://commands
+[17:05:56][DEBUG] Validating channel "data2[0]"... VALID
+[17:05:56][DEBUG] Initializing channel data2[0] (pull)
+[17:05:56][INFO] created socket sink1.data2[0].pull
+[17:05:56][DEBUG] Binding channel data2[0] on tcp://*:5556
+[17:05:56][INFO] bind socket sink1.data2[0].pull on tcp://*:5556
+[17:05:56][INFO] created socket internal.device-commands.sub
+[17:05:56][INFO] connect socket internal.device-commands.sub to inproc://commands
+[17:05:57][STATE] Entering DEVICE READY state
+[17:05:57][STATE] Entering INITIALIZING TASK state
+[17:05:57][STATE] Entering READY state
+[17:05:57][STATE] Entering RUNNING state
+[17:05:57][INFO] Use keys to control the state machine:
+[17:05:57][INFO] [h] help, [p] pause, [r] run, [s] stop, [t] reset task, [d] reset device, [q] end, [j] init task, [i] init device
+[17:05:57][INFO] DEVICE: Running...
+[17:05:57][INFO] Received message: "HelloHello"
+[17:05:57][INFO] Received message: "HelloHello"
+[17:05:57][INFO] Received message: "HelloHello"
+[...]
+[17:06:04][INFO] Received message: "HelloHello"
+[17:06:05][INFO] Received message: "HelloHello"
+[17:06:06][INFO] Received message: "HelloHello"
+[17:06:07][INFO] Received message: "HelloHello"
+[17:06:08][INFO] Received message: "HelloHello"
+q
+[17:06:12][INFO] [q] end
+[17:06:12][STATE] Entering EXITING state
+[17:06:12][DEBUG] unblocked
+[17:06:12][DEBUG] Closing sockets...
+[17:06:12][DEBUG] Closed all sockets!
+[17:06:12][STATE] Exiting FairMQ state machine
+```

--- a/examples/advanced/GoTutorial/go-processor/main.go
+++ b/examples/advanced/GoTutorial/go-processor/main.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"io"
+	"log"
+
+	"github.com/go-mangos/mangos"
+	"github.com/go-mangos/mangos/protocol/pull"
+	"github.com/go-mangos/mangos/protocol/push"
+	"github.com/go-mangos/mangos/transport/ipc"
+	"github.com/go-mangos/mangos/transport/tcp"
+)
+
+func main() {
+	var iaddr string
+	flag.StringVar(&iaddr, "iaddr", "tcp://localhost:5555", "input data port")
+
+	var oaddr string
+	flag.StringVar(&oaddr, "oaddr", "tcp://localhost:5556", "output data port")
+
+	flag.Parse()
+
+	isck, err := pull.NewSocket()
+	if err != nil {
+		log.Fatalf("error creating a nanomsg socket: %v\n", err)
+	}
+	defer isck.Close()
+
+	isck.AddTransport(ipc.NewTransport())
+	isck.AddTransport(tcp.NewTransport())
+
+	osck, err := push.NewSocket()
+	if err != nil {
+		log.Fatalf("error creating output port: %v\n", err)
+	}
+	defer osck.Close()
+
+	osck.AddTransport(ipc.NewTransport())
+	osck.AddTransport(tcp.NewTransport())
+
+	log.Printf("dialing %s ...\n", iaddr)
+	err = isck.Dial(iaddr)
+	if err != nil {
+		log.Fatalf("error dialing: %v\n", err)
+	}
+	log.Printf("dialing %s ... [done]\n", iaddr)
+
+	log.Printf("dialing %s ...\n", oaddr)
+	err = osck.Dial(oaddr)
+	if err != nil {
+		log.Fatalf("error dialing: %v\n", err)
+	}
+	log.Printf("dialing %s ... [done]\n", oaddr)
+
+	for {
+		msg, err := isck.Recv()
+		if err != nil {
+			if err == io.EOF || err == mangos.ErrClosed {
+				log.Printf("received EOF: %v\n", err)
+				break
+			}
+			log.Fatalf("error receiving data: %v\n", err)
+		}
+		log.Printf("recv: %v\n", string(msg))
+
+		omsg := bytes.Repeat(msg, 2)
+		err = osck.Send(omsg)
+		if err != nil {
+			log.Fatalf("error sending data: %v\n", err)
+		}
+	}
+
+}

--- a/examples/advanced/GoTutorial/go-sink/README.md
+++ b/examples/advanced/GoTutorial/go-sink/README.md
@@ -1,0 +1,97 @@
+# go-sink
+
+`go-sink` is a simple `Go` based program using `nanomsg` as a transport facility.
+It replicates the basic example from [FairRootMQ example 1](https://github.com/FairRootGroup/FairRoot/tree/master/examples/MQ/1-sampler-sink).
+
+## Build
+
+```sh
+$> cd go-sink
+$> go build
+```
+
+## Usage
+
+- First, you need to run the `C++` `FairRootMQ` `sampler` program:
+
+```sh
+$> ex1-sampler --id sampler1 \
+  --transport nanomsg \
+  --config-json-file /opt/alice/src/fair-root/examples/MQ/1-sampler-sink/ex1-sampler-sink.json
+[14:36:48][STATE] Entering FairMQ state machine
+[14:36:48][INFO] *******************************************************************************************************************************
+[14:36:48][INFO] ************************************************     Program options found     ************************************************
+[14:36:48][INFO] *******************************************************************************************************************************
+[14:36:48][INFO] config-json-file = /opt/alice/src/fair-root/examples/MQ/1-sampler-sink/ex1-sampler-sink.json  [Type=string]  [provided value] *
+[14:36:48][INFO] id               = sampler1                                                                   [Type=string]  [provided value] *
+[14:36:48][INFO] io-threads       = 1                                                                          [Type=int]     [default value]  *
+[14:36:48][INFO] log-color        = 1                                                                          [Type=bool]    [default value]  *
+[14:36:48][INFO] text             = Hello                                                                      [Type=string]  [default value]  *
+[14:36:48][INFO] transport        = nanomsg                                                                    [Type=string]  [provided value] *
+[14:36:48][INFO] verbose          = DEBUG                                                                      [Type=string]  [default value]  *
+[14:36:48][INFO] *******************************************************************************************************************************
+[14:36:48][DEBUG] Found device id 'sampler1' in JSON input
+[14:36:48][DEBUG] Found device id 'sink1' in JSON input
+[14:36:48][DEBUG] [node = device]   id = sampler1
+[14:36:48][DEBUG] 	 [node = channel]   name = data
+[14:36:48][DEBUG] 	 	 [node = socket]   socket index = 1
+[14:36:48][DEBUG] 	 	 	 type        = push
+[14:36:48][DEBUG] 	 	 	 method      = bind
+[14:36:48][DEBUG] 	 	 	 address     = tcp://*:5555
+[14:36:48][DEBUG] 	 	 	 sndBufSize  = 1000
+[14:36:48][DEBUG] 	 	 	 rcvBufSize  = 1000
+[14:36:48][DEBUG] 	 	 	 rateLogging = 0
+[14:36:48][DEBUG] ---- Channel-keys found are :
+[14:36:48][DEBUG] data
+[14:36:48][INFO] PID: 143
+[14:36:48][INFO] Using nanomsg library
+[14:36:48][STATE] Entering INITIALIZING DEVICE state
+[14:36:48][INFO] created socket sampler1.device-commands.pub
+[14:36:48][INFO] bind socket sampler1.device-commands.pub on inproc://commands
+[14:36:48][DEBUG] Validating channel "data[0]"... VALID
+[14:36:48][DEBUG] Initializing channel data[0] (push)
+[14:36:48][INFO] created socket sampler1.data[0].push
+[14:36:48][DEBUG] Binding channel data[0] on tcp://*:5555
+[14:36:48][INFO] bind socket sampler1.data[0].push on tcp://*:5555
+[14:36:48][INFO] created socket internal.device-commands.sub
+[14:36:48][INFO] connect socket internal.device-commands.sub to inproc://commands
+[14:36:49][STATE] Entering DEVICE READY state
+[14:36:49][STATE] Entering INITIALIZING TASK state
+[14:36:49][STATE] Entering READY state
+[14:36:49][STATE] Entering RUNNING state
+[14:36:49][INFO] DEVICE: Running...
+[14:36:49][INFO] Use keys to control the state machine:
+[14:36:49][INFO] [h] help, [p] pause, [r] run, [s] stop, [t] reset task, [d] reset device, [q] end, [j] init task, [i] init device
+[14:36:50][INFO] Sending "Hello"
+[14:37:29][INFO] Sending "Hello"
+[14:37:30][INFO] Sending "Hello"
+[14:37:31][INFO] Sending "Hello"
+[14:37:32][INFO] Sending "Hello"
+[14:37:33][INFO] Sending "Hello"
+[14:37:34][INFO] Sending "Hello"
+[14:37:35][INFO] Sending "Hello"
+q
+[14:37:36][INFO] [q] end
+[14:37:36][STATE] Entering EXITING state
+[14:37:36][DEBUG] unblocked
+[14:37:36][DEBUG] Closing sockets...
+[14:37:36][DEBUG] Closed all sockets!
+[14:37:36][STATE] Exiting FairMQ state machine
+```
+
+- Then, in another terminal:
+
+```sh
+$> go-sink
+2016/03/11 14:37:28 dialing tcp://localhost:5555 ...
+2016/03/11 14:37:28 dialing tcp://localhost:5555 ... [done]
+2016/03/11 14:37:28 recv: Hello
+2016/03/11 14:37:29 recv: Hello
+2016/03/11 14:37:30 recv: Hello
+2016/03/11 14:37:31 recv: Hello
+2016/03/11 14:37:32 recv: Hello
+2016/03/11 14:37:33 recv: Hello
+2016/03/11 14:37:34 recv: Hello
+^C
+$>
+```

--- a/examples/advanced/GoTutorial/go-sink/main.go
+++ b/examples/advanced/GoTutorial/go-sink/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"flag"
+	"io"
+	"log"
+
+	"github.com/go-mangos/mangos"
+	"github.com/go-mangos/mangos/protocol/pull"
+	"github.com/go-mangos/mangos/transport/ipc"
+	"github.com/go-mangos/mangos/transport/tcp"
+)
+
+func main() {
+	var addr string
+	flag.StringVar(&addr, "addr", "tcp://localhost:5555", "input data port")
+
+	flag.Parse()
+
+	sck, err := pull.NewSocket()
+	if err != nil {
+		log.Fatalf("error creating a nanomsg socket: %v\n", err)
+	}
+	defer sck.Close()
+
+	sck.AddTransport(ipc.NewTransport())
+	sck.AddTransport(tcp.NewTransport())
+
+	log.Printf("dialing %s ...\n", addr)
+	err = sck.Dial(addr)
+	if err != nil {
+		log.Fatalf("error dialing: %v\n", err)
+	}
+	log.Printf("dialing %s ... [done]\n", addr)
+
+	for {
+		msg, err := sck.Recv()
+		if err != nil {
+			if err == io.EOF || err == mangos.ErrClosed {
+				log.Printf("received EOF: %v\n", err)
+				break
+			}
+			log.Fatalf("error receiving from bus: %v\n", err)
+		}
+		log.Printf("recv: %v\n", string(msg))
+	}
+
+}

--- a/examples/advanced/README.md
+++ b/examples/advanced/README.md
@@ -15,3 +15,8 @@ Use of FairDB
 Shows how to use MBS data unpacking with FairRunOnline steering class. FairTut8Unpack implement parsing of MBS subevents and 
 creates output in form of array of FairTut8RawItem data objects.
 
+## GoTutorial
+
+Shows how one can use devices written in the [Go](https://golang.org)
+programming language and integrate them into a `C++` base device topology.
+


### PR DESCRIPTION
This CL adds basic examples showing how one can write devices in Go
and integrate them into an already existing topology of C++ devices.

Fixes #310.