### PR TITLE
Fix parallel running FairMQ tests failure

### DIFF
--- a/fairmq/test/pub-sub/runTestPub.cxx
+++ b/fairmq/test/pub-sub/runTestPub.cxx
@@ -19,13 +19,23 @@ int main(int argc, char** argv)
 {
     FairMQTestPub testPub;
     testPub.CatchSignals();
-    if (argc == 2)
+
+    std::string transport;
+    if (argc != 2)
     {
-        testPub.SetTransport(argv[1]);
+        LOG(ERROR) << "Transport for the test not specified!";
+        return 1;
+    }
+    transport = argv[1];
+
+    if (transport == "zeromq" || transport == "nanomsg")
+    {
+        testPub.SetTransport(transport);
     }
     else
     {
-        testPub.SetTransport("zeromq");
+        LOG(ERROR) << "Incorrect transport requested! Expected 'zeromq' or 'nanomsg', found: " << transport;
+        return 1;
     }
 
     reinit_logger(false);
@@ -33,7 +43,7 @@ int main(int argc, char** argv)
     testPub.SetProperty(FairMQTestPub::Id, "testPub");
 
     FairMQChannel controlChannel("pull", "bind", "tcp://127.0.0.1:5555");
-    if (argc == 2)
+    if (transport == "nanomsg")
     {
         controlChannel.UpdateAddress("tcp://127.0.0.1:5755");
     }
@@ -41,7 +51,7 @@ int main(int argc, char** argv)
     testPub.fChannels["control"].push_back(controlChannel);
 
     FairMQChannel pubChannel("pub", "bind", "tcp://127.0.0.1:5556");
-    if (argc == 2)
+    if (transport == "nanomsg")
     {
         pubChannel.UpdateAddress("tcp://127.0.0.1:5756");
     }

--- a/fairmq/test/pub-sub/runTestSub.cxx
+++ b/fairmq/test/pub-sub/runTestSub.cxx
@@ -21,13 +21,23 @@ int main(int argc, char** argv)
 {
     FairMQTestSub testSub;
     testSub.CatchSignals();
-    if (argc == 2)
+
+    std::string transport;
+    if (argc != 2)
     {
-        testSub.SetTransport(argv[1]);
+        LOG(ERROR) << "Transport for the test not specified!";
+        return 1;
+    }
+    transport = argv[1];
+
+    if (transport == "zeromq" || transport == "nanomsg")
+    {
+        testSub.SetTransport(transport);
     }
     else
     {
-        testSub.SetTransport("zeromq");
+        LOG(ERROR) << "Incorrect transport requested! Expected 'zeromq' or 'nanomsg', found: " << transport;
+        return 1;
     }
 
     reinit_logger(false);
@@ -36,7 +46,7 @@ int main(int argc, char** argv)
     testSub.SetProperty(FairMQTestSub::Id, "testSub_" + std::to_string(getpid()));
 
     FairMQChannel controlChannel("push", "connect", "tcp://127.0.0.1:5555");
-    if (argc == 2)
+    if (transport == "nanomsg")
     {
         controlChannel.UpdateAddress("tcp://127.0.0.1:5755");
     }
@@ -44,7 +54,7 @@ int main(int argc, char** argv)
     testSub.fChannels["control"].push_back(controlChannel);
 
     FairMQChannel subChannel("sub", "connect", "tcp://127.0.0.1:5556");
-    if (argc == 2)
+    if (transport == "nanomsg")
     {
         subChannel.UpdateAddress("tcp://127.0.0.1:5756");
     }

--- a/fairmq/test/push-pull/runTestPull.cxx
+++ b/fairmq/test/push-pull/runTestPull.cxx
@@ -19,13 +19,23 @@ int main(int argc, char** argv)
 {
     FairMQTestPull testPull;
     testPull.CatchSignals();
-    if (argc == 2)
+
+    std::string transport;
+    if (argc != 2)
     {
-        testPull.SetTransport(argv[1]);
+        LOG(ERROR) << "Transport for the test not specified!";
+        return 1;
+    }
+    transport = argv[1];
+
+    if (transport == "zeromq" || transport == "nanomsg")
+    {
+        testPull.SetTransport(transport);
     }
     else
     {
-        testPull.SetTransport("zeromq");
+        LOG(ERROR) << "Incorrect transport requested! Expected 'zeromq' or 'nanomsg', found: " << transport;
+        return 1;
     }
 
     reinit_logger(false);
@@ -33,7 +43,7 @@ int main(int argc, char** argv)
     testPull.SetProperty(FairMQTestPull::Id, "testPull");
 
     FairMQChannel pullChannel("pull", "connect", "tcp://127.0.0.1:5557");
-    if (argc == 2)
+    if (transport == "nanomsg")
     {
         pullChannel.UpdateAddress("tcp://127.0.0.1:5757");
     }

--- a/fairmq/test/push-pull/runTestPush.cxx
+++ b/fairmq/test/push-pull/runTestPush.cxx
@@ -19,13 +19,23 @@ int main(int argc, char** argv)
 {
     FairMQTestPush testPush;
     testPush.CatchSignals();
-    if (argc == 2)
+
+    std::string transport;
+    if (argc != 2)
     {
-        testPush.SetTransport(argv[1]);
+        LOG(ERROR) << "Transport for the test not specified!";
+        return 1;
+    }
+    transport = argv[1];
+
+    if (transport == "zeromq" || transport == "nanomsg")
+    {
+        testPush.SetTransport(transport);
     }
     else
     {
-        testPush.SetTransport("zeromq");
+        LOG(ERROR) << "Incorrect transport requested! Expected 'zeromq' or 'nanomsg', found: " << transport;
+        return 1;
     }
 
     reinit_logger(false);
@@ -34,7 +44,7 @@ int main(int argc, char** argv)
     testPush.SetProperty(FairMQTestPush::Id, "testPush");
 
     FairMQChannel pushChannel("push", "bind", "tcp://127.0.0.1:5557");
-    if (argc == 2)
+    if (transport == "nanomsg")
     {
         pushChannel.UpdateAddress("tcp://127.0.0.1:5757");
     }

--- a/fairmq/test/req-rep/runTestRep.cxx
+++ b/fairmq/test/req-rep/runTestRep.cxx
@@ -21,13 +21,23 @@ int main(int argc, char** argv)
 {
     FairMQTestRep testRep;
     testRep.CatchSignals();
-    if (argc == 2)
+
+    std::string transport;
+    if (argc != 2)
     {
-        testRep.SetTransport(argv[1]);
+        LOG(ERROR) << "Transport for the test not specified!";
+        return 1;
+    }
+    transport = argv[1];
+
+    if (transport == "zeromq" || transport == "nanomsg")
+    {
+        testRep.SetTransport(transport);
     }
     else
     {
-        testRep.SetTransport("zeromq");
+        LOG(ERROR) << "Incorrect transport requested! Expected 'zeromq' or 'nanomsg', found: " << transport;
+        return 1;
     }
 
     reinit_logger(false);
@@ -35,7 +45,7 @@ int main(int argc, char** argv)
     testRep.SetProperty(FairMQTestRep::Id, "testRep");
 
     FairMQChannel repChannel("rep", "bind", "tcp://127.0.0.1:5558");
-    if (argc == 2)
+    if (transport == "nanomsg")
     {
         repChannel.UpdateAddress("tcp://127.0.0.1:5758");
     }

--- a/fairmq/test/req-rep/runTestReq.cxx
+++ b/fairmq/test/req-rep/runTestReq.cxx
@@ -21,13 +21,23 @@ int main(int argc, char** argv)
 {
     FairMQTestReq testReq;
     testReq.CatchSignals();
-    if (argc == 2)
+
+    std::string transport;
+    if (argc != 2)
     {
-        testReq.SetTransport(argv[1]);
+        LOG(ERROR) << "Transport for the test not specified!";
+        return 1;
+    }
+    transport = argv[1];
+
+    if (transport == "zeromq" || transport == "nanomsg")
+    {
+        testReq.SetTransport(transport);
     }
     else
     {
-        testReq.SetTransport("zeromq");
+        LOG(ERROR) << "Incorrect transport requested! Expected 'zeromq' or 'nanomsg', found: " << transport;
+        return 1;
     }
 
     reinit_logger(false);
@@ -36,7 +46,7 @@ int main(int argc, char** argv)
     testReq.SetProperty(FairMQTestReq::Id, "testReq" + std::to_string(getpid()));
 
     FairMQChannel reqChannel("req", "connect", "tcp://127.0.0.1:5558");
-    if (argc == 2)
+    if (transport == "nanomsg")
     {
         reqChannel.UpdateAddress("tcp://127.0.0.1:5758");
     }

--- a/fairmq/test/runTransferTimeoutTest.cxx
+++ b/fairmq/test/runTransferTimeoutTest.cxx
@@ -91,13 +91,23 @@ int main(int argc, char** argv)
 {
     TransferTimeoutTester timeoutTester;
     timeoutTester.CatchSignals();
-    if (argc == 2)
+
+    std::string transport;
+    if (argc != 2)
     {
-        timeoutTester.SetTransport(argv[1]);
+        LOG(ERROR) << "Transport for the test not specified!";
+        return 1;
+    }
+    transport = argv[1];
+
+    if (transport == "zeromq" || transport == "nanomsg")
+    {
+        timeoutTester.SetTransport(transport);
     }
     else
     {
-        timeoutTester.SetTransport("zeromq");
+        LOG(ERROR) << "Incorrect transport requested! Expected 'zeromq' or 'nanomsg', found: " << transport;
+        return 1;
     }
 
     reinit_logger(false);
@@ -108,7 +118,7 @@ int main(int argc, char** argv)
     dataOutChannel.UpdateType("push");
     dataOutChannel.UpdateMethod("bind");
     dataOutChannel.UpdateAddress("tcp://127.0.0.1:5559");
-    if (argc == 2)
+    if (transport == "nanomsg")
     {
         dataOutChannel.UpdateAddress("tcp://127.0.0.1:5759");
     }
@@ -121,7 +131,7 @@ int main(int argc, char** argv)
     dataInChannel.UpdateType("pull");
     dataInChannel.UpdateMethod("bind");
     dataInChannel.UpdateAddress("tcp://127.0.0.1:5560");
-    if (argc == 2)
+    if (transport == "nanomsg")
     {
         dataInChannel.UpdateAddress("tcp://127.0.0.1:5760");
     }


### PR DESCRIPTION
Recent update of the FairMQ tests to include nanomsg transport has introduced a silly bug which caused tests to fail when they were running at the same time. This corrects it.