### PR TITLE
encapsulate and use fairmq default xml and json parser if command lin…

### DIFF
--- a/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9.sh.in
+++ b/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9.sh.in
@@ -48,47 +48,47 @@ OUTPUTFILE="@CMAKE_SOURCE_DIR@/examples/MQ/9-PixelDetector/macros/out.pixel.hit.
 
 ########################## start Parameter server
 SERVER="parmq-server $TRANSPORT"
-SERVER+=" --id parmq-server  --config-json-file $MQCONFIGFILE"
+SERVER+=" --id parmq-server  --mq-config $MQCONFIGFILE"
 SERVER+=" --first-input-name $ROOTPARAM --second-input-name $ASCIIPARAM --second-input-type ASCII"
 xterm -geometry 100x27+800+500 -hold -e @CMAKE_BINARY_DIR@/bin/$SERVER &
 
 
 ########################## start SAMPLER
 SAMPLER="FairMQEx9Sampler $TRANSPORT"
-SAMPLER+=" --id sampler1  --config-json-file $MQCONFIGFILE"
+SAMPLER+=" --id sampler1  --mq-config $MQCONFIGFILE"
 SAMPLER+=" --input-name $INPUTFILE --input-branch $INPUTBRANCH"
 xterm -geometry 120x27+0+0 -hold -e @CMAKE_BINARY_DIR@/bin/$SAMPLER &
 
 ########################## start SPLITTER
 SPLITTER="FairMQEx9Splitter $TRANSPORT"
-SPLITTER+=" --id splitter1 --config-json-file $MQCONFIGFILE"
+SPLITTER+=" --id splitter1 --mq-config $MQCONFIGFILE"
 xterm +aw -geometry 100x27+800+500 -hold -e @CMAKE_BINARY_DIR@/bin/$SPLITTER &
 
 ########################## start PROCESSORs
 PROCESSOR1="FairMQEx9Processor $TRANSPORT"
 PROCESSOR1+=" $RUNID $VERBOSE"
-PROCESSOR1+=" --id processor1 --config-json-file $MQCONFIGFILE"
+PROCESSOR1+=" --id processor1 --mq-config $MQCONFIGFILE"
 #xterm +aw -geometry 100x27+800+0 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR1 &
 xterm -geometry 100x27+800+0 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR1 &
 
 PROCESSOR2="FairMQEx9Processor $TRANSPORT"
 PROCESSOR2+=" $RUNID $VERBOSE"
-PROCESSOR2+=" --id processor2 --config-json-file $MQCONFIGFILE"
+PROCESSOR2+=" --id processor2 --mq-config $MQCONFIGFILE"
 xterm -geometry 100x27+800+0 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR2 &
 
 PROCESSOR3="FairMQEx9Processor $TRANSPORT"
 PROCESSOR3+=" $RUNID $VERBOSE"
-PROCESSOR3+=" --id processor3 --config-json-file $MQCONFIGFILE"
+PROCESSOR3+=" --id processor3 --mq-config $MQCONFIGFILE"
 xterm -geometry 100x27+800+0 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR3 &
 
 ########################## start MERGER
 MERGER="FairMQEx9Merger $TRANSPORT"
-MERGER+=" --id merger1 --config-json-file $MQCONFIGFILE"
+MERGER+=" --id merger1 --mq-config $MQCONFIGFILE"
 xterm +aw -geometry 100x27+800+500 -hold -e @CMAKE_BINARY_DIR@/bin/$MERGER &
 
 ########################## start FILESINK
 FILESINK="FairMQEx9Sink $TRANSPORT"
-FILESINK+=" --id sink1 --config-json-file $MQCONFIGFILE"
+FILESINK+=" --id sink1 --mq-config $MQCONFIGFILE"
 FILESINK+=" --output-name $OUTPUTFILE"
 xterm +aw -geometry 120x27+0+500 -hold -e @CMAKE_BINARY_DIR@/bin/$FILESINK &
 

--- a/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9New.sh.in
+++ b/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9New.sh.in
@@ -69,47 +69,47 @@ fi
 
 ########################## start Parameter server
 SERVER="parmq-server $TRANSPORT"
-SERVER+=" --id parmq-server  --config-json-file $MQCONFIGFILE"
+SERVER+=" --id parmq-server  --mq-config $MQCONFIGFILE"
 SERVER+=" --first-input-name $ROOTPARAM --second-input-name $ASCIIPARAM --second-input-type ASCII"
 xterm -geometry 80x25+0+350 -hold -e @EXAMPLE9_BIN_LOCATION@/$SERVER &
 
 
 ########################## start SAMPLER
 SAMPLER="FairMQEx9Sampler $TRANSPORT"
-SAMPLER+=" --id sampler1  --config-json-file $MQCONFIGFILE"
+SAMPLER+=" --id sampler1  --mq-config $MQCONFIGFILE"
 SAMPLER+=" --file-name $INPUTFILE --branch-name $INPUTBRANCH $MAXINDEX"
 xterm -geometry 80x25+0+0 -hold -e @EXAMPLE9_BIN_LOCATION@/$SAMPLER &
 
 ########################## start PROCESSORs
 PROCESSOR1="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR1+=" $VERBOSE"
-PROCESSOR1+=" --id processor1 $FAIRTASKNAME --config-json-file $MQCONFIGFILE"
+PROCESSOR1+=" --id processor1 $FAIRTASKNAME --mq-config $MQCONFIGFILE"
 #xterm +aw -geometry 100x27+800+0 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR1 &
 xterm -geometry 80x25+500+0 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR1 &
 
 PROCESSOR2="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR2+=" $VERBOSE"
-PROCESSOR2+=" --id processor2 $FAIRTASKNAME --config-json-file $MQCONFIGFILE"
+PROCESSOR2+=" --id processor2 $FAIRTASKNAME --mq-config $MQCONFIGFILE"
 xterm -geometry 80x25+500+350 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR2 &
 
 PROCESSOR3="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR3+=" $VERBOSE"
-PROCESSOR3+=" --id processor3 $FAIRTASKNAME --config-json-file $MQCONFIGFILE"
+PROCESSOR3+=" --id processor3 $FAIRTASKNAME --mq-config $MQCONFIGFILE"
 xterm -geometry 80x25+500+700 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR3 &
 
 PROCESSOR4="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR4+=" $VERBOSE"
-PROCESSOR4+=" --id processor4 $FAIRTASKNAME --config-json-file $MQCONFIGFILE"
+PROCESSOR4+=" --id processor4 $FAIRTASKNAME --mq-config $MQCONFIGFILE"
 xterm -geometry 80x25+1000+0 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR4 &
 
 PROCESSOR5="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR5+=" $VERBOSE"
-PROCESSOR5+=" --id processor5 $FAIRTASKNAME --config-json-file $MQCONFIGFILE"
+PROCESSOR5+=" --id processor5 $FAIRTASKNAME --mq-config $MQCONFIGFILE"
 xterm -geometry 80x25+1000+350 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR5 &
 
 ########################## start FILESINK
 FILESINK="FairMQEx9FileSink $TRANSPORT"
-FILESINK+=" --id sink1 --config-json-file $MQCONFIGFILE"
+FILESINK+=" --id sink1 --mq-config $MQCONFIGFILE"
 FILESINK+=" --file-name $OUTPUTFILE $OUTPUTCLASS $OUTPUTBRANCH"
 xterm +aw -geometry 80x25+0+700 -hold -e @EXAMPLE9_BIN_LOCATION@/$FILESINK &
 

--- a/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9_2Levels.sh.in
+++ b/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9_2Levels.sh.in
@@ -75,53 +75,53 @@ fi
 
 ########################## start Parameter server
 SERVER="parmq-server $TRANSPORT"
-SERVER+=" --id parmq-server  --config-json-file $MQCONFIGFILE"
+SERVER+=" --id parmq-server  --mq-config $MQCONFIGFILE"
 SERVER+=" --first-input-name $ROOTPARAM --second-input-name $ASCIIPARAM --second-input-type ASCII"
 xterm -geometry 80x22+0+350 -hold -e @EXAMPLE9_BIN_LOCATION@/$SERVER &
 
 
 ########################## start SAMPLER
 SAMPLER="FairMQEx9Sampler $TRANSPORT"
-SAMPLER+=" --id sampler1  --config-json-file $MQCONFIGFILE"
+SAMPLER+=" --id sampler1  --mq-config $MQCONFIGFILE"
 SAMPLER+=" --file-name $INPUTFILE --branch-name $INPUTBRANCH $MAXINDEX"
 xterm -geometry 80x22+0+0 -hold -e @EXAMPLE9_BIN_LOCATION@/$SAMPLER &
 
 ########################## start PROCESSORs on level 1
 PROCESSOR1_1="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR1_1+=" $VERBOSE"
-PROCESSOR1_1+=" --id processor1_1 $FAIRTASKNAME1 --config-json-file $MQCONFIGFILE"
+PROCESSOR1_1+=" --id processor1_1 $FAIRTASKNAME1 --mq-config $MQCONFIGFILE"
 xterm -geometry 80x22+500+0 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR1_1 &
 
 PROCESSOR1_2="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR1_2+=" $VERBOSE"
-PROCESSOR1_2+=" --id processor1_2 $FAIRTASKNAME1 --config-json-file $MQCONFIGFILE"
+PROCESSOR1_2+=" --id processor1_2 $FAIRTASKNAME1 --mq-config $MQCONFIGFILE"
 xterm -geometry 80x22+500+350 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR1_2 &
 
 PROCESSOR1_3="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR1_3+=" $VERBOSE"
-PROCESSOR1_3+=" --id processor1_3 $FAIRTASKNAME1 --config-json-file $MQCONFIGFILE"
+PROCESSOR1_3+=" --id processor1_3 $FAIRTASKNAME1 --mq-config $MQCONFIGFILE"
 xterm -geometry 80x22+500+700 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR1_3 &
 
 ########################## start PROCESSORs on level 2
 PROCESSOR2_1="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR2_1+=" $VERBOSE"
-PROCESSOR2_1+=" --id processor2_1 $FAIRTASKNAME2 --config-json-file $MQCONFIGFILE"
+PROCESSOR2_1+=" --id processor2_1 $FAIRTASKNAME2 --mq-config $MQCONFIGFILE"
 xterm -geometry 80x22+1000+0 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR2_1 &
 
 PROCESSOR2_2="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR2_2+=" $VERBOSE"
-PROCESSOR2_2+=" --id processor2_2 $FAIRTASKNAME2 --config-json-file $MQCONFIGFILE"
+PROCESSOR2_2+=" --id processor2_2 $FAIRTASKNAME2 --mq-config $MQCONFIGFILE"
 xterm -geometry 80x22+1000+350 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR2_2 &
 
 PROCESSOR2_3="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR2_3+=" $VERBOSE"
-PROCESSOR2_3+=" --id processor2_3 $FAIRTASKNAME2 --config-json-file $MQCONFIGFILE"
+PROCESSOR2_3+=" --id processor2_3 $FAIRTASKNAME2 --mq-config $MQCONFIGFILE"
 xterm -geometry 80x22+1000+700 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR2_3 &
 
 
 ########################## start FILESINK
 FILESINK="FairMQEx9FileSink $TRANSPORT"
-FILESINK+=" --id sink1 --config-json-file $MQCONFIGFILE"
+FILESINK+=" --id sink1 --mq-config $MQCONFIGFILE"
 FILESINK+=" --file-name $OUTPUTFILE $OUTPUTCLASS $OUTPUTBRANCH"
 xterm +aw -geometry 80x22+0+700 -hold -e @EXAMPLE9_BIN_LOCATION@/$FILESINK &
 

--- a/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9_3Levels.sh.in
+++ b/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9_3Levels.sh.in
@@ -52,53 +52,53 @@ OUTPUTBRANCH="--branch-name PixelFitTracks"
 
 ########################## start Parameter server
 SERVER="parmq-server $TRANSPORT"
-SERVER+=" --id parmq-server  --config-json-file $MQCONFIGFILE"
+SERVER+=" --id parmq-server  --mq-config $MQCONFIGFILE"
 SERVER+=" --first-input-name $ROOTPARAM --second-input-name $ASCIIPARAM --second-input-type ASCII"
 xterm -geometry 80x22+0+350 -hold -e @EXAMPLE9_BIN_LOCATION@/$SERVER &
 
 
 ########################## start SAMPLER
 SAMPLER="FairMQEx9Sampler $TRANSPORT"
-SAMPLER+=" --id sampler1  --config-json-file $MQCONFIGFILE"
+SAMPLER+=" --id sampler1  --mq-config $MQCONFIGFILE"
 SAMPLER+=" --file-name $INPUTFILE --branch-name $INPUTBRANCH $MAXINDEX"
 xterm -geometry 80x22+0+0 -hold -e @EXAMPLE9_BIN_LOCATION@/$SAMPLER &
 
 ########################## start PROCESSORs on level 1
 PROCESSOR1_1="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR1_1+=" $VERBOSE"
-PROCESSOR1_1+=" --id processor1_1 $FAIRTASKNAME1 --config-json-file $MQCONFIGFILE"
+PROCESSOR1_1+=" --id processor1_1 $FAIRTASKNAME1 --mq-config $MQCONFIGFILE"
 xterm -geometry 80x22+500+0 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR1_1 &
 
 PROCESSOR1_2="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR1_2+=" $VERBOSE"
-PROCESSOR1_2+=" --id processor1_2 $FAIRTASKNAME1 --config-json-file $MQCONFIGFILE"
+PROCESSOR1_2+=" --id processor1_2 $FAIRTASKNAME1 --mq-config $MQCONFIGFILE"
 xterm -geometry 80x22+1000+0 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR1_2 &
 
 ########################## start PROCESSORs on level 2
 PROCESSOR2_1="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR2_1+=" $VERBOSE"
-PROCESSOR2_1+=" --id processor2_1 $FAIRTASKNAME2 --config-json-file $MQCONFIGFILE"
+PROCESSOR2_1+=" --id processor2_1 $FAIRTASKNAME2 --mq-config $MQCONFIGFILE"
 xterm -geometry 80x22+500+350 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR2_1 &
 
 PROCESSOR2_2="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR2_2+=" $VERBOSE"
-PROCESSOR2_2+=" --id processor2_2 $FAIRTASKNAME2 --config-json-file $MQCONFIGFILE"
+PROCESSOR2_2+=" --id processor2_2 $FAIRTASKNAME2 --mq-config $MQCONFIGFILE"
 xterm -geometry 80x22+1000+350 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR2_2 &
 
 ########################## start PROCESSORs on level 3
 PROCESSOR3_1="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR3_1+=" $VERBOSE"
-PROCESSOR3_1+=" --id processor3_1 $FAIRTASKNAME3 --config-json-file $MQCONFIGFILE"
+PROCESSOR3_1+=" --id processor3_1 $FAIRTASKNAME3 --mq-config $MQCONFIGFILE"
 xterm -geometry 80x22+500+700 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR3_1 &
 
 PROCESSOR3_2="FairMQEx9TaskProcessor $TRANSPORT"
 PROCESSOR3_2+=" $VERBOSE"
-PROCESSOR3_2+=" --id processor3_2 $FAIRTASKNAME3 --config-json-file $MQCONFIGFILE"
+PROCESSOR3_2+=" --id processor3_2 $FAIRTASKNAME3 --mq-config $MQCONFIGFILE"
 xterm -geometry 80x22+1000+700 -hold -e @EXAMPLE9_BIN_LOCATION@/$PROCESSOR3_2 &
 
 ########################## start FILESINK
 FILESINK="FairMQEx9FileSink $TRANSPORT"
-FILESINK+=" --id sink1 --config-json-file $MQCONFIGFILE"
+FILESINK+=" --id sink1 --mq-config $MQCONFIGFILE"
 FILESINK+=" --file-name $OUTPUTFILE $OUTPUTCLASS $OUTPUTBRANCH"
 xterm +aw -geometry 80x22+0+700 -hold -e @EXAMPLE9_BIN_LOCATION@/$FILESINK &
 

--- a/examples/MQ/LmdSampler/macro/startLmdMQChain.sh.in
+++ b/examples/MQ/LmdSampler/macro/startLmdMQChain.sh.in
@@ -8,7 +8,7 @@ VERBOSE="DEBUG"
 
 ########################## start SAMPLER
 SAMPLER="runLmdSampler"
-SAMPLER+=" --id LmdSampler -c $CONFIGFILE --config-json-file $MQCONFIGFILE"
+SAMPLER+=" --id LmdSampler -c $CONFIGFILE --mq-config $MQCONFIGFILE"
 SAMPLER+=" --input-file-name $LMDFILE --verbose $VERBOSE"
 xterm +aw -geometry 120x27+0+0 -hold -e @CMAKE_BINARY_DIR@/bin/$SAMPLER &
 
@@ -16,14 +16,14 @@ xterm +aw -geometry 120x27+0+0 -hold -e @CMAKE_BINARY_DIR@/bin/$SAMPLER &
 
 ########################## start Unpacker
 UNPACKER="runTut8MQUnpacker"
-UNPACKER+=" --id unpacker1 -c $CONFIGFILE --config-json-file $MQCONFIGFILE"
+UNPACKER+=" --id unpacker1 -c $CONFIGFILE --mq-config $MQCONFIGFILE"
 UNPACKER+=" --verbose $VERBOSE"
 xterm +aw -geometry 120x27+800+500 -hold -e @CMAKE_BINARY_DIR@/bin/$UNPACKER &
 
 
 ########################## start FILESINK
 FILESINK="runTut8Sink"
-FILESINK+=" --id sink1 --config-json-file $MQCONFIGFILE"
+FILESINK+=" --id sink1 --mq-config $MQCONFIGFILE"
 FILESINK+=" --output-file-name @CMAKE_SOURCE_DIR@/examples/MQ/LmdSampler/datasource/MQLmdOutput.root"
 FILESINK+=" --verbose $VERBOSE"
 xterm +aw -geometry 120x27+0+500 -hold -e @CMAKE_BINARY_DIR@/bin/$FILESINK &

--- a/examples/MQ/serialization/options/ConfigGenEx2.cfg.in
+++ b/examples/MQ/serialization/options/ConfigGenEx2.cfg.in
@@ -20,7 +20,7 @@
 
 
 #-------------------
-config-json-file =@CMAKE_SOURCE_DIR@/examples/MQ/GenericDevices/options/MQConfig.json
+mq-config =@CMAKE_SOURCE_DIR@/examples/MQ/GenericDevices/options/MQConfig.json
 
 #-------------------
 [input.file]

--- a/examples/MQ/serialization/scripts/startGenEx1All.sh.in
+++ b/examples/MQ/serialization/scripts/startGenEx1All.sh.in
@@ -47,25 +47,25 @@ JSONCONFIGFILE="@CMAKE_SOURCE_DIR@/examples/MQ/serialization/options/MQConfig.js
 
 ########################## start SAMPLER
 SAMPLER="genEx1Sampler --transport $TRANSPORT --verbose $VERBOSE"
-SAMPLER+=" --id sampler1  --input-file $INPUTFILE --config-json-file $JSONCONFIGFILE"
+SAMPLER+=" --id sampler1  --input-file $INPUTFILE --mq-config $JSONCONFIGFILE"
 xterm -geometry 120x27+0+0 -hold -e @CMAKE_BINARY_DIR@/bin/$SAMPLER &
 
 ########################## start three PROCESSORs
 PROCESSOR1="genEx1Processor --transport $TRANSPORT --verbose $VERBOSE"
-PROCESSOR1+=" --id processor1 --config-json-file $JSONCONFIGFILE"
+PROCESSOR1+=" --id processor1 --mq-config $JSONCONFIGFILE"
 xterm -geometry 100x27+800+0 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR1 &
 
 PROCESSOR2="genEx1Processor --transport $TRANSPORT"
-PROCESSOR2+=" --id processor2 --config-json-file $JSONCONFIGFILE"
+PROCESSOR2+=" --id processor2 --mq-config $JSONCONFIGFILE"
 xterm -geometry 100x27+800+0 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR2 &
 
 PROCESSOR3="genEx1Processor --transport $TRANSPORT --verbose $VERBOSE"
-PROCESSOR3+=" --id processor3 --config-json-file $JSONCONFIGFILE"
+PROCESSOR3+=" --id processor3 --mq-config $JSONCONFIGFILE"
 xterm -geometry 100x27+800+0 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR3 &
 
 ########################## start FILESINK
 FILESINK="genEx1Sink --transport $TRANSPORT --verbose $VERBOSE"
-FILESINK+=" --id sink1 --config-json-file $JSONCONFIGFILE"
+FILESINK+=" --id sink1 --mq-config $JSONCONFIGFILE"
 FILESINK+=" --output-file $OUTPUTFILE"
 xterm +aw -geometry 120x27+0+500 -hold -e @CMAKE_BINARY_DIR@/bin/$FILESINK &
 

--- a/examples/MQ/serialization/scripts/startGenEx2Processor.sh.in
+++ b/examples/MQ/serialization/scripts/startGenEx2Processor.sh.in
@@ -31,6 +31,6 @@ MQCONFIGFILE="@CMAKE_SOURCE_DIR@/examples/MQ/GenericDevices/options/genericMQTut
 ########################## start PROCESSOR
 PROCESSOR="genericMQTutoProcessor$opt"
 PROCESSOR+=" --id processor1 --config $CONFIGFILE --data-format $dataFormat"
-PROCESSOR+=" --config-json-file $MQCONFIGFILE"
+PROCESSOR+=" --mq-config $MQCONFIGFILE"
 @CMAKE_BINARY_DIR@/bin/$PROCESSOR
 

--- a/examples/MQ/serialization/scripts/startGenEx2Sampler.sh.in
+++ b/examples/MQ/serialization/scripts/startGenEx2Sampler.sh.in
@@ -30,5 +30,5 @@ MQCONFIGFILE="@CMAKE_SOURCE_DIR@/examples/MQ/GenericDevices/options/genericMQTut
 ########################## start SAMPLER
 SAMPLER="genericMQTutoSampler$opt"
 SAMPLER+=" --id sampler1 --config $CONFIGFILE --data-format $dataFormat"
-SAMPLER+=" --config-json-file $MQCONFIGFILE"
+SAMPLER+=" --mq-config $MQCONFIGFILE"
 @CMAKE_BINARY_DIR@/bin/$SAMPLER

--- a/examples/MQ/serialization/scripts/startGenEx2Sink.sh.in
+++ b/examples/MQ/serialization/scripts/startGenEx2Sink.sh.in
@@ -30,7 +30,7 @@ MQCONFIGFILE="@CMAKE_SOURCE_DIR@/examples/MQ/GenericDevices/options/genericMQTut
 ########################## start FILESINK
 FILESINK="genericMQTutoFileSink$opt"
 FILESINK+=" --id sink1 --config $CONFIGFILE --data-format $dataFormat"
-FILESINK+=" --config-json-file $MQCONFIGFILE"
+FILESINK+=" --mq-config $MQCONFIGFILE"
 FILESINK+=" --output.file.name @CMAKE_SOURCE_DIR@/examples/MQ/GenericDevices/data_io/GenericMQTutoOutputFile$dataFormat.root"
 @CMAKE_BINARY_DIR@/bin/$FILESINK
 

--- a/examples/MQ/serialization/scripts/startSerializationEx2.sh.in
+++ b/examples/MQ/serialization/scripts/startSerializationEx2.sh.in
@@ -47,25 +47,25 @@ JSONCONFIGFILE="@CMAKE_SOURCE_DIR@/examples/MQ/serialization/options/MQConfig.js
 
 ########################## start SAMPLER
 SAMPLER="serialization-Ex2Sampler --transport $TRANSPORT --verbose $VERBOSE"
-SAMPLER+=" --id sampler1  --input-file $INPUTFILE --config-json-file $JSONCONFIGFILE"
+SAMPLER+=" --id sampler1  --input-file $INPUTFILE --mq-config $JSONCONFIGFILE"
 xterm -geometry 120x27+0+0 -hold -e @CMAKE_BINARY_DIR@/bin/$SAMPLER &
 
 ########################## start three PROCESSORs
 PROCESSOR1="serialization-Ex2Processor --transport $TRANSPORT --verbose $VERBOSE"
-PROCESSOR1+=" --id processor1 --config-json-file $JSONCONFIGFILE"
+PROCESSOR1+=" --id processor1 --mq-config $JSONCONFIGFILE"
 xterm -geometry 100x27+800+0 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR1 &
 
 PROCESSOR2="serialization-Ex2Processor --transport $TRANSPORT"
-PROCESSOR2+=" --id processor2 --config-json-file $JSONCONFIGFILE"
+PROCESSOR2+=" --id processor2 --mq-config $JSONCONFIGFILE"
 xterm -geometry 100x27+800+0 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR2 &
 
 PROCESSOR3="serialization-Ex2Processor --transport $TRANSPORT --verbose $VERBOSE"
-PROCESSOR3+=" --id processor3 --config-json-file $JSONCONFIGFILE"
+PROCESSOR3+=" --id processor3 --mq-config $JSONCONFIGFILE"
 xterm -geometry 100x27+800+0 -hold -e @CMAKE_BINARY_DIR@/bin/$PROCESSOR3 &
 
 ########################## start FILESINK
 FILESINK="serialization-Ex2Sink --transport $TRANSPORT --verbose $VERBOSE"
-FILESINK+=" --id sink1 --config-json-file $JSONCONFIGFILE"
+FILESINK+=" --id sink1 --mq-config $JSONCONFIGFILE"
 FILESINK+=" --output-file $OUTPUTFILE"
 xterm +aw -geometry 120x27+0+500 -hold -e @CMAKE_BINARY_DIR@/bin/$FILESINK &
 

--- a/fairmq/options/FairMQProgOptions.cxx
+++ b/fairmq/options/FairMQProgOptions.cxx
@@ -14,7 +14,7 @@
 
 #include "FairMQProgOptions.h"
 #include <algorithm>
-
+#include "FairMQParser.h"
 using namespace std;
 
 FairMQProgOptions::FairMQProgOptions()
@@ -24,6 +24,8 @@ FairMQProgOptions::FairMQProgOptions()
     , fMQOptionsInCmd("MQ-Device options")
     , fMQtree()
     , fFairMQMap()
+    , fHelpTitle("***** FAIRMQ Program Options ***** ")
+    , fVersion("Beta version 0.1")
 {
 }
 
@@ -104,6 +106,32 @@ int FairMQProgOptions::ParseAll(const int argc, char** argv, bool allowUnregiste
         LOG(WARN) << "No channels will be created (You can create them manually).";
         // return 1;
     }
+    else
+    {
+        if(fVarMap.count("mq-config"))
+        {
+            LOG(DEBUG)<<"mq-config command line called : default xml/json parser will be used";
+            std::string file = fVarMap["mq-config"].as<std::string>();
+            std::string id = fVarMap["id"].as<std::string>();
+
+            std::string file_extension = boost::filesystem::extension(file);
+
+            std::transform(file_extension.begin(), file_extension.end(), file_extension.begin(), ::tolower);
+
+            if(file_extension==".json")
+                UserParser<FairMQParser::JSON>(file, id);
+            else
+                if(file_extension==".xml")
+                    UserParser<FairMQParser::XML>(file, id);
+                else
+                {
+                    LOG(ERROR)  <<"mq-config command line called but file extension '"
+                                <<file_extension 
+                                << "' not recognized. Program will now exit";
+                    return 1;
+                }
+        }
+    }
 
     return 0;
 }
@@ -112,13 +140,13 @@ int FairMQProgOptions::NotifySwitchOption()
 {
     if (fVarMap.count("help"))
     {
-        LOG(INFO) << "***** FAIRMQ Program Options ***** \n" << fVisibleOptions;
+        LOG(INFO) << fHelpTitle << "\n" << fVisibleOptions;
         return 1;
     }
 
     if (fVarMap.count("version")) 
     {
-        LOG(INFO) << "Beta version 0.1\n";
+        LOG(INFO) << fVersion << "\n";
         return 1;
     }
 
@@ -152,7 +180,9 @@ void FairMQProgOptions::InitOptionDescription()
         ("config-xml-string",  po::value<vector<string>>()->multitoken(), "XML input as command line string.")
         ("config-xml-file",    po::value<string>(),                       "XML input as file.")
         ("config-json-string", po::value<vector<string>>()->multitoken(), "JSON input as command line string.")
-        ("config-json-file",   po::value<string>(),                       "JSON input as file.");
+        ("config-json-file",   po::value<string>(),                       "JSON input as file.")
+        ("mq-config",          po::value<string>(),                       "JSON/XML input as file. The configuration object will check xml or json file extention and will call the json or xml parser accordingly")
+        ;
 
     AddToCmdLineOptions(fGenericDesc);
     AddToCmdLineOptions(fMQOptionsInCmd);

--- a/fairmq/options/FairMQProgOptions.h
+++ b/fairmq/options/FairMQProgOptions.h
@@ -34,6 +34,8 @@ class FairMQProgOptions : public FairProgOptions
     FairMQProgOptions();
     virtual ~FairMQProgOptions();
 
+    // parse command line and txt/INI configuration file. 
+    // default parser for the mq-configuration file (JSON/XML) is called if command line key mq-config is called
     virtual int ParseAll(const int argc, char** argv, bool allowUnregistered = false);
 
     // external parser, store function 
@@ -75,12 +77,25 @@ class FairMQProgOptions : public FairProgOptions
         return fFairMQMap;
     }
 
+    // to customize title of the executable help command line  
+    void SetHelpTitle(const std::string& title)
+    {
+        fHelpTitle=title;
+    }
+    // to customize the executable version command line
+    void SetVersion(const std::string& version)
+    {
+        fVersion=version;
+    }
+
   protected:
     po::options_description fMQParserOptions;
     po::options_description fMQOptionsInCfg;
     po::options_description fMQOptionsInCmd;
     pt::ptree fMQtree;
     FairMQMap fFairMQMap;
+    std::string fHelpTitle;
+    std::string fVersion;
 
     virtual int NotifySwitchOption(); // for custom help & version printing
     void InitOptionDescription();

--- a/fairmq/tools/runSimpleMQStateMachine.h
+++ b/fairmq/tools/runSimpleMQStateMachine.h
@@ -27,11 +27,8 @@ template<typename TMQDevice>
 inline int runStateMachine(TMQDevice& device, FairMQProgOptions& config)
 {
     device.CatchSignals();
-    std::string jsonfile = config.GetValue<std::string>("config-json-file");
     std::string id = config.GetValue<std::string>("id");
     int ioThreads = config.GetValue<int>("io-threads");
-
-    config.UserParser<FairMQParser::JSON>(jsonfile, id);
 
     device.fChannels = config.GetFairMQMap();
 
@@ -58,11 +55,8 @@ template<typename TMQDevice>
 inline int runNonInteractiveStateMachine(TMQDevice& device, FairMQProgOptions& config)
 {
     device.CatchSignals();
-    std::string jsonfile = config.GetValue<std::string>("config-json-file");
     std::string id = config.GetValue<std::string>("id");
     int ioThreads = config.GetValue<int>("io-threads");
-
-    config.UserParser<FairMQParser::JSON>(jsonfile, id);
 
     device.fChannels = config.GetFairMQMap();
 


### PR DESCRIPTION
…e mq-config file.extension is called. The .xml and .json files are recognized internally. Remove explicit json parsing in runSimpleMQStateMAchine.h. Propagate the new commandline mq-config where the runstatemachine function is used.

If mq-config called but extension not recognize -> exit