### PR TITLE
solve issue #393 with installation of go examples

### DIFF
--- a/cmake/modules/FindGo.cmake
+++ b/cmake/modules/FindGo.cmake
@@ -38,13 +38,17 @@ find_package_handle_standard_args(Go REQUIRED_VARS GO_EXECUTABLE GO_VERSION GO_P
 # if 'gopath' is empty "", the environment variable $GOPATH will be used and passed to
 # 'go get'.
 macro(build_go_package pkg gopath)
+#  message("Building Go Stuff")
 	string(REPLACE "/" "_" tgt ${pkg})
 	if(gopath STREQUAL "")
 		set(gopath $ENV{GOPATH})
 	endif()
-	add_custom_target(${tgt}
-		COMMAND ${CMAKE_COMMAND} -E env "GOPATH=${gopath}"
-		${GO_EXECUTABLE} get ${pkg}
-		COMMENT "Building Go package: ${pkg}"
-	)
+
+  set(workdir "${gopath}/src/${pkg}")
+#  message("Working directory:  ${workdir}")
+  execute_process (COMMAND ${GO_EXECUTABLE} get
+                   WORKING_DIRECTORY ${workdir}
+  )
+
+
 endmacro(build_go_package)

--- a/examples/advanced/GoTutorial/CMakeLists.txt
+++ b/examples/advanced/GoTutorial/CMakeLists.txt
@@ -1,13 +1,13 @@
 
-set(GOPATH $ENV{GOPATH})
-set(GOPATH ${CMAKE_SOURCE_DIR}/examples/advanced/GoTutorial/)
+#set(GOPATH $ENV{GOPATH})
+set(GOPATH ${CMAKE_SOURCE_DIR}/examples/advanced/GoTutorial)
 set(ENV{GOPATH} "${GOPATH}")
 
-build_go_package(go-processor ${GOPATH})
-build_go_package(go-sink ${GOPATH})
+build_go_package(go-processor "${GOPATH}")
+build_go_package(go-sink "${GOPATH}")
 
 Install(
-  FILES ${GOPATH}/bin/go-sink ${GOPATH}/bin/go-processor
+  FILES ${GOPATH}/bin/go-processor ${GOPATH}/bin/go-sink
   PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
   DESTINATION bin
 )


### PR DESCRIPTION
Go examples are build when calling cmake but the install will copy the binary to the install_dir/bin correctly now, this solves the issue #393 by reported by @ktf 