### PR TITLE
Some fixes in the MQ/9-PixelDetector

### DIFF
--- a/examples/MQ/9-PixelDetector/macros/run_tracks.C
+++ b/examples/MQ/9-PixelDetector/macros/run_tracks.C
@@ -1,0 +1,87 @@
+/********************************************************************************
+ *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             * 
+ *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *  
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+void run_tracks( TString mcEngine="TGeant3" )
+{
+  // Verbosity level (0=quiet, 1=event level, 2=track level, 3=debug)
+  Int_t iVerbose = 0; // just forget about it, for the moment
+  
+  // Input file (MC events)
+  TString inFile = "pixel_";
+  inFile = inFile + mcEngine + ".hits.root";
+  
+  // Parameter file
+  TString parFile = "pixel_"; 
+  parFile = parFile + mcEngine + ".params.root";
+
+  // Digitization parameter file
+  TString dir = getenv("VMCWORKDIR");
+  TString tutdir = dir + "/MQ/9-PixelDetector";
+  TString digParFile = tutdir + "/param/pixel_digi.par";
+
+  // Output file
+  TString outFile = "pixel_";
+  outFile = outFile + mcEngine + ".tracks.root";
+  
+  // -----   Timer   --------------------------------------------------------
+  TStopwatch timer;
+  
+  // -----   Reconstruction run   -------------------------------------------
+  FairRunAna *fRun= new FairRunAna();
+  fRun->SetInputFile(inFile);
+  fRun->SetOutputFile(outFile);
+  
+  FairRuntimeDb* rtdb = fRun->GetRuntimeDb();
+  FairParRootFileIo* parInput1 = new FairParRootFileIo();
+  parInput1->open(parFile.Data());
+
+  FairParAsciiFileIo* parIo1 = new FairParAsciiFileIo();
+  parIo1->open(digParFile.Data(),"in");
+        
+  rtdb->setFirstInput(parInput1);
+  rtdb->setSecondInput(parIo1);
+  
+  // -----   TorinoDetector hit  producers   ---------------------------------
+  PixelFindTracks* trackFinderTask = new PixelFindTracks();
+  fRun->AddTask(trackFinderTask);
+  
+
+  fRun->Init();
+
+  timer.Start();
+  fRun->Run();
+
+  // -----   Finish   -------------------------------------------------------
+
+  cout << endl << endl;
+
+  // Extract the maximal used memory an add is as Dart measurement
+  // This line is filtered by CTest and the value send to CDash
+  FairSystemInfo sysInfo;
+  Float_t maxMemory=sysInfo.GetMaxMemory();
+  cout << "<DartMeasurement name=\"MaxMemory\" type=\"numeric/double\">";
+  cout << maxMemory;
+  cout << "</DartMeasurement>" << endl;
+
+  timer.Stop();
+  Double_t rtime = timer.RealTime();
+  Double_t ctime = timer.CpuTime();
+
+  Float_t cpuUsage=ctime/rtime;
+  cout << "<DartMeasurement name=\"CpuLoad\" type=\"numeric/double\">";
+  cout << cpuUsage;
+  cout << "</DartMeasurement>" << endl;
+
+  cout << endl << endl;
+  cout << "Output file is "    << outFile << endl;
+  cout << "Parameter file is " << parFile << endl;
+  cout << "Real time " << rtime << " s, CPU time " << ctime
+       << "s" << endl << endl;
+  cout << "Macro finished successfully." << endl;
+
+  // ------------------------------------------------------------------------
+}

--- a/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9New.sh.in
+++ b/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9New.sh.in
@@ -46,8 +46,8 @@ if [ "$FAIRTASKNAME" == "--task-name PixelFindHits" ] ; then
     
     # output file for sink
     OUTPUTFILE="@CMAKE_SOURCE_DIR@/examples/MQ/9-PixelDetector/macros/MQ.pixel_TGeant3.hit.root"
-    OUTPUTCLASS="TClonesArray(PixelHit)"
-    OUTPUTBRANCH="PixelHits"
+    OUTPUTCLASS="--class-name TClonesArray(PixelHit)"
+    OUTPUTBRANCH="--branch-name PixelHits"
 elif [ "$FAIRTASKNAME" == "--task-name PixelFindTracks" ] ; then
     # input file and branch for the sampler device
     INPUTFILE="@CMAKE_SOURCE_DIR@/examples/MQ/9-PixelDetector/macros/MQ.pixel_TGeant3.hit.root"
@@ -55,8 +55,8 @@ elif [ "$FAIRTASKNAME" == "--task-name PixelFindTracks" ] ; then
     
     # output file for sink
     OUTPUTFILE="@CMAKE_SOURCE_DIR@/examples/MQ/9-PixelDetector/macros/MQ.pixel_TGeant3.track.root"
-    OUTPUTCLASS="TClonesArray(PixelTrack)"
-    OUTPUTBRANCH="PixelTracks"
+    OUTPUTCLASS="--class-name TClonesArray(PixelTrack)"
+    OUTPUTBRANCH="--branch-name PixelTracks"
 else
     echo "TASK $FAIRTASKNAME UNKNOWN!!!"
     exit
@@ -111,7 +111,7 @@ xterm -geometry 80x25+1000+350 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR5 &
 ########################## start FILESINK
 FILESINK="FairMQEx9FileSink $TRANSPORT"
 FILESINK+=" --id sink1 --config-json-file $MQCONFIGFILE"
-FILESINK+=" --file-name $OUTPUTFILE --class-name $OUTPUTCLASS --branch-name $OUTPUTBRANCH"
+FILESINK+=" --file-name $OUTPUTFILE $OUTPUTCLASS $OUTPUTBRANCH"
 xterm +aw -geometry 80x25+0+700 -hold -e @CMAKE_BINARY_DIR@/bin/$FILESINK &
 
 

--- a/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9_2Levels.sh.in
+++ b/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9_2Levels.sh.in
@@ -50,8 +50,8 @@ if [ "$FAIRTASKNAME1" == "--task-name PixelFindHits" -a "$FAIRTASKNAME2" == "--t
     
     # output file for sink
     OUTPUTFILE="@CMAKE_SOURCE_DIR@/examples/MQ/9-PixelDetector/macros/MQ.pixel_TGeant3.track.root"
-    OUTPUTCLASS="TClonesArray(PixelTrack)"
-    OUTPUTBRANCH="PixelTracks"
+    OUTPUTCLASS="--class-name TClonesArray(PixelTrack)"
+    OUTPUTBRANCH="--branch-name PixelTracks"
 elif [ "$FAIRTASKNAME1" == "--task-name PixelFindTracks" -a "$FAIRTASKNAME2" == "--task-name PixelFitTracks" ] ; then
     # input file and branch for the sampler device
     FAIRTASKNAME1+=" --keep-data PixelHits"

--- a/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9_3Levels.sh.in
+++ b/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9_3Levels.sh.in
@@ -42,8 +42,8 @@ INPUTBRANCH="PixelDigis"
 
 # output file for sink
 OUTPUTFILE="@CMAKE_SOURCE_DIR@/examples/MQ/9-PixelDetector/macros/MQ.pixel_TGeant3.fitTrack.root"
-OUTPUTCLASS="TClonesArray(PixelTrack)"
-OUTPUTBRANCH="PixelFitTracks"
+OUTPUTCLASS="--class-name TClonesArray(PixelTrack)"
+OUTPUTBRANCH="--branch-name PixelFitTracks"
 ###########################
 
 
@@ -99,7 +99,7 @@ xterm -geometry 80x22+1000+700 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR3_2 &
 ########################## start FILESINK
 FILESINK="FairMQEx9FileSink $TRANSPORT"
 FILESINK+=" --id sink1 --config-json-file $MQCONFIGFILE"
-FILESINK+=" --file-name $OUTPUTFILE --class-name $OUTPUTCLASS --branch-name $OUTPUTBRANCH"
+FILESINK+=" --file-name $OUTPUTFILE $OUTPUTCLASS $OUTPUTBRANCH"
 xterm +aw -geometry 80x22+0+700 -hold -e @CMAKE_BINARY_DIR@/bin/$FILESINK &
 
 


### PR DESCRIPTION
Using the same scheme when setting output class and branch names in MQ shell scripts.
Added another macro to reconstruct tracks from hits.