### PR TITLE
merge MQ parameters in the variable_map container of FairMQProgramOpt…

### DIFF
--- a/fairmq/options/FairProgOptions.h
+++ b/fairmq/options/FairProgOptions.h
@@ -138,9 +138,9 @@ class FairProgOptions
     boost::filesystem::path fConfigFile;
     virtual int NotifySwitchOption();
 
-    // UpadateVarMap() and replace() --> helper functions to modify the value of variable map after calling po::store
+    // UpdateVarMap() and replace() --> helper functions to modify the value of variable map after calling po::store
     template<typename T>
-    void UpadateVarMap(const std::string& key, const T& val)
+    void UpdateVarMap(const std::string& key, const T& val)
     {
         replace(fVarMap, key, val);
     }


### PR DESCRIPTION
…ions class
* add UpdateValue function which update the variable_map. Use: config.UpdateValue<type>(key,val). The updated values are propagated to the channel map if the latter was initialized by UserParser() or by UpdateChannelMap() call.