### PR TITLE
Put example9 files in install directory.

### DIFF
--- a/examples/MQ/9-PixelDetector/macros/CMakeLists.txt
+++ b/examples/MQ/9-PixelDetector/macros/CMakeLists.txt
@@ -17,7 +17,7 @@ ForEach(_mcEngine IN ITEMS TGeant3 TGeant4)
 
 EndForEach(_mcEngine IN ITEMS TGeant3 TGeant4) 
 
-Install(FILES run_sim.C
+Install(FILES run_sim.C run_digi.C run_reco.C
         DESTINATION share/fairbase/examples/MQ/9-PixelDetector/macros/
        )
 

--- a/examples/MQ/9-PixelDetector/param/CMakeLists.txt
+++ b/examples/MQ/9-PixelDetector/param/CMakeLists.txt
@@ -5,7 +5,8 @@
  #         GNU Lesser General Public Licence version 3 (LGPL) version 3,        #  
  #                  copied verbatim in the file "LICENSE"                       #
  ################################################################################
-Add_Subdirectory(src)
-Add_Subdirectory(macros)
-Add_Subdirectory(run)
-Add_Subdirectory(param)
+Install(FILES pixel_digi.par
+        DESTINATION share/fairbase/examples/MQ/9-PixelDetector/param/
+       )
+
+

--- a/examples/MQ/9-PixelDetector/run/CMakeLists.txt
+++ b/examples/MQ/9-PixelDetector/run/CMakeLists.txt
@@ -31,9 +31,22 @@ include_directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
 
 
 configure_file( ${CMAKE_SOURCE_DIR}/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9.sh.in         ${CMAKE_BINARY_DIR}/bin/startFairMQEx9.sh )
+
+set(EXAMPLE9_FILE_LOCATION ${CMAKE_SOURCE_DIR})
+set(EXAMPLE9_BIN_LOCATION  ${CMAKE_BINARY_DIR}/bin)
 configure_file( ${CMAKE_SOURCE_DIR}/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9New.sh.in      ${CMAKE_BINARY_DIR}/bin/startFairMQEx9New.sh )
 configure_file( ${CMAKE_SOURCE_DIR}/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9_2Levels.sh.in ${CMAKE_BINARY_DIR}/bin/startFairMQEx9_2Levels.sh )
 configure_file( ${CMAKE_SOURCE_DIR}/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9_3Levels.sh.in ${CMAKE_BINARY_DIR}/bin/startFairMQEx9_3Levels.sh )
+
+set(EXAMPLE9_FILE_LOCATION ${CMAKE_INSTALL_PREFIX}/share/fairbase)
+set(EXAMPLE9_BIN_LOCATION  ${CMAKE_INSTALL_PREFIX}/bin)
+configure_file( ${CMAKE_SOURCE_DIR}/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9New.sh.in      ${CMAKE_INSTALL_PREFIX}/bin/startFairMQEx9New.sh )
+configure_file( ${CMAKE_SOURCE_DIR}/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9_2Levels.sh.in ${CMAKE_INSTALL_PREFIX}/bin/startFairMQEx9_2Levels.sh )
+configure_file( ${CMAKE_SOURCE_DIR}/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9_3Levels.sh.in ${CMAKE_INSTALL_PREFIX}/bin/startFairMQEx9_3Levels.sh )
+
+Install(FILES options/Pixel9MQConfig_Multipart.json options/Pixel9MQConfig_2Levels.json options/Pixel9MQConfig_3Levels.json
+        DESTINATION share/fairbase/examples/MQ/9-PixelDetector/run/options/
+       )
 
 
 set(LINK_DIRECTORIES

--- a/examples/MQ/9-PixelDetector/run/CMakeLists.txt
+++ b/examples/MQ/9-PixelDetector/run/CMakeLists.txt
@@ -40,9 +40,19 @@ configure_file( ${CMAKE_SOURCE_DIR}/examples/MQ/9-PixelDetector/run/scripts/star
 
 set(EXAMPLE9_FILE_LOCATION ${CMAKE_INSTALL_PREFIX}/share/fairbase)
 set(EXAMPLE9_BIN_LOCATION  ${CMAKE_INSTALL_PREFIX}/bin)
-configure_file( ${CMAKE_SOURCE_DIR}/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9New.sh.in      ${CMAKE_INSTALL_PREFIX}/bin/startFairMQEx9New.sh )
-configure_file( ${CMAKE_SOURCE_DIR}/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9_2Levels.sh.in ${CMAKE_INSTALL_PREFIX}/bin/startFairMQEx9_2Levels.sh )
-configure_file( ${CMAKE_SOURCE_DIR}/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9_3Levels.sh.in ${CMAKE_INSTALL_PREFIX}/bin/startFairMQEx9_3Levels.sh )
+configure_file( ${CMAKE_SOURCE_DIR}/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9New.sh.in      ${CMAKE_BINARY_DIR}/bin/startFairMQEx9New.sh_install )
+configure_file( ${CMAKE_SOURCE_DIR}/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9_2Levels.sh.in ${CMAKE_BINARY_DIR}/bin/startFairMQEx9_2Levels.sh_install )
+configure_file( ${CMAKE_SOURCE_DIR}/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9_3Levels.sh.in ${CMAKE_BINARY_DIR}/bin/startFairMQEx9_3Levels.sh_install )
+
+Install(FILES ${CMAKE_BINARY_DIR}/bin/startFairMQEx9New.sh_install
+        DESTINATION bin
+        RENAME startFairMQEx9New.sh)
+Install(FILES ${CMAKE_BINARY_DIR}/bin/startFairMQEx9_2Levels.sh_install
+        DESTINATION bin
+        RENAME startFairMQEx9_2Levels.sh)
+Install(FILES ${CMAKE_BINARY_DIR}/bin/startFairMQEx9_3Levels.sh_install
+        DESTINATION bin
+        RENAME startFairMQEx9_3Levels.sh)
 
 Install(FILES options/Pixel9MQConfig_Multipart.json options/Pixel9MQConfig_2Levels.json options/Pixel9MQConfig_3Levels.json
         DESTINATION share/fairbase/examples/MQ/9-PixelDetector/run/options/

--- a/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9New.sh.in
+++ b/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9New.sh.in
@@ -30,31 +30,30 @@ esac
 shift 
 done
 
-
 ########################### Define some variables
 # JSON file containing the configuration parameters of all FairMQ devices of this example
-MQCONFIGFILE="@CMAKE_SOURCE_DIR@/examples/MQ/9-PixelDetector/run/options/Pixel9MQConfig_Multipart.json"
+MQCONFIGFILE="@EXAMPLE9_FILE_LOCATION@/examples/MQ/9-PixelDetector/run/options/Pixel9MQConfig_Multipart.json"
 # ASCII and ROOT parameter files for the processor device
-ROOTPARAM="@CMAKE_SOURCE_DIR@/examples/MQ/9-PixelDetector/macros/pixel_TGeant3.params.root"
-ASCIIPARAM="@CMAKE_SOURCE_DIR@/examples/MQ/9-PixelDetector/param/pixel_digi.par"
+ROOTPARAM="@EXAMPLE9_FILE_LOCATION@/examples/MQ/9-PixelDetector/macros/pixel_TGeant3.params.root"
+ASCIIPARAM="@EXAMPLE9_FILE_LOCATION@/examples/MQ/9-PixelDetector/param/pixel_digi.par"
 
 if [ "$FAIRTASKNAME" == "--task-name PixelFindHits" ] ; then
     # input file and branch for the sampler device
-    INPUTFILE="@CMAKE_SOURCE_DIR@/examples/MQ/9-PixelDetector/macros/pixel_TGeant3.digi.root"
- #   INPUTFILE+=" --file-name @CMAKE_SOURCE_DIR@/examples/MQ/9-PixelDetector/macros/pixel_TGeant3.digi.f1.root"
+    INPUTFILE="@EXAMPLE9_FILE_LOCATION@/examples/MQ/9-PixelDetector/macros/pixel_TGeant3.digi.root"
+ #   INPUTFILE+=" --file-name @EXAMPLE9_FILE_LOCATION@/examples/MQ/9-PixelDetector/macros/pixel_TGeant3.digi.f1.root"
     INPUTBRANCH="PixelDigis"
     
     # output file for sink
-    OUTPUTFILE="@CMAKE_SOURCE_DIR@/examples/MQ/9-PixelDetector/macros/MQ.pixel_TGeant3.hit.root"
+    OUTPUTFILE="@EXAMPLE9_FILE_LOCATION@/examples/MQ/9-PixelDetector/macros/MQ.pixel_TGeant3.hit.root"
     OUTPUTCLASS="--class-name TClonesArray(PixelHit)"
     OUTPUTBRANCH="--branch-name PixelHits"
 elif [ "$FAIRTASKNAME" == "--task-name PixelFindTracks" ] ; then
     # input file and branch for the sampler device
-    INPUTFILE="@CMAKE_SOURCE_DIR@/examples/MQ/9-PixelDetector/macros/MQ.pixel_TGeant3.hit.root"
+    INPUTFILE="@EXAMPLE9_FILE_LOCATION@/examples/MQ/9-PixelDetector/macros/MQ.pixel_TGeant3.hit.root"
     INPUTBRANCH="PixelHits"
     
     # output file for sink
-    OUTPUTFILE="@CMAKE_SOURCE_DIR@/examples/MQ/9-PixelDetector/macros/MQ.pixel_TGeant3.track.root"
+    OUTPUTFILE="@EXAMPLE9_FILE_LOCATION@/examples/MQ/9-PixelDetector/macros/MQ.pixel_TGeant3.track.root"
     OUTPUTCLASS="--class-name TClonesArray(PixelTrack)"
     OUTPUTBRANCH="--branch-name PixelTracks"
 else
@@ -72,46 +71,46 @@ fi
 SERVER="parmq-server $TRANSPORT"
 SERVER+=" --id parmq-server  --config-json-file $MQCONFIGFILE"
 SERVER+=" --first-input-name $ROOTPARAM --second-input-name $ASCIIPARAM --second-input-type ASCII"
-xterm -geometry 80x25+0+350 -hold -e @CMAKE_BINARY_DIR@/bin/$SERVER &
+xterm -geometry 80x25+0+350 -hold -e @EXAMPLE9_BIN_LOCATION@/$SERVER &
 
 
 ########################## start SAMPLER
 SAMPLER="FairMQEx9Sampler $TRANSPORT"
 SAMPLER+=" --id sampler1  --config-json-file $MQCONFIGFILE"
 SAMPLER+=" --file-name $INPUTFILE --branch-name $INPUTBRANCH $MAXINDEX"
-xterm -geometry 80x25+0+0 -hold -e @CMAKE_BINARY_DIR@/bin/$SAMPLER &
+xterm -geometry 80x25+0+0 -hold -e @EXAMPLE9_BIN_LOCATION@/$SAMPLER &
 
 ########################## start PROCESSORs
 PROCESSOR1="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR1+=" $VERBOSE"
 PROCESSOR1+=" --id processor1 $FAIRTASKNAME --config-json-file $MQCONFIGFILE"
-#xterm +aw -geometry 100x27+800+0 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR1 &
-xterm -geometry 80x25+500+0 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR1 &
+#xterm +aw -geometry 100x27+800+0 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR1 &
+xterm -geometry 80x25+500+0 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR1 &
 
 PROCESSOR2="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR2+=" $VERBOSE"
 PROCESSOR2+=" --id processor2 $FAIRTASKNAME --config-json-file $MQCONFIGFILE"
-xterm -geometry 80x25+500+350 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR2 &
+xterm -geometry 80x25+500+350 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR2 &
 
 PROCESSOR3="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR3+=" $VERBOSE"
 PROCESSOR3+=" --id processor3 $FAIRTASKNAME --config-json-file $MQCONFIGFILE"
-xterm -geometry 80x25+500+700 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR3 &
+xterm -geometry 80x25+500+700 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR3 &
 
 PROCESSOR4="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR4+=" $VERBOSE"
 PROCESSOR4+=" --id processor4 $FAIRTASKNAME --config-json-file $MQCONFIGFILE"
-xterm -geometry 80x25+1000+0 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR4 &
+xterm -geometry 80x25+1000+0 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR4 &
 
 PROCESSOR5="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR5+=" $VERBOSE"
 PROCESSOR5+=" --id processor5 $FAIRTASKNAME --config-json-file $MQCONFIGFILE"
-xterm -geometry 80x25+1000+350 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR5 &
+xterm -geometry 80x25+1000+350 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR5 &
 
 ########################## start FILESINK
 FILESINK="FairMQEx9FileSink $TRANSPORT"
 FILESINK+=" --id sink1 --config-json-file $MQCONFIGFILE"
 FILESINK+=" --file-name $OUTPUTFILE $OUTPUTCLASS $OUTPUTBRANCH"
-xterm +aw -geometry 80x25+0+700 -hold -e @CMAKE_BINARY_DIR@/bin/$FILESINK &
+xterm +aw -geometry 80x25+0+700 -hold -e @EXAMPLE9_BIN_LOCATION@/$FILESINK &
 
 

--- a/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9_2Levels.sh.in
+++ b/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9_2Levels.sh.in
@@ -38,29 +38,29 @@ done
 
 ########################### Define some variables
 # JSON file containing the configuration parameters of all FairMQ devices of this example
-MQCONFIGFILE="@CMAKE_SOURCE_DIR@/examples/MQ/9-PixelDetector/run/options/Pixel9MQConfig_2Levels.json"
+MQCONFIGFILE="@EXAMPLE9_FILE_LOCATION@/examples/MQ/9-PixelDetector/run/options/Pixel9MQConfig_2Levels.json"
 # ASCII and ROOT parameter files for the processor device
-ROOTPARAM="@CMAKE_SOURCE_DIR@/examples/MQ/9-PixelDetector/macros/pixel_TGeant3.params.root"
-ASCIIPARAM="@CMAKE_SOURCE_DIR@/examples/MQ/9-PixelDetector/param/pixel_digi.par"
+ROOTPARAM="@EXAMPLE9_FILE_LOCATION@/examples/MQ/9-PixelDetector/macros/pixel_TGeant3.params.root"
+ASCIIPARAM="@EXAMPLE9_FILE_LOCATION@/examples/MQ/9-PixelDetector/param/pixel_digi.par"
 
 if [ "$FAIRTASKNAME1" == "--task-name PixelFindHits" -a "$FAIRTASKNAME2" == "--task-name PixelFindTracks" ] ; then
     # input file and branch for the sampler device
-    INPUTFILE="@CMAKE_SOURCE_DIR@/examples/MQ/9-PixelDetector/macros/pixel_TGeant3.digi.root"
+    INPUTFILE="@EXAMPLE9_FILE_LOCATION@/examples/MQ/9-PixelDetector/macros/pixel_TGeant3.digi.root"
     INPUTBRANCH="PixelDigis"
     
     # output file for sink
-    OUTPUTFILE="@CMAKE_SOURCE_DIR@/examples/MQ/9-PixelDetector/macros/MQ.pixel_TGeant3.track.root"
+    OUTPUTFILE="@EXAMPLE9_FILE_LOCATION@/examples/MQ/9-PixelDetector/macros/MQ.pixel_TGeant3.track.root"
     OUTPUTCLASS="--class-name TClonesArray(PixelTrack)"
     OUTPUTBRANCH="--branch-name PixelTracks"
 elif [ "$FAIRTASKNAME1" == "--task-name PixelFindTracks" -a "$FAIRTASKNAME2" == "--task-name PixelFitTracks" ] ; then
     # input file and branch for the sampler device
     FAIRTASKNAME1+=" --keep-data PixelHits"
     FAIRTASKNAME2+=" --keep-data PixelHits"
-    INPUTFILE="@CMAKE_SOURCE_DIR@/examples/MQ/9-PixelDetector/macros/MQ.pixel_TGeant3.hit.root"
+    INPUTFILE="@EXAMPLE9_FILE_LOCATION@/examples/MQ/9-PixelDetector/macros/MQ.pixel_TGeant3.hit.root"
     INPUTBRANCH="PixelHits"
     
     # output file for sink
-    OUTPUTFILE="@CMAKE_SOURCE_DIR@/examples/MQ/9-PixelDetector/macros/MQ.pixel_TGeant3.hit_fitTrack.root"
+    OUTPUTFILE="@EXAMPLE9_FILE_LOCATION@/examples/MQ/9-PixelDetector/macros/MQ.pixel_TGeant3.hit_fitTrack.root"
     OUTPUTCLASS="--class-name TClonesArray(PixelHit) --class-name TClonesArray(PixelTrack)"
     OUTPUTBRANCH="--branch-name PixelHits --branch-name PixelFitTracks"
 else
@@ -77,52 +77,52 @@ fi
 SERVER="parmq-server $TRANSPORT"
 SERVER+=" --id parmq-server  --config-json-file $MQCONFIGFILE"
 SERVER+=" --first-input-name $ROOTPARAM --second-input-name $ASCIIPARAM --second-input-type ASCII"
-xterm -geometry 80x22+0+350 -hold -e @CMAKE_BINARY_DIR@/bin/$SERVER &
+xterm -geometry 80x22+0+350 -hold -e @EXAMPLE9_BIN_LOCATION@/$SERVER &
 
 
 ########################## start SAMPLER
 SAMPLER="FairMQEx9Sampler $TRANSPORT"
 SAMPLER+=" --id sampler1  --config-json-file $MQCONFIGFILE"
 SAMPLER+=" --file-name $INPUTFILE --branch-name $INPUTBRANCH $MAXINDEX"
-xterm -geometry 80x22+0+0 -hold -e @CMAKE_BINARY_DIR@/bin/$SAMPLER &
+xterm -geometry 80x22+0+0 -hold -e @EXAMPLE9_BIN_LOCATION@/$SAMPLER &
 
 ########################## start PROCESSORs on level 1
 PROCESSOR1_1="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR1_1+=" $VERBOSE"
 PROCESSOR1_1+=" --id processor1_1 $FAIRTASKNAME1 --config-json-file $MQCONFIGFILE"
-xterm -geometry 80x22+500+0 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR1_1 &
+xterm -geometry 80x22+500+0 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR1_1 &
 
 PROCESSOR1_2="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR1_2+=" $VERBOSE"
 PROCESSOR1_2+=" --id processor1_2 $FAIRTASKNAME1 --config-json-file $MQCONFIGFILE"
-xterm -geometry 80x22+500+350 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR1_2 &
+xterm -geometry 80x22+500+350 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR1_2 &
 
 PROCESSOR1_3="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR1_3+=" $VERBOSE"
 PROCESSOR1_3+=" --id processor1_3 $FAIRTASKNAME1 --config-json-file $MQCONFIGFILE"
-xterm -geometry 80x22+500+700 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR1_3 &
+xterm -geometry 80x22+500+700 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR1_3 &
 
 ########################## start PROCESSORs on level 2
 PROCESSOR2_1="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR2_1+=" $VERBOSE"
 PROCESSOR2_1+=" --id processor2_1 $FAIRTASKNAME2 --config-json-file $MQCONFIGFILE"
-xterm -geometry 80x22+1000+0 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR2_1 &
+xterm -geometry 80x22+1000+0 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR2_1 &
 
 PROCESSOR2_2="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR2_2+=" $VERBOSE"
 PROCESSOR2_2+=" --id processor2_2 $FAIRTASKNAME2 --config-json-file $MQCONFIGFILE"
-xterm -geometry 80x22+1000+350 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR2_2 &
+xterm -geometry 80x22+1000+350 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR2_2 &
 
 PROCESSOR2_3="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR2_3+=" $VERBOSE"
 PROCESSOR2_3+=" --id processor2_3 $FAIRTASKNAME2 --config-json-file $MQCONFIGFILE"
-xterm -geometry 80x22+1000+700 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR2_3 &
+xterm -geometry 80x22+1000+700 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR2_3 &
 
 
 ########################## start FILESINK
 FILESINK="FairMQEx9FileSink $TRANSPORT"
 FILESINK+=" --id sink1 --config-json-file $MQCONFIGFILE"
 FILESINK+=" --file-name $OUTPUTFILE $OUTPUTCLASS $OUTPUTBRANCH"
-xterm +aw -geometry 80x22+0+700 -hold -e @CMAKE_BINARY_DIR@/bin/$FILESINK &
+xterm +aw -geometry 80x22+0+700 -hold -e @EXAMPLE9_BIN_LOCATION@/$FILESINK &
 
 

--- a/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9_3Levels.sh.in
+++ b/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9_3Levels.sh.in
@@ -28,20 +28,20 @@ done
 
 ########################### Define some variables
 # JSON file containing the configuration parameters of all FairMQ devices of this example
-MQCONFIGFILE="@CMAKE_SOURCE_DIR@/examples/MQ/9-PixelDetector/run/options/Pixel9MQConfig_3Levels.json"
+MQCONFIGFILE="@EXAMPLE9_FILE_LOCATION@/examples/MQ/9-PixelDetector/run/options/Pixel9MQConfig_3Levels.json"
 # ASCII and ROOT parameter files for the processor device
-ROOTPARAM="@CMAKE_SOURCE_DIR@/examples/MQ/9-PixelDetector/macros/pixel_TGeant3.params.root"
-ASCIIPARAM="@CMAKE_SOURCE_DIR@/examples/MQ/9-PixelDetector/param/pixel_digi.par"
+ROOTPARAM="@EXAMPLE9_FILE_LOCATION@/examples/MQ/9-PixelDetector/macros/pixel_TGeant3.params.root"
+ASCIIPARAM="@EXAMPLE9_FILE_LOCATION@/examples/MQ/9-PixelDetector/param/pixel_digi.par"
 
 FAIRTASKNAME1="--task-name PixelFindHits"
 FAIRTASKNAME2="--task-name PixelFindTracks --keep-data PixelHits"
 FAIRTASKNAME3="--task-name PixelFitTracks"
 # input file and branch for the sampler device
-INPUTFILE="@CMAKE_SOURCE_DIR@/examples/MQ/9-PixelDetector/macros/pixel_TGeant3.digi.root"
+INPUTFILE="@EXAMPLE9_FILE_LOCATION@/examples/MQ/9-PixelDetector/macros/pixel_TGeant3.digi.root"
 INPUTBRANCH="PixelDigis"
 
 # output file for sink
-OUTPUTFILE="@CMAKE_SOURCE_DIR@/examples/MQ/9-PixelDetector/macros/MQ.pixel_TGeant3.fitTrack.root"
+OUTPUTFILE="@EXAMPLE9_FILE_LOCATION@/examples/MQ/9-PixelDetector/macros/MQ.pixel_TGeant3.fitTrack.root"
 OUTPUTCLASS="--class-name TClonesArray(PixelTrack)"
 OUTPUTBRANCH="--branch-name PixelFitTracks"
 ###########################
@@ -54,52 +54,52 @@ OUTPUTBRANCH="--branch-name PixelFitTracks"
 SERVER="parmq-server $TRANSPORT"
 SERVER+=" --id parmq-server  --config-json-file $MQCONFIGFILE"
 SERVER+=" --first-input-name $ROOTPARAM --second-input-name $ASCIIPARAM --second-input-type ASCII"
-xterm -geometry 80x22+0+350 -hold -e @CMAKE_BINARY_DIR@/bin/$SERVER &
+xterm -geometry 80x22+0+350 -hold -e @EXAMPLE9_BIN_LOCATION@/$SERVER &
 
 
 ########################## start SAMPLER
 SAMPLER="FairMQEx9Sampler $TRANSPORT"
 SAMPLER+=" --id sampler1  --config-json-file $MQCONFIGFILE"
 SAMPLER+=" --file-name $INPUTFILE --branch-name $INPUTBRANCH $MAXINDEX"
-xterm -geometry 80x22+0+0 -hold -e @CMAKE_BINARY_DIR@/bin/$SAMPLER &
+xterm -geometry 80x22+0+0 -hold -e @EXAMPLE9_BIN_LOCATION@/$SAMPLER &
 
 ########################## start PROCESSORs on level 1
 PROCESSOR1_1="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR1_1+=" $VERBOSE"
 PROCESSOR1_1+=" --id processor1_1 $FAIRTASKNAME1 --config-json-file $MQCONFIGFILE"
-xterm -geometry 80x22+500+0 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR1_1 &
+xterm -geometry 80x22+500+0 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR1_1 &
 
 PROCESSOR1_2="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR1_2+=" $VERBOSE"
 PROCESSOR1_2+=" --id processor1_2 $FAIRTASKNAME1 --config-json-file $MQCONFIGFILE"
-xterm -geometry 80x22+1000+0 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR1_2 &
+xterm -geometry 80x22+1000+0 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR1_2 &
 
 ########################## start PROCESSORs on level 2
 PROCESSOR2_1="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR2_1+=" $VERBOSE"
 PROCESSOR2_1+=" --id processor2_1 $FAIRTASKNAME2 --config-json-file $MQCONFIGFILE"
-xterm -geometry 80x22+500+350 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR2_1 &
+xterm -geometry 80x22+500+350 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR2_1 &
 
 PROCESSOR2_2="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR2_2+=" $VERBOSE"
 PROCESSOR2_2+=" --id processor2_2 $FAIRTASKNAME2 --config-json-file $MQCONFIGFILE"
-xterm -geometry 80x22+1000+350 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR2_2 &
+xterm -geometry 80x22+1000+350 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR2_2 &
 
 ########################## start PROCESSORs on level 3
 PROCESSOR3_1="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR3_1+=" $VERBOSE"
 PROCESSOR3_1+=" --id processor3_1 $FAIRTASKNAME3 --config-json-file $MQCONFIGFILE"
-xterm -geometry 80x22+500+700 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR3_1 &
+xterm -geometry 80x22+500+700 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR3_1 &
 
 PROCESSOR3_2="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR3_2+=" $VERBOSE"
 PROCESSOR3_2+=" --id processor3_2 $FAIRTASKNAME3 --config-json-file $MQCONFIGFILE"
-xterm -geometry 80x22+1000+700 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR3_2 &
+xterm -geometry 80x22+1000+700 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR3_2 &
 
 ########################## start FILESINK
 FILESINK="FairMQEx9FileSink $TRANSPORT"
 FILESINK+=" --id sink1 --config-json-file $MQCONFIGFILE"
 FILESINK+=" --file-name $OUTPUTFILE $OUTPUTCLASS $OUTPUTBRANCH"
-xterm +aw -geometry 80x22+0+700 -hold -e @CMAKE_BINARY_DIR@/bin/$FILESINK &
+xterm +aw -geometry 80x22+0+700 -hold -e @EXAMPLE9_BIN_LOCATION@/$FILESINK &
 
 


### PR DESCRIPTION
Made changes to add all the necessary files to run the example9 inside the install directory of FairRoot:
    
    - param file (added CMakeLists.txt to param, and calling it from the example9 CMakeLists.txt)
    - macros (run_digi.C and run_reco.C)
    - scripts (startFairMQEx0New,2Levels,3Levels.sh are now properly created in build/bin/ and install/bin/ directories)