### PR TITLE
Proper cleanup on termination and let splitter/merger/proxy handle both single and multipart payloads.

### DIFF
--- a/examples/MQ/9-PixelDetector/src/devices/FairMQEx9FileSink.cxx
+++ b/examples/MQ/9-PixelDetector/src/devices/FairMQEx9FileSink.cxx
@@ -133,22 +133,6 @@ void FairMQEx9FileSink::Run()
 	    Send(msg, fAckChannelName);
 	  }
 	}
-      else 
-	{
-	  // temporary solution to close the file, when quitting.
-	  LOG(INFO) << "Saving tree, and closing file!";
-	  if (fTree)
-	    {
-	      fTree->Write();
-	      delete fTree;
-	    }
-	  if (fOutFile)
-	    {
-	      if (fOutFile->IsOpen())
-		fOutFile->Close();
-	      delete fOutFile;
-	    }
-	}
     }
 }
 

--- a/fairmq/FairMQStateMachine.h
+++ b/fairmq/FairMQStateMachine.h
@@ -343,7 +343,7 @@ struct FairMQFSM_ : public msm::front::state_machine_def<FairMQFSM_>
     virtual void Terminate() {} // Termination method called during StopFct action.
     virtual void Unblock() {} // Method to send commands.
 
-    // Transition table for FairMQFMS
+    // Transition table for FairMQFSM
     struct transition_table : mpl::vector<
         //        Start                    Event                  Next                     Action           Guard
         //        +------------------------+----------------------+------------------------+----------------+---------+
@@ -369,7 +369,7 @@ struct FairMQFSM_ : public msm::front::state_machine_def<FairMQFSM_>
     template <class FSM, class Event>
     void no_transition(Event const& e, FSM&, int state)
     {
-        LOG(STATE) << "no transition from state " << GetStateName(state) << " on event " << e.name();
+        LOG(STATE) << "no transition from state " << GetStateName(state) << " (" << state << ") on event " << e.name();
     }
 
     // backward compatibility to FairMQStateMachine

--- a/fairmq/devices/FairMQBenchmarkSampler.h
+++ b/fairmq/devices/FairMQBenchmarkSampler.h
@@ -37,8 +37,6 @@ class FairMQBenchmarkSampler : public FairMQDevice
     FairMQBenchmarkSampler();
     virtual ~FairMQBenchmarkSampler();
 
-    void Log(int intervalInMs);
-
     virtual void SetProperty(const int key, const std::string& value);
     virtual std::string GetProperty(const int key, const std::string& default_ = "");
     virtual void SetProperty(const int key, const int value);

--- a/fairmq/devices/FairMQMerger.h
+++ b/fairmq/devices/FairMQMerger.h
@@ -20,10 +20,26 @@
 class FairMQMerger : public FairMQDevice
 {
   public:
+    enum
+    {
+        Multipart = FairMQDevice::Last,
+        Last
+    };
+
     FairMQMerger();
     virtual ~FairMQMerger();
 
+    virtual void SetProperty(const int key, const std::string& value);
+    virtual std::string GetProperty(const int key, const std::string& default_ = "");
+    virtual void SetProperty(const int key, const int value);
+    virtual int GetProperty(const int key, const int default_ = 0);
+
+    virtual std::string GetPropertyDescription(const int key);
+    virtual void ListProperties();
+
   protected:
+    int fMultipart;
+
     virtual void Run();
 };
 

--- a/fairmq/devices/FairMQProxy.h
+++ b/fairmq/devices/FairMQProxy.h
@@ -20,10 +20,26 @@
 class FairMQProxy : public FairMQDevice
 {
   public:
+    enum
+    {
+        Multipart = FairMQDevice::Last,
+        Last
+    };
+
     FairMQProxy();
     virtual ~FairMQProxy();
 
+    virtual void SetProperty(const int key, const std::string& value);
+    virtual std::string GetProperty(const int key, const std::string& default_ = "");
+    virtual void SetProperty(const int key, const int value);
+    virtual int GetProperty(const int key, const int default_ = 0);
+
+    virtual std::string GetPropertyDescription(const int key);
+    virtual void ListProperties();
+
   protected:
+    int fMultipart;
+
     virtual void Run();
 };
 

--- a/fairmq/devices/FairMQSplitter.cxx
+++ b/fairmq/devices/FairMQSplitter.cxx
@@ -18,7 +18,10 @@
 #include "FairMQLogger.h"
 #include "FairMQSplitter.h"
 
+using namespace std;
+
 FairMQSplitter::FairMQSplitter()
+    : fMultipart(1)
 {
 }
 
@@ -32,28 +35,123 @@ void FairMQSplitter::Run()
 
     int direction = 0;
 
-    while (CheckCurrentState(RUNNING))
+    if (fMultipart)
     {
-        FairMQParts parts;
-
-        if (Receive(parts, "data-in") >= 0)
+        while (CheckCurrentState(RUNNING))
         {
-            if (Send(parts, "data-out", direction) < 0)
+            FairMQParts payload;
+
+            if (Receive(payload, "data-in") >= 0)
+            {
+                if (Send(payload, "data-out", direction) < 0)
+                {
+                    LOG(DEBUG) << "Transfer interrupted";
+                    break;
+                }
+            }
+            else
             {
                 LOG(DEBUG) << "Transfer interrupted";
                 break;
             }
-        }
-        else
-        {
-            LOG(DEBUG) << "Transfer interrupted";
-            break;
-        }
 
-        ++direction;
-        if (direction >= numOutputs)
+            ++direction;
+            if (direction >= numOutputs)
+            {
+                direction = 0;
+            }
+        }
+    }
+    else
+    {
+        while (CheckCurrentState(RUNNING))
         {
-            direction = 0;
+            unique_ptr<FairMQMessage> payload(fTransportFactory->CreateMessage());
+
+            if (Receive(payload, "data-in") >= 0)
+            {
+                if (Send(payload, "data-out", direction) < 0)
+                {
+                    LOG(DEBUG) << "Transfer interrupted";
+                    break;
+                }
+            }
+            else
+            {
+                LOG(DEBUG) << "Transfer interrupted";
+                break;
+            }
+
+            ++direction;
+            if (direction >= numOutputs)
+            {
+                direction = 0;
+            }
         }
     }
 }
+
+void FairMQSplitter::SetProperty(const int key, const string& value)
+{
+    switch (key)
+    {
+        default:
+            FairMQDevice::SetProperty(key, value);
+            break;
+    }
+}
+
+string FairMQSplitter::GetProperty(const int key, const string& default_ /*= ""*/)
+{
+    switch (key)
+    {
+        default:
+            return FairMQDevice::GetProperty(key, default_);
+    }
+}
+
+void FairMQSplitter::SetProperty(const int key, const int value)
+{
+    switch (key)
+    {
+        case Multipart:
+            fMultipart = value;
+            break;
+        default:
+            FairMQDevice::SetProperty(key, value);
+            break;
+    }
+}
+
+int FairMQSplitter::GetProperty(const int key, const int default_ /*= 0*/)
+{
+    switch (key)
+    {
+        case Multipart:
+            return fMultipart;
+        default:
+            return FairMQDevice::GetProperty(key, default_);
+    }
+}
+
+string FairMQSplitter::GetPropertyDescription(const int key)
+{
+    switch (key)
+    {
+        case Multipart:
+            return "Multipart: Handle payloads as multipart messages.";
+        default:
+            return FairMQDevice::GetPropertyDescription(key);
+    }
+}
+
+void FairMQSplitter::ListProperties()
+{
+    LOG(INFO) << "Properties of FairMQSplitter:";
+    for (int p = FairMQConfigurable::Last; p < FairMQSplitter::Last; ++p)
+    {
+        LOG(INFO) << " " << GetPropertyDescription(p);
+    }
+    LOG(INFO) << "---------------------------";
+}
+

--- a/fairmq/devices/FairMQSplitter.h
+++ b/fairmq/devices/FairMQSplitter.h
@@ -20,10 +20,26 @@
 class FairMQSplitter : public FairMQDevice
 {
   public:
+    enum
+    {
+        Multipart = FairMQDevice::Last,
+        Last
+    };
+
     FairMQSplitter();
     virtual ~FairMQSplitter();
 
+    virtual void SetProperty(const int key, const std::string& value);
+    virtual std::string GetProperty(const int key, const std::string& default_ = "");
+    virtual void SetProperty(const int key, const int value);
+    virtual int GetProperty(const int key, const int default_ = 0);
+
+    virtual std::string GetPropertyDescription(const int key);
+    virtual void ListProperties();
+
   protected:
+    int fMultipart;
+
     virtual void Run();
 };
 

--- a/fairmq/run/runMerger.cxx
+++ b/fairmq/run/runMerger.cxx
@@ -14,19 +14,31 @@
 
 #include <iostream>
 
+#include "boost/program_options.hpp"
+
 #include "FairMQLogger.h"
 #include "FairMQProgOptions.h"
 #include "FairMQMerger.h"
 #include "runSimpleMQStateMachine.h"
 
+using namespace boost::program_options;
+
 int main(int argc, char** argv)
 {
     try
     {
+        int multipart;
+
+        options_description mergerOptions("Proxy options");
+        mergerOptions.add_options()
+            ("multipart", value<int>(&multipart)->default_value(1), "Handle multipart payloads");
+
         FairMQProgOptions config;
+        config.AddToCmdLineOptions(mergerOptions);
         config.ParseAll(argc, argv);
 
         FairMQMerger merger;
+        merger.SetProperty(FairMQMerger::Multipart, multipart);
         runStateMachine(merger, config);
     }
     catch (std::exception& e)

--- a/fairmq/run/runProxy.cxx
+++ b/fairmq/run/runProxy.cxx
@@ -14,19 +14,31 @@
 
 #include <iostream>
 
+#include "boost/program_options.hpp"
+
 #include "FairMQLogger.h"
 #include "FairMQProgOptions.h"
 #include "FairMQProxy.h"
 #include "runSimpleMQStateMachine.h"
 
+using namespace boost::program_options;
+
 int main(int argc, char** argv)
 {
     try
     {
+        int multipart;
+
+        options_description proxyOptions("Proxy options");
+        proxyOptions.add_options()
+            ("multipart", value<int>(&multipart)->default_value(1), "Handle multipart payloads");
+
         FairMQProgOptions config;
+        config.AddToCmdLineOptions(proxyOptions);
         config.ParseAll(argc, argv);
 
         FairMQProxy proxy;
+        proxy.SetProperty(FairMQProxy::Multipart, multipart);
         runStateMachine(proxy, config);
     }
     catch (std::exception& e)

--- a/fairmq/run/runSplitter.cxx
+++ b/fairmq/run/runSplitter.cxx
@@ -14,19 +14,31 @@
 
 #include <iostream>
 
+#include "boost/program_options.hpp"
+
 #include "FairMQLogger.h"
 #include "FairMQProgOptions.h"
 #include "FairMQSplitter.h"
 #include "runSimpleMQStateMachine.h"
 
+using namespace boost::program_options;
+
 int main(int argc, char** argv)
 {
     try
     {
+        int multipart;
+
+        options_description proxyOptions("Proxy options");
+        proxyOptions.add_options()
+            ("multipart", value<int>(&multipart)->default_value(1), "Handle multipart payloads");
+
         FairMQProgOptions config;
+        config.AddToCmdLineOptions(proxyOptions);
         config.ParseAll(argc, argv);
 
         FairMQSplitter splitter;
+        splitter.SetProperty(FairMQSplitter::Multipart, multipart);
         runStateMachine(splitter, config);
     }
     catch (std::exception& e)

--- a/fairmq/tools/runSimpleMQStateMachine.h
+++ b/fairmq/tools/runSimpleMQStateMachine.h
@@ -48,13 +48,16 @@ inline int runStateMachine(TMQDevice& device, FairMQProgOptions& config)
     {
         device.WaitForEndOfState(TMQDevice::RUN);
 
-        device.ChangeState(TMQDevice::RESET_TASK);
-        device.WaitForEndOfState(TMQDevice::RESET_TASK);
+        if (!device.CheckCurrentState(TMQDevice::EXITING))
+        {
+            device.ChangeState(TMQDevice::RESET_TASK);
+            device.WaitForEndOfState(TMQDevice::RESET_TASK);
 
-        device.ChangeState(TMQDevice::RESET_DEVICE);
-        device.WaitForEndOfState(TMQDevice::RESET_DEVICE);
+            device.ChangeState(TMQDevice::RESET_DEVICE);
+            device.WaitForEndOfState(TMQDevice::RESET_DEVICE);
 
-        device.ChangeState(TMQDevice::END);
+            device.ChangeState(TMQDevice::END);
+        }
     }
     else
     {


### PR DESCRIPTION
- Gracefully end the device also in the termination case with all the necessary state transitions (instead of abort).
- Handle both single and multi part payloads in splitter/merger/proxy (only affects nanomsg).
- example 9: close the file in the destructor instead of in the Run(). This will now always work because of the first change.