### PR TITLE
Update Travis configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,13 @@ before_install:
       fi
     - if test "$TRAVIS_OS_NAME" = "osx"; then
         brew update;
+        brew tap homebrew/versions;        
         brew install openssl;
         brew uninstall gcc;
-        brew install gcc;
+        brew install homebrew/versions/gcc5;
+        ln -s /usr/local/bin/gfortran-5 /usr/local/bin/gfortran;
+        mkdir -p /usr/local/opt/gcc/lib/gcc;
+        ln -s /usr/local/Cellar/gcc5/5.3.0/lib/gcc/5 /usr/local/opt/gcc/lib/gcc/5;
         curl -L -O http://fairroot.gsi.de/downloads/fairsoft_nov15p2_${ROOT_VERSION}-1.0.pkg;
         sudo installer -pkg ./fairsoft_nov15p2_${ROOT_VERSION}-1.0.pkg -target /;
       fi


### PR DESCRIPTION
brew update the gcc version from 5.3 to 6.1. This conflicts with our fairsoft package which was compiled using gcc 5.3.
Install gcc 5.3 for Travis tests.