### PR TITLE
rename c++11 test function. In CMakeLists, move the add_subdirectory(…

### DIFF
--- a/cmake/checks/cxx11-test-funcptr-to-lambda-conversion.cpp
+++ b/cmake/checks/cxx11-test-funcptr-to-lambda-conversion.cpp
@@ -1,5 +1,6 @@
 
-
+// test funcptr to lambda conversion in such pattern. Some old compiler may not compile the following code
+// comment : direct lambda assignment to function ptr in the main() may still works for the same compilers, however.
 using func_type = int();
 struct A
 {

--- a/cmake/modules/CheckCXX11Features.cmake
+++ b/cmake/modules/CheckCXX11Features.cmake
@@ -150,5 +150,5 @@ cxx11_check_feature("sizeof_member" HAS_CXX11_SIZEOF_MEMBER)
 cxx11_check_feature("static_assert" HAS_CXX11_STATIC_ASSERT)
 cxx11_check_feature("variadic_templates" HAS_CXX11_VARIADIC_TEMPLATES)
 cxx11_check_feature("sharedpointer" HAS_CXX11_SHAREDPOINTER)
-cxx11_check_feature("pattern1" HAS_CXX11_PATTERN1)
+cxx11_check_feature("funcptr-to-lambda-conversion" HAS_CXX11_PATTERN1)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -12,13 +12,14 @@ If(GEANT3_FOUND)
 
   add_subdirectory (simulation/Tutorial1)
   add_subdirectory (simulation/Tutorial2)
-  add_subdirectory (advanced/Tutorial3)
+  
   add_subdirectory (simulation/Tutorial4)
   If(WITH_DBASE)
     add_subdirectory (advanced/Tutorial5)
   EndIf()
 
   If(Boost_FOUND AND POS_C++11 AND ZMQ_FOUND AND HAS_CXX11_PATTERN1)
+    add_subdirectory (advanced/Tutorial3)
     add_subdirectory(MQ/7-parameters)
     add_subdirectory(MQ/serialization)
     add_subdirectory(MQ/9-PixelDetector)


### PR DESCRIPTION
…advanced/Tutorial3) in the if(zmq AND c++11 AND etc...) statement.