### PR TITLE
Dev

### DIFF
--- a/base/steer/FairRootManager.cxx
+++ b/base/steer/FairRootManager.cxx
@@ -106,6 +106,7 @@ FairRootManager::FairRootManager()
     fSource(0),
     fSourceChain( new TChain("cbmsim", "/cbmroot")),
     fSignalChainList(),
+    fEventHeader(new FairEventHeader()),
     fUseFairLinks(kFALSE),
     fFinishRun(kFALSE),
     fListOfBranchesFromInput(0),
@@ -556,10 +557,8 @@ Int_t  FairRootManager::ReadEvent(Int_t i)
 
   Int_t readEventResult = fSource->ReadEvent(i);
 
-  FairEventHeader* tempEH = new FairEventHeader();
-  fSource->FillEventHeader(tempEH);
-  fCurrentTime = tempEH->GetEventTime();
-  tempEH->Delete();
+  fSource->FillEventHeader(fEventHeader);
+  fCurrentTime = fEventHeader->GetEventTime();
 
   LOG(DEBUG) << "--Event number --- "
 	     << fCurrentEntryNo << " with time ---- " 
@@ -572,10 +571,9 @@ Int_t  FairRootManager::ReadEvent(Int_t i)
 //_____________________________________________________________________________
 Int_t FairRootManager::GetRunId() 
 {
-  FairEventHeader* tempEH = new FairEventHeader();
   if ( fSource ) {
-    fSource->FillEventHeader(tempEH);
-    return tempEH->GetRunId();
+    fSource->FillEventHeader(fEventHeader);
+    return fEventHeader->GetRunId();
   }
   return -1;
 }

--- a/base/steer/FairRootManager.h
+++ b/base/steer/FairRootManager.h
@@ -23,6 +23,7 @@
 #include <queue>                        // for queue
 #include "FairSource.h"
 class BinaryFunctor;
+class FairEventHeader;
 class FairFileHeader;
 class FairGeoNode;
 class FairLink;
@@ -309,6 +310,8 @@ class FairRootManager : public TObject
 
     TChain                              *fSourceChain;
     std::map<UInt_t, TChain*>            fSignalChainList;//!
+
+    FairEventHeader                     *fEventHeader;
     
     Bool_t fUseFairLinks; //!
     Bool_t fFinishRun; //!

--- a/examples/MQ/9-PixelDetector/macros/CMakeLists.txt
+++ b/examples/MQ/9-PixelDetector/macros/CMakeLists.txt
@@ -17,7 +17,7 @@ ForEach(_mcEngine IN ITEMS TGeant3 TGeant4)
 
 EndForEach(_mcEngine IN ITEMS TGeant3 TGeant4) 
 
-Install(FILES run_sim.C run_digi.C run_reco.C
+Install(FILES run_sim.C run_digi.C run_tracks.C run_reco.C
         DESTINATION share/fairbase/examples/MQ/9-PixelDetector/macros/
        )
 

--- a/examples/MQ/9-PixelDetector/run/CMakeLists.txt
+++ b/examples/MQ/9-PixelDetector/run/CMakeLists.txt
@@ -46,13 +46,13 @@ configure_file( ${CMAKE_SOURCE_DIR}/examples/MQ/9-PixelDetector/run/scripts/star
 
 Install(FILES ${CMAKE_BINARY_DIR}/bin/startFairMQEx9New.sh_install
         DESTINATION bin
-        RENAME startFairMQEx9New.sh)
+        RENAME startFairMQEx9New.sh PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ WORLD_READ)
 Install(FILES ${CMAKE_BINARY_DIR}/bin/startFairMQEx9_2Levels.sh_install
         DESTINATION bin
-        RENAME startFairMQEx9_2Levels.sh)
+        RENAME startFairMQEx9_2Levels.sh PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ WORLD_READ)
 Install(FILES ${CMAKE_BINARY_DIR}/bin/startFairMQEx9_3Levels.sh_install
         DESTINATION bin
-        RENAME startFairMQEx9_3Levels.sh)
+        RENAME startFairMQEx9_3Levels.sh PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ WORLD_READ)
 
 Install(FILES options/Pixel9MQConfig_Multipart.json options/Pixel9MQConfig_2Levels.json options/Pixel9MQConfig_3Levels.json
         DESTINATION share/fairbase/examples/MQ/9-PixelDetector/run/options/

--- a/examples/MQ/9-PixelDetector/src/PixelDigitize.cxx
+++ b/examples/MQ/9-PixelDetector/src/PixelDigitize.cxx
@@ -241,7 +241,7 @@ InitStatus PixelDigitize::ReInit() {
 // -----   Private method Reset   ------------------------------------------
 void PixelDigitize::Reset() {
   fNPoints = fNDigis = 0;
-  if ( fDigis ) fDigis->Delete();
+  if ( fDigis ) fDigis->Clear();
 }
 // -------------------------------------------------------------------------
 

--- a/examples/MQ/9-PixelDetector/src/PixelFindHits.cxx
+++ b/examples/MQ/9-PixelDetector/src/PixelFindHits.cxx
@@ -348,7 +348,7 @@ InitStatus PixelFindHits::ReInit() {
 // -----   Private method Reset   ------------------------------------------
 void PixelFindHits::Reset() {
   fNDigis = fNHits = 0;
-  if ( fHits ) fHits->Delete();
+  if ( fHits ) fHits->Clear();
 }
 // -------------------------------------------------------------------------
 

--- a/examples/MQ/9-PixelDetector/src/PixelFindTracks.cxx
+++ b/examples/MQ/9-PixelDetector/src/PixelFindTracks.cxx
@@ -242,7 +242,7 @@ InitStatus PixelFindTracks::ReInit() {
 // -----   Private method Reset   ------------------------------------------
 void PixelFindTracks::Reset() {
   fNTracks = fNHits = 0;
-  if ( fTracks ) fTracks->Delete();
+  if ( fTracks ) fTracks->Clear();
 }
 // -------------------------------------------------------------------------
 

--- a/examples/MQ/9-PixelDetector/src/PixelFitTracks.cxx
+++ b/examples/MQ/9-PixelDetector/src/PixelFitTracks.cxx
@@ -270,7 +270,7 @@ InitStatus PixelFitTracks::ReInit() {
 // -----   Private method Reset   ------------------------------------------
 void PixelFitTracks::Reset() {
   fNFitTracks = fNTracks = fNHits = 0;
-  if ( fFitTracks ) fFitTracks->Delete();
+  if ( fFitTracks ) fFitTracks->Clear();
 }
 // -------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixed memory leak in FairRootManager caused by creating FairEventHeader every event.
Changed permissions of the shell scripts in the install/bin/ directory.