### PR TITLE
MQ/Example9 - added topology and executables to run in DDS.

### DIFF
--- a/examples/MQ/9-PixelDetector/README.md
+++ b/examples/MQ/9-PixelDetector/README.md
@@ -77,3 +77,34 @@ hit finding is run on processors separately for each station data
 merges event data from different stations and sends whole events with PixelHits
 the second level of processors runs the track finding 
 **preparations:** root -l -q 'run_sim.C(100000)' &> sim_100k.dat; root -l -q run_digi.C; root -l -q run_digiToBin.C;
+
+##Running with DDS
+To run the example in the DDS, please check http://dds.gsi.de for the installation instructions.
+The next step, you have to configure fairroot with -DDDS_PATH="/path/to/dds/install/dir/" and rebuild it.
+
+There are following executables created that run the devices on the DDS:
+####ex9-dds-sampler;
+####ex9-dds-processor;
+####ex9-dds-sink;
+####dds-parmq-server.
+
+These programs are started with the ex9-dds-topology.xml topology, that can be started in the following way:
+
+```bash
+dds-server start -s
+dds-submit --rms localhost -n 10
+dds-topology --set bin/ex9-dds-topology.xml
+dds-topology --activate
+```
+
+One can check devices status using:
+
+```bash
+./bin/fairmq-dds-command-ui
+```
+
+Once the sampler finishes stops running, the DDS server may be stopped:
+
+```bash
+dds-server stop
+```

--- a/examples/MQ/9-PixelDetector/run/CMakeLists.txt
+++ b/examples/MQ/9-PixelDetector/run/CMakeLists.txt
@@ -9,6 +9,7 @@
 set(INCLUDE_DIRECTORIES
     ${BASE_INCLUDE_DIRECTORIES}
     ${CMAKE_SOURCE_DIR}/fairmq
+    ${CMAKE_SOURCE_DIR}/fairmq/deployment
     ${CMAKE_SOURCE_DIR}/fairmq/devices
     ${CMAKE_SOURCE_DIR}/fairmq/options
     ${CMAKE_SOURCE_DIR}/fairmq/tools
@@ -50,6 +51,8 @@ configure_file( ${CMAKE_SOURCE_DIR}/examples/MQ/9-PixelDetector/run/scripts/star
 		${CMAKE_BINARY_DIR}/bin/startFairMQEx9Merger.sh )
 configure_file( ${CMAKE_SOURCE_DIR}/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9Merger2Levels.sh.in      
 		${CMAKE_BINARY_DIR}/bin/startFairMQEx9Merger2Levels.sh )
+configure_file( ${CMAKE_SOURCE_DIR}/examples/MQ/9-PixelDetector/run/scripts/ex9-dds-topology.xml
+		${CMAKE_BINARY_DIR}/bin/ex9-dds-topology.xml )
 
 set(EXAMPLE9_FILE_LOCATION ${CMAKE_INSTALL_PREFIX}/share/fairbase)
 set(EXAMPLE9_BIN_LOCATION  ${CMAKE_INSTALL_PREFIX}/bin)
@@ -69,6 +72,8 @@ configure_file( ${CMAKE_SOURCE_DIR}/examples/MQ/9-PixelDetector/run/scripts/star
 		${CMAKE_BINARY_DIR}/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9Merger.sh_install )
 configure_file( ${CMAKE_SOURCE_DIR}/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9Merger2Levels.sh.in
 		${CMAKE_BINARY_DIR}/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9Merger2Levels.sh_install )
+configure_file( ${CMAKE_SOURCE_DIR}/examples/MQ/9-PixelDetector/run/scripts/ex9-dds-topology.xml
+		${CMAKE_BINARY_DIR}/examples/MQ/9-PixelDetector/run/scripts/ex9-dds-topology.xml_install )
 
 Install(FILES ${CMAKE_BINARY_DIR}/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9New.sh_install
         DESTINATION bin
@@ -94,8 +99,11 @@ Install(FILES ${CMAKE_BINARY_DIR}/examples/MQ/9-PixelDetector/run/scripts/startF
 Install(FILES ${CMAKE_BINARY_DIR}/examples/MQ/9-PixelDetector/run/scripts/startFairMQEx9Merger2Levels.sh_install
         DESTINATION bin
         RENAME startFairMQEx9Merger2Levels.sh PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ WORLD_READ)
+Install(FILES ${CMAKE_BINARY_DIR}/examples/MQ/9-PixelDetector/run/scripts/ex9-dds-topology.xml_install
+        DESTINATION bin
+        RENAME ex9-dds-topology.xml PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ WORLD_READ)
 
-Install(FILES options/Pixel9MQConfig_Multipart.json options/Pixel9MQConfig_2Levels.json options/Pixel9MQConfig_3Levels.json options/Pixel9MQConfig_Proxy.json options/Pixel9MQConfig_2Samplers.json options/Pixel9MQConfig_Merger.json options/Pixel9MQConfig_Merger2Levels.json
+Install(FILES options/Pixel9MQConfig_Multipart.json options/Pixel9MQConfig_2Levels.json options/Pixel9MQConfig_3Levels.json options/Pixel9MQConfig_Proxy.json options/Pixel9MQConfig_2Samplers.json options/Pixel9MQConfig_Merger.json options/Pixel9MQConfig_Merger2Levels.json options/ex9-dds.json
         DESTINATION share/fairbase/examples/MQ/9-PixelDetector/run/options/
        )
 
@@ -133,7 +141,6 @@ set(Exe_Source
 )
 
 
-
 List(LENGTH Exe_Names _length)
 Math(EXPR _length ${_length}-1)
 
@@ -146,7 +153,56 @@ ForEach(_file RANGE 0 ${_length})
     GENERATE_EXECUTABLE()
 EndForEach(_file RANGE 0 ${_length})
 
+If(DDS_FOUND)
+  Set(SYSTEM_INCLUDE_DIRECTORIES
+    ${SYSTEM_INCLUDE_DIRECTORIES}
+    ${CMAKE_SOURCE_DIR}/parmq
+    ${DDS_INCLUDE_DIR}
+  )
 
+  Include_Directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
+
+  Set(LINK_DIRECTORIES
+    ${LINK_DIRECTORIES}
+    ${DDS_LIBRARY_DIR}
+  )
+
+  Link_Directories(${LINK_DIRECTORIES})
+
+  Set(DEPENDENCIES
+    ${DEPENDENCIES}
+    dds_intercom_lib
+  )
+
+  Set(Dds_Names
+      ex9-dds-sampler
+      ex9-dds-processor
+      ex9-dds-sink
+
+      dds-parmq-server
+  )
+
+  set(Dds_Source
+      ddsEx9Sampler.cxx
+      ddsEx9TaskProcessor.cxx
+      ddsEx9FileSink.cxx
+
+      ddsParameterMQServer.cxx
+  )
+
+
+  List(LENGTH Dds_Names _length)
+  Math(EXPR _length ${_length}-1)
+
+  ForEach(_file RANGE 0 ${_length})
+      List(GET Dds_Names ${_file} _name)
+      List(GET Dds_Source ${_file} _src)
+      Set(EXE_NAME ${_name})
+      Set(SRCS ${_src})
+      Set(DEPENDENCIES Pixel ParMQ dds_intercom_lib)
+      GENERATE_EXECUTABLE()
+  EndForEach(_file RANGE 0 ${_length})
+EndIf(DDS_FOUND)
 
 
 

--- a/examples/MQ/9-PixelDetector/run/ddsEx9FileSink.cxx
+++ b/examples/MQ/9-PixelDetector/run/ddsEx9FileSink.cxx
@@ -1,0 +1,84 @@
+
+/// std
+#include <csignal>
+
+/// FairRoot - FairMQ - base/MQ
+#include "FairMQLogger.h"
+#include "FairMQDDSTools.h"
+#include "FairMQProgOptions.h"
+
+#include "dds_intercom.h" // DDS
+
+// 9-PixelDetector example
+#include "FairMQEx9FileSink.h"
+
+using namespace dds::intercom_api;
+
+// ////////////////////////////////////////////////////////////////////////
+
+int main(int argc, char** argv)
+{
+
+  FairMQEx9FileSink fileSink;
+  fileSink.CatchSignals();
+
+  FairMQProgOptions config;
+
+  try
+    {
+
+      std::string interfaceName; // name of the network interface to use for communication.
+      std::string filename;
+      std::vector<std::string> classname;
+      std::vector<std::string> branchname;
+      
+      namespace po = boost::program_options;
+      po::options_description fileSink_options("FileSink options");
+      fileSink_options.add_options()
+	("file-name",   po::value<std::string>             (&filename)  , "Path to the output file")
+	("class-name",  po::value<std::vector<std::string>>(&classname) , "class name")
+	("branch-name", po::value<std::vector<std::string>>(&branchname), "branch name");
+      config.AddToCmdLineOptions(fileSink_options);
+      
+      if (config.ParseAll(argc, argv))
+        {
+	  return 1;
+        }
+
+      fileSink.SetProperty(FairMQEx9FileSink::OutputFileName,filename);
+
+      if ( classname.size() != branchname.size() ) {
+	LOG(ERROR) << "The classname size (" << classname.size() << ") and branchname size (" << branchname.size() << ") MISMATCH!!!";
+      }
+      
+      fileSink.AddOutputBranch("FairEventHeader","EventHeader.");
+      for ( unsigned int ielem = 0 ; ielem < classname.size() ; ielem++ ) {
+	fileSink.AddOutputBranch(classname.at(ielem),branchname.at(ielem));
+      }
+      
+      fileSink.SetInputChannelName ("data2");
+
+      fileSink.SetConfig(config);
+      
+      fileSink.ChangeState("INIT_DEVICE");
+      HandleConfigViaDDS(fileSink);
+      fileSink.WaitForEndOfState("INIT_DEVICE");
+      
+      fileSink.ChangeState("INIT_TASK");
+      fileSink.WaitForEndOfState("INIT_TASK");
+      
+      fileSink.ChangeState("RUN");
+
+      runDDSStateHandler(fileSink);
+
+    }
+    catch (exception& e)
+    {
+        LOG(ERROR) << e.what();
+        LOG(INFO) << "Command line options are the following: ";
+        config.PrintHelp();
+        return 1;
+    }
+
+    return 0;
+}

--- a/examples/MQ/9-PixelDetector/run/ddsEx9Sampler.cxx
+++ b/examples/MQ/9-PixelDetector/run/ddsEx9Sampler.cxx
@@ -1,0 +1,83 @@
+
+/// std
+#include <csignal>
+
+/// FairRoot - FairMQ - base/MQ
+#include "FairMQLogger.h"
+#include "FairMQDDSTools.h"
+#include "FairMQProgOptions.h"
+
+#include "dds_intercom.h" // DDS
+
+// 9-PixelDetector example
+#include "FairMQEx9Sampler.h"
+
+using namespace dds::intercom_api;
+
+// ////////////////////////////////////////////////////////////////////////
+
+int main(int argc, char** argv)
+{
+  
+  FairMQEx9Sampler sampler;
+  sampler.CatchSignals();
+  
+  FairMQProgOptions config;
+  
+  try
+    {
+      std::vector<std::string> filename;
+      std::vector<std::string> branchname;
+      int64_t     maxindex;
+      std::string samplerType;
+
+      namespace po = boost::program_options;
+      po::options_description sampler_options("Sampler options");
+      sampler_options.add_options()
+	("file-name",    po::value<std::vector<std::string>>(&filename)                                    , "Path to the input file")
+	("max-index",    po::value<int64_t>                 (&maxindex)   ->default_value(-1)              , "number of events to read")
+	("branch-name",  po::value<std::vector<std::string>>(&branchname) ->required()                     , "branch name")
+	("sampler-type", po::value<std::string>             (&samplerType)->default_value("FairFileSource"), "FairSource type");
+      
+      config.AddToCmdLineOptions(sampler_options);
+      
+      if (config.ParseAll(argc, argv))           
+	{
+	  return 1;
+	}
+
+      for ( unsigned int ielem = 0 ; ielem < filename.size() ; ielem++ ) {
+	sampler.AddInputFileName(filename.at(ielem));	  
+      }
+      sampler.SetMaxIndex(maxindex);
+      for ( unsigned int ielem = 0 ; ielem < branchname.size() ; ielem++ ) {
+	sampler.AddInputBranchName(branchname.at(ielem));	  
+      }
+      sampler.AddInputBranchName("EventHeader.");
+
+      sampler.SetOutputChannelName("data1");
+      
+      sampler.SetConfig(config);
+      
+      sampler.ChangeState("INIT_DEVICE");
+      HandleConfigViaDDS(sampler);
+      sampler.WaitForEndOfState("INIT_DEVICE");
+      
+      sampler.ChangeState("INIT_TASK");
+      sampler.WaitForEndOfState("INIT_TASK");
+      
+      sampler.ChangeState("RUN");
+
+      runDDSStateHandler(sampler);
+    }
+  catch (exception& e)
+    {
+      LOG(ERROR) << e.what();
+      LOG(INFO) << "Command line options are the following: ";
+      config.PrintHelp();
+      return 1;
+    }
+  
+  return 0;
+}
+

--- a/examples/MQ/9-PixelDetector/run/ddsEx9TaskProcessor.cxx
+++ b/examples/MQ/9-PixelDetector/run/ddsEx9TaskProcessor.cxx
@@ -1,0 +1,80 @@
+
+/// std
+#include <csignal>
+
+/// FairRoot - FairMQ - base/MQ
+#include "FairMQLogger.h"
+#include "FairMQDDSTools.h"
+#include "FairMQProgOptions.h"
+
+#include "dds_intercom.h" // DDS
+
+// 9-PixelDetector example
+#include "FairMQEx9TaskProcessor.h"
+
+#include "PixelFindHits.h"
+#include "PixelFindTracks.h"
+#include "PixelFitTracks.h"
+
+using HitFinder   = FairMQEx9TaskProcessor<PixelFindHits>;
+
+using namespace dds::intercom_api;
+
+// ////////////////////////////////////////////////////////////////////////
+
+int main(int argc, char** argv)
+{
+  
+  HitFinder processor;
+  processor.CatchSignals();
+
+  FairMQProgOptions config;
+  
+  try 
+    {
+      std::string interfaceName; // name of the network interface to use for communication.
+      std::string taskname;
+      std::string keepdata;
+      
+      namespace po = boost::program_options;
+      po::options_description processor_options("Processor options");
+      processor_options.add_options()
+	("task-name",   po::value<std::string>(&taskname)->required(),  "Name of task to run")
+	("keep-data",   po::value<std::string>(&keepdata)            ,  "Name of data to keep in stream");
+      
+      config.AddToCmdLineOptions(processor_options);
+      
+      if (config.ParseAll(argc, argv)) 
+	{
+	  return 1;
+	}
+      
+      processor.SetDataToKeep(keepdata);
+
+      processor.SetInputChannelName ("data1");
+      processor.SetOutputChannelName("data2");
+      processor.SetParamChannelName ("param");
+
+      processor.SetConfig(config);
+      
+      processor.ChangeState("INIT_DEVICE");
+      HandleConfigViaDDS(processor);
+      processor.WaitForEndOfState("INIT_DEVICE");
+      
+      processor.ChangeState("INIT_TASK");
+      processor.WaitForEndOfState("INIT_TASK");
+
+      processor.ChangeState("RUN");
+      
+      runDDSStateHandler(processor);
+    }
+  catch (exception& e)
+    {
+      LOG(ERROR) << e.what();
+      LOG(INFO) << "Command line options are the following: ";
+      config.PrintHelp();
+      return 1;
+    }
+  
+  return 0;
+}

--- a/examples/MQ/9-PixelDetector/run/ddsParameterMQServer.cxx
+++ b/examples/MQ/9-PixelDetector/run/ddsParameterMQServer.cxx
@@ -1,0 +1,85 @@
+/// std
+#include <csignal>
+
+/// FairRoot - FairMQ - base/MQ
+#include "FairMQLogger.h"
+#include "FairMQDDSTools.h"
+#include "FairMQProgOptions.h"
+#include "FairMQParser.h"
+
+#include "dds_intercom.h" // DDS
+
+#include "ParameterMQServer.h"
+#include "TApplication.h"
+
+// ////////////////////////////////////////////////////////////////////////
+
+int main(int argc, char** argv)
+{
+
+  ParameterMQServer server;
+  server.CatchSignals();
+  
+  FairMQProgOptions config;
+  
+    try
+    {
+        std::string interfaceName; // name of the network interface to use for communication.
+        string firstInputName;
+        string firstInputType;
+        string secondInputName;
+        string secondInputType;
+        string outputName;
+        string outputType;
+	string channelName;
+
+        namespace po = boost::program_options;
+        po::options_description serverOptions("Parameter MQ Server options");
+        serverOptions.add_options()
+	  ("first-input-name", po::value<string>(&firstInputName)->default_value("first_input.root"), "First input file name")
+	  ("first-input-type", po::value<string>(&firstInputType)->default_value("ROOT"), "First input file type (ROOT/ASCII)")
+	  ("second-input-name", po::value<string>(&secondInputName)->default_value(""), "Second input file name")
+	  ("second-input-type", po::value<string>(&secondInputType)->default_value("ROOT"), "Second input file type (ROOT/ASCII)")
+	  ("output-name", po::value<string>(&outputName)->default_value(""), "Output file name")
+	  ("output-type", po::value<string>(&outputType)->default_value("ROOT"), "Output file type")
+	  ("channel-name", po::value<string>(&channelName)->default_value("param"), "Parameter channel name");
+	
+        config.AddToCmdLineOptions(serverOptions);
+	
+	
+	if (config.ParseAll(argc, argv))
+	  {
+	    return 1;
+	  }
+
+      server.SetConfig(config);
+      
+      server.SetProperty(ParameterMQServer::FirstInputName, firstInputName);
+      server.SetProperty(ParameterMQServer::FirstInputType, firstInputType);
+      server.SetProperty(ParameterMQServer::SecondInputName, secondInputName);
+      server.SetProperty(ParameterMQServer::SecondInputType, secondInputType);
+      server.SetProperty(ParameterMQServer::OutputName, outputName);
+      server.SetProperty(ParameterMQServer::OutputType, outputType);
+      server.SetProperty(ParameterMQServer::ChannelName,channelName);
+
+      server.ChangeState("INIT_DEVICE");
+      HandleConfigViaDDS(server);
+      server.WaitForEndOfState("INIT_DEVICE");
+      
+      server.ChangeState("INIT_TASK");
+      server.WaitForEndOfState("INIT_TASK");
+      
+      server.ChangeState("RUN");
+
+      runDDSStateHandler(server);
+    }
+    catch (exception& e)
+    {
+        LOG(ERROR) << e.what();
+        LOG(INFO) << "Command line options are the following: ";
+        config.PrintHelp();
+        return 1;
+    }
+
+    return 0;
+}

--- a/examples/MQ/9-PixelDetector/run/options/ex9-dds.json
+++ b/examples/MQ/9-PixelDetector/run/options/ex9-dds.json
@@ -1,0 +1,58 @@
+{
+    "fairMQOptions":
+    {
+        "devices":
+        [{
+            "id": "sampler",
+            "channel":
+            {
+                "name": "data1",
+                "property": "samplerAddr",
+                "type": "push",
+                "method": "bind"
+            }
+        },
+        {
+            "key": "processor",
+            "channels":
+            [{
+                "name": "data1",
+                "property": "samplerAddr",
+                "type": "pull",
+                "method": "connect"
+            },
+            {
+                "name": "data2",
+                "property": "sinkAddr",
+                "type": "push",
+                "method": "connect"
+            },
+            {
+                "name": "param",
+                "property": "paramAddr",
+                "type": "req",
+                "method": "connect"
+            }]
+        },
+        {
+            "id": "sink",
+            "channel":
+            {
+                "name": "data2",
+                "property": "sinkAddr",
+                "type": "pull",
+                "method": "bind"
+            }
+        },
+        {
+            "id": "parmq-server",
+            "channel":
+            {
+                "name": "param",
+                "property": "paramAddr",
+                "type": "rep",
+                "method": "bind"
+            }
+        }]
+    }
+}

--- a/examples/MQ/9-PixelDetector/run/scripts/ex9-dds-topology.xml
+++ b/examples/MQ/9-PixelDetector/run/scripts/ex9-dds-topology.xml
@@ -1,0 +1,67 @@
+<topology id="ExampleDDS">
+
+    <property id="samplerAddr" />
+    <property id="sinkAddr" />
+    <property id="paramAddr" />
+
+<!--    <declrequirement id="SamplerWorker">
+        <hostPattern type="wnname" value="sampler"/>
+    </declrequirement>
+
+    <declrequirement id="ProcessorWorker">
+        <hostPattern type="wnname" value="processor"/>
+    </declrequirement>
+
+    <declrequirement id="SinkWorker">
+        <hostPattern type="wnname" value="sink"/>
+    </declrequirement>
+
+    <declrequirement id="ParamServerWorker">
+        <hostPattern type="wnname" value="parmq-server"/>
+    </declrequirement>
+-->
+
+    <decltask id="Sampler">
+        <exe reachable="true">@EXAMPLE9_BIN_LOCATION@/ex9-dds-sampler --id sampler --file-name @EXAMPLE9_FILE_LOCATION@/examples/MQ/9-PixelDetector/macros/pixel_TGeant3.digi.root --branch-name PixelDigis --log-color false --mq-config @EXAMPLE9_FILE_LOCATION@/examples/MQ/9-PixelDetector/run/options/ex9-dds.json --network-interface lo0</exe>
+<!--        <requirement>SamplerWorker</requirement> -->
+        <properties>
+            <id access="write">samplerAddr</id>
+        </properties>
+    </decltask>
+
+    <decltask id="Processor">
+        <exe reachable="true">@EXAMPLE9_BIN_LOCATION@/ex9-dds-processor --id processor_%taskIndex% --config-key processor --task-name PixelFindHits --log-color false --mq-config @EXAMPLE9_FILE_LOCATION@/examples/MQ/9-PixelDetector/run/options/ex9-dds.json  --network-interface lo0</exe>
+<!--        <requirement>ProcessorWorker</requirement> -->
+        <properties>
+            <id access="read">samplerAddr</id>
+            <id access="read">sinkAddr</id>
+            <id access="read">paramAddr</id>
+        </properties>
+    </decltask>
+
+    <decltask id="Sink">
+        <exe reachable="true">@EXAMPLE9_BIN_LOCATION@/ex9-dds-sink --id sink --file-name @EXAMPLE9_FILE_LOCATION@/examples/MQ/9-PixelDetector/macros/DDS.pixel_TGeant3.hits.root --class-name "TClonesArray(PixelHit)" --branch-name PixelHits --log-color false --mq-config @EXAMPLE9_FILE_LOCATION@/examples/MQ/9-PixelDetector/run/options/ex9-dds.json  --network-interface lo0</exe>
+<!--        <requirement>SinkWorker</requirement> -->
+        <properties>
+            <id access="write">sinkAddr</id>
+        </properties>
+    </decltask>
+
+    <decltask id="ParamServer">
+        <exe reachable="true">@EXAMPLE9_BIN_LOCATION@/dds-parmq-server --id parmq-server --first-input-name @EXAMPLE9_FILE_LOCATION@/examples/MQ/9-PixelDetector/macros/pixel_TGeant3.params.root --second-input-name @EXAMPLE9_FILE_LOCATION@/examples/MQ/9-PixelDetector/param/pixel_digi.par --second-input-type ASCII --channel-name=param --log-color false --mq-config @EXAMPLE9_FILE_LOCATION@/examples/MQ/9-PixelDetector/run/options/ex9-dds.json  --network-interface lo0</exe>
+<!--        <requirement>ParamServerWorker</requirement> -->
+        <properties>
+            <id access="write">paramAddr</id>
+        </properties>
+    </decltask>
+
+    <main id="main">
+        <task>Sampler</task>
+        <task>Sink</task>
+        <task>ParamServer</task>
+        <group id="ProcessorGroup" n="3">
+            <task>Processor</task>
+        </group>
+    </main>
+
+</topology>

--- a/examples/MQ/9-PixelDetector/src/devices/FairMQEx9FileSink.cxx
+++ b/examples/MQ/9-PixelDetector/src/devices/FairMQEx9FileSink.cxx
@@ -35,6 +35,7 @@ class Ex9TMessage : public TMessage
 
 FairMQEx9FileSink::FairMQEx9FileSink()
   : FairMQDevice()
+  , fInputChannelName("data-in")
   , fFileName()
   , fTreeName()
  
@@ -107,7 +108,7 @@ void FairMQEx9FileSink::Run()
     {
       FairMQParts parts;
       
-      if (Receive(parts, "data-in") >= 0)
+      if (Receive(parts, fInputChannelName) >= 0)
 	{
 
 	  TObject* tempObjects[10];

--- a/examples/MQ/9-PixelDetector/src/devices/FairMQEx9FileSink.h
+++ b/examples/MQ/9-PixelDetector/src/devices/FairMQEx9FileSink.h
@@ -48,11 +48,15 @@ class FairMQEx9FileSink : public FairMQDevice
     }
     std::string GetOutputFileName () { return fFileName;}
 
+    void SetInputChannelName (std::string tstr) {fInputChannelName = tstr;}
+
   protected:
     virtual void Init();
     virtual void Run();
 
  private:
+    std::string     fInputChannelName;
+
     std::string fFileName;
     std::string fTreeName;
 

--- a/examples/MQ/9-PixelDetector/src/devices/FairMQEx9Sampler.cxx
+++ b/examples/MQ/9-PixelDetector/src/devices/FairMQEx9Sampler.cxx
@@ -29,6 +29,7 @@ using namespace std;
 
 FairMQEx9Sampler::FairMQEx9Sampler()
   : FairMQDevice()
+  , fOutputChannelName("data-out")
   , fRunAna(NULL)
   , fSource(NULL)
   , fInputObjects()
@@ -93,7 +94,7 @@ void FairMQEx9Sampler::Run()
 	parts.AddPart(NewMessage(message[iobj]->Buffer(), message[iobj]->BufferSize(), free_tmessage2, message[iobj]));
       }
       
-      Send(parts, "data-out");
+      Send(parts, fOutputChannelName);
       
       eventCounter++;
     }

--- a/examples/MQ/9-PixelDetector/src/devices/FairMQEx9Sampler.h
+++ b/examples/MQ/9-PixelDetector/src/devices/FairMQEx9Sampler.h
@@ -43,11 +43,15 @@ class FairMQEx9Sampler : public FairMQDevice
 
     void SetSource(FairSource* tempSource) {fSource = tempSource;}
 
+    void SetOutputChannelName(std::string tstr) {fOutputChannelName = tstr;}
+
  protected:
     virtual void Run();
     virtual void InitTask();
     
  private: 
+    std::string     fOutputChannelName;
+
     FairRunAna*     fRunAna;
     FairSource*     fSource;
     TObject*        fInputObjects[100];

--- a/examples/MQ/9-PixelDetector/src/devices/FairMQEx9TaskProcessor.h
+++ b/examples/MQ/9-PixelDetector/src/devices/FairMQEx9TaskProcessor.h
@@ -41,9 +41,18 @@ class FairMQEx9TaskProcessor : public FairMQDevice
 
     void SetDataToKeep(std::string tStr) { fDataToKeep = tStr;}
 
+    void SetInputChannelName (std::string tstr) {fInputChannelName = tstr;}
+    void SetOutputChannelName(std::string tstr) {fOutputChannelName = tstr;}
+    void SetParamChannelName (std::string tstr) {fParamChannelName  = tstr;}
+
   protected:
     virtual void Run();
     virtual void Init();
+
+  private:
+    std::string     fInputChannelName;
+    std::string     fOutputChannelName;
+    std::string     fParamChannelName;
 
     void UpdateParameters();
     FairParGenericSet* UpdateParameter(FairParGenericSet* thisPar);

--- a/examples/MQ/9-PixelDetector/src/devices/FairMQEx9TaskProcessor.tpl
+++ b/examples/MQ/9-PixelDetector/src/devices/FairMQEx9TaskProcessor.tpl
@@ -26,6 +26,9 @@ void free_tmessage4(void* /*data*/, void *hint)
 template <typename T>
 FairMQEx9TaskProcessor<T>::FairMQEx9TaskProcessor()
   : FairMQDevice()
+  , fInputChannelName("data-in")
+  , fOutputChannelName("data-out")
+  , fParamChannelName("param")
   , fEventHeader(NULL)
   , fInput(NULL)
   , fOutput(NULL)
@@ -89,7 +92,7 @@ void FairMQEx9TaskProcessor<T>::Run()
     {
       FairMQParts parts;
       
-      if ( Receive(parts,"data-in") >= 0 )
+      if ( Receive(parts,fInputChannelName) >= 0 )
         {
 	  LOG(DEBUG)<<"message received with " << parts.Size() << " parts.";
 	  receivedMsgs++;
@@ -140,7 +143,7 @@ void FairMQEx9TaskProcessor<T>::Run()
 	    messageTCA[iobj]->WriteObject(fOutput->At(iobj));
 	    partsOut.AddPart(NewMessage(messageTCA[iobj]->Buffer(), messageTCA[iobj]->BufferSize(), free_tmessage4, messageTCA[iobj]));
 	  }
-	  Send(partsOut, "data-out");
+	  Send(partsOut, fOutputChannelName);
 	  sentMsgs++;
         }
       fInput->Clear();
@@ -220,9 +223,9 @@ FairParGenericSet* FairMQEx9TaskProcessor<T>::UpdateParameter(FairParGenericSet*
   std::unique_ptr<FairMQMessage> req(NewMessage(const_cast<char*>(reqStr->c_str()), reqStr->length(), CustomCleanup, reqStr));
   std::unique_ptr<FairMQMessage> rep(NewMessage());
   
-  if (Send(req,"param") > 0)
+  if (Send(req,fParamChannelName) > 0)
     {
-      if (Receive(rep,"param") > 0)
+      if (Receive(rep,fParamChannelName) > 0)
 	{
 	  Ex9TMessage2 tm(rep->GetData(), rep->GetSize());
 	  thisPar = (FairParGenericSet*)tm.ReadObject(tm.GetClass());

--- a/parmq/ParameterMQServer.cxx
+++ b/parmq/ParameterMQServer.cxx
@@ -35,7 +35,8 @@ ParameterMQServer::ParameterMQServer() :
     fSecondInputName(""),
     fSecondInputType("ROOT"),
     fOutputName(""),
-    fOutputType("ROOT")
+    fOutputType("ROOT"),
+    fChannelName("data")
 {
 }
 
@@ -103,7 +104,7 @@ void ParameterMQServer::Run()
     {
         unique_ptr<FairMQMessage> req(fTransportFactory->CreateMessage());
 
-        if (fChannels.at("data").at(0).Receive(req) > 0)
+        if (fChannels.at(fChannelName).at(0).Receive(req) > 0)
         {
             string reqStr(static_cast<char*>(req->GetData()), req->GetSize());
             LOG(INFO) << "Received parameter request from client: \"" << reqStr << "\"";
@@ -133,7 +134,7 @@ void ParameterMQServer::Run()
 
                 unique_ptr<FairMQMessage> reply(fTransportFactory->CreateMessage(tmsg->Buffer(), tmsg->BufferSize(), free_tmessage, tmsg));
 
-                fChannels.at("data").at(0).Send(reply);
+                fChannels.at(fChannelName).at(0).Send(reply);
             }
             else
             {
@@ -165,6 +166,9 @@ void ParameterMQServer::SetProperty(const int key, const string& value)
         case OutputType:
             fOutputType = value;
             break;
+        case ChannelName:
+            fChannelName = value;
+            break;
         default:
             FairMQDevice::SetProperty(key, value);
             break;
@@ -187,6 +191,8 @@ string ParameterMQServer::GetProperty(const int key, const string& default_ /*= 
             return fOutputName;
         case OutputType:
             return fOutputType;
+        case ChannelName:
+            return fChannelName;
         default:
             return FairMQDevice::GetProperty(key, default_);
     }

--- a/parmq/ParameterMQServer.h
+++ b/parmq/ParameterMQServer.h
@@ -32,6 +32,7 @@ class ParameterMQServer : public FairMQDevice
         SecondInputType,
         OutputName,
         OutputType,
+	ChannelName,
         Last
     };
 
@@ -59,6 +60,7 @@ class ParameterMQServer : public FairMQDevice
     std::string fSecondInputType;
     std::string fOutputName;
     std::string fOutputType;
+    std::string fChannelName;
 };
 
 #endif /* PARAMETERMQSERVER_H_ */


### PR DESCRIPTION
- ddsEx9Sampler.cxx, ddsEx9TaskProcessor.cxx, ddsEx9FileSink.cxx, ddsParameterMQServer.cxx - executables sources;
- FairMQEx9Sampler, FairMQEx9TaskProcessor, FairMQEx9FileSink, ParameterMQServer - added channel names setters;
- ex9-dds.json - config for the example to run on DDS;
- ex9-dds-topology.xml - topology (sampler-3processors-sink+parameterServer) to run on the DDS;
- updated the README file.