### PR TITLE
Changes in FairRunOnline needed by CBM.

### DIFF
--- a/base/source/FairFileSource.h
+++ b/base/source/FairFileSource.h
@@ -45,6 +45,12 @@ public:
 
     virtual Source_Type GetSourceType() { return kFILE; }
 
+    virtual void SetParUnpackers() {}
+
+    virtual Bool_t InitUnpackers() { return kTRUE; }
+
+    virtual Bool_t ReInitUnpackers() { return kTRUE; }
+
     /**Check the maximum event number we can run to*/
     virtual Int_t  CheckMaxEventNo(Int_t EvtEnd=0);
     /**Read the tree entry on one branch**/

--- a/base/source/FairMbsStreamSource.cxx
+++ b/base/source/FairMbsStreamSource.cxx
@@ -85,7 +85,7 @@ Bool_t FairMbsStreamSource::ConnectToServer()
 }
 
 
-Int_t FairMbsStreamSource::ReadEvent()
+Int_t FairMbsStreamSource::ReadEvent(UInt_t)
 {
   void* evtptr = &fxEvent;
   void* buffptr = &fxBuffer;

--- a/base/source/FairMbsStreamSource.h
+++ b/base/source/FairMbsStreamSource.h
@@ -30,7 +30,7 @@ class FairMbsStreamSource : public FairMbsSource
     virtual ~FairMbsStreamSource();
 
     virtual Bool_t Init();
-    virtual Int_t ReadEvent();
+    virtual Int_t ReadEvent(UInt_t = 0);
     virtual void Close();
 
     const char* GetServerName() const {return fServerName.Data();};

--- a/base/source/FairMixedSource.h
+++ b/base/source/FairMixedSource.h
@@ -48,6 +48,12 @@ public:
 
     virtual Source_Type GetSourceType() { return kFILE; }
 
+    virtual void SetParUnpackers() {}
+
+    virtual Bool_t InitUnpackers() { return kTRUE; }
+
+    virtual Bool_t ReInitUnpackers() { return kTRUE; }
+
     /**Check the maximum event number we can run to*/
     virtual Int_t  CheckMaxEventNo(Int_t EvtEnd=0);
     /**Read the tree entry on one branch**/

--- a/base/source/FairOnlineSource.cxx
+++ b/base/source/FairOnlineSource.cxx
@@ -37,6 +37,15 @@ Bool_t FairOnlineSource::InitUnpackers() {
   return kTRUE;
 }
 
+Bool_t FairOnlineSource::ReInitUnpackers() {
+  for (Int_t i = 0; i < fUnpackers->GetEntriesFast(); i++) {
+    if (!((FairUnpack *)fUnpackers->At(i))->ReInit()) {
+      return kFALSE;
+    }
+  }
+  return kTRUE;
+}
+
 void FairOnlineSource::SetParUnpackers() {
     for (Int_t i = 0; i < fUnpackers->GetEntriesFast(); i++) {
         ((FairUnpack *)fUnpackers->At(i))->SetParContainers();

--- a/base/source/FairOnlineSource.h
+++ b/base/source/FairOnlineSource.h
@@ -36,9 +36,11 @@ class FairOnlineSource : public FairSource
     virtual Int_t ReadEvent(UInt_t=0) = 0;
     virtual void Close() = 0;
 
-    void SetParUnpackers();
+    virtual void SetParUnpackers();
 
-    Bool_t InitUnpackers();
+    virtual Bool_t InitUnpackers();
+
+    virtual Bool_t ReInitUnpackers();
 
     void Reset();
 

--- a/base/source/FairRemoteSource.cxx
+++ b/base/source/FairRemoteSource.cxx
@@ -60,7 +60,7 @@ Bool_t FairRemoteSource::Init()
 }
 
 
-Int_t FairRemoteSource::ReadEvent()
+Int_t FairRemoteSource::ReadEvent(UInt_t)
 {
   usleep(10000);
   fREvent = fBuffer->RevGet(fSocket, 0, 0);

--- a/base/source/FairRemoteSource.h
+++ b/base/source/FairRemoteSource.h
@@ -30,7 +30,7 @@ class FairRemoteSource : public FairMbsSource
     virtual ~FairRemoteSource();
 
     virtual Bool_t Init();
-    virtual Int_t ReadEvent();
+    virtual Int_t ReadEvent(UInt_t = 0);
     virtual void Close();
 
     inline const char* GetNode() const { return fNode; }

--- a/base/source/FairSource.cxx
+++ b/base/source/FairSource.cxx
@@ -15,22 +15,33 @@
 #include <iostream>
 
 #include "FairSource.h"
+#include "FairEventHeader.h"
 
 
 FairSource::FairSource()
   : TObject()
+  , fRunId(0)
 {
 }
 
 
 FairSource::FairSource(const FairSource& source)
   : TObject(source)
+  , fRunId(source.fRunId)
 {
 }
 
 
 FairSource::~FairSource()
 {
+}
+
+void FairSource::FillEventHeader(FairEventHeader* eh)
+{
+  if(eh)
+  {
+    eh->SetRunId(fRunId);
+  }
 }
 
 ClassImp(FairSource)

--- a/base/source/FairSource.h
+++ b/base/source/FairSource.h
@@ -38,6 +38,12 @@ class FairSource : public TObject
 
     virtual Source_Type GetSourceType() = 0;
 
+    virtual void SetParUnpackers() = 0;
+
+    virtual Bool_t InitUnpackers() = 0;
+
+    virtual Bool_t ReInitUnpackers() = 0;
+
     virtual Bool_t   ActivateObject(TObject** obj, const char* ObjType)  { return kFALSE; }
     
     /**Check the maximum event number we can run to*/
@@ -45,7 +51,13 @@ class FairSource : public TObject
     /**Read the tree entry on one branch**/
     virtual void   ReadBranchEvent(const char* BrName) {return;}
     virtual void   ReadBranchEvent(const char* BrName, Int_t Event) {return;}
-    virtual void FillEventHeader(FairEventHeader* feh) { return; } 
+    virtual void FillEventHeader(FairEventHeader* feh);
+
+    void SetRunId(Int_t runId) { fRunId = runId; }
+    Int_t GetRunId() const     { return fRunId;  }
+
+  protected:
+    Int_t fRunId;
 
   public:
     ClassDef(FairSource, 1)

--- a/base/source/FairUnpack.h
+++ b/base/source/FairUnpack.h
@@ -26,6 +26,7 @@ class FairUnpack : public TObject
     virtual ~FairUnpack();
 
     virtual Bool_t Init() = 0;
+    virtual Bool_t ReInit() { return kTRUE; }
     virtual Bool_t DoUnpack(Int_t* data, Int_t size) = 0;
     virtual void   Reset() = 0;
     virtual void   SetParContainers() {  };

--- a/base/steer/FairRun.cxx
+++ b/base/steer/FairRun.cxx
@@ -47,7 +47,8 @@ FairRun::FairRun(Bool_t isMaster)
    fEvtHeader(NULL),
    fFileHeader(new FairFileHeader()),
    fGenerateRunInfo(kFALSE),
-   fIsMaster(isMaster)
+   fIsMaster(isMaster),
+   fMarkFill(kTRUE)
 {
   if (fRunInstance) {
     Fatal("FairRun", "Singleton instance already exists.");

--- a/base/steer/FairRun.h
+++ b/base/steer/FairRun.h
@@ -149,6 +149,9 @@ class FairRun : public TNamed
     //** Get info if run on master */
     Bool_t GetIsMaster() const { return fIsMaster;}
 
+    //** Mark/Unmark event to be filled into output. Default is TRUE. */
+    void MarkFill(Bool_t flag) { fMarkFill = flag; }
+
 
   private:
     FairRun(const FairRun& M);
@@ -188,6 +191,8 @@ class FairRun : public TNamed
     /** true if on master*/
     Bool_t                   fIsMaster;  //!
 
-    ClassDef(FairRun ,3)
+    Bool_t                   fMarkFill; //!
+
+    ClassDef(FairRun ,4)
 };
 #endif //FAIRRUN_H

--- a/base/steer/FairRunAna.cxx
+++ b/base/steer/FairRunAna.cxx
@@ -887,6 +887,22 @@ void FairRunAna::SetBeamTime(Double_t beamTime, Double_t gapTime)
 }
 //_____________________________________________________________________________
 
+
+//_____________________________________________________________________________
+void FairRunAna::Fill()
+{
+  if(fMarkFill)
+  {
+    fRootManager->Fill();
+  }
+  else
+  {
+    fMarkFill = kTRUE;
+  }
+}
+//_____________________________________________________________________________
+
+
 // void  FairRunAna::SetMixAllInputs(Bool_t Status)
 // {
 //    fLogger->Info(MESSAGE_ORIGIN, "Mixing for all input is choosed, in this mode one event per input file is read per step");

--- a/base/steer/FairRunAna.h
+++ b/base/steer/FairRunAna.h
@@ -163,7 +163,7 @@ class FairRunAna : public FairRun
      * Virtual function which calls the Fill function of the IOManager.
      * Allows to override the function with an experiment specific version.
     **/
-    virtual void Fill() { fRootManager->Fill(); }            
+    virtual void Fill();
                                                
   private:
 

--- a/base/steer/FairRunOnline.h
+++ b/base/steer/FairRunOnline.h
@@ -120,6 +120,8 @@ class FairRunOnline : public FairRun
     void WriteObjects();
     void GenerateHtml();
 
+    virtual void Fill();
+
     ClassDef(FairRunOnline, 0)
 };
 

--- a/cmake/modules/CheckCompiler.cmake
+++ b/cmake/modules/CheckCompiler.cmake
@@ -19,7 +19,7 @@ endif (NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 # the compiler and compiler flags used to install fairsoft.
 # Compare compiler and compiler flags used to compile fairsoft with the compiler and flags used now
 # In case of differences print a warning
-Find_Program(FAIRSOFT_CONFIG fairsoft-config PATHS $ENV{SIMPATH}/bin NO_DEFAULT_PATH)
+Find_Program(FAIRSOFT_CONFIG fairsoft-config PATHS $ENV{SIMPATH}/bin $ENV{FAIRSOFT_ROOT}/bin NO_DEFAULT_PATH)
 
 If(FAIRSOFT_CONFIG)
   Message(STATUS "fairsoft-config found")
@@ -175,8 +175,24 @@ if (CMAKE_SYSTEM_NAME MATCHES Darwin)
         SET(CMAKE_Fortran_FLAGS "-m64")
       ENDIF(MAC_OS_10_5 OR MAC_OS_10_6 OR MAC_OS_10_7)
 
-      SET(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS} -flat_namespace -single_module -undefined dynamic_lookup")
-      SET(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS} -flat_namespace -single_module -undefined dynamic_lookup")
+      # Check for Xcode version 7.3.0
+      SET(CLANG_730 -1)
+      IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        EXEC_PROGRAM("clang --version | grep \"version 7.3.0\"" OUTPUT_VARIABLE CLANG_VERSION)
+        IF(CLANG_VERSION)
+          STRING(FIND ${CLANG_VERSION} "version 7.3.0" CLANG_730)
+        ENDIF(CLANG_VERSION)
+      ENDIF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+
+      SET(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS} -single_module -undefined dynamic_lookup")
+      SET(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS} -single_module -undefined dynamic_lookup")
+
+      # Do not use -flat_namespace flag for Xcode 7.3.0
+      IF(CLANG_730 LESS 0)
+        SET(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS} -flat_namespace")
+        SET(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS} -flat_namespace")
+      ENDIF(CLANG_730 LESS 0)
+
 #      MESSAGE("C_FLAGS: ${CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS}")
 #      MESSAGE("CXX_FLAGS: ${CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS}")
       Execute_Process(COMMAND gfortran -print-file-name=libgfortran.dylib
@@ -194,7 +210,7 @@ if (CMAKE_SYSTEM_NAME MATCHES Darwin)
       set(CMAKE_CXX_FLAGS_RELEASE        "-O2 -Wshadow ")
       set(CMAKE_CXX_FLAGS_DEBUG          "-g -O2 -Wshadow  -fno-inline")
       set(CMAKE_CXX_FLAGS_DEBUGFULL      "-g3 -fno-inline -Wnon-virtual-dtor -Wno-long-long -ansi -Wundef -Wcast-align -Wchar-subscripts -Wall -W -Wpointer-arith -Wformat-security -fno-exceptions -fno-check-new -fno-common")
-      set(CMAKE_CXX_FLAGS_PROFILE        "-g3 -fno-inline -ftest-coverage -fprofile-arcs")
+      set(CMAKE_CXX_FLAGS_PROFILE        "-g3 -fno-inline -ftest-coverage -fprofile-arcs -Wall -Wextra")
       set(CMAKE_C_FLAGS_RELWITHDEBINFO   "-O2 -g")
       set(CMAKE_C_FLAGS_RELEASE          "-O2")
       set(CMAKE_C_FLAGS_DEBUG            "-g -O2  -fno-inline")


### PR DESCRIPTION
Add possibility to skip writing an event to tree.
Move SetParContainers for unpackers to base FairSource class. Avoid dynamic cast in FairRunOnline.
Set the run ID using source.
Fix linking error with Xcode 7.3.
Add ReInit to the Unpacker class. Call ReInitUnpackers from FairRunOnline.