### PR TITLE
Call FairDetector::Initialize() again in derrived classes.

### DIFF
--- a/examples/MQ/9-PixelDetector/src/Pixel.cxx
+++ b/examples/MQ/9-PixelDetector/src/Pixel.cxx
@@ -82,8 +82,8 @@ Pixel::~Pixel()
 
 void Pixel::Initialize()
 {
-/*
   FairDetector::Initialize();
+/*
   FairRuntimeDb* rtdb= FairRun::Instance()->GetRuntimeDb();
   PixelGeoPar* par=(PixelGeoPar*)(rtdb->getContainer("PixelGeoPar"));
 */

--- a/examples/simulation/Tutorial1/src/FairTutorialDet1.cxx
+++ b/examples/simulation/Tutorial1/src/FairTutorialDet1.cxx
@@ -68,8 +68,8 @@ FairTutorialDet1::~FairTutorialDet1()
 
 void FairTutorialDet1::Initialize()
 {
-/*
   FairDetector::Initialize();
+/*
   FairRuntimeDb* rtdb= FairRun::Instance()->GetRuntimeDb();
   FairTutorialDet1GeoPar* par=(FairTutorialDet1GeoPar*)(rtdb->getContainer("FairTutorialDet1GeoPar"));
 */

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2.cxx
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2.cxx
@@ -61,8 +61,8 @@ FairTutorialDet2::~FairTutorialDet2()
 
 void FairTutorialDet2::Initialize()
 {
-/*
   FairDetector::Initialize();
+/*
   FairRuntimeDb* rtdb= FairRun::Instance()->GetRuntimeDb();
   FairTutorialDet2GeoPar* par=(FairTutorialDet2GeoPar*)(rtdb->getContainer("FairTutorialDet2GeoPar"));
 */

--- a/examples/simulation/rutherford/src/FairRutherford.cxx
+++ b/examples/simulation/rutherford/src/FairRutherford.cxx
@@ -70,8 +70,8 @@ FairRutherford::~FairRutherford()
 
 void FairRutherford::Initialize()
 {
-/*
   FairDetector::Initialize();
+/*
   FairRuntimeDb* rtdb= FairRun::Instance()->GetRuntimeDb();
   FairRutherfordGeoPar* par=(FairRutherfordGeoPar*)(rtdb->getContainer("FairRutherfordGeoPar"));
 */


### PR DESCRIPTION
By accident the call was removed with one of the last commits which results in a situation where no MCPoints are created for affected detectors.