### PR TITLE
Several fixes and improvements

### DIFF
--- a/examples/MQ/1-sampler-sink/runExample1Sampler.cxx
+++ b/examples/MQ/1-sampler-sink/runExample1Sampler.cxx
@@ -32,10 +32,7 @@ int main(int argc, char** argv)
 
         FairMQProgOptions config;
         config.AddToCmdLineOptions(samplerOptions);
-        if (config.ParseAll(argc, argv))
-        {
-            return 0;
-        }
+        config.ParseAll(argc, argv);
 
         FairMQExample1Sampler sampler;
         sampler.CatchSignals();

--- a/examples/MQ/1-sampler-sink/runExample1Sampler.cxx
+++ b/examples/MQ/1-sampler-sink/runExample1Sampler.cxx
@@ -12,12 +12,9 @@
  * @author D. Klein, A. Rybalchenko
  */
 
-#include <iostream>
-
 #include "boost/program_options.hpp"
 
 #include "FairMQLogger.h"
-#include "FairMQParser.h"
 #include "FairMQProgOptions.h"
 #include "FairMQExample1Sampler.h"
 
@@ -25,11 +22,6 @@ using namespace boost::program_options;
 
 int main(int argc, char** argv)
 {
-    FairMQExample1Sampler sampler;
-    sampler.CatchSignals();
-
-    FairMQProgOptions config;
-
     try
     {
         std::string text;
@@ -38,13 +30,15 @@ int main(int argc, char** argv)
         samplerOptions.add_options()
             ("text", value<std::string>(&text)->default_value("Hello"), "Text to send out");
 
+        FairMQProgOptions config;
         config.AddToCmdLineOptions(samplerOptions);
-
         if (config.ParseAll(argc, argv))
         {
             return 0;
         }
 
+        FairMQExample1Sampler sampler;
+        sampler.CatchSignals();
         sampler.SetConfig(config);
         sampler.SetProperty(FairMQExample1Sampler::Text, text);
 
@@ -59,9 +53,8 @@ int main(int argc, char** argv)
     }
     catch (std::exception& e)
     {
-        LOG(ERROR) << e.what();
-        LOG(INFO) << "Command line options are the following: ";
-        config.PrintHelp();
+        LOG(ERROR) << "Unhandled Exception reached the top of main: "
+                   << e.what() << ", application will now exit";
         return 1;
     }
 

--- a/examples/MQ/1-sampler-sink/runExample1Sink.cxx
+++ b/examples/MQ/1-sampler-sink/runExample1Sink.cxx
@@ -15,24 +15,21 @@
 #include <iostream>
 
 #include "FairMQLogger.h"
-#include "FairMQParser.h"
 #include "FairMQProgOptions.h"
 #include "FairMQExample1Sink.h"
 
 int main(int argc, char** argv)
 {
-    FairMQExample1Sink sink;
-    sink.CatchSignals();
-
-    FairMQProgOptions config;
-
     try
     {
+        FairMQProgOptions config;
         if (config.ParseAll(argc, argv))
         {
             return 0;
         }
 
+        FairMQExample1Sink sink;
+        sink.CatchSignals();
         sink.SetConfig(config);
 
         sink.ChangeState("INIT_DEVICE");
@@ -46,9 +43,8 @@ int main(int argc, char** argv)
     }
     catch (std::exception& e)
     {
-        LOG(ERROR) << e.what();
-        LOG(INFO) << "Command line options are the following: ";
-        config.PrintHelp();
+        LOG(ERROR) << "Unhandled Exception reached the top of main: "
+                   << e.what() << ", application will now exit";
         return 1;
     }
 

--- a/examples/MQ/1-sampler-sink/runExample1Sink.cxx
+++ b/examples/MQ/1-sampler-sink/runExample1Sink.cxx
@@ -23,10 +23,7 @@ int main(int argc, char** argv)
     try
     {
         FairMQProgOptions config;
-        if (config.ParseAll(argc, argv))
-        {
-            return 0;
-        }
+        config.ParseAll(argc, argv);
 
         FairMQExample1Sink sink;
         sink.CatchSignals();

--- a/examples/MQ/2-sampler-processor-sink/runExample2Processor.cxx
+++ b/examples/MQ/2-sampler-processor-sink/runExample2Processor.cxx
@@ -22,10 +22,7 @@ int main(int argc, char** argv)
     try
     {
         FairMQProgOptions config;
-        if (config.ParseAll(argc, argv))
-        {
-            return 0;
-        }
+        config.ParseAll(argc, argv);
 
         FairMQExample2Processor processor;
         processor.CatchSignals();

--- a/examples/MQ/2-sampler-processor-sink/runExample2Processor.cxx
+++ b/examples/MQ/2-sampler-processor-sink/runExample2Processor.cxx
@@ -12,27 +12,23 @@
  * @author D. Klein, A. Rybalchenko
  */
 
-#include <iostream>
-
 #include "FairMQLogger.h"
-#include "FairMQParser.h"
+
 #include "FairMQProgOptions.h"
 #include "FairMQExample2Processor.h"
 
 int main(int argc, char** argv)
 {
-    FairMQExample2Processor processor;
-    processor.CatchSignals();
-
-    FairMQProgOptions config;
-
     try
     {
+        FairMQProgOptions config;
         if (config.ParseAll(argc, argv))
         {
             return 0;
         }
 
+        FairMQExample2Processor processor;
+        processor.CatchSignals();
         processor.SetConfig(config);
 
         processor.ChangeState("INIT_DEVICE");
@@ -46,9 +42,8 @@ int main(int argc, char** argv)
     }
     catch (std::exception& e)
     {
-        LOG(ERROR) << e.what();
-        LOG(INFO) << "Command line options are the following: ";
-        config.PrintHelp();
+        LOG(ERROR) << "Unhandled Exception reached the top of main: "
+                   << e.what() << ", application will now exit";
         return 1;
     }
 

--- a/examples/MQ/2-sampler-processor-sink/runExample2Sampler.cxx
+++ b/examples/MQ/2-sampler-processor-sink/runExample2Sampler.cxx
@@ -12,12 +12,10 @@
  * @author D. Klein, A. Rybalchenko
  */
 
-#include <iostream>
-
 #include "boost/program_options.hpp"
 
 #include "FairMQLogger.h"
-#include "FairMQParser.h"
+
 #include "FairMQProgOptions.h"
 #include "FairMQExample2Sampler.h"
 
@@ -25,11 +23,6 @@ using namespace boost::program_options;
 
 int main(int argc, char** argv)
 {
-    FairMQExample2Sampler sampler;
-    sampler.CatchSignals();
-
-    FairMQProgOptions config;
-
     try
     {
         std::string text;
@@ -38,13 +31,15 @@ int main(int argc, char** argv)
         samplerOptions.add_options()
             ("text", value<std::string>(&text)->default_value("Hello"), "Text to send out");
 
+        FairMQProgOptions config;
         config.AddToCmdLineOptions(samplerOptions);
-
         if (config.ParseAll(argc, argv))
         {
             return 0;
         }
 
+        FairMQExample2Sampler sampler;
+        sampler.CatchSignals();
         sampler.SetConfig(config);
         sampler.SetProperty(FairMQExample2Sampler::Text, text);
 
@@ -59,9 +54,8 @@ int main(int argc, char** argv)
     }
     catch (std::exception& e)
     {
-        LOG(ERROR) << e.what();
-        LOG(INFO) << "Command line options are the following: ";
-        config.PrintHelp();
+        LOG(ERROR) << "Unhandled Exception reached the top of main: "
+                   << e.what() << ", application will now exit";
         return 1;
     }
 

--- a/examples/MQ/2-sampler-processor-sink/runExample2Sampler.cxx
+++ b/examples/MQ/2-sampler-processor-sink/runExample2Sampler.cxx
@@ -33,10 +33,7 @@ int main(int argc, char** argv)
 
         FairMQProgOptions config;
         config.AddToCmdLineOptions(samplerOptions);
-        if (config.ParseAll(argc, argv))
-        {
-            return 0;
-        }
+        config.ParseAll(argc, argv);
 
         FairMQExample2Sampler sampler;
         sampler.CatchSignals();

--- a/examples/MQ/2-sampler-processor-sink/runExample2Sink.cxx
+++ b/examples/MQ/2-sampler-processor-sink/runExample2Sink.cxx
@@ -12,27 +12,23 @@
  * @author D. Klein, A. Rybalchenko
  */
 
-#include <iostream>
-
 #include "FairMQLogger.h"
-#include "FairMQParser.h"
+
 #include "FairMQProgOptions.h"
 #include "FairMQExample2Sink.h"
 
 int main(int argc, char** argv)
 {
-    FairMQExample2Sink sink;
-    sink.CatchSignals();
-
-    FairMQProgOptions config;
-
     try
     {
+        FairMQProgOptions config;
         if (config.ParseAll(argc, argv))
         {
             return 0;
         }
 
+        FairMQExample2Sink sink;
+        sink.CatchSignals();
         sink.SetConfig(config);
 
         sink.ChangeState("INIT_DEVICE");
@@ -46,9 +42,8 @@ int main(int argc, char** argv)
     }
     catch (std::exception& e)
     {
-        LOG(ERROR) << e.what();
-        LOG(INFO) << "Command line options are the following: ";
-        config.PrintHelp();
+        LOG(ERROR) << "Unhandled Exception reached the top of main: "
+                   << e.what() << ", application will now exit";
         return 1;
     }
 

--- a/examples/MQ/2-sampler-processor-sink/runExample2Sink.cxx
+++ b/examples/MQ/2-sampler-processor-sink/runExample2Sink.cxx
@@ -22,10 +22,7 @@ int main(int argc, char** argv)
     try
     {
         FairMQProgOptions config;
-        if (config.ParseAll(argc, argv))
-        {
-            return 0;
-        }
+        config.ParseAll(argc, argv);
 
         FairMQExample2Sink sink;
         sink.CatchSignals();

--- a/examples/MQ/3-dds/ex3-dds-hosts.cfg
+++ b/examples/MQ/3-dds/ex3-dds-hosts.cfg
@@ -2,6 +2,6 @@
 # source setup.sh
 @bash_end@
 
-sampler, orybalch@localhost, , /home/orybalch/dds-work/, 1
-processor, orybalch@localhost, , /home/orybalch/dds-work/, 10
-sink, orybalch@localhost, , /home/orybalch/dds-work/, 1
+sampler, username@localhost, , /path/to/dds-work-dir/, 1
+processor, username@localhost, , /path/to/dds-work-dir/, 10
+sink, username@localhost, , /path/to/dds-work-dir/, 1

--- a/examples/MQ/3-dds/ex3-dds-hosts.cfg
+++ b/examples/MQ/3-dds/ex3-dds-hosts.cfg
@@ -2,6 +2,6 @@
 # source setup.sh
 @bash_end@
 
-sampler, username@localhost, , /path/to/dds-work-dir/, 1
-processor, username@localhost, , /path/to/dds-work-dir/, 10
-sink, username@localhost, , /path/to/dds-work-dir/, 1
+sampler, orybalch@localhost, , /home/orybalch/dds-work/, 1
+processor, orybalch@localhost, , /home/orybalch/dds-work/, 10
+sink, orybalch@localhost, , /home/orybalch/dds-work/, 1

--- a/examples/MQ/3-dds/runExample3Processor.cxx
+++ b/examples/MQ/3-dds/runExample3Processor.cxx
@@ -22,10 +22,7 @@ int main(int argc, char** argv)
     try
     {
         FairMQProgOptions config;
-        if (config.ParseAll(argc, argv))
-        {
-            return 0;
-        }
+        config.ParseAll(argc, argv);
 
         FairMQExample3Processor processor;
         processor.CatchSignals();

--- a/examples/MQ/3-dds/runExample3Processor.cxx
+++ b/examples/MQ/3-dds/runExample3Processor.cxx
@@ -17,23 +17,18 @@
 #include "FairMQProgOptions.h"
 #include "FairMQExample3Processor.h"
 
-using namespace std;
-using namespace boost::program_options;
-
 int main(int argc, char** argv)
 {
-    FairMQExample3Processor processor;
-    processor.CatchSignals();
-
-    FairMQProgOptions config;
-
     try
     {
+        FairMQProgOptions config;
         if (config.ParseAll(argc, argv))
         {
             return 0;
         }
 
+        FairMQExample3Processor processor;
+        processor.CatchSignals();
         processor.SetConfig(config);
 
         processor.ChangeState("INIT_DEVICE");
@@ -45,11 +40,10 @@ int main(int argc, char** argv)
 
         runDDSStateHandler(processor);
     }
-    catch (exception& e)
+    catch (std::exception& e)
     {
-        LOG(ERROR) << e.what();
-        LOG(INFO) << "Command line options are the following: ";
-        config.PrintHelp();
+        LOG(ERROR) << "Unhandled Exception reached the top of main: "
+                   << e.what() << ", application will now exit";
         return 1;
     }
 

--- a/examples/MQ/3-dds/runExample3Sampler.cxx
+++ b/examples/MQ/3-dds/runExample3Sampler.cxx
@@ -17,23 +17,18 @@
 #include "FairMQProgOptions.h"
 #include "FairMQExample3Sampler.h"
 
-using namespace std;
-using namespace boost::program_options;
-
 int main(int argc, char** argv)
 {
-    FairMQExample3Sampler sampler;
-    sampler.CatchSignals();
-
-    FairMQProgOptions config;
-
     try
     {
+        FairMQProgOptions config;
         if (config.ParseAll(argc, argv))
         {
             return 0;
         }
 
+        FairMQExample3Sampler sampler;
+        sampler.CatchSignals();
         sampler.SetConfig(config);
 
         sampler.ChangeState("INIT_DEVICE");
@@ -45,11 +40,10 @@ int main(int argc, char** argv)
 
         runDDSStateHandler(sampler);
     }
-    catch (exception& e)
+    catch (std::exception& e)
     {
-        LOG(ERROR) << e.what();
-        LOG(INFO) << "Command line options are the following: ";
-        config.PrintHelp();
+        LOG(ERROR) << "Unhandled Exception reached the top of main: "
+                   << e.what() << ", application will now exit";
         return 1;
     }
 

--- a/examples/MQ/3-dds/runExample3Sampler.cxx
+++ b/examples/MQ/3-dds/runExample3Sampler.cxx
@@ -22,10 +22,7 @@ int main(int argc, char** argv)
     try
     {
         FairMQProgOptions config;
-        if (config.ParseAll(argc, argv))
-        {
-            return 0;
-        }
+        config.ParseAll(argc, argv);
 
         FairMQExample3Sampler sampler;
         sampler.CatchSignals();

--- a/examples/MQ/3-dds/runExample3Sink.cxx
+++ b/examples/MQ/3-dds/runExample3Sink.cxx
@@ -17,23 +17,18 @@
 #include "FairMQProgOptions.h"
 #include "FairMQExample3Sink.h"
 
-using namespace std;
-using namespace boost::program_options;
-
 int main(int argc, char** argv)
 {
-    FairMQExample3Sink sink;
-    sink.CatchSignals();
-
-    FairMQProgOptions config;
-
     try
     {
+        FairMQProgOptions config;
         if (config.ParseAll(argc, argv))
         {
             return 0;
         }
 
+        FairMQExample3Sink sink;
+        sink.CatchSignals();
         sink.SetConfig(config);
 
         sink.ChangeState("INIT_DEVICE");
@@ -45,11 +40,10 @@ int main(int argc, char** argv)
 
         runDDSStateHandler(sink);
     }
-    catch (exception& e)
+    catch (std::exception& e)
     {
-        LOG(ERROR) << e.what();
-        LOG(INFO) << "Command line options are the following: ";
-        config.PrintHelp();
+        LOG(ERROR) << "Unhandled Exception reached the top of main: "
+                   << e.what() << ", application will now exit";
         return 1;
     }
 

--- a/examples/MQ/3-dds/runExample3Sink.cxx
+++ b/examples/MQ/3-dds/runExample3Sink.cxx
@@ -22,10 +22,7 @@ int main(int argc, char** argv)
     try
     {
         FairMQProgOptions config;
-        if (config.ParseAll(argc, argv))
-        {
-            return 0;
-        }
+        config.ParseAll(argc, argv);
 
         FairMQExample3Sink sink;
         sink.CatchSignals();

--- a/examples/MQ/4-copypush/runExample4Sampler.cxx
+++ b/examples/MQ/4-copypush/runExample4Sampler.cxx
@@ -15,24 +15,21 @@
 #include <iostream>
 
 #include "FairMQLogger.h"
-#include "FairMQParser.h"
 #include "FairMQProgOptions.h"
 #include "FairMQExample4Sampler.h"
 
 int main(int argc, char** argv)
 {
-    FairMQExample4Sampler sampler;
-    sampler.CatchSignals();
-
-    FairMQProgOptions config;
-
     try
     {
+        FairMQProgOptions config;
         if (config.ParseAll(argc, argv))
         {
             return 0;
         }
 
+        FairMQExample4Sampler sampler;
+        sampler.CatchSignals();
         sampler.SetConfig(config);
 
         sampler.ChangeState("INIT_DEVICE");
@@ -46,9 +43,8 @@ int main(int argc, char** argv)
     }
     catch (std::exception& e)
     {
-        LOG(ERROR) << e.what();
-        LOG(INFO) << "Command line options are the following: ";
-        config.PrintHelp();
+        LOG(ERROR) << "Unhandled Exception reached the top of main: "
+                   << e.what() << ", application will now exit";
         return 1;
     }
 

--- a/examples/MQ/4-copypush/runExample4Sampler.cxx
+++ b/examples/MQ/4-copypush/runExample4Sampler.cxx
@@ -23,10 +23,7 @@ int main(int argc, char** argv)
     try
     {
         FairMQProgOptions config;
-        if (config.ParseAll(argc, argv))
-        {
-            return 0;
-        }
+        config.ParseAll(argc, argv);
 
         FairMQExample4Sampler sampler;
         sampler.CatchSignals();

--- a/examples/MQ/4-copypush/runExample4Sink.cxx
+++ b/examples/MQ/4-copypush/runExample4Sink.cxx
@@ -15,24 +15,21 @@
 #include <iostream>
 
 #include "FairMQLogger.h"
-#include "FairMQParser.h"
 #include "FairMQProgOptions.h"
 #include "FairMQExample4Sink.h"
 
 int main(int argc, char** argv)
 {
-    FairMQExample4Sink sink;
-    sink.CatchSignals();
-
-    FairMQProgOptions config;
-
     try
     {
+        FairMQProgOptions config;
         if (config.ParseAll(argc, argv))
         {
             return 0;
         }
 
+        FairMQExample4Sink sink;
+        sink.CatchSignals();
         sink.SetConfig(config);
 
         sink.ChangeState("INIT_DEVICE");
@@ -46,9 +43,8 @@ int main(int argc, char** argv)
     }
     catch (std::exception& e)
     {
-        LOG(ERROR) << e.what();
-        LOG(INFO) << "Command line options are the following: ";
-        config.PrintHelp();
+        LOG(ERROR) << "Unhandled Exception reached the top of main: "
+                   << e.what() << ", application will now exit";
         return 1;
     }
 

--- a/examples/MQ/4-copypush/runExample4Sink.cxx
+++ b/examples/MQ/4-copypush/runExample4Sink.cxx
@@ -23,10 +23,7 @@ int main(int argc, char** argv)
     try
     {
         FairMQProgOptions config;
-        if (config.ParseAll(argc, argv))
-        {
-            return 0;
-        }
+        config.ParseAll(argc, argv);
 
         FairMQExample4Sink sink;
         sink.CatchSignals();

--- a/examples/MQ/5-req-rep/runExample5Client.cxx
+++ b/examples/MQ/5-req-rep/runExample5Client.cxx
@@ -32,11 +32,7 @@ int main(int argc, char** argv)
 
         FairMQProgOptions config;
         config.AddToCmdLineOptions(clientOptions);
-
-        if (config.ParseAll(argc, argv))
-        {
-            return 0;
-        }
+        config.ParseAll(argc, argv);
 
         FairMQExample5Client client;
         client.CatchSignals();

--- a/examples/MQ/5-req-rep/runExample5Client.cxx
+++ b/examples/MQ/5-req-rep/runExample5Client.cxx
@@ -12,33 +12,25 @@
  * @author D. Klein, A. Rybalchenko
  */
 
-#include <iostream>
-
 #include "boost/program_options.hpp"
 
 #include "FairMQLogger.h"
-#include "FairMQParser.h"
 #include "FairMQProgOptions.h"
 #include "FairMQExample5Client.h"
 
-using namespace std;
 using namespace boost::program_options;
 
 int main(int argc, char** argv)
 {
-    FairMQExample5Client client;
-    client.CatchSignals();
-
-    FairMQProgOptions config;
-
     try
     {
-        string text;
+        std::string text;
 
         options_description clientOptions("Client options");
         clientOptions.add_options()
-            ("text", value<string>(&text)->default_value("Hello"), "Text to send out");
+            ("text", value<std::string>(&text)->default_value("Hello"), "Text to send out");
 
+        FairMQProgOptions config;
         config.AddToCmdLineOptions(clientOptions);
 
         if (config.ParseAll(argc, argv))
@@ -46,6 +38,8 @@ int main(int argc, char** argv)
             return 0;
         }
 
+        FairMQExample5Client client;
+        client.CatchSignals();
         client.SetConfig(config);
         client.SetProperty(FairMQExample5Client::Text, text);
 
@@ -58,11 +52,10 @@ int main(int argc, char** argv)
         client.ChangeState("RUN");
         client.InteractiveStateLoop();
     }
-    catch (exception& e)
+    catch (std::exception& e)
     {
-        LOG(ERROR) << e.what();
-        LOG(INFO) << "Command line options are the following: ";
-        config.PrintHelp();
+        LOG(ERROR) << "Unhandled Exception reached the top of main: "
+                   << e.what() << ", application will now exit";
         return 1;
     }
 

--- a/examples/MQ/5-req-rep/runExample5Server.cxx
+++ b/examples/MQ/5-req-rep/runExample5Server.cxx
@@ -23,10 +23,7 @@ int main(int argc, char** argv)
     try
     {
         FairMQProgOptions config;
-        if (config.ParseAll(argc, argv))
-        {
-            return 0;
-        }
+        config.ParseAll(argc, argv);
 
         FairMQExample5Server server;
         server.CatchSignals();

--- a/examples/MQ/5-req-rep/runExample5Server.cxx
+++ b/examples/MQ/5-req-rep/runExample5Server.cxx
@@ -15,26 +15,21 @@
 #include <iostream>
 
 #include "FairMQLogger.h"
-#include "FairMQParser.h"
 #include "FairMQProgOptions.h"
 #include "FairMQExample5Server.h"
 
-using namespace std;
-
 int main(int argc, char** argv)
 {
-    FairMQExample5Server server;
-    server.CatchSignals();
-
-    FairMQProgOptions config;
-
     try
     {
+        FairMQProgOptions config;
         if (config.ParseAll(argc, argv))
         {
             return 0;
         }
 
+        FairMQExample5Server server;
+        server.CatchSignals();
         server.SetConfig(config);
 
         server.ChangeState("INIT_DEVICE");
@@ -46,11 +41,10 @@ int main(int argc, char** argv)
         server.ChangeState("RUN");
         server.InteractiveStateLoop();
     }
-    catch (exception& e)
+    catch (std::exception& e)
     {
-        LOG(ERROR) << e.what();
-        LOG(INFO) << "Command line options are the following: ";
-        config.PrintHelp();
+        LOG(ERROR) << "Unhandled Exception reached the top of main: "
+                   << e.what() << ", application will now exit";
         return 1;
     }
 

--- a/examples/MQ/6-multiple-channels/runExample6Broadcaster.cxx
+++ b/examples/MQ/6-multiple-channels/runExample6Broadcaster.cxx
@@ -12,27 +12,22 @@
  * @author A. Rybalchenko
  */
 
-#include <iostream>
-
 #include "FairMQLogger.h"
-#include "FairMQParser.h"
 #include "FairMQProgOptions.h"
 #include "FairMQExample6Broadcaster.h"
 
 int main(int argc, char** argv)
 {
-    FairMQExample6Broadcaster broadcaster;
-    broadcaster.CatchSignals();
-
-    FairMQProgOptions config;
-
     try
     {
+        FairMQProgOptions config;
         if (config.ParseAll(argc, argv))
         {
             return 0;
         }
 
+        FairMQExample6Broadcaster broadcaster;
+        broadcaster.CatchSignals();
         broadcaster.SetConfig(config);
 
         broadcaster.ChangeState("INIT_DEVICE");
@@ -46,9 +41,8 @@ int main(int argc, char** argv)
     }
     catch (std::exception& e)
     {
-        LOG(ERROR) << e.what();
-        LOG(INFO) << "Command line options are the following: ";
-        config.PrintHelp();
+        LOG(ERROR) << "Unhandled Exception reached the top of main: "
+                   << e.what() << ", application will now exit";
         return 1;
     }
 

--- a/examples/MQ/6-multiple-channels/runExample6Broadcaster.cxx
+++ b/examples/MQ/6-multiple-channels/runExample6Broadcaster.cxx
@@ -21,10 +21,7 @@ int main(int argc, char** argv)
     try
     {
         FairMQProgOptions config;
-        if (config.ParseAll(argc, argv))
-        {
-            return 0;
-        }
+        config.ParseAll(argc, argv);
 
         FairMQExample6Broadcaster broadcaster;
         broadcaster.CatchSignals();

--- a/examples/MQ/6-multiple-channels/runExample6Sampler.cxx
+++ b/examples/MQ/6-multiple-channels/runExample6Sampler.cxx
@@ -32,10 +32,7 @@ int main(int argc, char** argv)
 
         FairMQProgOptions config;
         config.AddToCmdLineOptions(samplerOptions);
-        if (config.ParseAll(argc, argv))
-        {
-            return 0;
-        }
+        config.ParseAll(argc, argv);
 
         FairMQExample6Sampler sampler;
         sampler.CatchSignals();

--- a/examples/MQ/6-multiple-channels/runExample6Sampler.cxx
+++ b/examples/MQ/6-multiple-channels/runExample6Sampler.cxx
@@ -12,12 +12,9 @@
  * @author D. Klein, A. Rybalchenko
  */
 
-#include <iostream>
-
 #include "boost/program_options.hpp"
 
 #include "FairMQLogger.h"
-#include "FairMQParser.h"
 #include "FairMQProgOptions.h"
 #include "FairMQExample6Sampler.h"
 
@@ -25,11 +22,6 @@ using namespace boost::program_options;
 
 int main(int argc, char** argv)
 {
-    FairMQExample6Sampler sampler;
-    sampler.CatchSignals();
-
-    FairMQProgOptions config;
-
     try
     {
         std::string text;
@@ -38,13 +30,15 @@ int main(int argc, char** argv)
         samplerOptions.add_options()
             ("text", value<std::string>(&text)->default_value("Hello"), "Text to send out");
 
+        FairMQProgOptions config;
         config.AddToCmdLineOptions(samplerOptions);
-
         if (config.ParseAll(argc, argv))
         {
             return 0;
         }
 
+        FairMQExample6Sampler sampler;
+        sampler.CatchSignals();
         sampler.SetConfig(config);
         sampler.SetProperty(FairMQExample6Sampler::Text, text);
 
@@ -59,9 +53,8 @@ int main(int argc, char** argv)
     }
     catch (std::exception& e)
     {
-        LOG(ERROR) << e.what();
-        LOG(INFO) << "Command line options are the following: ";
-        config.PrintHelp();
+        LOG(ERROR) << "Unhandled Exception reached the top of main: "
+                   << e.what() << ", application will now exit";
         return 1;
     }
 

--- a/examples/MQ/6-multiple-channels/runExample6Sink.cxx
+++ b/examples/MQ/6-multiple-channels/runExample6Sink.cxx
@@ -21,10 +21,7 @@ int main(int argc, char** argv)
     try
     {
         FairMQProgOptions config;
-        if (config.ParseAll(argc, argv))
-        {
-            return 0;
-        }
+        config.ParseAll(argc, argv);
 
         FairMQExample6Sink sink;
         sink.CatchSignals();

--- a/examples/MQ/6-multiple-channels/runExample6Sink.cxx
+++ b/examples/MQ/6-multiple-channels/runExample6Sink.cxx
@@ -12,31 +12,22 @@
  * @author D. Klein, A. Rybalchenko
  */
 
-#include <iostream>
-
-#include "boost/program_options.hpp"
-
 #include "FairMQLogger.h"
-#include "FairMQParser.h"
 #include "FairMQProgOptions.h"
 #include "FairMQExample6Sink.h"
 
-using namespace boost::program_options;
-
 int main(int argc, char** argv)
 {
-    FairMQExample6Sink sink;
-    sink.CatchSignals();
-
-    FairMQProgOptions config;
-
     try
     {
+        FairMQProgOptions config;
         if (config.ParseAll(argc, argv))
         {
             return 0;
         }
 
+        FairMQExample6Sink sink;
+        sink.CatchSignals();
         sink.SetConfig(config);
 
         sink.ChangeState("INIT_DEVICE");
@@ -50,9 +41,8 @@ int main(int argc, char** argv)
     }
     catch (std::exception& e)
     {
-        LOG(ERROR) << e.what();
-        LOG(INFO) << "Command line options are the following: ";
-        config.PrintHelp();
+        LOG(ERROR) << "Unhandled Exception reached the top of main: "
+                   << e.what() << ", application will now exit";
         return 1;
     }
 

--- a/examples/MQ/7-parameters/fill_parameters.C
+++ b/examples/MQ/7-parameters/fill_parameters.C
@@ -8,7 +8,7 @@
   //rtdb->saveOutput();
   //rtdb->print();
 
-  FairMQExample7ParOne *par = rtdb->getContainer("FairMQExample7ParOne");
+  FairMQExample7ParOne *par = (FairMQExample7ParOne*)rtdb->getContainer("FairMQExample7ParOne");
 
   for(Int_t i = 0; i < 100; i++)
   {

--- a/examples/MQ/7-parameters/runExample7Client.cxx
+++ b/examples/MQ/7-parameters/runExample7Client.cxx
@@ -12,38 +12,33 @@
  * @author D. Klein, A. Rybalchenko
  */
 
-#include <iostream>
+#include "boost/program_options.hpp"
 
 #include "FairMQLogger.h"
-#include "FairMQParser.h"
 #include "FairMQProgOptions.h"
 #include "FairMQExample7Client.h"
 
-using namespace std;
 using namespace boost::program_options;
 
 int main(int argc, char** argv)
 {
-    FairMQExample7Client client;
-    client.CatchSignals();
-
-    FairMQProgOptions config;
-
     try
     {
-        string parameterName;
+        std::string parameterName;
 
         options_description clientOptions("Parameter Client options");
         clientOptions.add_options()
-            ("parameter-name", value<string>(&parameterName)->default_value("FairMQExample7ParOne"), "Parameter Name");
+            ("parameter-name", value<std::string>(&parameterName)->default_value("FairMQExample7ParOne"), "Parameter Name");
 
+        FairMQProgOptions config;
         config.AddToCmdLineOptions(clientOptions);
-
         if (config.ParseAll(argc, argv))
         {
             return 0;
         }
 
+        FairMQExample7Client client;
+        client.CatchSignals();
         client.SetConfig(config);
         client.SetProperty(FairMQExample7Client::ParameterName, parameterName);
 
@@ -56,11 +51,10 @@ int main(int argc, char** argv)
         client.ChangeState("RUN");
         client.InteractiveStateLoop();
     }
-    catch (exception& e)
+    catch (std::exception& e)
     {
-        LOG(ERROR) << e.what();
-        LOG(INFO) << "Command line options are the following: ";
-        config.PrintHelp();
+        LOG(ERROR) << "Unhandled Exception reached the top of main: "
+                   << e.what() << ", application will now exit";
         return 1;
     }
 

--- a/examples/MQ/7-parameters/runExample7Client.cxx
+++ b/examples/MQ/7-parameters/runExample7Client.cxx
@@ -32,10 +32,7 @@ int main(int argc, char** argv)
 
         FairMQProgOptions config;
         config.AddToCmdLineOptions(clientOptions);
-        if (config.ParseAll(argc, argv))
-        {
-            return 0;
-        }
+        config.ParseAll(argc, argv);
 
         FairMQExample7Client client;
         client.CatchSignals();

--- a/examples/MQ/8-multipart/runExample8Sampler.cxx
+++ b/examples/MQ/8-multipart/runExample8Sampler.cxx
@@ -12,27 +12,22 @@
  * @author D. Klein, A. Rybalchenko
  */
 
-#include <iostream>
-
 #include "FairMQLogger.h"
-#include "FairMQParser.h"
 #include "FairMQProgOptions.h"
 #include "FairMQExample8Sampler.h"
 
 int main(int argc, char** argv)
 {
-    FairMQExample8Sampler sampler;
-    sampler.CatchSignals();
-
-    FairMQProgOptions config;
-
     try
     {
+        FairMQProgOptions config;
         if (config.ParseAll(argc, argv))
         {
             return 0;
         }
 
+        FairMQExample8Sampler sampler;
+        sampler.CatchSignals();
         sampler.SetConfig(config);
 
         sampler.ChangeState("INIT_DEVICE");
@@ -46,9 +41,8 @@ int main(int argc, char** argv)
     }
     catch (std::exception& e)
     {
-        LOG(ERROR) << e.what();
-        LOG(INFO) << "Command line options are the following: ";
-        config.PrintHelp();
+        LOG(ERROR) << "Unhandled Exception reached the top of main: "
+                   << e.what() << ", application will now exit";
         return 1;
     }
 

--- a/examples/MQ/8-multipart/runExample8Sampler.cxx
+++ b/examples/MQ/8-multipart/runExample8Sampler.cxx
@@ -21,10 +21,7 @@ int main(int argc, char** argv)
     try
     {
         FairMQProgOptions config;
-        if (config.ParseAll(argc, argv))
-        {
-            return 0;
-        }
+        config.ParseAll(argc, argv);
 
         FairMQExample8Sampler sampler;
         sampler.CatchSignals();

--- a/examples/MQ/8-multipart/runExample8Sink.cxx
+++ b/examples/MQ/8-multipart/runExample8Sink.cxx
@@ -21,10 +21,7 @@ int main(int argc, char** argv)
     try
     {
         FairMQProgOptions config;
-        if (config.ParseAll(argc, argv))
-        {
-            return 0;
-        }
+        config.ParseAll(argc, argv);
 
         FairMQExample8Sink sink;
         sink.CatchSignals();

--- a/examples/MQ/8-multipart/runExample8Sink.cxx
+++ b/examples/MQ/8-multipart/runExample8Sink.cxx
@@ -12,27 +12,22 @@
  * @author D. Klein, A. Rybalchenko
  */
 
-#include <iostream>
-
 #include "FairMQLogger.h"
-#include "FairMQParser.h"
 #include "FairMQProgOptions.h"
 #include "FairMQExample8Sink.h"
 
 int main(int argc, char** argv)
 {
-    FairMQExample8Sink sink;
-    sink.CatchSignals();
-
-    FairMQProgOptions config;
-
     try
     {
+        FairMQProgOptions config;
         if (config.ParseAll(argc, argv))
         {
             return 0;
         }
 
+        FairMQExample8Sink sink;
+        sink.CatchSignals();
         sink.SetConfig(config);
 
         sink.ChangeState("INIT_DEVICE");
@@ -46,9 +41,8 @@ int main(int argc, char** argv)
     }
     catch (std::exception& e)
     {
-        LOG(ERROR) << e.what();
-        LOG(INFO) << "Command line options are the following: ";
-        config.PrintHelp();
+        LOG(ERROR) << "Unhandled Exception reached the top of main: "
+                   << e.what() << ", application will now exit";
         return 1;
     }
 

--- a/examples/MQ/9-PixelDetector/run/ddsEx9FileSink.cxx
+++ b/examples/MQ/9-PixelDetector/run/ddsEx9FileSink.cxx
@@ -39,11 +39,7 @@ int main(int argc, char** argv)
 	("class-name",  po::value<std::vector<std::string>>(&classname) , "class name")
 	("branch-name", po::value<std::vector<std::string>>(&branchname), "branch name");
       config.AddToCmdLineOptions(fileSink_options);
-      
-      if (config.ParseAll(argc, argv))
-        {
-	  return 1;
-        }
+      config.ParseAll(argc, argv);
 
       fileSink.SetProperty(FairMQEx9FileSink::OutputFileName,filename);
 

--- a/examples/MQ/9-PixelDetector/run/ddsEx9Sampler.cxx
+++ b/examples/MQ/9-PixelDetector/run/ddsEx9Sampler.cxx
@@ -40,11 +40,7 @@ int main(int argc, char** argv)
 	("sampler-type", po::value<std::string>             (&samplerType)->default_value("FairFileSource"), "FairSource type");
       
       config.AddToCmdLineOptions(sampler_options);
-      
-      if (config.ParseAll(argc, argv))           
-	{
-	  return 1;
-	}
+      config.ParseAll(argc, argv);
 
       for ( unsigned int ielem = 0 ; ielem < filename.size() ; ielem++ ) {
 	sampler.AddInputFileName(filename.at(ielem));	  

--- a/examples/MQ/9-PixelDetector/run/ddsEx9TaskProcessor.cxx
+++ b/examples/MQ/9-PixelDetector/run/ddsEx9TaskProcessor.cxx
@@ -43,11 +43,7 @@ int main(int argc, char** argv)
 	("keep-data",   po::value<std::string>(&keepdata)            ,  "Name of data to keep in stream");
       
       config.AddToCmdLineOptions(processor_options);
-      
-      if (config.ParseAll(argc, argv)) 
-	{
-	  return 1;
-	}
+      config.ParseAll(argc, argv);
       
       processor.SetDataToKeep(keepdata);
 

--- a/examples/MQ/9-PixelDetector/run/ddsParameterMQServer.cxx
+++ b/examples/MQ/9-PixelDetector/run/ddsParameterMQServer.cxx
@@ -47,10 +47,7 @@ int main(int argc, char** argv)
         config.AddToCmdLineOptions(serverOptions);
 	
 	
-	if (config.ParseAll(argc, argv))
-	  {
-	    return 1;
-	  }
+      config.ParseAll(argc, argv);
 
       server.SetConfig(config);
       

--- a/examples/MQ/9-PixelDetector/run/runEx9FileSink.cxx
+++ b/examples/MQ/9-PixelDetector/run/runEx9FileSink.cxx
@@ -33,8 +33,7 @@ int main(int argc, char** argv)
         FairMQProgOptions config;
         config.AddToCmdLineOptions(fileSink_options);
 
-        if (config.ParseAll(argc, argv))
-            return 1;
+        config.ParseAll(argc, argv);
 
         FairMQEx9FileSink fileSink;
         fileSink.SetProperty(FairMQEx9FileSink::OutputFileName,filename);

--- a/examples/MQ/9-PixelDetector/run/runEx9FileSinkBin.cxx
+++ b/examples/MQ/9-PixelDetector/run/runEx9FileSinkBin.cxx
@@ -31,8 +31,7 @@ int main(int argc, char** argv)
         FairMQProgOptions config;
         config.AddToCmdLineOptions(fileSink_options);
 
-        if (config.ParseAll(argc, argv))
-            return 1;
+        config.ParseAll(argc, argv);
 
         FairMQEx9FileSinkBin fileSink;
         fileSink.SetProperty(FairMQEx9FileSinkBin::OutputFileName,filename);

--- a/examples/MQ/9-PixelDetector/run/runEx9Merger.cxx
+++ b/examples/MQ/9-PixelDetector/run/runEx9Merger.cxx
@@ -31,8 +31,7 @@ int main(int argc, char** argv)
         FairMQProgOptions config;
         config.AddToCmdLineOptions(merger_options);
 
-        if (config.ParseAll(argc, argv))
-            return 1;
+        config.ParseAll(argc, argv);
 
         FairMQEx9Merger merger;
 	

--- a/examples/MQ/9-PixelDetector/run/runEx9Sampler.cxx
+++ b/examples/MQ/9-PixelDetector/run/runEx9Sampler.cxx
@@ -37,8 +37,7 @@ int main(int argc, char** argv)
 	FairMQProgOptions config;
 	config.AddToCmdLineOptions(sampler_options);
 	
-	if (config.ParseAll(argc, argv))           
-	  return 1;
+        config.ParseAll(argc, argv);
 	
 	LOG(INFO) << "Using source \"" << samplerType << "\"";
 

--- a/examples/MQ/9-PixelDetector/run/runEx9SamplerBin.cxx
+++ b/examples/MQ/9-PixelDetector/run/runEx9SamplerBin.cxx
@@ -31,8 +31,7 @@ int main(int argc, char** argv)
         FairMQProgOptions config;
         config.AddToCmdLineOptions(sampler_options);
 
-        if (config.ParseAll(argc, argv))
-            return 1;
+        config.ParseAll(argc, argv);
 
         FairMQEx9SamplerBin sampler;
 	

--- a/examples/MQ/9-PixelDetector/run/runEx9TaskProcessor.cxx
+++ b/examples/MQ/9-PixelDetector/run/runEx9TaskProcessor.cxx
@@ -37,8 +37,7 @@ int main(int argc, char** argv)
         FairMQProgOptions config;
         config.AddToCmdLineOptions(processor_options);
 	
-        if (config.ParseAll(argc, argv))
-	  return 1;
+        config.ParseAll(argc, argv);
 	
 	if      ( strcmp(taskname.c_str(),"PixelFindHits") == 0 ) {
 	  HitFinder processor;

--- a/examples/MQ/9-PixelDetector/run/runEx9TaskProcessorBin.cxx
+++ b/examples/MQ/9-PixelDetector/run/runEx9TaskProcessorBin.cxx
@@ -37,8 +37,7 @@ int main(int argc, char** argv)
         FairMQProgOptions config;
         config.AddToCmdLineOptions(processor_options);
 	
-        if (config.ParseAll(argc, argv))
-	  return 1;
+        config.ParseAll(argc, argv);
 	
 	if      ( strcmp(taskname.c_str(),"PixelFindHits") == 0 ) {
 	  HitFinder processor;

--- a/examples/MQ/9-PixelDetector/run/runFileSinkT9.cxx
+++ b/examples/MQ/9-PixelDetector/run/runFileSinkT9.cxx
@@ -39,10 +39,7 @@ int main(int argc, char** argv)
 
         config.AddToCmdLineOptions(sink_options);
 
-        if (config.ParseAll(argc, argv))
-        {
-            return 1;
-        }
+        config.ParseAll(argc, argv);
 
         TSinkRoot sink;
         // call function member from storage policy

--- a/examples/MQ/9-PixelDetector/run/runMergerT9.cxx
+++ b/examples/MQ/9-PixelDetector/run/runMergerT9.cxx
@@ -24,10 +24,7 @@ int main(int argc, char** argv)
     {
         FairMQMerger merger;
         FairMQProgOptions config;
-        if (config.ParseAll(argc, argv))
-        {
-            return 1;
-        }
+        config.ParseAll(argc, argv);
 
         runStateMachine(merger, config);
     }

--- a/examples/MQ/9-PixelDetector/run/runProcessorT9.cxx
+++ b/examples/MQ/9-PixelDetector/run/runProcessorT9.cxx
@@ -31,8 +31,7 @@ int main(int argc, char** argv)
         FairMQProgOptions config;
         config.AddToCmdLineOptions(processor_options);
 
-        if (config.ParseAll(argc, argv))
-            return 1;
+        config.ParseAll(argc, argv);
 
         FairMQEx9Processor processor;
         processor.SetProperty(FairMQEx9Processor::InputClassName,diginame);

--- a/examples/MQ/9-PixelDetector/run/runSamplerT9.cxx
+++ b/examples/MQ/9-PixelDetector/run/runSamplerT9.cxx
@@ -46,8 +46,7 @@ int main(int argc, char** argv)
         FairMQProgOptions config;
         config.AddToCmdLineOptions(sampler_options);
 
-        if (config.ParseAll(argc, argv))
-            return 1;
+        config.ParseAll(argc, argv);
 
         
         TSamplerTMessage sampler;

--- a/examples/MQ/9-PixelDetector/run/runSplitterT9.cxx
+++ b/examples/MQ/9-PixelDetector/run/runSplitterT9.cxx
@@ -15,10 +15,7 @@ int main(int argc, char** argv)
     {
         FairMQSplitter splitter;
         FairMQProgOptions config;
-        if (config.ParseAll(argc, argv))
-        {
-            return 1;
-        }
+        config.ParseAll(argc, argv);
 
         runStateMachine(splitter, config);
     }

--- a/examples/MQ/LmdSampler/run/runLmdSampler.cxx
+++ b/examples/MQ/LmdSampler/run/runLmdSampler.cxx
@@ -57,10 +57,7 @@ int main(int argc, char** argv)
         config.AddToCfgFileOptions(lmd_header_def);
 
         // parse command line and INI file arguments
-        if (config.ParseAll(argc, argv))
-        {
-            return 1;
-        }
+        config.ParseAll(argc, argv);
 
         FairMQLmdSampler sampler;
         sampler.AddFile(filename);

--- a/examples/MQ/LmdSampler/run/runTut8MQUnpacker.cxx
+++ b/examples/MQ/LmdSampler/run/runTut8MQUnpacker.cxx
@@ -52,11 +52,7 @@ int main(int argc, char** argv)
         ;
 
         config.AddToCfgFileOptions(lmd_header_def);
-
-        if (config.ParseAll(argc, argv, true))
-        {
-            return 1;
-        }
+        config.ParseAll(argc, argv, true);
 
         FairMQUnpacker<FairTut8Unpacker> unpacker;
         // combination of sub-event header value = one special channel

--- a/examples/MQ/LmdSampler/run/runTut8Sink.cxx
+++ b/examples/MQ/LmdSampler/run/runTut8Sink.cxx
@@ -40,11 +40,7 @@ int main(int argc, char** argv)
         ;
 
         config.AddToCmdLineOptions(sink_options);
-
-        if (config.ParseAll(argc, argv, true))
-        {
-            return 1;
-        }
+        config.ParseAll(argc, argv, true);
 
         TSink sink;
         // call function member from storage policy

--- a/examples/MQ/SharedMemory/runExampleShmSampler.cxx
+++ b/examples/MQ/SharedMemory/runExampleShmSampler.cxx
@@ -29,7 +29,6 @@ int main(int argc, char** argv)
 
         FairMQProgOptions config;
         config.AddToCmdLineOptions(samplerOptions);
-
         if (config.ParseAll(argc, argv))
         {
             return 0;

--- a/examples/MQ/SharedMemory/runExampleShmSampler.cxx
+++ b/examples/MQ/SharedMemory/runExampleShmSampler.cxx
@@ -29,10 +29,7 @@ int main(int argc, char** argv)
 
         FairMQProgOptions config;
         config.AddToCmdLineOptions(samplerOptions);
-        if (config.ParseAll(argc, argv))
-        {
-            return 0;
-        }
+        config.ParseAll(argc, argv);
 
         FairMQExampleShmSampler sampler;
         sampler.SetProperty(FairMQExampleShmSampler::MsgSize, msgSize);

--- a/examples/MQ/SharedMemory/runExampleShmSink.cxx
+++ b/examples/MQ/SharedMemory/runExampleShmSink.cxx
@@ -18,10 +18,7 @@ int main(int argc, char** argv)
     try
     {
         FairMQProgOptions config;
-        if (config.ParseAll(argc, argv))
-        {
-            return 0;
-        }
+        config.ParseAll(argc, argv);
 
         FairMQExampleShmSink sink;
 

--- a/examples/MQ/SharedMemory/runExampleShmSink.cxx
+++ b/examples/MQ/SharedMemory/runExampleShmSink.cxx
@@ -18,7 +18,6 @@ int main(int argc, char** argv)
     try
     {
         FairMQProgOptions config;
-
         if (config.ParseAll(argc, argv))
         {
             return 0;

--- a/examples/MQ/serialization/data_generator/RooDataGenerator.h
+++ b/examples/MQ/serialization/data_generator/RooDataGenerator.h
@@ -35,12 +35,12 @@ class Tuto7DataGeneratorProgOptions : public FairProgOptions
         AddToCmdLineOptions(fGenericDesc);
     }
     virtual ~Tuto7DataGeneratorProgOptions(){}
-    virtual int ParseAll(const int argc, char** argv, bool allowUnregistered = false)
+    virtual void ParseAll(const int argc, char** argv, bool allowUnregistered = false)
     {
         // parse command line options
         if (ParseCmdLine(argc, argv, fCmdLineOptions, fVarMap, allowUnregistered))
         {
-            return 1;
+            exit(EXIT_FAILURE);
         }
 
         // if txt/INI configuration file enabled then parse it as well
@@ -51,13 +51,13 @@ class Tuto7DataGeneratorProgOptions : public FairProgOptions
             {
                 if (ParseCfgFile(fConfigFile.string(), fConfigFileOptions, fVarMap, allowUnregistered))
                 {
-                    return 1;
+                    exit(EXIT_FAILURE);
                 }
             }
             else
             {
                 LOG(ERROR) << "config file '" << fConfigFile << "' not found";
-                return 1;
+                exit(EXIT_FAILURE);
             }
         }
 
@@ -80,7 +80,6 @@ class Tuto7DataGeneratorProgOptions : public FairProgOptions
         }
 
         PrintOptions();
-        return 0;
     }
 };
 

--- a/examples/MQ/serialization/data_generator/runGenerateData.cxx
+++ b/examples/MQ/serialization/data_generator/runGenerateData.cxx
@@ -97,37 +97,29 @@ int main(int argc, char** argv)
             ("Nsigma",          po::value<double>(&Nsigma)->default_value(25.98),               "<unsigned int> : std deviation of the number of generated data / bunch")
             ;
 
-
         config.AddToCmdLineOptions(desc);
-
-        
-        if (config.ParseAll(argc, argv, true))
-        {
-            return 1;
-        }
-
+        config.ParseAll(argc, argv, true);
 
         //----------------------------------------------
         // Init output file manager 
         RootFileManager* rootman = new RootFileManager();
         rootman->SetFileProperties(filename, treename, branchname, classname,fileoption,useTCA);
         rootman->InitOutputFile();
-        
+
         //----------------------------------------------
         // Init density function for the number of digi/ bunch
         RdmVarParameters Nval(Nmean,Nsigma);
         RooRealVar N("N","N",Nval.min,Nval.max);
         RooGaussian Gauss_N("Gauss_N", "gaussian PDF", N, RooConst(Nval.mean), RooConst(Nval.sigma));// mean/sigma same as tutorial 3
-        
+
         // Init density function for the (x,y,z,t,terr) random variables
         PDFConfig pdfconfig;// default setting (i.e. default range, mean, standard deviation)
         MultiVariatePDF* Model = new MultiVariatePDF(pdfconfig);
-        
+
         //----------------------------------------------
         // loop over t (= bunch index), generate data from pdf, fill digi and save to file
         for(unsigned int t(0); t<tmax;t++)
         {
-            
             unsigned int NDigi=static_cast<unsigned int>(Gauss_N.generate(N,1)->get(0)->getRealValue("N"));
             LOG(INFO)  <<"Bunch number "<<t+1<<"/"<<tmax 
                        <<" ("<< 100.*static_cast<double>(t+1)/static_cast<double>(tmax)<<" %). Number of generated digi : "
@@ -155,7 +147,7 @@ int main(int argc, char** argv)
             TH1D* histot = new TH1D("ftimestamp","digi.ftimestamp",10*tmax, 0., static_cast<double>(tmax+1));
             TH1D* histoterr = new TH1D("ftimestampErr","digi.ftimestampErr",100,pdfconfig.tErr.min,pdfconfig.tErr.max);
             TH1D* histoN = new TH1D("f_N","Number of digi distribution",100,Nval.min,Nval.max);
-        
+
             for(auto& p : data)
             {
                 histoN->Fill(static_cast<double>(p.size()));
@@ -169,36 +161,35 @@ int main(int argc, char** argv)
                     histoterr->Fill(q.GetTimeStampError());
                 }
             }
-            
+
             TApplication app("App", &argc, argv);
-            
+
             TCanvas *T7Canvas = new  TCanvas("Tutorial7","Tutorial7",1000,800);
             T7Canvas->Divide(4,2);
-            
+
             T7Canvas->cd(1);
             histox->Draw();
-            
+
             T7Canvas->cd(2);
             histoy->Draw();
-            
+
             T7Canvas->cd(3);
             histoxy->Draw("zcol");
-            
+
             T7Canvas->cd(4);
             histoz->Draw();
-            
+
             T7Canvas->cd(5);
             histot->Draw();
-            
+
             T7Canvas->cd(6);
             histoterr->Draw();
-            
+
             T7Canvas->cd(7);
             histoN->Draw();
-            
+
             app.Run();
-            
-            
+
             delete histox;
             delete histoy;
             delete histoz;
@@ -214,9 +205,8 @@ int main(int argc, char** argv)
         LOG(ERROR) << e.what();
         return 1;
     }
-    
+
     return 0;
-   
 }
 
 

--- a/examples/MQ/serialization/src/1-simple/run/runProcessorGenEx1.cxx
+++ b/examples/MQ/serialization/src/1-simple/run/runProcessorGenEx1.cxx
@@ -21,10 +21,7 @@ int main(int argc, char** argv)
     {
         FairMQProgOptions config;
         // parse command line
-        if (config.ParseAll(argc, argv))
-        {
-            return 1;
-        }
+        config.ParseAll(argc, argv);
 
         GenExPart1Processor processor;
         runStateMachine(processor, config);

--- a/examples/MQ/serialization/src/1-simple/run/runSamplerGenEx1.cxx
+++ b/examples/MQ/serialization/src/1-simple/run/runSamplerGenEx1.cxx
@@ -42,14 +42,11 @@ int main(int argc, char** argv)
         config.AddToCmdLineOptions(sampler_options);
 
         // parse command lines
-        if (config.ParseAll(argc, argv))
-        {
-            return 1;
-        }
+        config.ParseAll(argc, argv);
 
         //get parsed input-file option
         std::string filename = config.GetValue<std::string>("input-file");
-        
+
         // create sampler 
         GenExPart1Sampler sampler;
         sampler.SetFileName(filename);

--- a/examples/MQ/serialization/src/1-simple/run/runSinkGenEx1.cxx
+++ b/examples/MQ/serialization/src/1-simple/run/runSinkGenEx1.cxx
@@ -23,9 +23,7 @@ int main(int argc, char** argv)
             ("output-file", po::value<std::string>(), "Path to the input file");
 
         config.AddToCmdLineOptions(sink_options);
-
-        if (config.ParseAll(argc, argv))
-            return 1;
+        config.ParseAll(argc, argv);
 
         std::string filename = config.GetValue<std::string>("output-file");
 

--- a/examples/MQ/serialization/src/2-multi-part/run/runProcessorEx2.cxx
+++ b/examples/MQ/serialization/src/2-multi-part/run/runProcessorEx2.cxx
@@ -20,10 +20,7 @@ int main(int argc, char** argv)
     {
         FairMQProgOptions config;
         // parse command line
-        if (config.ParseAll(argc, argv))
-        {
-            return 1;
-        }
+        config.ParseAll(argc, argv);
 
         Ex2Processor processor;
         runStateMachine(processor, config);

--- a/examples/MQ/serialization/src/2-multi-part/run/runSamplerEx2.cxx
+++ b/examples/MQ/serialization/src/2-multi-part/run/runSamplerEx2.cxx
@@ -42,10 +42,7 @@ int main(int argc, char** argv)
         config.AddToCmdLineOptions(sampler_options);
 
         // parse command lines
-        if (config.ParseAll(argc, argv))
-        {
-            return 1;
-        }
+        config.ParseAll(argc, argv);
 
         //get parsed input-file option
         std::string filename = config.GetValue<std::string>("input-file");

--- a/examples/MQ/serialization/src/2-multi-part/run/runSinkEx2.cxx
+++ b/examples/MQ/serialization/src/2-multi-part/run/runSinkEx2.cxx
@@ -23,9 +23,7 @@ int main(int argc, char** argv)
             ("output-file", po::value<std::string>(), "Path to the input file");
 
         config.AddToCmdLineOptions(sink_options);
-
-        if (config.ParseAll(argc, argv))
-            return 1;
+        config.ParseAll(argc, argv);
 
         std::string filename = config.GetValue<std::string>("output-file");
 

--- a/examples/MQ/serialization/src/part2/run/runMergerT7.cxx
+++ b/examples/MQ/serialization/src/part2/run/runMergerT7.cxx
@@ -25,10 +25,7 @@ int main(int argc, char** argv)
         FairMQMerger merger;
         FairMQProgOptions config;
         config.UseConfigFile();
-        if (config.ParseAll(argc, argv, true))
-        {
-            return 1;
-        }
+        config.ParseAll(argc, argv, true);
 
         runStateMachine(merger, config);
     }

--- a/examples/MQ/serialization/src/part2/run/runSplitterT7.cxx
+++ b/examples/MQ/serialization/src/part2/run/runSplitterT7.cxx
@@ -16,10 +16,7 @@ int main(int argc, char** argv)
         FairMQSplitter splitter;
         FairMQProgOptions config;
         config.UseConfigFile();
-        if (config.ParseAll(argc, argv, true))
-        {
-            return 1;
-        }
+        config.ParseAll(argc, argv, true);
 
         runStateMachine(splitter, config);
     }

--- a/examples/advanced/Tutorial3/MQ/run/runTestDetectorFileSink.cxx
+++ b/examples/advanced/Tutorial3/MQ/run/runTestDetectorFileSink.cxx
@@ -26,16 +26,16 @@
 using namespace std;
 using namespace boost::program_options;
 
-using TSinkBin                    = FairTestDetectorFileSink<FairTestDetectorHit, TestDetectorPayload::Hit>;
-using TSinkBoostBin               = FairTestDetectorFileSink<FairTestDetectorHit, boost::archive::binary_iarchive>;
-using TSinkBoostText              = FairTestDetectorFileSink<FairTestDetectorHit, boost::archive::text_iarchive>;
-using TSinkProtobuf               = FairTestDetectorFileSink<FairTestDetectorHit, TestDetectorProto::HitPayload>;
-using TSinkTMessage               = FairTestDetectorFileSink<FairTestDetectorHit, TMessage>;
+using TSinkBin         = FairTestDetectorFileSink<FairTestDetectorHit, TestDetectorPayload::Hit>;
+using TSinkBoostBin    = FairTestDetectorFileSink<FairTestDetectorHit, boost::archive::binary_iarchive>;
+using TSinkBoostText   = FairTestDetectorFileSink<FairTestDetectorHit, boost::archive::text_iarchive>;
+using TSinkProtobuf    = FairTestDetectorFileSink<FairTestDetectorHit, TestDetectorProto::HitPayload>;
+using TSinkTMessage    = FairTestDetectorFileSink<FairTestDetectorHit, TMessage>;
 #ifdef FLATBUFFERS
-using TSinkFlatBuffers            = FairTestDetectorFileSink<FairTestDetectorHit, TestDetectorFlat::HitPayload>;
+using TSinkFlatBuffers = FairTestDetectorFileSink<FairTestDetectorHit, TestDetectorFlat::HitPayload>;
 #endif
 #ifdef MSGPACK
-using TSinkMsgPack                = FairTestDetectorFileSink<FairTestDetectorHit, MsgPack>;
+using TSinkMsgPack     = FairTestDetectorFileSink<FairTestDetectorHit, MsgPack>;
 #endif
 
 template<typename T>
@@ -60,8 +60,6 @@ void runFileSink(FairMQProgOptions& config)
 
 int main(int argc, char** argv)
 {
-    FairMQProgOptions config;
-
     try
     {
         string dataFormat;
@@ -70,12 +68,9 @@ int main(int argc, char** argv)
         sinkOptions.add_options()
             ("data-format", value<string>(&dataFormat)->default_value("binary"), "Data format (binary|boost|boost-text|flatbuffers|msgpack|protobuf|tmessage)");
 
+        FairMQProgOptions config;
         config.AddToCmdLineOptions(sinkOptions);
-
-        if (config.ParseAll(argc, argv))
-        {
-            return 0;
-        }
+        config.ParseAll(argc, argv);
 
         if (dataFormat == "binary") { runFileSink<TSinkBin>(config); }
         else if (dataFormat == "boost") { runFileSink<TSinkBoostBin>(config); }
@@ -96,9 +91,8 @@ int main(int argc, char** argv)
     }
     catch (exception& e)
     {
-        LOG(ERROR) << e.what();
-        LOG(INFO) << "Command line options are the following: ";
-        config.PrintHelp();
+        LOG(ERROR) << "Unhandled Exception reached the top of main: "
+                   << e.what() << ", application will now exit";
         return 1;
     }
 

--- a/examples/advanced/Tutorial3/MQ/run/runTestDetectorProcessor.cxx
+++ b/examples/advanced/Tutorial3/MQ/run/runTestDetectorProcessor.cxx
@@ -26,16 +26,16 @@
 using namespace std;
 using namespace boost::program_options;
 
-using TProcessorTaskBin           = FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TestDetectorPayload::Digi,       TestDetectorPayload::Hit>;
-using TProcessorTaskBoostBin      = FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, boost::archive::binary_iarchive, boost::archive::binary_oarchive>;
-using TProcessorTaskBoostText     = FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, boost::archive::text_iarchive,   boost::archive::text_oarchive>;
-using TProcessorTaskProtobuf      = FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TestDetectorProto::DigiPayload,  TestDetectorProto::HitPayload>;
-using TProcessorTaskTMessage      = FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TMessage,                        TMessage>;
+using TProcessorTaskBin         = FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TestDetectorPayload::Digi,       TestDetectorPayload::Hit>;
+using TProcessorTaskBoostBin    = FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, boost::archive::binary_iarchive, boost::archive::binary_oarchive>;
+using TProcessorTaskBoostText   = FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, boost::archive::text_iarchive,   boost::archive::text_oarchive>;
+using TProcessorTaskProtobuf    = FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TestDetectorProto::DigiPayload,  TestDetectorProto::HitPayload>;
+using TProcessorTaskTMessage    = FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TMessage,                        TMessage>;
 #ifdef FLATBUFFERS
-using TProcessorTaskFlatBuffers   = FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TestDetectorFlat::DigiPayload,   TestDetectorFlat::HitPayload>;
+using TProcessorTaskFlatBuffers = FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TestDetectorFlat::DigiPayload,   TestDetectorFlat::HitPayload>;
 #endif
 #ifdef MSGPACK
-using TProcessorTaskMsgPack       = FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, MsgPack,                         MsgPack>;
+using TProcessorTaskMsgPack     = FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, MsgPack,                         MsgPack>;
 #endif
 
 template<typename T>
@@ -69,8 +69,6 @@ void runProcessor(FairMQProgOptions& config)
 
 int main(int argc, char** argv)
 {
-    FairMQProgOptions config;
-
     try
     {
         string dataFormat;
@@ -81,12 +79,9 @@ int main(int argc, char** argv)
             ("data-format", value<string>(&dataFormat)->default_value("binary"), "Data format (binary|boost|boost-text|flatbuffers|msgpack|protobuf|tmessage)")
             ("processor-task", value<string>(&processorTask)->default_value("FairTestDetectorMQRecoTask"), "Name of the Processor Task");
 
+        FairMQProgOptions config;
         config.AddToCmdLineOptions(processorOptions);
-
-        if (config.ParseAll(argc, argv))
-        {
-            return 0;
-        }
+        config.ParseAll(argc, argv);
 
         if (dataFormat == "binary") { runProcessor<TProcessorTaskBin>(config); }
         else if (dataFormat == "boost") { runProcessor<TProcessorTaskBoostBin>(config); }
@@ -107,9 +102,8 @@ int main(int argc, char** argv)
     }
     catch (exception& e)
     {
-        LOG(ERROR) << e.what();
-        LOG(INFO) << "Command line options are the following: ";
-        config.PrintHelp();
+        LOG(ERROR) << "Unhandled Exception reached the top of main: "
+                   << e.what() << ", application will now exit";
         return 1;
     }
 

--- a/examples/advanced/Tutorial3/MQ/run/runTestDetectorSampler.cxx
+++ b/examples/advanced/Tutorial3/MQ/run/runTestDetectorSampler.cxx
@@ -26,16 +26,16 @@
 using namespace std;
 using namespace boost::program_options;
 
-using TSamplerBin                 = FairMQSampler<FairTestDetectorDigiLoader<FairTestDetectorDigi, TestDetectorPayload::Digi>>;
-using TSamplerBoostBin            = FairMQSampler<FairTestDetectorDigiLoader<FairTestDetectorDigi, boost::archive::binary_oarchive>>;
-using TSamplerBoostText           = FairMQSampler<FairTestDetectorDigiLoader<FairTestDetectorDigi, boost::archive::text_oarchive>>;
-using TSamplerProtobuf            = FairMQSampler<FairTestDetectorDigiLoader<FairTestDetectorDigi, TestDetectorProto::DigiPayload>>;
-using TSamplerTMessage            = FairMQSampler<FairTestDetectorDigiLoader<FairTestDetectorDigi, TMessage>>;
+using TSamplerBin         = FairMQSampler<FairTestDetectorDigiLoader<FairTestDetectorDigi, TestDetectorPayload::Digi>>;
+using TSamplerBoostBin    = FairMQSampler<FairTestDetectorDigiLoader<FairTestDetectorDigi, boost::archive::binary_oarchive>>;
+using TSamplerBoostText   = FairMQSampler<FairTestDetectorDigiLoader<FairTestDetectorDigi, boost::archive::text_oarchive>>;
+using TSamplerProtobuf    = FairMQSampler<FairTestDetectorDigiLoader<FairTestDetectorDigi, TestDetectorProto::DigiPayload>>;
+using TSamplerTMessage    = FairMQSampler<FairTestDetectorDigiLoader<FairTestDetectorDigi, TMessage>>;
 #ifdef FLATBUFFERS
-using TSamplerFlatBuffers         = FairMQSampler<FairTestDetectorDigiLoader<FairTestDetectorDigi, TestDetectorFlat::DigiPayload>>;
+using TSamplerFlatBuffers = FairMQSampler<FairTestDetectorDigiLoader<FairTestDetectorDigi, TestDetectorFlat::DigiPayload>>;
 #endif
 #ifdef MSGPACK
-using TSamplerMsgPack             = FairMQSampler<FairTestDetectorDigiLoader<FairTestDetectorDigi, MsgPack>>;
+using TSamplerMsgPack     = FairMQSampler<FairTestDetectorDigiLoader<FairTestDetectorDigi, MsgPack>>;
 #endif
 
 template<typename T>
@@ -64,8 +64,6 @@ void runSampler(FairMQProgOptions& config)
 
 int main(int argc, char** argv)
 {
-    FairMQProgOptions config;
-
     try
     {
         string dataFormat;
@@ -84,12 +82,9 @@ int main(int argc, char** argv)
             ("event-rate", value<int>(&eventRate)->default_value(0), "Event rate limit in maximum number of events per second")
             ("chain-input", value<int>(&chainInput)->default_value(0), "Chain input file more than once (default)");
 
+        FairMQProgOptions config;
         config.AddToCmdLineOptions(samplerOptions);
-
-        if (config.ParseAll(argc, argv))
-        {
-            return 0;
-        }
+        config.ParseAll(argc, argv);
 
         if (dataFormat == "binary") { runSampler<TSamplerBin>(config); }
         else if (dataFormat == "boost") { runSampler<TSamplerBoostBin>(config); }
@@ -110,9 +105,8 @@ int main(int argc, char** argv)
     }
     catch (exception& e)
     {
-        LOG(ERROR) << e.what();
-        LOG(INFO) << "Command line options are the following: ";
-        config.PrintHelp();
+        LOG(ERROR) << "Unhandled Exception reached the top of main: "
+                   << e.what() << ", application will now exit";
         return 1;
     }
 

--- a/fairmq/FairMQDevice.cxx
+++ b/fairmq/FairMQDevice.cxx
@@ -90,18 +90,19 @@ void FairMQDevice::SignalHandler(int signal)
     fTerminateStateThread.join();
 
     stop();
-    fRunning = false;
-    if (!fTerminated)
-    {
-        fTerminated = true;
-        LOG(INFO) << "Exiting.";
-    }
-    else
-    {
-        LOG(WARN) << "Repeated termination or bad initialization? Aborting.";
-        // std::abort();
-        exit(EXIT_FAILURE);
-    }
+    exit(EXIT_FAILURE);
+    // fRunning = false;
+    // if (!fTerminated)
+    // {
+    //     fTerminated = true;
+    //     LOG(INFO) << "Exiting.";
+    // }
+    // else
+    // {
+    //     LOG(WARN) << "Repeated termination or bad initialization? Aborting.";
+    //     // std::abort();
+    //     exit(EXIT_FAILURE);
+    // }
 }
 
 void FairMQDevice::ConnectChannels(list<FairMQChannel*>& chans)

--- a/fairmq/nanomsg/FairMQSocketNN.h
+++ b/fairmq/nanomsg/FairMQSocketNN.h
@@ -16,6 +16,7 @@
 #define FAIRMQSOCKETNN_H_
 
 #include <vector>
+#include <atomic>
 
 #include "FairMQSocket.h"
 
@@ -64,10 +65,10 @@ class FairMQSocketNN : public FairMQSocket
   private:
     int fSocket;
     std::string fId;
-    unsigned long fBytesTx;
-    unsigned long fBytesRx;
-    unsigned long fMessagesTx;
-    unsigned long fMessagesRx;
+    std::atomic<unsigned long> fBytesTx;
+    std::atomic<unsigned long> fBytesRx;
+    std::atomic<unsigned long> fMessagesTx;
+    std::atomic<unsigned long> fMessagesRx;
 };
 
 #endif /* FAIRMQSOCKETNN_H_ */

--- a/fairmq/options/FairMQProgOptions.cxx
+++ b/fairmq/options/FairMQProgOptions.cxx
@@ -33,7 +33,7 @@ FairMQProgOptions::~FairMQProgOptions()
 {
 }
 
-int FairMQProgOptions::ParseAll(const int argc, char** argv, bool allowUnregistered)
+void FairMQProgOptions::ParseAll(const int argc, char** argv, bool allowUnregistered)
 {
     LOG(NOLOG) << "";
     // init description
@@ -41,7 +41,8 @@ int FairMQProgOptions::ParseAll(const int argc, char** argv, bool allowUnregiste
     // parse command line options
     if (ParseCmdLine(argc, argv, fCmdLineOptions, fVarMap, allowUnregistered))
     {
-        return 1;
+        LOG(ERROR) << "Could not parse cmd options";
+        exit(EXIT_FAILURE);
     }
 
     // if txt/INI configuration file enabled then parse it as well
@@ -52,13 +53,14 @@ int FairMQProgOptions::ParseAll(const int argc, char** argv, bool allowUnregiste
         {
             if (ParseCfgFile(fConfigFile.string(), fConfigFileOptions, fVarMap, allowUnregistered))
             {
-                return 1;
+                LOG(ERROR) << "Could not parse config";
+                exit(EXIT_FAILURE);
             }
         }
         else
         {
             LOG(ERROR) << "config file '" << fConfigFile << "' not found";
-            return 1;
+            exit(EXIT_FAILURE);
         }
     }
 
@@ -123,32 +125,30 @@ int FairMQProgOptions::ParseAll(const int argc, char** argv, bool allowUnregiste
                 id = fVarMap["id"].as<std::string>();
             }
 
-            std::string file_extension = boost::filesystem::extension(file);
+            std::string fileExtension = boost::filesystem::extension(file);
 
-            std::transform(file_extension.begin(), file_extension.end(), file_extension.begin(), ::tolower);
+            std::transform(fileExtension.begin(), fileExtension.end(), fileExtension.begin(), ::tolower);
 
-            if (file_extension == ".json")
+            if (fileExtension == ".json")
             {
                 UserParser<FairMQParser::JSON>(file, id);
             }
             else
             {
-                if (file_extension == ".xml")
+                if (fileExtension == ".xml")
                 {
                     UserParser<FairMQParser::XML>(file, id);
                 }
                 else
                 {
                     LOG(ERROR)  << "mq-config command line called but file extension '"
-                                << file_extension
+                                << fileExtension
                                 << "' not recognized. Program will now exit";
-                    return 1;
+                    exit(EXIT_FAILURE);
                 }
             }
         }
     }
-
-    return 0;
 }
 
 int FairMQProgOptions::NotifySwitchOption()

--- a/fairmq/options/FairMQProgOptions.h
+++ b/fairmq/options/FairMQProgOptions.h
@@ -36,7 +36,7 @@ class FairMQProgOptions : public FairProgOptions
 
     // parse command line and txt/INI configuration file. 
     // default parser for the mq-configuration file (JSON/XML) is called if command line key mq-config is called
-    virtual int ParseAll(const int argc, char** argv, bool allowUnregistered = false);
+    virtual void ParseAll(const int argc, char** argv, bool allowUnregistered = false);
 
     // external parser, store function 
     template <typename T, typename ...Args>

--- a/fairmq/options/FairProgOptions.h
+++ b/fairmq/options/FairProgOptions.h
@@ -27,7 +27,7 @@
 #include <tuple>
 
 /*
- * FairProgOptions abstract base class 
+ * FairProgOptions abstract base class
  * parse command line, configuration file options as well as environment variables.
  * 
  * The user defines in the derived class the option descriptions and
@@ -42,15 +42,14 @@
  *          fVisibleOptions.add(fCmdlineOptions);
  *      }
  *      virtual ~MyOptions() {}
- *      virtual int ParseAll(const int argc, char** argv, bool allowUnregistered = false)
+ *      virtual void ParseAll(const int argc, char** argv, bool allowUnregistered = false)
  *      {
- *          if(ParseCmdLine(argc, argv, fCmdlineOptions, fVarMap, allowUnregistered))
+ *          if (ParseCmdLine(argc, argv, fCmdlineOptions, fVarMap, allowUnregistered))
  *          {
- *              return 1;
+ *              exit(EXIT_FAILURE);
  *          }
  *
  *          PrintOptions();
- *          return 0;
  *      }
  * }
  */
@@ -110,7 +109,7 @@ class FairProgOptions
 
     int ParseEnvironment(const std::function<std::string(std::string)>&);
 
-    virtual int ParseAll(const int argc, char** argv, bool allowUnregistered = false) = 0;// TODO change return type to bool and propagate to executable
+    virtual void ParseAll(const int argc, char** argv, bool allowUnregistered = false) = 0;// TODO change return type to bool and propagate to executable
 
     virtual int PrintOptions();
     int PrintHelp() const;

--- a/fairmq/run/runBenchmarkSampler.cxx
+++ b/fairmq/run/runBenchmarkSampler.cxx
@@ -37,11 +37,7 @@ int main(int argc, char** argv)
 
         FairMQProgOptions config;
         config.AddToCmdLineOptions(samplerOptions);
-
-        if (config.ParseAll(argc, argv))
-        {
-            return 0;
-        }
+        config.ParseAll(argc, argv);
 
         FairMQBenchmarkSampler sampler;
         sampler.SetProperty(FairMQBenchmarkSampler::MsgSize, msgSize);

--- a/fairmq/run/runMerger.cxx
+++ b/fairmq/run/runMerger.cxx
@@ -24,11 +24,7 @@ int main(int argc, char** argv)
     try
     {
         FairMQProgOptions config;
-
-        if (config.ParseAll(argc, argv))
-        {
-            return 0;
-        }
+        config.ParseAll(argc, argv);
 
         FairMQMerger merger;
         runStateMachine(merger, config);

--- a/fairmq/run/runProxy.cxx
+++ b/fairmq/run/runProxy.cxx
@@ -24,11 +24,7 @@ int main(int argc, char** argv)
     try
     {
         FairMQProgOptions config;
-
-        if (config.ParseAll(argc, argv))
-        {
-            return 0;
-        }
+        config.ParseAll(argc, argv);
 
         FairMQProxy proxy;
         runStateMachine(proxy, config);

--- a/fairmq/run/runSink.cxx
+++ b/fairmq/run/runSink.cxx
@@ -35,11 +35,7 @@ int main(int argc, char** argv)
 
         FairMQProgOptions config;
         config.AddToCmdLineOptions(sinkOptions);
-
-        if (config.ParseAll(argc, argv))
-        {
-            return 0;
-        }
+        config.ParseAll(argc, argv);
 
         FairMQSink sink;
         sink.SetProperty(FairMQSink::NumMsgs, numMsgs);

--- a/fairmq/run/runSplitter.cxx
+++ b/fairmq/run/runSplitter.cxx
@@ -24,11 +24,7 @@ int main(int argc, char** argv)
     try
     {
         FairMQProgOptions config;
-
-        if (config.ParseAll(argc, argv))
-        {
-            return 0;
-        }
+        config.ParseAll(argc, argv);
 
         FairMQSplitter splitter;
         runStateMachine(splitter, config);

--- a/fairmq/tools/runSimpleMQStateMachine.h
+++ b/fairmq/tools/runSimpleMQStateMachine.h
@@ -46,7 +46,6 @@ inline int runStateMachine(TMQDevice& device, FairMQProgOptions& config)
     }
     else if (control == "static")
     {
-        device.ChangeState(TMQDevice::RUN);
         device.WaitForEndOfState(TMQDevice::RUN);
 
         device.ChangeState(TMQDevice::RESET_TASK);

--- a/fairmq/zeromq/FairMQSocketZMQ.h
+++ b/fairmq/zeromq/FairMQSocketZMQ.h
@@ -15,6 +15,8 @@
 #ifndef FAIRMQSOCKETZMQ_H_
 #define FAIRMQSOCKETZMQ_H_
 
+#include <atomic>
+
 #include <boost/shared_ptr.hpp>
 
 #include "FairMQSocket.h"
@@ -65,10 +67,10 @@ class FairMQSocketZMQ : public FairMQSocket
   private:
     void* fSocket;
     std::string fId;
-    unsigned long fBytesTx;
-    unsigned long fBytesRx;
-    unsigned long fMessagesTx;
-    unsigned long fMessagesRx;
+    std::atomic<unsigned long> fBytesTx;
+    std::atomic<unsigned long> fBytesRx;
+    std::atomic<unsigned long> fMessagesTx;
+    std::atomic<unsigned long> fMessagesRx;
 
     static boost::shared_ptr<FairMQContextZMQ> fContext;
 };

--- a/parmq/runParameterMQServer.cxx
+++ b/parmq/runParameterMQServer.cxx
@@ -42,10 +42,7 @@ int main(int argc, char** argv)
 
         FairMQProgOptions config;
         config.AddToCmdLineOptions(serverOptions);
-        if (config.ParseAll(argc, argv))
-        {
-            return 0;
-        }
+        config.ParseAll(argc, argv);
 
         TApplication app("ParameterMQServer", 0, 0);
 

--- a/parmq/runParameterMQServer.cxx
+++ b/parmq/runParameterMQServer.cxx
@@ -12,44 +12,36 @@
  * @author D. Klein, A. Rybalchenko
  */
 
-#include <iostream>
-
 #include "FairMQLogger.h"
-#include "FairMQParser.h"
 #include "FairMQProgOptions.h"
 #include "ParameterMQServer.h"
 #include "TApplication.h"
 #include "runSimpleMQStateMachine.h"
 
-using namespace std;
 using namespace boost::program_options;
 
 int main(int argc, char** argv)
 {
-    ParameterMQServer server;
-
-    FairMQProgOptions config;
-
     try
     {
-        string firstInputName;
-        string firstInputType;
-        string secondInputName;
-        string secondInputType;
-        string outputName;
-        string outputType;
+        std::string firstInputName;
+        std::string firstInputType;
+        std::string secondInputName;
+        std::string secondInputType;
+        std::string outputName;
+        std::string outputType;
 
         options_description serverOptions("Parameter MQ Server options");
         serverOptions.add_options()
-            ("first-input-name", value<string>(&firstInputName)->default_value("first_input.root"), "First input file name")
-            ("first-input-type", value<string>(&firstInputType)->default_value("ROOT"), "First input file type (ROOT/ASCII)")
-            ("second-input-name", value<string>(&secondInputName)->default_value(""), "Second input file name")
-            ("second-input-type", value<string>(&secondInputType)->default_value("ROOT"), "Second input file type (ROOT/ASCII)")
-            ("output-name", value<string>(&outputName)->default_value(""), "Output file name")
-            ("output-type", value<string>(&outputType)->default_value("ROOT"), "Output file type");
+            ("first-input-name", value<std::string>(&firstInputName)->default_value("first_input.root"), "First input file name")
+            ("first-input-type", value<std::string>(&firstInputType)->default_value("ROOT"), "First input file type (ROOT/ASCII)")
+            ("second-input-name", value<std::string>(&secondInputName)->default_value(""), "Second input file name")
+            ("second-input-type", value<std::string>(&secondInputType)->default_value("ROOT"), "Second input file type (ROOT/ASCII)")
+            ("output-name", value<std::string>(&outputName)->default_value(""), "Output file name")
+            ("output-type", value<std::string>(&outputType)->default_value("ROOT"), "Output file type");
 
+        FairMQProgOptions config;
         config.AddToCmdLineOptions(serverOptions);
-
         if (config.ParseAll(argc, argv))
         {
             return 0;
@@ -57,6 +49,7 @@ int main(int argc, char** argv)
 
         TApplication app("ParameterMQServer", 0, 0);
 
+        ParameterMQServer server;
         server.SetProperty(ParameterMQServer::FirstInputName, firstInputName);
         server.SetProperty(ParameterMQServer::FirstInputType, firstInputType);
         server.SetProperty(ParameterMQServer::SecondInputName, secondInputName);
@@ -64,15 +57,14 @@ int main(int argc, char** argv)
         server.SetProperty(ParameterMQServer::OutputName, outputName);
         server.SetProperty(ParameterMQServer::OutputType, outputType);
 
-        runStateMachine(server,config);
+        runStateMachine(server, config);
 
         gApplication->Terminate();
     }
-    catch (exception& e)
+    catch (std::exception& e)
     {
-        LOG(ERROR) << e.what();
-        LOG(INFO) << "Command line options are the following: ";
-        config.PrintHelp();
+        LOG(ERROR) << "Unhandled Exception reached the top of main: "
+                   << e.what() << ", application will now exit";
         return 1;
     }
 


### PR DESCRIPTION
- runStateMachine: Remove redundant state change call
- FairMQDevice: revert the termination handler (needs to be done differently).
- FairMQSocket: Thread safe socket rate stats (to avoid very rare incorrect rate logging information).
- Cleanup examples (remove unused includes and unify code approach).
- MQ Parameter client example: cast returned parameter type to the expected type.
- Let config.ParseAll exit if unsuccessful:
```C++
// OLD:
if (config.ParseAll(argc, argv))
{
    return 0;
}
// NEW:
config.ParseAll(argc, argv);
``` 
