### PR TITLE
Possibility to set output tree name.

### DIFF
--- a/base/sim/FairMCApplication.cxx
+++ b/base/sim/FairMCApplication.cxx
@@ -999,7 +999,7 @@ void FairMCApplication::InitGeometry()
   /// save Geo Params in Output file
   if (fRootManager) {
     fRootManager->WriteFolder();
-    TTree* outTree =new TTree("cbmsim", "/cbmroot", 99);
+    TTree* outTree =new TTree(FairRootManager::GetTreeName(), "/cbmroot", 99);
     fRootManager->TruncateBranchNames(outTree, "cbmroot");
     fRootManager->SetOutTree(outTree);
   }

--- a/base/source/FairFileSource.cxx
+++ b/base/source/FairFileSource.cxx
@@ -179,7 +179,7 @@ Bool_t FairFileSource::Init()
        return kTRUE;
     }
     if (!fInChain ) {
-        fInChain = new TChain("cbmsim", "/cbmroot");
+        fInChain = new TChain(FairRootManager::GetTreeName(), "/cbmroot");
         LOG(DEBUG) << "FairFileSource::Init() chain created"
 		   << FairLogger::endl;
 	FairRootManager::Instance()->SetInChain(fInChain);
@@ -427,7 +427,7 @@ void FairFileSource::AddFriendsToChain()
         }
         
         TChain* chain = static_cast<TChain*>(fFriendTypeList[inputLevel]);
-        chain->AddFile((*iter1), 1234567890, "cbmsim");
+        chain->AddFile((*iter1), 1234567890, FairRootManager::GetTreeName());
     }
     gFile=temp;
     

--- a/base/source/FairMixedSource.cxx
+++ b/base/source/FairMixedSource.cxx
@@ -194,7 +194,7 @@ FairMixedSource::FairMixedSource(const TString RootFileName, const Int_t signalI
   // fBackgroundFile =  new TFile(name);
   // if (fBackgroundFile->IsZombie()) {
   // } else {
-  //   fBackgroundChain = new TChain("cbmsim", "/cbmroot");
+  //   fBackgroundChain = new TChain(FairRootManager::GetTreeName(), "/cbmroot");
   //   fBackgroundChain->AddFile(name.Data());
   // }
 }
@@ -213,7 +213,7 @@ Bool_t FairMixedSource::Init()
     return kTRUE;
   }
   if (!fBackgroundChain ) {
-    fBackgroundChain = new TChain("cbmsim", "/cbmroot");
+    fBackgroundChain = new TChain(FairRootManager::GetTreeName(), "/cbmroot");
     LOG(INFO) << "FairMixedSource::Init() chain created" << FairLogger::endl;
   }
 
@@ -467,7 +467,7 @@ void FairMixedSource::SetSignalFile(TString name, UInt_t identifier )
   } else {
     /** Set a signal file of certain type (identifier) if already exist add the file to the chain*/
     if(fSignalTypeList[identifier]==0) {
-      TChain* chain = new TChain("cbmsim", "/cbmroot");
+      TChain* chain = new TChain(FairRootManager::GetTreeName(), "/cbmroot");
       fSignalTypeList[identifier]=chain;
       FairRootManager::Instance()->SetInChain(chain,identifier);
       fCurrentEntry[identifier]= 0;

--- a/base/steer/FairRootManager.cxx
+++ b/base/steer/FairRootManager.cxx
@@ -104,7 +104,6 @@ FairRootManager::FairRootManager()
     fEntryNr(0),
     fListFolder(0),
     fSource(0),
-    fSourceChain( new TChain("cbmsim", "/cbmroot")),
     fSignalChainList(),
     fEventHeader(new FairEventHeader()),
     fUseFairLinks(kFALSE),
@@ -119,6 +118,7 @@ FairRootManager::FairRootManager()
     return;
   }
   fgInstance = this;
+  fSourceChain = new TChain(GetTreeName(), "/cbmroot");
 }
 //_____________________________________________________________________________
 
@@ -1247,6 +1247,43 @@ void FairRootManager::DeleteOldWriteoutBufferData()
   for(std::map<TString, FairWriteoutBuffer*>::const_iterator iter = fWriteoutBufferMap.begin(); iter != fWriteoutBufferMap.end(); iter++) {
     iter->second->DeleteOldData();
   }
+}
+//_____________________________________________________________________________
+
+//_____________________________________________________________________________
+char* FairRootManager::GetTreeName()
+{
+    char* default_name = (char*)"cbmsim";
+    char* workdir = getenv("VMCWORKDIR");
+    if(NULL == workdir)
+    {
+        return default_name;
+    }
+    
+    // Open file with output tree name
+    FILE* file = fopen(Form("%s/gconfig/rootmanager.dat",workdir), "r");
+    // If file does not exist -> default
+    if(NULL == file)
+    {
+        return default_name;
+    }
+    // If file is empty -> default
+    char str[100];
+    if(NULL == fgets(str, 100, file))
+    {
+        fclose(file);
+        return default_name;
+    }
+    // If file does not contain treename key -> default
+    char* treename = new char[100];
+    if(1 != sscanf(str, "treename=%s", treename))
+    {
+        fclose(file);
+        return default_name;
+    }
+    // Close file and return read value
+    fclose(file);
+    return treename;
 }
 //_____________________________________________________________________________
 

--- a/base/steer/FairRootManager.h
+++ b/base/steer/FairRootManager.h
@@ -222,6 +222,8 @@ class FairRootManager : public TObject
 
     void SetFinishRun(Bool_t val = kTRUE){ fFinishRun = val;}
     Bool_t FinishRun() {return fFinishRun;}
+    
+    static char* GetTreeName();
   private:
     /**private methods*/
     FairRootManager(const FairRootManager&);

--- a/base/steer/FairRunAna.cxx
+++ b/base/steer/FairRunAna.cxx
@@ -284,7 +284,7 @@ void FairRunAna::Init()
   
   // create the output tree after tasks initialisation
   fOutFile->cd();
-  TTree* outTree =new TTree("cbmsim", "/cbmout", 99);
+  TTree* outTree =new TTree(FairRootManager::GetTreeName(), "/cbmout", 99);
   fRootManager->TruncateBranchNames(outTree, "cbmout");
   fRootManager->SetOutTree(outTree);
   fRootManager->WriteFolder();

--- a/base/steer/FairRunAnaProof.cxx
+++ b/base/steer/FairRunAnaProof.cxx
@@ -256,7 +256,7 @@ void FairRunAnaProof::Init()
 
   // create the output tree after tasks initialisation
   fOutFile->cd();
-  TTree* outTree =new TTree("cbmsim", "/cbmout", 99);
+  TTree* outTree =new TTree(FairRootManager::GetTreeName(), "/cbmout", 99);
   fRootManager->TruncateBranchNames(outTree, "cbmout");
   fRootManager->SetOutTree(outTree);
   fRootManager->WriteFolder();

--- a/base/steer/FairRunOnline.cxx
+++ b/base/steer/FairRunOnline.cxx
@@ -236,7 +236,7 @@ void FairRunOnline::Init()
 
   // create the output tree after tasks initialisation
   fOutFile->cd();
-  TTree* outTree =new TTree("cbmsim", "/cbmout", 99);
+  TTree* outTree =new TTree(FairRootManager::GetTreeName(), "/cbmout", 99);
   fRootManager->TruncateBranchNames(outTree, "cbmout");
   fRootManager->SetOutTree(outTree);
   fRootManager->WriteFolder();


### PR DESCRIPTION
Read name of the output tree from VMCWORKDIR/gconfig/rootmanager.dat. Default name is cbmsim.