### PR TITLE
ROOT test script did not take into account externally defined LD_LIBR…

### DIFF
--- a/cmake/scripts/root_macro.sh.in
+++ b/cmake/scripts/root_macro.sh.in
@@ -8,8 +8,8 @@
 # to be passed to root.
 
 # Setup the needed environment
-export LD_LIBRARY_PATH=@MY_LD_LIBRARY_PATH@
-export DYLD_LIBRARY_PATH=@MY_LD_LIBRARY_PATH@
+export LD_LIBRARY_PATH=@MY_LD_LIBRARY_PATH@:$LD_LIBRARY_PATH
+export DYLD_LIBRARY_PATH=@MY_LD_LIBRARY_PATH@:$DYLD_LIBRARY_PATH
 export PATH=@SIMPATH@/bin:$PATH:@Geant4_DIR@
 export ROOTSYS=@ROOTSYS@
 export ROOTEXE=@ROOT_INSTALL_DIR@/bin/root.exe


### PR DESCRIPTION
…ARY_PATH

detail: test scripts generated from ROOT macros (such as examples/simulation/Tutorial1/macros)
        set an LD_LIBRARY_PATH which is not complete. In particular it does not pick up any external
        LD_LIBRARY_PATH to my compiler (which in this case resides somewhere on the afs) but just
        overwrites it.

        This patch provides a workaround by augmenting the tests LD_LIBRARY_PATH with the externally
        user-defined LD_LIBRARY_PATH. An alternative solution might be to fix the generated
        LD_LIBRARY_PATH which should take into account the compiler/libc paths
        (as it does in PATH by the way).