### PR TITLE
Update FairMQParts with doxygen comments and non-blocking send

### DIFF
--- a/examples/MQ/serialization/src/1-simple/devices/GenExPart1Processor.h
+++ b/examples/MQ/serialization/src/1-simple/devices/GenExPart1Processor.h
@@ -14,21 +14,22 @@
 
 class GenExPart1Processor : public FairMQDevice 
 {
-public:
-	GenExPart1Processor() : FairMQDevice(), 
-	    					fInput(nullptr),
-	    					fOutput(nullptr)
+  public:
+    GenExPart1Processor() :
+        FairMQDevice(),
+        fInput(nullptr),
+        fOutput(nullptr)
     {}
-	virtual ~GenExPart1Processor(){}
 
-protected:
-    
+    virtual ~GenExPart1Processor() {}
 
+  protected:
     virtual void Init()
     {
         fOutput = new TClonesArray("MyHit");
     }
-	virtual void Run()
+
+    virtual void Run()
     {
         int receivedMsgs = 0;
         int sentMsgs = 0;
@@ -49,31 +50,28 @@ protected:
         LOG(INFO) << "Received " << receivedMsgs << " and sent " << sentMsgs << " messages!";
     }
 
-
-
     // do some random dummy task
     void Exec(TClonesArray* digis, TClonesArray* hits)
-	{
-		hits->Delete();
-	    for(unsigned int idigi(0);idigi<digis->GetEntriesFast();idigi++)
-	    {
-	        TVector3 pos;
-	        TVector3 dpos;
-	        Double_t timestamp=0;
-	        Double_t timestampErr=0;
-	        Int_t fDetID=0;
-    		Int_t fMCIndex=0;
-	        MyDigi* digi = (MyDigi*)digis->At(idigi);
-	        pos.SetXYZ(digi->GetX() + 0.5, digi->GetY() + 0.5, digi->GetZ() + 0.5);
-	        dpos.SetXYZ(1 / TMath::Sqrt(12), 1 / TMath::Sqrt(12), 1 / TMath::Sqrt(12));
-	        MyHit* hit = new ((*hits)[idigi]) MyHit(fDetID, fMCIndex, pos, dpos);
-	        hit->SetTimeStamp(digi->GetTimeStamp());
-	        hit->SetTimeStampError(digi->GetTimeStampError());
-	    }
-	}
+    {
+        hits->Delete();
+        for(unsigned int idigi(0); idigi<digis->GetEntriesFast(); idigi++)
+        {
+            TVector3 pos;
+            TVector3 dpos;
+            Double_t timestamp = 0;
+            Double_t timestampErr = 0;
+            Int_t fDetID = 0;
+            Int_t fMCIndex = 0;
+            MyDigi* digi = static_cast<MyDigi*>(digis->At(idigi));
+            pos.SetXYZ(digi->GetX() + 0.5, digi->GetY() + 0.5, digi->GetZ() + 0.5);
+            dpos.SetXYZ(1 / TMath::Sqrt(12), 1 / TMath::Sqrt(12), 1 / TMath::Sqrt(12));
+            MyHit* hit = new ((*hits)[idigi]) MyHit(fDetID, fMCIndex, pos, dpos);
+            hit->SetTimeStamp(digi->GetTimeStamp());
+            hit->SetTimeStampError(digi->GetTimeStampError());
+        }
+    }
 
-private:
-	/* data */
+  private:
     TClonesArray* fInput;
     TClonesArray* fOutput;
 };

--- a/examples/MQ/serialization/src/1-simple/devices/GenExPart1Sampler.h
+++ b/examples/MQ/serialization/src/1-simple/devices/GenExPart1Sampler.h
@@ -1,50 +1,48 @@
-
 #ifndef GENEXPART1SAMPLER_H
 #define GENEXPART1SAMPLER_H
 
-//std
+// std
 #include <iostream>
 #include <memory>
 
-//boost
+// boost
 #include <boost/thread.hpp>
 #include <boost/bind.hpp>
 #include <boost/timer/timer.hpp>
 
-
-//FairRoot
+// FairRoot
 #include "FairMQDevice.h"
 
 #include "SerializerExample.h"
 
 // root
-
 #include "Rtypes.h"
 #include "TFile.h"
 #include "TTree.h"
 
-
 class GenExPart1Sampler : public FairMQDevice
 {
-public:
-	GenExPart1Sampler() : 	FairMQDevice(), 
-    						fInput(nullptr),
-    						fTree(nullptr),
-    						fFileName(),
-    						fInputFile(nullptr)
+  public:
+    GenExPart1Sampler() :
+        FairMQDevice(),
+        fInput(nullptr),
+        fTree(nullptr),
+        fFileName(),
+        fInputFile(nullptr)
     {}
-	virtual ~GenExPart1Sampler()
-	{
-		if (fInputFile)
+
+    virtual ~GenExPart1Sampler()
+    {
+        if (fInputFile)
         {
             fInputFile->Close();
             delete fInputFile;
         }
-	}
-	void SetFileName(const std::string& name){fFileName=name;}
+    }
 
-protected:
-    
+    void SetFileName(const std::string& name){fFileName=name;}
+
+  protected:
     virtual void Init()
     {
         fInputFile = TFile::Open(fFileName.c_str(), "READ");
@@ -52,41 +50,48 @@ protected:
         {
             fTree = static_cast<TTree*>(fInputFile->Get("cbmsim"));
             if (fTree)
+            {
                 fTree->SetBranchAddress("MyDigi", &fInput);
+            }
             else
-				LOG(ERROR) << "Could not find tree 'MyDigi'";
+            {
+                LOG(ERROR) << "Could not find tree 'MyDigi'";
+            }
         }
         else
+        {
             LOG(ERROR) << "Could not open file " << fFileName << " in SimpleTreeReader::InitSource()";
+        }
     }
-	virtual void Run()
+
+    virtual void Run()
     {
-    	int64_t sentMsgs(0);
-    	const int64_t numEvents=fTree->GetEntries();
+        int64_t sentMsgs(0);
+        const int64_t numEvents = fTree->GetEntries();
         LOG(INFO) << "Number of events to process: " << numEvents;
         boost::timer::auto_cpu_timer timer;
         for (int64_t idx(0); idx < numEvents; idx++)
         {
             std::unique_ptr<FairMQMessage> msg(NewMessage());
             fTree->GetEntry(idx);
-            Serialize<MySerializer>(*msg,fInput);
+            Serialize<MySerializer>(*msg, fInput);
             Send(msg, "data-out");
             sentMsgs++;
             if (!CheckCurrentState(RUNNING))
+            {
                 break;
+            }
         }
         boost::timer::cpu_times const elapsed_time(timer.elapsed());
         LOG(INFO) << "Sent everything in:\n" << boost::timer::format(elapsed_time, 2);
         LOG(INFO) << "Sent " << sentMsgs << " messages!";
     }
 
-private:
-	/* data */
+  private:
     TClonesArray* fInput;
     TTree* fTree;
     std::string fFileName;
     TFile* fInputFile;
 };
-
 
 #endif

--- a/examples/MQ/serialization/src/1-simple/devices/GenExPart1Sink.h
+++ b/examples/MQ/serialization/src/1-simple/devices/GenExPart1Sink.h
@@ -1,56 +1,56 @@
-
-
-
-
 #ifndef GENEXPART1SINK_H
 #define GENEXPART1SINK_H
 
-//std
+// std
 #include <iostream>
 #include <memory>
 
-//FairRoot
+// FairRoot
 #include "FairMQDevice.h"
 #include "SerializerExample.h"
 
-//root
+// root
 #include "TFile.h"
 #include "TTree.h"
 
-
-
-class GenExPart1Sink : public FairMQDevice 
+class GenExPart1Sink : public FairMQDevice
 {
-public:
-	GenExPart1Sink() : 	FairMQDevice(), 
-						fInput(nullptr),
-						fFileName(),
-						fOutFile(nullptr),
-						fTree(nullptr)
+  public:
+    GenExPart1Sink() :
+        FairMQDevice(),
+        fInput(nullptr),
+        fFileName(),
+        fOutFile(nullptr),
+        fTree(nullptr)
     {}
-	virtual ~GenExPart1Sink()
-	{
-	    fTree->Write("", TObject::kOverwrite);
 
-	    if (fTree)
-	        delete fTree;
+    virtual ~GenExPart1Sink()
+    {
+        if (fTree)
+        {
+            fTree->Write("", TObject::kOverwrite);
+            delete fTree;
+        }
 
-	    if (fOutFile)
-	    {
-	        if (fOutFile->IsOpen())
-	            fOutFile->Close();
-	        delete fOutFile;
-	    }
-	}
-	void SetFileName(const std::string& filename){fFileName=filename;}
+        if (fOutFile)
+        {
+            if (fOutFile->IsOpen())
+            {
+                fOutFile->Close();
+            }
+            delete fOutFile;
+        }
+    }
 
-protected:
+    void SetFileName(const std::string& filename) { fFileName = filename; }
+
+  protected:
     virtual void Init()
     {
-	    fOutFile = TFile::Open(fFileName.c_str(),"RECREATE");
-	    fInput = new TClonesArray("MyHit");
-	    fTree = new TTree("GenExPart1", "Test output");
-	    fTree->Branch("MyHit","TClonesArray", &fInput);	       
+        fOutFile = TFile::Open(fFileName.c_str(),"RECREATE");
+        fInput = new TClonesArray("MyHit");
+        fTree = new TTree("GenExPart1", "Test output");
+        fTree->Branch("MyHit","TClonesArray", &fInput);
     }
 
     virtual void Run()
@@ -71,8 +71,7 @@ protected:
         LOG(INFO) << "Received " << receivedMsgs << " and sent " << sentMsgs << " messages!";
     }
 
-private:
-	/* data */
+  private:
     TClonesArray* fInput;
     std::string fFileName;
     TFile* fOutFile;

--- a/examples/MQ/serialization/src/2-multi-part/devices/Ex2Processor.h
+++ b/examples/MQ/serialization/src/2-multi-part/devices/Ex2Processor.h
@@ -1,30 +1,28 @@
 #ifndef EX2PROCESSOR_H
 #define EX2PROCESSOR_H
 
-//std
+// std
 #include <iostream>
 #include <memory>
 
-//FairRoot
+// FairRoot
 #include "FairMQDevice.h"
 #include "FairMQParts.h"
 #include "SerializerExample2.h"
 #include "TMath.h"
 
-
-
-class Ex2Processor : public FairMQDevice 
+class Ex2Processor : public FairMQDevice
 {
-public:
-	Ex2Processor() : FairMQDevice(), 
-	    			 fInput(nullptr),
-	    			 fOutput(nullptr)
+  public:
+    Ex2Processor() :
+        FairMQDevice(),
+        fInput(nullptr),
+        fOutput(nullptr)
     {}
-	virtual ~Ex2Processor(){}
 
-protected:
-    
+    virtual ~Ex2Processor() {}
 
+  protected:
     virtual void Init()
     {
         fOutput = new TClonesArray("MyHit");
@@ -38,22 +36,22 @@ protected:
         while (CheckCurrentState(RUNNING))
         {
             FairMQParts parts;
-            //
-            if (Receive(parts,"data-in") > 0)
+
+            if (Receive(parts, "data-in") > 0)
             {
                 Ex2Header* header=nullptr;
-                Deserialize<SerializerEx2>(parts.At_ref(0),header);
-                Deserialize<SerializerEx2>(parts.At_ref(1),fInput);
-                
+                Deserialize<SerializerEx2>(parts.AtRef(0), header);
+                Deserialize<SerializerEx2>(parts.AtRef(1), fInput);
+
                 receivedMsgs++;
 
-                Exec(fInput,fOutput);
+                Exec(fInput, fOutput);
                 FairMQParts partsToSend;
                 partsToSend.AddPart(parts.At(0));
 
                 partsToSend.AddPart(NewMessage());
-                Serialize<SerializerEx2Boost>(partsToSend.At_ref(0),*header);
-                Serialize<SerializerEx2Boost>(partsToSend.At_ref(1),fOutput);
+                Serialize<SerializerEx2Boost>(partsToSend.AtRef(0), *header);
+                Serialize<SerializerEx2Boost>(partsToSend.AtRef(1), fOutput);
                 Send(partsToSend, "data-out");
                 sentMsgs++;
             }
@@ -61,33 +59,31 @@ protected:
         LOG(INFO) << "Received " << receivedMsgs << " and sent " << sentMsgs << " messages!";
     }
 
-
     // do some random dummy task
     void Exec(TClonesArray* digis, TClonesArray* hits)
-	{
-		hits->Delete();
-	    for(unsigned int idigi(0);idigi<digis->GetEntriesFast();idigi++)
-	    {
-	        TVector3 pos;
-	        TVector3 dpos;
-	        Double_t timestamp=0;
-	        Double_t timestampErr=0;
-	        Int_t fDetID=0;
-    		Int_t fMCIndex=0;
-	        MyDigi* digi = (MyDigi*)digis->At(idigi);
-	        pos.SetXYZ(digi->GetX() + 0.5, digi->GetY() + 0.5, digi->GetZ() + 0.5);
-	        dpos.SetXYZ(1 / TMath::Sqrt(12), 1 / TMath::Sqrt(12), 1 / TMath::Sqrt(12));
-	        MyHit* hit = new ((*hits)[idigi]) MyHit(fDetID, fMCIndex, pos, dpos);
-	        hit->SetTimeStamp(digi->GetTimeStamp());
-	        hit->SetTimeStampError(digi->GetTimeStampError());
-	    }
-	}
+    {
+        hits->Delete();
+        for (unsigned int idigi(0); idigi<digis->GetEntriesFast(); idigi++)
+        {
+            TVector3 pos;
+            TVector3 dpos;
+            Double_t timestamp = 0;
+            Double_t timestampErr = 0;
+            Int_t fDetID = 0;
+            Int_t fMCIndex = 0;
+            MyDigi* digi = (MyDigi*)digis->At(idigi);
+            pos.SetXYZ(digi->GetX() + 0.5, digi->GetY() + 0.5, digi->GetZ() + 0.5);
+            dpos.SetXYZ(1 / TMath::Sqrt(12), 1 / TMath::Sqrt(12), 1 / TMath::Sqrt(12));
+            MyHit* hit = new ((*hits)[idigi]) MyHit(fDetID, fMCIndex, pos, dpos);
+            hit->SetTimeStamp(digi->GetTimeStamp());
+            hit->SetTimeStampError(digi->GetTimeStampError());
+        }
+    }
 
-private:
-	/* data */
+  private:
+    /* data */
     TClonesArray* fInput;
     TClonesArray* fOutput;
 };
-
 
 #endif

--- a/examples/MQ/serialization/src/2-multi-part/devices/Ex2Sampler.h
+++ b/examples/MQ/serialization/src/2-multi-part/devices/Ex2Sampler.h
@@ -1,36 +1,36 @@
-
 #ifndef EX2SAMPLER_H
 #define EX2SAMPLER_H
 
-//std
+// std
 #include <iostream>
 #include <memory>
 
-//boost
+// boost
 #include <boost/thread.hpp>
 #include <boost/bind.hpp>
 #include <boost/timer/timer.hpp>
 
-//FairRoot
+// FairRoot
 #include "FairMQDevice.h"
 #include "FairMQMessageZMQ.h"
 #include "SerializerExample2.h"
 
 // root
-
 #include "Rtypes.h"
 #include "TFile.h"
 #include "TTree.h"
 
 class Ex2Sampler : public FairMQDevice
 {
-public:
-    Ex2Sampler() :  FairMQDevice(), 
-                    fInput(nullptr),
-                    fTree(nullptr),
-                    fFileName(),
-                    fInputFile(nullptr)
+  public:
+    Ex2Sampler() :
+        FairMQDevice(),
+        fInput(nullptr),
+        fTree(nullptr),
+        fFileName(),
+        fInputFile(nullptr)
     {}
+
     virtual ~Ex2Sampler()
     {
         if (fInputFile)
@@ -41,8 +41,7 @@ public:
     }
     void SetFileName(const std::string& name){fFileName=name;}
 
-protected:
-    
+  protected:
     virtual void Init()
     {
         fInputFile = TFile::Open(fFileName.c_str(), "READ");
@@ -50,32 +49,39 @@ protected:
         {
             fTree = static_cast<TTree*>(fInputFile->Get("cbmsim"));
             if (fTree)
+            {
                 fTree->SetBranchAddress("MyDigi", &fInput);
+            }
             else
+            {
                 LOG(ERROR) << "Could not find tree 'MyDigi'";
+            }
         }
         else
+        {
             LOG(ERROR) << "Could not open file " << fFileName << " in SimpleTreeReader::InitSource()";
+        }
     }
+
     virtual void Run()
     {
         int64_t sentMsgs(0);
-        const int64_t numEvents=fTree->GetEntries();
+        const int64_t numEvents = fTree->GetEntries();
         LOG(INFO) << "Number of events to process: " << numEvents;
         boost::timer::auto_cpu_timer timer;
         for (int64_t idx(0); idx < numEvents; idx++)
         {
             fTree->GetEntry(idx);
             Ex2Header* header = new Ex2Header();
-            header->EventNumber=idx;
+            header->EventNumber = idx;
             std::unique_ptr<FairMQMessage> msgHeader(NewMessage(
-                header, 
+                header,
                 sizeof(Ex2Header),
                 [](void* data, void* hint) { delete static_cast<Ex2Header*>(data); }
                 ));
             std::unique_ptr<FairMQMessage> msg(NewMessage());
             
-            Serialize<SerializerEx2>(*msg,fInput);
+            Serialize<SerializerEx2>(*msg, fInput);
             FairMQParts parts;
             parts.AddPart(std::move(msgHeader));
             parts.AddPart(msg);
@@ -83,20 +89,20 @@ protected:
             sentMsgs++;
 
             if (!CheckCurrentState(RUNNING))
+            {
                 break;
+            }
         }
         boost::timer::cpu_times const elapsed_time(timer.elapsed());
         LOG(INFO) << "Sent everything in:\n" << boost::timer::format(elapsed_time, 2);
         LOG(INFO) << "Sent " << sentMsgs << " messages!";
     }
 
-private:
-    /* data */
+  private:
     TClonesArray* fInput;
     TTree* fTree;
     std::string fFileName;
     TFile* fInputFile;
 };
-
 
 #endif

--- a/examples/MQ/serialization/src/2-multi-part/devices/Ex2Sink.h
+++ b/examples/MQ/serialization/src/2-multi-part/devices/Ex2Sink.h
@@ -1,53 +1,58 @@
 #ifndef EX2SINK_H
 #define EX2SINK_H
 
-//std
+// std
 #include <iostream>
 #include <memory>
 
-//FairRoot
+// FairRoot
 #include "FairMQDevice.h"
 #include "SerializerExample2.h"
 
 #include <boost/core/null_deleter.hpp>
 
-//root
+// root
 #include "TFile.h"
 #include "TTree.h"
 
-
 class Ex2Sink : public FairMQDevice 
 {
-public:
-    Ex2Sink() : FairMQDevice(), 
-                fInput(nullptr),
-                fFileName(),
-                fOutFile(nullptr),
-                fTree(nullptr)
+  public:
+    Ex2Sink() :
+        FairMQDevice(),
+        fInput(nullptr),
+        fFileName(),
+        fOutFile(nullptr),
+        fTree(nullptr)
     {}
+
     virtual ~Ex2Sink()
     {
-        fTree->Write("", TObject::kOverwrite);
-
         if (fTree)
+        {
+            fTree->Write("", TObject::kOverwrite);
+
             delete fTree;
+        }
 
         if (fOutFile)
         {
             if (fOutFile->IsOpen())
+            {
                 fOutFile->Close();
+            }
             delete fOutFile;
         }
     }
-    void SetFileName(const std::string& filename){fFileName=filename;}
+    void SetFileName(const std::string& filename) { fFileName = filename; }
 
-protected:
+  protected:
     virtual void Init()
     {
-        fOutFile = TFile::Open(fFileName.c_str(),"RECREATE");
+        fOutFile = TFile::Open(fFileName.c_str(), "RECREATE");
         fInput = new TClonesArray("MyHit");
         fTree = new TTree("cbmsimout", "output");
-        fTree->Branch("MyHit","TClonesArray", &fInput);           
+        fTree->Branch("MyHit", "TClonesArray", &fInput);
     }
 
     virtual void Run()
@@ -57,11 +62,11 @@ protected:
         while (CheckCurrentState(RUNNING))
         {
             FairMQParts parts;
-            if (Receive(parts,"data-in") > 0)
+            if (Receive(parts, "data-in") > 0)
             {
                 Ex2Header header;
-                Deserialize<SerializerEx2Boost>(parts.At_ref(0),header);
-                Deserialize<SerializerEx2Boost>(parts.At_ref(1),fInput);
+                Deserialize<SerializerEx2Boost>(parts.AtRef(0), header);
+                Deserialize<SerializerEx2Boost>(parts.AtRef(1), fInput);
                 receivedMsgs++;
                 fTree->SetBranchAddress("MyHit", &fInput);
                 fTree->Fill();
@@ -70,8 +75,7 @@ protected:
         LOG(INFO) << "Received " << receivedMsgs << " and sent " << sentMsgs << " messages!";
     }
 
-private:
-    /* data */
+  private:
     TClonesArray* fInput;
     std::string fFileName;
     TFile* fOutFile;

--- a/examples/MQ/serialization/src/2-multi-part/devices/SerializerExample2.h
+++ b/examples/MQ/serialization/src/2-multi-part/devices/SerializerExample2.h
@@ -1,5 +1,3 @@
-
-
 #ifndef BASICSERIALIZEREXAMPLE2_H
 #define BASICSERIALIZEREXAMPLE2_H
 
@@ -20,10 +18,9 @@
 
 struct Ex2Header
 {
-    int EventNumber=0;
-    int DetectorId=0;
+    int EventNumber = 0;
+    int DetectorId = 0;
 };
-
 
 class FairTMessage : public TMessage
 {
@@ -43,7 +40,6 @@ void free_tmessage(void *data, void *hint)
 
 struct SerializerEx2
 {
-
     void Serialize(FairMQMessage& msg, TClonesArray* input)
     {
         TMessage* tm = new TMessage(kMESS_OBJECT);
@@ -55,14 +51,13 @@ struct SerializerEx2
     {
         header=static_cast<Ex2Header*>(msg.GetData());
     }
-    
+
     void Deserialize(FairMQMessage& msg, TClonesArray*& output)
     {
-        if(output) delete output;
+        if (output) delete output;
         FairTMessage tm(msg.GetData(), msg.GetSize());
         output = static_cast<TClonesArray*>(tm.ReadObject(tm.GetClass()));
     }
-
 };
 
 
@@ -84,12 +79,10 @@ struct SerializerEx2Boost
     typedef boost::archive::binary_iarchive         BoostBinArchIn;
     typedef boost::archive::binary_oarchive         BoostBinArchOut;
 
-
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Header
     void Serialize(FairMQMessage& msg, const Ex2Header& header)
     {
-        
         std::ostringstream buffer;
         BoostBinArchOut OutputArchive(buffer);
         OutputArchive << header;
@@ -102,7 +95,6 @@ struct SerializerEx2Boost
 
     void Deserialize(FairMQMessage& msg, Ex2Header& header)
     {
-        
         std::string msgStr(static_cast<char*>(msg.GetData()), msg.GetSize());
         std::istringstream buffer(msgStr);
         BoostBinArchIn InputArchive(buffer);
@@ -111,7 +103,6 @@ struct SerializerEx2Boost
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // TClonesArray (Note : TClonesArray is converted to boost serializable object std::vector<T>
-    
 
     void Serialize(FairMQMessage& msg, TClonesArray* input)
     {
@@ -174,5 +165,3 @@ struct SerializerEx2Boost
 };
 
 #endif
-
-

--- a/fairmq/FairMQChannel.h
+++ b/fairmq/FairMQChannel.h
@@ -119,17 +119,18 @@ class FairMQChannel
     /// for some other reason (e.g. no peers connected for a binding socket), the method blocks.
     ///
     /// @param msg Constant reference of unique_ptr to a FairMQMessage
-    /// @return Number of bytes that have been queued. -2 If queueing was not possible or timed out. In case of errors, returns -1.
+    /// @return Number of bytes that have been queued. -2 If queueing was not possible or timed out.
+    /// In case of errors, returns -1.
     int Send(const std::unique_ptr<FairMQMessage>& msg) const;
 
     /// Sends a message in non-blocking mode.
     /// @details SendAsync method attempts to send a message without blocking by
-    /// putting it in the queue. If the queue is full or queueing is not possible
-    /// for some other reason (e.g. no peers connected for a binding socket), the method returns 0.
-    /// 
+    /// putting it in the queue.
+    ///
     /// @param msg Constant reference of unique_ptr to a FairMQMessage
     /// @return Number of bytes that have been queued. If queueing failed due to
-    /// full queue or no connected peers (when binding), returns -2. In case of errors, returns -1.
+    /// full queue or no connected peers (when binding), returns -2.
+    /// In case of errors, returns -1.
     inline int SendAsync(const std::unique_ptr<FairMQMessage>& msg) const
     {
         return fSocket->Send(msg.get(), fNoBlockFlag);
@@ -138,9 +139,10 @@ class FairMQChannel
     /// Queues the current message as a part of a multi-part message
     /// @details SendPart method queues the provided message as a part of a multi-part message.
     /// The actual transfer over the network is initiated once final part has been queued with the Send() or SendAsync() methods.
-    /// 
+    ///
     /// @param msg Constant reference of unique_ptr to a FairMQMessage
-    /// @return Number of bytes that have been queued. -2 If queueing was not possible. In case of errors, returns -1.
+    /// @return Number of bytes that have been queued. -2 If queueing was not possible.
+    /// In case of errors, returns -1.
     inline int SendPart(const std::unique_ptr<FairMQMessage>& msg) const
     {
         return fSocket->Send(msg.get(), fSndMoreFlag);
@@ -149,12 +151,32 @@ class FairMQChannel
     /// Queues the current message as a part of a multi-part message without blocking
     /// @details SendPart method queues the provided message as a part of a multi-part message without blocking.
     /// The actual transfer over the network is initiated once final part has been queued with the Send() or SendAsync() methods.
-    /// 
+    ///
     /// @param msg Constant reference of unique_ptr to a FairMQMessage
-    /// @return Number of bytes that have been queued. -2 If queueing was not possible. In case of errors, returns -1.
+    /// @return Number of bytes that have been queued. -2 If queueing was not possible.
+    /// In case of errors, returns -1.
     inline int SendPartAsync(const std::unique_ptr<FairMQMessage>& msg) const
     {
         return fSocket->Send(msg.get(), fSndMoreFlag|fNoBlockFlag);
+    }
+
+    /// Send a vector of messages
+    ///
+    /// @param msgVec message vector reference
+    /// @return Number of bytes that have been queued. -2 If queueing was not possible or timed out.
+    /// In case of errors, returns -1.
+    int64_t Send(const std::vector<std::unique_ptr<FairMQMessage>>& msgVec) const;
+
+    /// Sends a vector of message in non-blocking mode.
+    /// @details SendAsync method attempts to send a vector of messages without blocking by
+    /// putting it them the queue.
+    ///
+    /// @param msgVec message vector reference
+    /// @return Number of bytes that have been queued. If queueing failed due to
+    /// full queue or no connected peers (when binding), returns -2. In case of errors, returns -1.
+    inline int64_t SendAsync(const std::vector<std::unique_ptr<FairMQMessage>>& msgVec) const
+    {
+        return fSocket->Send(msgVec, fNoBlockFlag);
     }
 
     /// Receives a message from the socket queue.
@@ -162,12 +184,11 @@ class FairMQChannel
     /// If the queue is empty the method blocks.
     ///
     /// @param msg Constant reference of unique_ptr to a FairMQMessage
-    /// @return Number of bytes that have been received. -2 If reading from the queue was not possible or timed out. In case of errors, returns -1.
+    /// @return Number of bytes that have been received. -2 If reading from the queue was not possible or timed out.
+    /// In case of errors, returns -1.
     int Receive(const std::unique_ptr<FairMQMessage>& msg) const;
 
     /// Receives a message in non-blocking mode.
-    /// @details ReceiveAsync method attempts to receive a message without blocking from the input queue.
-    /// If the queue is empty the method returns 0.
     ///
     /// @param msg Constant reference of unique_ptr to a FairMQMessage
     /// @return Number of bytes that have been received. If queue is empty, returns -2.
@@ -177,19 +198,22 @@ class FairMQChannel
         return fSocket->Receive(msg.get(), fNoBlockFlag);
     }
 
-    /// Shorthand method to send a vector of messages on `chan` at index `i`
+    /// Receive a vector of messages
+    ///
     /// @param msgVec message vector reference
-    /// @param chan channel name
-    /// @param i channel index
-    /// @return Number of bytes that have been queued. -2 If queueing was not possible or timed out. In case of errors, returns -1.
-    int64_t Send(const std::vector<std::unique_ptr<FairMQMessage>>& msgVec) const;
-
-    /// Shorthand method to receive a vector of messages on `chan` at index `i`
-    /// @param msgVec message vector reference
-    /// @param chan channel name
-    /// @param i channel index
-    /// @return Number of bytes that have been received. -2 If reading from the queue was not possible or timed out. In case of errors, returns -1.
+    /// @return Number of bytes that have been received. -2 If reading from the queue was not possible or timed out.
+    /// In case of errors, returns -1.
     int64_t Receive(std::vector<std::unique_ptr<FairMQMessage>>& msgVec) const;
+
+    /// Receives a vector of messages in non-blocking mode.
+    ///
+    /// @param msgVec message vector reference
+    /// @return Number of bytes that have been received. If queue is empty, returns -2.
+    /// In case of errors, returns -1.
+    inline int64_t ReceiveAsync(std::vector<std::unique_ptr<FairMQMessage>>& msgVec) const
+    {
+        return fSocket->Receive(msgVec, fNoBlockFlag);
+    }
 
     // DEPRECATED socket method wrappers with raw pointers and flag checks
     int Send(FairMQMessage* msg, const std::string& flag = "") const;

--- a/fairmq/FairMQDevice.h
+++ b/fairmq/FairMQDevice.h
@@ -69,76 +69,104 @@ class FairMQDevice : public FairMQStateMachine, public FairMQConfigurable
     /// @param name Name of the channel
     void PrintChannel(const std::string& name);
 
-    /// Shorthand method to send `msg` on `chan` at index `i`
-    /// @param msg message reference
-    /// @param chan channel name
-    /// @param i channel index
-    /// @return Number of bytes that have been queued. -2 If queueing was not possible or timed out. In case of errors, returns -1.
-    inline int Send(const std::unique_ptr<FairMQMessage>& msg, const std::string& chan, const int i = 0) const
-    {
-        return fChannels.at(chan).at(i).Send(msg);
-    }
-
     template<typename Serializer, typename DataType, typename... Args>
     void Serialize(FairMQMessage& msg, DataType&& data, Args&&... args) const
     {
-        Serializer().Serialize(msg,std::forward<DataType>(data),std::forward<Args>(args)...);
+        Serializer().Serialize(msg, std::forward<DataType>(data), std::forward<Args>(args)...);
     }
 
     template<typename Deserializer, typename DataType, typename... Args>
     void Deserialize(FairMQMessage& msg, DataType&& data, Args&&... args) const
     {
-        Deserializer().Deserialize(msg,std::forward<DataType>(data),std::forward<Args>(args)...);
+        Deserializer().Deserialize(msg, std::forward<DataType>(data), std::forward<Args>(args)...);
     }
 
-    /// Shorthand method to receive `msg` on `chan` at index `i`
+    /// Shorthand method to send `msg` on `chan` at index `i`
     /// @param msg message reference
     /// @param chan channel name
     /// @param i channel index
-    /// @return Number of bytes that have been received. -2 If reading from the queue was not possible or timed out. In case of errors, returns -1.
-    inline int Receive(const std::unique_ptr<FairMQMessage>& msg, const std::string& chan, const int i = 0) const
+    /// @return Number of bytes that have been queued. -2 If queueing was not possible or timed out.
+    /// In case of errors, returns -1.
+    inline int Send(const std::unique_ptr<FairMQMessage>& msg, const std::string& chan, const int i = 0) const
     {
-        return fChannels.at(chan).at(i).Receive(msg);
+        return fChannels.at(chan).at(i).Send(msg);
     }
 
-    /// Shorthand method to send a vector of messages on `chan` at index `i`
-    /// @param msgVec message vector reference
+    /// Shorthand method to send `msg` on `chan` at index `i` without blocking
+    /// @param msg message reference
     /// @param chan channel name
     /// @param i channel index
-    /// @return Number of bytes that have been queued. -2 If queueing was not possible or timed out. In case of errors, returns -1.
-    inline int64_t Send(const std::vector<std::unique_ptr<FairMQMessage>>& msgVec, const std::string& chan, const int i = 0) const
+    /// @return Number of bytes that have been queued. -2 If queueing was not possible or timed out.
+    /// In case of errors, returns -1.
+    inline int SendAsync(const std::unique_ptr<FairMQMessage>& msg, const std::string& chan, const int i = 0) const
     {
-        return fChannels.at(chan).at(i).Send(msgVec);
-    }
-
-    /// Shorthand method to receive a vector of messages on `chan` at index `i`
-    /// @param msgVec message vector reference
-    /// @param chan channel name
-    /// @param i channel index
-    /// @return Number of bytes that have been received. -2 If reading from the queue was not possible or timed out. In case of errors, returns -1.
-    inline int64_t Receive(std::vector<std::unique_ptr<FairMQMessage>>& msgVec, const std::string& chan, const int i = 0) const
-    {
-        return fChannels.at(chan).at(i).Receive(msgVec);
+        return fChannels.at(chan).at(i).SendAsync(msg);
     }
 
     /// Shorthand method to send FairMQParts on `chan` at index `i`
     /// @param parts parts reference
     /// @param chan channel name
     /// @param i channel index
-    /// @return Number of bytes that have been queued. -2 If queueing was not possible or timed out. In case of errors, returns -1.
+    /// @return Number of bytes that have been queued. -2 If queueing was not possible or timed out.
+    /// In case of errors, returns -1.
     inline int64_t Send(const FairMQParts& parts, const std::string& chan, const int i = 0) const
     {
         return fChannels.at(chan).at(i).Send(parts.fParts);
+    }
+
+    /// Shorthand method to send FairMQParts on `chan` at index `i` without blocking
+    /// @param parts parts reference
+    /// @param chan channel name
+    /// @param i channel index
+    /// @return Number of bytes that have been queued. -2 If queueing was not possible or timed out.
+    /// In case of errors, returns -1.
+    inline int64_t SendAsync(const FairMQParts& parts, const std::string& chan, const int i = 0) const
+    {
+        return fChannels.at(chan).at(i).SendAsync(parts.fParts);
+    }
+
+    /// Shorthand method to receive `msg` on `chan` at index `i`
+    /// @param msg message reference
+    /// @param chan channel name
+    /// @param i channel index
+    /// @return Number of bytes that have been received. -2 If reading from the queue was not possible or timed out.
+    /// In case of errors, returns -1.
+    inline int Receive(const std::unique_ptr<FairMQMessage>& msg, const std::string& chan, const int i = 0) const
+    {
+        return fChannels.at(chan).at(i).Receive(msg);
+    }
+
+    /// Shorthand method to receive `msg` on `chan` at index `i` without blocking
+    /// @param msg message reference
+    /// @param chan channel name
+    /// @param i channel index
+    /// @return Number of bytes that have been received. -2 If reading from the queue was not possible or timed out.
+    /// In case of errors, returns -1.
+    inline int ReceiveAsync(const std::unique_ptr<FairMQMessage>& msg, const std::string& chan, const int i = 0) const
+    {
+        return fChannels.at(chan).at(i).ReceiveAsync(msg);
     }
 
     /// Shorthand method to receive FairMQParts on `chan` at index `i`
     /// @param parts parts reference
     /// @param chan channel name
     /// @param i channel index
-    /// @return Number of bytes that have been received. -2 If reading from the queue was not possible or timed out. In case of errors, returns -1.
+    /// @return Number of bytes that have been received. -2 If reading from the queue was not possible or timed out.
+    /// In case of errors, returns -1.
     inline int64_t Receive(FairMQParts& parts, const std::string& chan, const int i = 0) const
     {
         return fChannels.at(chan).at(i).Receive(parts.fParts);
+    }
+
+    /// Shorthand method to receive FairMQParts on `chan` at index `i` without blocking
+    /// @param parts parts reference
+    /// @param chan channel name
+    /// @param i channel index
+    /// @return Number of bytes that have been received. -2 If reading from the queue was not possible or timed out.
+    /// In case of errors, returns -1.
+    inline int64_t ReceiveAsync(FairMQParts& parts, const std::string& chan, const int i = 0) const
+    {
+        return fChannels.at(chan).at(i).ReceiveAsync(parts.fParts);
     }
 
     /// @brief Create empty FairMQMessage

--- a/fairmq/FairMQParts.h
+++ b/fairmq/FairMQParts.h
@@ -63,7 +63,7 @@ class FairMQParts
     inline std::unique_ptr<FairMQMessage>& At(const int index) { return fParts.at(index); }
 
     // ref version
-    inline FairMQMessage& At_ref(const int index) { return *(fParts.at(index)); }
+    inline FairMQMessage& AtRef(const int index) { return *(fParts.at(index)); }
 
     /// Get number of parts in the container
     /// @return number of parts in the container

--- a/fairmq/FairMQParts.h
+++ b/fairmq/FairMQParts.h
@@ -37,7 +37,6 @@ class FairMQParts
     {
         fParts.push_back(std::unique_ptr<FairMQMessage>(msg));
     }
-    
 
     /// Adds part (std::unique_ptr<FairMQMessage>&) to the container (move)
     /// @param msg unique pointer to FairMQMessage

--- a/fairmq/FairMQSocket.h
+++ b/fairmq/FairMQSocket.h
@@ -40,11 +40,11 @@ class FairMQSocket
 
     virtual int Send(FairMQMessage* msg, const std::string& flag = "") = 0;
     virtual int Send(FairMQMessage* msg, const int flags = 0) = 0;
-    virtual int64_t Send(const std::vector<std::unique_ptr<FairMQMessage>>& msgVec) = 0;
+    virtual int64_t Send(const std::vector<std::unique_ptr<FairMQMessage>>& msgVec, const int flags = 0) = 0;
 
     virtual int Receive(FairMQMessage* msg, const std::string& flag = "") = 0;
     virtual int Receive(FairMQMessage* msg, const int flags = 0) = 0;
-    virtual int64_t Receive(std::vector<std::unique_ptr<FairMQMessage>>& msgVec) = 0;
+    virtual int64_t Receive(std::vector<std::unique_ptr<FairMQMessage>>& msgVec, const int flags = 0) = 0;
 
     virtual void* GetSocket() const = 0;
     virtual int GetSocket(int nothing) const = 0;

--- a/fairmq/nanomsg/FairMQSocketNN.cxx
+++ b/fairmq/nanomsg/FairMQSocketNN.cxx
@@ -145,7 +145,7 @@ int FairMQSocketNN::Send(FairMQMessage* msg, const int flags)
     return nbytes;
 }
 
-int64_t FairMQSocketNN::Send(const vector<unique_ptr<FairMQMessage>>& msgVec)
+int64_t FairMQSocketNN::Send(const vector<unique_ptr<FairMQMessage>>& msgVec, const int flags)
 {
 #ifdef MSGPACK_FOUND
     // create msgpack simple buffer
@@ -161,7 +161,7 @@ int64_t FairMQSocketNN::Send(const vector<unique_ptr<FairMQMessage>>& msgVec)
         packer.pack_bin_body(static_cast<char*>(msgVec[i]->GetData()), msgVec[i]->GetSize());
     }
 
-    int64_t nbytes = nn_send(fSocket, sbuf.data(), sbuf.size(), 0);
+    int64_t nbytes = nn_send(fSocket, sbuf.data(), sbuf.size(), flags);
     if (nbytes >= 0)
     {
         fBytesTx += nbytes;
@@ -236,7 +236,7 @@ int FairMQSocketNN::Receive(FairMQMessage* msg, const int flags)
     return nbytes;
 }
 
-int64_t FairMQSocketNN::Receive(vector<unique_ptr<FairMQMessage>>& msgVec)
+int64_t FairMQSocketNN::Receive(vector<unique_ptr<FairMQMessage>>& msgVec, const int flags)
 {
 #ifdef MSGPACK_FOUND
     // Warn if the vector is filled before Receive() and empty it.
@@ -249,7 +249,7 @@ int64_t FairMQSocketNN::Receive(vector<unique_ptr<FairMQMessage>>& msgVec)
     // pointer to point to received message buffer
     char* ptr = NULL;
     // receive the message into a buffer allocated by nanomsg and let ptr point to it
-    int nbytes = nn_recv(fSocket, &ptr, NN_MSG, 0);
+    int nbytes = nn_recv(fSocket, &ptr, NN_MSG, flags);
     if (nbytes >= 0) // if no errors or non-blocking timeouts
     {
         // store statistics on how many bytes received

--- a/fairmq/nanomsg/FairMQSocketNN.h
+++ b/fairmq/nanomsg/FairMQSocketNN.h
@@ -39,11 +39,11 @@ class FairMQSocketNN : public FairMQSocket
 
     virtual int Send(FairMQMessage* msg, const std::string& flag = "");
     virtual int Send(FairMQMessage* msg, const int flags = 0);
-    virtual int64_t Send(const std::vector<std::unique_ptr<FairMQMessage>>& msgVec);
+    virtual int64_t Send(const std::vector<std::unique_ptr<FairMQMessage>>& msgVec, const int flags = 0);
 
     virtual int Receive(FairMQMessage* msg, const std::string& flag = "");
     virtual int Receive(FairMQMessage* msg, const int flags = 0);
-    virtual int64_t Receive(std::vector<std::unique_ptr<FairMQMessage>>& msgVec);
+    virtual int64_t Receive(std::vector<std::unique_ptr<FairMQMessage>>& msgVec, const int flags = 0);
 
     virtual void* GetSocket() const;
     virtual int GetSocket(int nothing) const;

--- a/fairmq/zeromq/FairMQSocketZMQ.h
+++ b/fairmq/zeromq/FairMQSocketZMQ.h
@@ -34,11 +34,11 @@ class FairMQSocketZMQ : public FairMQSocket
 
     virtual int Send(FairMQMessage* msg, const std::string& flag = "");
     virtual int Send(FairMQMessage* msg, const int flags = 0);
-    virtual int64_t Send(const std::vector<std::unique_ptr<FairMQMessage>>& msgVec);
+    virtual int64_t Send(const std::vector<std::unique_ptr<FairMQMessage>>& msgVec, const int flags = 0);
 
     virtual int Receive(FairMQMessage* msg, const std::string& flag = "");
     virtual int Receive(FairMQMessage* msg, const int flags = 0);
-    virtual int64_t Receive(std::vector<std::unique_ptr<FairMQMessage>>& msgVec);
+    virtual int64_t Receive(std::vector<std::unique_ptr<FairMQMessage>>& msgVec, const int flags = 0);
 
     virtual void* GetSocket() const;
     virtual int GetSocket(int nothing) const;


### PR DESCRIPTION
 - Update FairMQParts with doxygen comments and non-blocking send.
 - Fix dereference before null check in serialization example (fTree in sinks destructors) and formatting.