### PR TITLE
Coverity issue and treename in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ The template demonstrate and implement the following:
 6.  Track visualisation tool (Event display)
 7.  A rename script which replace all the generic names to user defined ones
 
+### Optional change of output tree name
+
+By default, the name of the tree in output ROOT file is "cbmsim". In case you want to change it for your Project, you need to create "config" folder inside of top source directory of the Project and place there "rootmanager.dat" text file with following single line: "treename=name_you_chose".
+
+```bash
+cd PROJECT_TOP_DIR
+mkdir config
+echo 'treename=name_you_chose' > config/rootmanager.dat
+```
+
+
 ### Step by Step installation
 
 1. Install [FairSoft](https://github.com/FairRootGroup/FairSoft/tree/dev)

--- a/base/steer/FairRootManager.cxx
+++ b/base/steer/FairRootManager.cxx
@@ -104,6 +104,7 @@ FairRootManager::FairRootManager()
     fEntryNr(0),
     fListFolder(0),
     fSource(0),
+    fSourceChain(new TChain(GetTreeName(), "/cbmroot")),
     fSignalChainList(),
     fEventHeader(new FairEventHeader()),
     fUseFairLinks(kFALSE),
@@ -117,7 +118,6 @@ FairRootManager::FairRootManager()
     LOG(FATAL) << "Singleton instance already exists." << FairLogger::endl;
   }
   fgInstance = this;
-  fSourceChain = new TChain(GetTreeName(), "/cbmroot");
 }
 //_____________________________________________________________________________
 
@@ -1260,7 +1260,7 @@ char* FairRootManager::GetTreeName()
     }
     
     // Open file with output tree name
-    FILE* file = fopen(Form("%s/gconfig/rootmanager.dat",workdir), "r");
+    FILE* file = fopen(Form("%s/config/rootmanager.dat",workdir), "r");
     // If file does not exist -> default
     if(NULL == file)
     {


### PR DESCRIPTION
Fix coverity issue 98828. Look for rootmanager.dat inside VMCWORKDIR/config. Add instructions on how to change treename to main README.