### PR TITLE
Use different ports in tests to prevent parallel run fail

### DIFF
--- a/fairmq/test/pub-sub/runTestPub.cxx
+++ b/fairmq/test/pub-sub/runTestPub.cxx
@@ -33,10 +33,18 @@ int main(int argc, char** argv)
     testPub.SetProperty(FairMQTestPub::Id, "testPub");
 
     FairMQChannel controlChannel("pull", "bind", "tcp://127.0.0.1:5555");
+    if (argc == 2)
+    {
+        controlChannel.UpdateAddress("tcp://127.0.0.1:5755");
+    }
     controlChannel.UpdateRateLogging(0);
     testPub.fChannels["control"].push_back(controlChannel);
 
     FairMQChannel pubChannel("pub", "bind", "tcp://127.0.0.1:5556");
+    if (argc == 2)
+    {
+        pubChannel.UpdateAddress("tcp://127.0.0.1:5756");
+    }
     pubChannel.UpdateRateLogging(0);
     testPub.fChannels["data"].push_back(pubChannel);
 

--- a/fairmq/test/pub-sub/runTestSub.cxx
+++ b/fairmq/test/pub-sub/runTestSub.cxx
@@ -36,10 +36,18 @@ int main(int argc, char** argv)
     testSub.SetProperty(FairMQTestSub::Id, "testSub_" + std::to_string(getpid()));
 
     FairMQChannel controlChannel("push", "connect", "tcp://127.0.0.1:5555");
+    if (argc == 2)
+    {
+        controlChannel.UpdateAddress("tcp://127.0.0.1:5755");
+    }
     controlChannel.UpdateRateLogging(0);
     testSub.fChannels["control"].push_back(controlChannel);
 
     FairMQChannel subChannel("sub", "connect", "tcp://127.0.0.1:5556");
+    if (argc == 2)
+    {
+        subChannel.UpdateAddress("tcp://127.0.0.1:5756");
+    }
     subChannel.UpdateRateLogging(0);
     testSub.fChannels["data"].push_back(subChannel);
 

--- a/fairmq/test/push-pull/runTestPull.cxx
+++ b/fairmq/test/push-pull/runTestPull.cxx
@@ -33,6 +33,11 @@ int main(int argc, char** argv)
     testPull.SetProperty(FairMQTestPull::Id, "testPull");
 
     FairMQChannel pullChannel("pull", "connect", "tcp://127.0.0.1:5557");
+    if (argc == 2)
+    {
+        pullChannel.UpdateAddress("tcp://127.0.0.1:5757");
+    }
+    pullChannel.UpdateRateLogging(0);
     testPull.fChannels["data"].push_back(pullChannel);
 
     testPull.ChangeState("INIT_DEVICE");

--- a/fairmq/test/push-pull/runTestPush.cxx
+++ b/fairmq/test/push-pull/runTestPush.cxx
@@ -34,6 +34,11 @@ int main(int argc, char** argv)
     testPush.SetProperty(FairMQTestPush::Id, "testPush");
 
     FairMQChannel pushChannel("push", "bind", "tcp://127.0.0.1:5557");
+    if (argc == 2)
+    {
+        pushChannel.UpdateAddress("tcp://127.0.0.1:5757");
+    }
+    pushChannel.UpdateRateLogging(0);
     testPush.fChannels["data"].push_back(pushChannel);
 
     testPush.ChangeState("INIT_DEVICE");

--- a/fairmq/test/req-rep/runTestRep.cxx
+++ b/fairmq/test/req-rep/runTestRep.cxx
@@ -35,6 +35,11 @@ int main(int argc, char** argv)
     testRep.SetProperty(FairMQTestRep::Id, "testRep");
 
     FairMQChannel repChannel("rep", "bind", "tcp://127.0.0.1:5558");
+    if (argc == 2)
+    {
+        repChannel.UpdateAddress("tcp://127.0.0.1:5758");
+    }
+    repChannel.UpdateRateLogging(0);
     testRep.fChannels["data"].push_back(repChannel);
 
     testRep.ChangeState("INIT_DEVICE");

--- a/fairmq/test/req-rep/runTestReq.cxx
+++ b/fairmq/test/req-rep/runTestReq.cxx
@@ -36,6 +36,11 @@ int main(int argc, char** argv)
     testReq.SetProperty(FairMQTestReq::Id, "testReq" + std::to_string(getpid()));
 
     FairMQChannel reqChannel("req", "connect", "tcp://127.0.0.1:5558");
+    if (argc == 2)
+    {
+        reqChannel.UpdateAddress("tcp://127.0.0.1:5758");
+    }
+    reqChannel.UpdateRateLogging(0);
     testReq.fChannels["data"].push_back(reqChannel);
 
     testReq.ChangeState("INIT_DEVICE");

--- a/fairmq/test/runTransferTimeoutTest.cxx
+++ b/fairmq/test/runTransferTimeoutTest.cxx
@@ -108,6 +108,10 @@ int main(int argc, char** argv)
     dataOutChannel.UpdateType("push");
     dataOutChannel.UpdateMethod("bind");
     dataOutChannel.UpdateAddress("tcp://127.0.0.1:5559");
+    if (argc == 2)
+    {
+        dataOutChannel.UpdateAddress("tcp://127.0.0.1:5759");
+    }
     dataOutChannel.UpdateSndBufSize(1000);
     dataOutChannel.UpdateRcvBufSize(1000);
     dataOutChannel.UpdateRateLogging(0);
@@ -117,6 +121,10 @@ int main(int argc, char** argv)
     dataInChannel.UpdateType("pull");
     dataInChannel.UpdateMethod("bind");
     dataInChannel.UpdateAddress("tcp://127.0.0.1:5560");
+    if (argc == 2)
+    {
+        dataInChannel.UpdateAddress("tcp://127.0.0.1:5760");
+    }
     dataInChannel.UpdateSndBufSize(1000);
     dataInChannel.UpdateRcvBufSize(1000);
     dataInChannel.UpdateRateLogging(0);


### PR DESCRIPTION
Use different ports for ZeroMQ/nanomsg tests (The recently introduced FairMQ/nanomsg tests used same ports as the ZeroMQ test, which leads to test failures when both are running in parallel).