### PR TITLE
Solve coverity issues with LOG(FATAL) macro.

### DIFF
--- a/fairtools/FairLogger.cxx
+++ b/fairtools/FairLogger.cxx
@@ -316,6 +316,9 @@ void FairLogger::SetMinLogLevel()
 
 Bool_t FairLogger::IsLogNeeded(FairLogLevel logLevel)
 {
+  if (FATAL == logLevel) {
+    return true;
+  }
   if (logLevel <= fMinLogLevel) {
     return true;
   } else {
@@ -333,6 +336,68 @@ FairLogger& FairLogger::GetOutputStream(FairLogLevel level, const char* file, co
     fLogVerbosityLevel = verbosityHIGH;
     fLogColored = true;
   }
+
+
+  if (fIsNewLine) {
+    if ( (fLogToScreen && level <= fLogScreenLevel) ) {
+
+      if ( fLogColored ) {
+        *fScreenStream << LogLevelColor[level];
+      }
+
+      *fScreenStream << "[" << std::setw(7) << std::left << LogLevelString[level] <<"] ";
+
+      if ( fLogVerbosityLevel == verbosityHIGH ) {
+        GetTime();
+        *fScreenStream << fTimeBuffer;
+      }
+
+      if ( fLogVerbosityLevel <= verbosityMEDIUM ) {
+        TString bla(file);
+        Ssiz_t pos = bla.Last('/');
+        TString s2(bla(pos+1, bla.Length()));
+        TString s3 = s2 + "::" + func + ":" + line;
+        *fScreenStream << "[" << s3 <<"] ";
+      }
+    }
+
+    if ( fLogToFile && level <= fLogFileLevel ) {
+      if(!fLogFileOpen) {
+        OpenLogFile();
+      }
+
+      *fFileStream << "[" << std::setw(7) << std::left << LogLevelString[level] <<"] ";
+
+      if ( fLogVerbosityLevel == verbosityHIGH ) {
+        GetTime();
+        *fFileStream << fTimeBuffer;
+      }
+
+      if ( fLogVerbosityLevel <= verbosityMEDIUM ) {
+        TString bla(file);
+        Ssiz_t pos = bla.Last('/');
+        TString s2(bla(pos+1, bla.Length()));
+        TString s3 = s2 + "::" + func + ":" + line;
+        *fFileStream << "[" << s3 <<"] ";
+      }
+    }
+    fIsNewLine = kFALSE;
+  }
+  return *this;
+}
+
+// coverity[+kill]
+FairLogger& FairLogger::GetFATALOutputStream(const char* file, const char* line, const char* func)
+{
+
+  fLevel = FATAL;
+  FairLogLevel level = FATAL;
+
+//  if (level == FATAL) {
+    fLogToScreen = true;
+    fLogVerbosityLevel = verbosityHIGH;
+    fLogColored = true;
+//  }
 
 
   if (fIsNewLine) {

--- a/fairtools/FairLogger.h
+++ b/fairtools/FairLogger.h
@@ -30,8 +30,11 @@ class FairLogger;
 #define CONVERTTOSTRING(s)      IMP_CONVERTTOSTRING(s)
 #define MESSAGE_ORIGIN          __FILE__, CONVERTTOSTRING(__LINE__), __FUNCTION__
 
+#define LOG_LEVEL(level) \
+  !(FATAL == level) ? gLogger->GetOutputStream(level, MESSAGE_ORIGIN) : gLogger->GetFATALOutputStream(MESSAGE_ORIGIN)
+
 #define LOG(level)        \
-  !(gLogger->IsLogNeeded(level)) ? gLogger->GetNullStream(level) : gLogger->GetOutputStream(level, MESSAGE_ORIGIN)
+  !(gLogger->IsLogNeeded(level)) ? gLogger->GetNullStream(level) : LOG_LEVEL(level)
 
 #define LOG_IF(level, condition) \
   !(condition) ? gLogger->GetNullStream(level) : LOG(level)
@@ -143,6 +146,7 @@ class FairLogger : public std::ostream
                 const char* format, ...);
 
     FairLogger& GetOutputStream(FairLogLevel level, const char* file, const char* line, const char* func);
+    FairLogger& GetFATALOutputStream(const char* file, const char* line, const char* func);
 
     std::ostream& GetNullStream(FairLogLevel level) {
       fLevel=level;


### PR DESCRIPTION
Add explicit return value to function IsLogNeeded when log level is FATAL.
Add new function GetFATALOutputStream which is used for FATAL log messages.
Extent LOG macro to use the new function when the log level is FATAL.
Mark the new function as Coverity kill function which signals Coverity that
the function will terminate the execution.