### PR TITLE
Allow specifying where to find root-config explicitly

### DIFF
--- a/cmake/modules/FindROOT.cmake
+++ b/cmake/modules/FindROOT.cmake
@@ -45,6 +45,7 @@
 Message(STATUS "Looking for Root...")
 
 Set(ROOT_CONFIG_SEARCHPATH
+  ${ROOT_DIR}/bin
   ${SIMPATH}/bin
   ${SIMPATH}/tools/root/bin
   $ENV{ROOTSYS}/bin


### PR DESCRIPTION
This way we do not need to have ROOTSYS set when compiling FairRoot.