### PR TITLE
Use Variables for Boost libraries instead of explicit names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,7 @@ Message("-- Looking for Boost ...")
 # for boost.
 Unset(Boost_INCLUDE_DIR CACHE)
 Unset(Boost_LIBRARY_DIRS CACHE)
-find_package(Boost 1.41 COMPONENTS thread system timer program_options random filesystem chrono exception regex)
+find_package(Boost 1.41 COMPONENTS thread system timer program_options random filesystem chrono exception regex serialization log log_setup)
 If (Boost_FOUND)
   Set(Boost_Avail 1)
   Set(LD_LIBRARY_PATH ${LD_LIBRARY_PATH} ${Boost_LIBRARY_DIR})

--- a/base/MQ/CMakeLists.txt
+++ b/base/MQ/CMakeLists.txt
@@ -66,10 +66,10 @@ set(DEPENDENCIES
   ParBase
   FairTools
   GeoBase
-  boost_thread
-  boost_timer
-  boost_system
-  boost_filesystem
+  ${Boost_THREAD_LIBRARY}
+  ${Boost_TIMER_LIBRARY}
+  ${Boost_SYSTEM_LIBRARY}
+  ${Boost_FILESYSTEM_LIBRARY}
   FairMQ
 )
 

--- a/examples/MQ/9-PixelDetector/src/CMakeLists.txt
+++ b/examples/MQ/9-PixelDetector/src/CMakeLists.txt
@@ -80,10 +80,10 @@ Set(DEPENDENCIES
     BaseMQ 
     Gen
     Passive
-    boost_thread 
-    boost_system 
-    boost_serialization 
-    boost_program_options
+    ${Boost_THREAD_LIBRARY} 
+    ${Boost_SYSTEM_LIBRARY} 
+    ${Boost_SERIALIZATION_LIBRARY} 
+   ${Boost_PROGRAM_OPTIONS_LIBRARY}
 )
 
 GENERATE_LIBRARY()

--- a/examples/MQ/GenericDevices/CMakeLists.txt
+++ b/examples/MQ/GenericDevices/CMakeLists.txt
@@ -125,10 +125,10 @@ Set(DEPENDENCIES
     FairMQ 
     BaseMQ 
     FairTestDetector
-    boost_thread 
-    boost_system 
-    boost_serialization 
-    boost_program_options
+    ${Boost_THREAD_LIBRARY} 
+    ${Boost_SYSTEM_LIBRARY} 
+    ${Boost_SERIALIZATION_LIBRARY} 
+    ${Boost_PROGRAM_OPTIONS_LIBRARY}
     Minuit
     XMLIO
     MathMore

--- a/examples/MQ/LmdSampler/CMakeLists.txt
+++ b/examples/MQ/LmdSampler/CMakeLists.txt
@@ -96,10 +96,10 @@ ForEach(_file RANGE 0 ${_length})
     Set(DEPENDENCIES
         FairMQ 
         BaseMQ 
-        boost_thread 
-        boost_system 
-        boost_serialization 
-        boost_program_options 
+        ${Boost_THREAD_LIBRARY}
+        ${Boost_SYSTEM_LIBRARY}
+        ${Boost_SERIALIZATION_LIBRARY} 
+        ${Boost_PROGRAM_OPTIONS_LIBRARY}
         MbsTutorial
         LmdMQSampler
     )

--- a/examples/advanced/Tutorial3/CMakeLists.txt
+++ b/examples/advanced/Tutorial3/CMakeLists.txt
@@ -160,7 +160,14 @@ Set(LIBRARY_NAME FairTestDetector)
 
 If (Boost_FOUND AND POS_C++11 AND ZMQ_FOUND)
   Set(DEPENDENCIES
-    Base MCStack FairMQ BaseMQ boost_thread boost_system boost_serialization boost_program_options)
+    Base MCStack FairMQ BaseMQ
+    ${Boost_THREAD_LIBRARY}
+    ${Boost_SYSTEM_LIBRARY}
+    ${Boost_SERIALIZATION_LIBRARY}
+#    boost_serialization
+    ${Boost_PROGRAM_OPTIONS_LIBRARY})
+
+
   If(PROTOBUF_FOUND)
     Set(DEPENDENCIES
       ${DEPENDENCIES}

--- a/fairmq/CMakeLists.txt
+++ b/fairmq/CMakeLists.txt
@@ -116,16 +116,15 @@ Install(FILES ${FAIRMQHEADERS} DESTINATION include)
 Set(DEPENDENCIES
   ${DEPENDENCIES}
   ${ZMQ_LIBRARY_SHARED}
-  boost_thread
+  ${Boost_THREAD_LIBRARY}
   fairmq_logger
-  boost_timer
-  boost_system
-  boost_filesystem
-  boost_program_options
-  boost_random
-  boost_chrono
-  boost_exception
-  boost_regex
+  ${Boost_TIMER_LIBRARY}
+  ${Boost_SYSTEM_LIBRARY}
+  ${Boost_FILESYSTEM_LIBRARY}
+  ${Boost_PROGRAM_OPTIONS_LIBRARY}
+  ${Boost_RANDOM_LIBRARY}
+  ${Boost_CHRONO_LIBRARY}
+  ${Boost_REGEX_LIBRARY}
 )
 
 If(NANOMSG_FOUND)

--- a/fairmq/logger/CMakeLists.txt
+++ b/fairmq/logger/CMakeLists.txt
@@ -26,12 +26,13 @@ set(SRCS logger.cxx)
 set(LIBRARY_NAME fairmq_logger)
 
 set(DEPENDENCIES
-    boost_log
-    boost_log_setup
-    boost_thread
-    boost_date_time
-    boost_filesystem
-    boost_system
+    ${Boost_LOG_LIBRARY}
+    ${Boost_LOG_SETUP_LIBRARY}
+    ${Boost_THREAD_LIBRARY}
+    ${Boost_THREAD_LIBRARY}
+    ${Boost_DATE_TIME_LIBRARY}
+    ${Boost_FILESYSTEM_LIBRARY}
+    ${Boost_SYSTEM_LIBRARY}
     pthread
   )
 

--- a/parmq/CMakeLists.txt
+++ b/parmq/CMakeLists.txt
@@ -51,8 +51,8 @@ Set(DEPENDENCIES
   Base
   ParBase
   FairMQ
-  boost_thread
-  boost_program_options
+  ${Boost_THREAD_LIBRARY}
+ ${Boost_PROGRAM_OPTIONS_LIBRARY}
 )
 
 Set(LIBRARY_NAME ParMQ)


### PR DESCRIPTION
Use the vairables filled by FindBoost instead explicit names in the CMakefile.txt(s) 
