### PR TITLE
Fix unit tests.

### DIFF
--- a/test/fairtools/_GTestFairTools.cxx
+++ b/test/fairtools/_GTestFairTools.cxx
@@ -7,6 +7,7 @@
  ********************************************************************************/
 #include "FairLogger.h"
 
+#include "FairCaptureOutputNew.h"
 #include "FairTestNewOutputHandler.h"
 
 #include "gtest/gtest.h"
@@ -53,7 +54,8 @@ template <class T> class _TestFairLoggerBase : public T
     std::string OutputString;
     std::string OutFileName;
     FairLogger* fLogger;
-    FairTestNewOutputHandler handler;
+    FairCaptureOutputNew handler;
+//    FairTestNewOutputHandler handler;
 
     virtual void SetUp() {
       logLevelSettingToTest="INFO";
@@ -239,7 +241,9 @@ class VerbosityLevelTest : public _TestFairLoggerBase<
 
 TEST_F(FairToolsTest, CheckDefaultSettings)
 {
+  handler.BeginCapture();
   LogNoArguments();
+  handler.EndCapture();
 
   std::vector<std::string> expected = CreateExpectedOutputNoArguments(logLevelSettingToTest, OutputString);
   {
@@ -251,10 +255,13 @@ TEST_F(FairToolsTest, CheckDefaultSettings)
 TEST_F(FairToolsTest, CheckOutputOnlyToFile)
 {
 
+  handler.BeginCapture();
   fLogger->SetLogFileName(OutFileName.c_str());
   fLogger->SetLogToFile(true);
   fLogger->SetLogToScreen(false);
   LogNoArguments();
+
+  handler.EndCapture();
 
   std::vector<std::string> expected = CreateExpectedOutputNoArguments(logLevelSettingToTest, OutputString);
   {
@@ -269,8 +276,10 @@ TEST_F(FairToolsTest, CheckWrongLogLevelSettings)
   fLogger->SetLogToFile(false);
   fLogger->SetLogToScreen(true);
 
+  handler.BeginCapture();
   fLogger->SetLogScreenLevel("BLA");
   LogNoArguments();
+  handler.EndCapture();
 
   std::vector<std::string> expected = CreateExpectedOutputNoArguments(logLevelSettingToTest, OutputString);
   std::string outString="[ERROR  ] Log level \"BLA\" not supported. Use default level \"INFO\".";
@@ -290,8 +299,10 @@ TEST_F(FairToolsTest, CheckVerbosityLevelSettings)
   fLogger->SetLogToFile(false);
   fLogger->SetLogToScreen(true);
 
+  handler.BeginCapture();
   fLogger->SetLogVerbosityLevel("BLA");
   LogNoArguments();
+  handler.EndCapture();
 
   std::vector<std::string> expected = CreateExpectedOutputNoArguments(logLevelSettingToTest, OutputString);
   std::string outString="[ERROR  ] Verbosity level \"BLA\" not supported. Use default level \"LOW\".";
@@ -309,11 +320,13 @@ TEST_F(FairToolsTest, CheckVerbosityLevelSettings)
 
 TEST_F(FairToolsTest, testScreenAndFileOutputWithoutArgument)
 {
+  handler.BeginCapture();
 
   fLogger->SetLogFileName(OutFileName.c_str());
   fLogger->SetLogToScreen(true);
   fLogger->SetLogToFile(true);
   LogNoArguments();
+  handler.EndCapture();
 
   std::vector<std::string> expected = CreateExpectedOutputNoArguments(logLevelSettingToTest, OutputString);
   {
@@ -334,10 +347,12 @@ TEST_P(LogLevelTest, testAllLogLevelsToScreenAndFile)
   fLogger->SetLogFileLevel(logLevelSettingToTest.c_str());
   fLogger->SetLogScreenLevel(logLevelSettingToTest.c_str());
 
+  handler.BeginCapture();
   fLogger->SetLogFileName(OutFileName.c_str());
   fLogger->SetLogToScreen(true);
   fLogger->SetLogToFile(true);
   LogNoArguments();
+  handler.EndCapture();
 
   std::vector<std::string> expected = CreateExpectedOutputNoArguments(logLevelSettingToTest, OutputString);
   {
@@ -361,10 +376,12 @@ TEST_P(VerbosityLevelTest, testAllVerbosityLevelsToScreenAndFile)
 {
   fLogger->SetLogVerbosityLevel(verbosityLevel.c_str());
 
+  handler.BeginCapture();
   fLogger->SetLogFileName(OutFileName.c_str());
   fLogger->SetLogToScreen(true);
   fLogger->SetLogToFile(true);
   LogNoArguments();
+  handler.EndCapture();
 
   std::vector<std::string> expected = CreateExpectedLogLevels(logLevelSettingToTest);
 

--- a/test/mock/CMakeLists.txt
+++ b/test/mock/CMakeLists.txt
@@ -12,30 +12,32 @@
 # here.
 
 set(INCLUDE_DIRECTORIES
-  ${ROOT_INCLUDE_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_SOURCE_DIR}/fairtools
 )
 
 include_directories( ${INCLUDE_DIRECTORIES})
 
-set(LINK_DIRECTORIES
+set(SYSTEM_INCLUDE_DIRECTORIES
+  ${ROOT_INCLUDE_DIR}
 )
 
-link_directories( ${LINK_DIRECTORIES})
+include_directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
+
+Set(LINK_DIRECTORIES
+  ${ROOT_LIBRARY_DIR}
+)
+
+Link_Directories(${LINK_DIRECTORIES})
 
 Set(Sources 
     FairMockMCApplication.cxx
     FairMockVirtualMC.cxx
 )
 
-CHANGE_FILE_EXTENSION(*.cxx *.h HDRS "${Sources}")
-set(LINKDEF MockLinkDef.h)
-set(DICTIONARY FairMockDict.cxx)
-ROOT_GENERATE_DICTIONARY()
+Set(HEADERS )
+Set(LINKDEF MockLinkDef.h)
+Set(LIBRARY_NAME FairMock)
+Set(DEPENDENCIES Core VMC)
 
-set(Sources ${Sources} ${DICTIONARY})
-
-############### build the library #####################
-add_library(FairMock SHARED ${Sources})
-
+GENERATE_LIBRARY()

--- a/test/mock/FairMockMCApplication.cxx
+++ b/test/mock/FairMockMCApplication.cxx
@@ -19,8 +19,8 @@ FairMockMCApplication::FairMockMCApplication()
 
 FairMockMCApplication::~FairMockMCApplication()
 {
-  delete gMC;
-  gMC=0;
+//  delete gMC;
+//  gMC=0;
 }
 
 

--- a/test/mock/FairMockVirtualMC.h
+++ b/test/mock/FairMockVirtualMC.h
@@ -27,116 +27,116 @@ class FairMockVirtualMC : public TVirtualMC
     void  SetRootGeometry();
     void StopExecution() const;
 
-    void Material(Int_t&, const char*, Double_t, Double_t, Double_t, Double_t, Double_t, Float_t*, Int_t) {StopExecution();}
-    void Material(Int_t&, const char*, Double_t, Double_t, Double_t, Double_t, Double_t, Double_t*, Int_t) {StopExecution();}
-    void Mixture(Int_t&, const char*, Float_t*, Float_t*, Double_t, Int_t, Float_t*) {StopExecution();}
-    void Mixture(Int_t&, const char*, Double_t*, Double_t*, Double_t, Int_t, Double_t*) {StopExecution();}
-    void Medium(Int_t&, const char*, Int_t, Int_t, Int_t, Double_t, Double_t, Double_t, Double_t, Double_t, Double_t, Float_t*, Int_t) {StopExecution();}
-    virtual void Medium(Int_t&, const char*, Int_t, Int_t, Int_t, Double_t, Double_t, Double_t, Double_t, Double_t, Double_t, Double_t*, Int_t) {StopExecution();}
-    virtual void Matrix(Int_t&, Double_t, Double_t, Double_t, Double_t, Double_t, Double_t) {StopExecution();}
-    virtual void Gstpar(Int_t, const char*, Double_t) {StopExecution();}
-    virtual Int_t Gsvolu(const char*, const char*, Int_t, Float_t*, Int_t) {StopExecution();}
-    virtual Int_t Gsvolu(const char*, const char*, Int_t, Double_t*, Int_t) {StopExecution();}
-    virtual void Gsdvn(const char*, const char*, Int_t, Int_t) {StopExecution();}
-    virtual void Gsdvn2(const char*, const char*, Int_t, Int_t, Double_t, Int_t) {StopExecution();}
-    virtual void Gsdvt(const char*, const char*, Double_t, Int_t, Int_t, Int_t) {StopExecution();}
-    virtual void Gsdvt2(const char*, const char*, Double_t, Int_t, Double_t, Int_t, Int_t) {StopExecution();}
-    virtual void Gfmate(Int_t, char*, Float_t&, Float_t&, Float_t&, Float_t&, Float_t&, Float_t*, Int_t&) {StopExecution();}
-    virtual void Gfmate(Int_t, char*, Double_t&, Double_t&, Double_t&, Double_t&, Double_t&, Double_t*, Int_t&) {StopExecution();}
-    virtual void Gckmat(Int_t, char*) {StopExecution();}
-    virtual void Gsord(const char*, Int_t) {StopExecution();}
-    virtual void Gspos(const char*, Int_t, const char*, Double_t, Double_t, Double_t, Int_t, const char*) {StopExecution();}
-    virtual void Gsposp(const char*, Int_t, const char*, Double_t, Double_t, Double_t, Int_t, const char*, Float_t*, Int_t) {StopExecution();}
-    virtual void Gsposp(const char*, Int_t, const char*, Double_t, Double_t, Double_t, Int_t, const char*, Double_t*, Int_t) {StopExecution();}
-    virtual void Gsbool(const char*, const char*) {StopExecution();}
-    virtual void SetCerenkov(Int_t, Int_t, Float_t*, Float_t*, Float_t*, Float_t*) {StopExecution();}
-    virtual void SetCerenkov(Int_t, Int_t, Double_t*, Double_t*, Double_t*, Double_t*) {StopExecution();}
-    virtual void DefineOpSurface(const char*, EMCOpSurfaceModel, EMCOpSurfaceType, EMCOpSurfaceFinish, Double_t) {StopExecution();}
-    virtual void SetBorderSurface(const char*, const char*, int, const char*, int, const char*) {StopExecution();}
-    virtual void SetSkinSurface(const char*, const char*, const char*) {StopExecution();}
-    virtual void SetMaterialProperty(Int_t, const char*, Int_t, Double_t*, Double_t*) {StopExecution();}
-    virtual void SetMaterialProperty(Int_t, const char*, Double_t) {StopExecution();}
-    virtual void SetMaterialProperty(const char*, const char*, Int_t, Double_t*, Double_t*) {StopExecution();}
-    virtual Bool_t GetTransformation(const TString&, TGeoHMatrix&) {StopExecution();}
-    virtual Bool_t GetShape(const TString&, TString&, TArrayD&) {StopExecution();}
-    virtual Bool_t GetMaterial(const TString&, TString&, Int_t&, Double_t&, Double_t&, Double_t&, Double_t&, Double_t&, TArrayD&) {StopExecution();}
-    virtual Bool_t GetMedium(const TString&, TString&, Int_t&, Int_t&, Int_t&, Int_t&, Double_t&, Double_t&, Double_t&, Double_t&, Double_t&, Double_t&, TArrayD&) {StopExecution();}
-    virtual void WriteEuclid(const char*, const char*, Int_t, Int_t) {StopExecution();}
-    virtual void SetUserParameters(Bool_t) {StopExecution();}
-    virtual const char* VolName(Int_t) const {StopExecution();}
-    virtual Int_t MediumId(const char*) const {StopExecution();}
-    virtual Int_t NofVolumes() const {StopExecution();}
-    virtual Int_t VolId2Mate(Int_t) const {StopExecution();}
-    virtual Int_t NofVolDaughters(const char*) const {StopExecution();}
-    virtual const char* VolDaughterName(const char*, Int_t) const {StopExecution();}
-    virtual Int_t VolDaughterCopyNo(const char*, Int_t) const {StopExecution();}
-    virtual Bool_t SetCut(const char*, Double_t) {StopExecution();}
-    virtual Bool_t SetProcess(const char*, Int_t) {StopExecution();}
-    virtual Bool_t DefineParticle(Int_t, const char*, TMCParticleType, Double_t, Double_t, Double_t) {StopExecution();}
-    virtual Bool_t DefineParticle(Int_t, const char*, TMCParticleType, Double_t, Double_t, Double_t, const TString&, Double_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Bool_t, Bool_t, const TString&, Int_t, Double_t, Double_t) {StopExecution();}
-    virtual Bool_t DefineIon(const char*, Int_t, Int_t, Int_t, Double_t, Double_t) {StopExecution();}
-    virtual Bool_t SetDecayMode(Int_t, Float_t*, Int_t (*)[3]) {StopExecution();}
-    virtual Double_t Xsec(char*, Double_t, Int_t, Int_t) {StopExecution();}
-    virtual Int_t IdFromPDG(Int_t) const {StopExecution();}
-    virtual Int_t PDGFromId(Int_t) const {StopExecution();}
-    virtual TString ParticleName(Int_t) const {StopExecution();}
-    virtual Double_t ParticleMass(Int_t) const {StopExecution();}
-    virtual Double_t ParticleCharge(Int_t) const {StopExecution();}
-    virtual Double_t ParticleLifeTime(Int_t) const {StopExecution();}
-    virtual TMCParticleType ParticleMCType(Int_t) const {StopExecution();}
-    virtual void StopTrack() {StopExecution();}
-    virtual void StopEvent() {StopExecution();}
-    virtual void StopRun() {StopExecution();}
-    virtual void SetMaxStep(Double_t) {StopExecution();}
-    virtual void SetMaxNStep(Int_t) {StopExecution();}
-    virtual void SetUserDecay(Int_t) {StopExecution();}
-    virtual void ForceDecayTime(Float_t) {StopExecution();}
+    void Material(Int_t&, const char*, Double_t, Double_t, Double_t, Double_t, Double_t, Float_t*, Int_t) {StopExecution(); return;}
+    void Material(Int_t&, const char*, Double_t, Double_t, Double_t, Double_t, Double_t, Double_t*, Int_t) {StopExecution(); return;}
+    void Mixture(Int_t&, const char*, Float_t*, Float_t*, Double_t, Int_t, Float_t*) {StopExecution(); return;}
+    void Mixture(Int_t&, const char*, Double_t*, Double_t*, Double_t, Int_t, Double_t*) {StopExecution(); return;}
+    void Medium(Int_t&, const char*, Int_t, Int_t, Int_t, Double_t, Double_t, Double_t, Double_t, Double_t, Double_t, Float_t*, Int_t) {StopExecution(); return;}
+    virtual void Medium(Int_t&, const char*, Int_t, Int_t, Int_t, Double_t, Double_t, Double_t, Double_t, Double_t, Double_t, Double_t*, Int_t) {StopExecution(); return;}
+    virtual void Matrix(Int_t&, Double_t, Double_t, Double_t, Double_t, Double_t, Double_t) {StopExecution(); return;}
+    virtual void Gstpar(Int_t, const char*, Double_t) {StopExecution(); return;}
+    virtual Int_t Gsvolu(const char*, const char*, Int_t, Float_t*, Int_t) {StopExecution(); return -1;}
+    virtual Int_t Gsvolu(const char*, const char*, Int_t, Double_t*, Int_t) {StopExecution(); return -1;}
+    virtual void Gsdvn(const char*, const char*, Int_t, Int_t) {StopExecution(); return;}
+    virtual void Gsdvn2(const char*, const char*, Int_t, Int_t, Double_t, Int_t) {StopExecution(); return;}
+    virtual void Gsdvt(const char*, const char*, Double_t, Int_t, Int_t, Int_t) {StopExecution(); return;}
+    virtual void Gsdvt2(const char*, const char*, Double_t, Int_t, Double_t, Int_t, Int_t) {StopExecution(); return;}
+    virtual void Gfmate(Int_t, char*, Float_t&, Float_t&, Float_t&, Float_t&, Float_t&, Float_t*, Int_t&) {StopExecution(); return;}
+    virtual void Gfmate(Int_t, char*, Double_t&, Double_t&, Double_t&, Double_t&, Double_t&, Double_t*, Int_t&) {StopExecution(); return;}
+    virtual void Gckmat(Int_t, char*) {StopExecution(); return;}
+    virtual void Gsord(const char*, Int_t) {StopExecution(); return;}
+    virtual void Gspos(const char*, Int_t, const char*, Double_t, Double_t, Double_t, Int_t, const char*) {StopExecution(); return;}
+    virtual void Gsposp(const char*, Int_t, const char*, Double_t, Double_t, Double_t, Int_t, const char*, Float_t*, Int_t) {StopExecution(); return;}
+    virtual void Gsposp(const char*, Int_t, const char*, Double_t, Double_t, Double_t, Int_t, const char*, Double_t*, Int_t) {StopExecution(); return;}
+    virtual void Gsbool(const char*, const char*) {StopExecution(); return;}
+    virtual void SetCerenkov(Int_t, Int_t, Float_t*, Float_t*, Float_t*, Float_t*) {StopExecution(); return;}
+    virtual void SetCerenkov(Int_t, Int_t, Double_t*, Double_t*, Double_t*, Double_t*) {StopExecution(); return;}
+    virtual void DefineOpSurface(const char*, EMCOpSurfaceModel, EMCOpSurfaceType, EMCOpSurfaceFinish, Double_t) {StopExecution(); return;}
+    virtual void SetBorderSurface(const char*, const char*, int, const char*, int, const char*) {StopExecution(); return;}
+    virtual void SetSkinSurface(const char*, const char*, const char*) {StopExecution(); return;}
+    virtual void SetMaterialProperty(Int_t, const char*, Int_t, Double_t*, Double_t*) {StopExecution(); return;}
+    virtual void SetMaterialProperty(Int_t, const char*, Double_t) {StopExecution(); return;}
+    virtual void SetMaterialProperty(const char*, const char*, Int_t, Double_t*, Double_t*) {StopExecution(); return;}
+    virtual Bool_t GetTransformation(const TString&, TGeoHMatrix&) {StopExecution(); return kFALSE;}
+    virtual Bool_t GetShape(const TString&, TString&, TArrayD&) {StopExecution(); return kFALSE;}
+    virtual Bool_t GetMaterial(const TString&, TString&, Int_t&, Double_t&, Double_t&, Double_t&, Double_t&, Double_t&, TArrayD&) {StopExecution();  return kFALSE;}
+    virtual Bool_t GetMedium(const TString&, TString&, Int_t&, Int_t&, Int_t&, Int_t&, Double_t&, Double_t&, Double_t&, Double_t&, Double_t&, Double_t&, TArrayD&) {StopExecution();  return kFALSE;}
+    virtual void WriteEuclid(const char*, const char*, Int_t, Int_t) {StopExecution(); return;}
+    virtual void SetUserParameters(Bool_t) {StopExecution(); return;}
+    virtual const char* VolName(Int_t) const {StopExecution(); return "";}
+    virtual Int_t MediumId(const char*) const {StopExecution(); return -1;}
+    virtual Int_t NofVolumes() const {StopExecution(); return -1;}
+    virtual Int_t VolId2Mate(Int_t) const {StopExecution(); return -1;}
+    virtual Int_t NofVolDaughters(const char*) const {StopExecution(); return -1;}
+    virtual const char* VolDaughterName(const char*, Int_t) const {StopExecution(); return "";}
+    virtual Int_t VolDaughterCopyNo(const char*, Int_t) const {StopExecution(); return -1;}
+    virtual Bool_t SetCut(const char*, Double_t) {StopExecution(); return kFALSE;}
+    virtual Bool_t SetProcess(const char*, Int_t) {StopExecution(); return kFALSE;}
+    virtual Bool_t DefineParticle(Int_t, const char*, TMCParticleType, Double_t, Double_t, Double_t) {StopExecution(); return kFALSE;}
+    virtual Bool_t DefineParticle(Int_t, const char*, TMCParticleType, Double_t, Double_t, Double_t, const TString&, Double_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Bool_t, Bool_t, const TString&, Int_t, Double_t, Double_t) {StopExecution();  return kFALSE;}
+    virtual Bool_t DefineIon(const char*, Int_t, Int_t, Int_t, Double_t, Double_t) {StopExecution(); return kFALSE;}
+    virtual Bool_t SetDecayMode(Int_t, Float_t*, Int_t (*)[3]) {StopExecution(); return kFALSE;}
+    virtual Double_t Xsec(char*, Double_t, Int_t, Int_t) {StopExecution(); return -1.;}
+    virtual Int_t IdFromPDG(Int_t) const {StopExecution(); return -1;}
+    virtual Int_t PDGFromId(Int_t) const {StopExecution();  return -1;}
+    virtual TString ParticleName(Int_t) const {StopExecution(); return "";}
+    virtual Double_t ParticleMass(Int_t) const {StopExecution(); return -1.;}
+    virtual Double_t ParticleCharge(Int_t) const {StopExecution(); return -1.;}
+    virtual Double_t ParticleLifeTime(Int_t) const {StopExecution(); return -1.;}
+    virtual TMCParticleType ParticleMCType(Int_t) const {StopExecution(); return kPTUndefined;}
+    virtual void StopTrack() {StopExecution();  return;}
+    virtual void StopEvent() {StopExecution(); return;}
+    virtual void StopRun() {StopExecution(); return;}
+    virtual void SetMaxStep(Double_t) {StopExecution(); return;}
+    virtual void SetMaxNStep(Int_t) {StopExecution(); return;}
+    virtual void SetUserDecay(Int_t) {StopExecution(); return;}
+    virtual void ForceDecayTime(Float_t) {StopExecution(); return;}
     virtual Int_t CurrentVolID(Int_t&) const;
     virtual Int_t CurrentVolOffID(Int_t, Int_t&) const;
-    virtual const char* CurrentVolName() const {StopExecution();}
-    virtual const char* CurrentVolOffName(Int_t) const {StopExecution();}
-    virtual const char* CurrentVolPath() {StopExecution();}
-    virtual Int_t CurrentMaterial(Float_t&, Float_t&, Float_t&, Float_t&, Float_t&) const {StopExecution();}
-    virtual Int_t CurrentMedium() const {StopExecution();}
-    virtual Int_t CurrentEvent() const {StopExecution();}
-    virtual void Gmtod(Float_t*, Float_t*, Int_t) {StopExecution();}
-    virtual void Gmtod(Double_t*, Double_t*, Int_t) {StopExecution();}
-    virtual void Gdtom(Float_t*, Float_t*, Int_t) {StopExecution();}
-    virtual void Gdtom(Double_t*, Double_t*, Int_t) {StopExecution();}
-    virtual Double_t MaxStep() const {StopExecution();}
-    virtual Int_t GetMaxNStep() const {StopExecution();}
-    virtual void TrackPosition(TLorentzVector&) const {StopExecution();}
-    virtual void TrackPosition(Double_t&, Double_t&, Double_t&) const {StopExecution();}
-    virtual void TrackMomentum(TLorentzVector&) const {StopExecution();}
-    virtual void TrackMomentum(Double_t&, Double_t&, Double_t&, Double_t&) const {StopExecution();}
-    virtual Double_t TrackStep() const {StopExecution();}
-    virtual Double_t TrackLength() const {StopExecution();}
-    virtual Double_t TrackTime() const {StopExecution();}
-    virtual Double_t Edep() const {StopExecution();}
-    virtual Int_t TrackPid() const {StopExecution();}
-    virtual Double_t TrackCharge() const {StopExecution();}
-    virtual Double_t TrackMass() const {StopExecution();}
-    virtual Double_t Etot() const {StopExecution();}
-    virtual Bool_t IsNewTrack() const {StopExecution();}
-    virtual Bool_t IsTrackInside() const {StopExecution();}
-    virtual Bool_t IsTrackEntering() const {StopExecution();}
-    virtual Bool_t IsTrackExiting() const {StopExecution();}
-    virtual Bool_t IsTrackOut() const {StopExecution();}
-    virtual Bool_t IsTrackDisappeared() const {StopExecution();}
-    virtual Bool_t IsTrackStop() const {StopExecution();}
-    virtual Bool_t IsTrackAlive() const {StopExecution();}
-    virtual Int_t NSecondaries() const {StopExecution();}
-    virtual void GetSecondary(Int_t, Int_t&, TLorentzVector&, TLorentzVector&) {StopExecution();}
-    virtual TMCProcess ProdProcess(Int_t) const {StopExecution();}
-    virtual Int_t StepProcesses(TArrayI&) const {StopExecution();}
-    virtual Bool_t SecondariesAreOrdered() const {StopExecution();}
-    virtual void Init() {StopExecution();}
-    virtual void BuildPhysics() {StopExecution();}
-    virtual void ProcessEvent() {StopExecution();}
-    virtual Bool_t ProcessRun(Int_t) {StopExecution();}
-    virtual void InitLego() {StopExecution();}
-    virtual void SetCollectTracks(Bool_t) {StopExecution();}
-    virtual Bool_t IsCollectTracks() const {StopExecution();}
+    virtual const char* CurrentVolName() const {StopExecution(); return "";}
+    virtual const char* CurrentVolOffName(Int_t) const {StopExecution(); return "";}
+    virtual const char* CurrentVolPath() {StopExecution(); return "";}
+    virtual Int_t CurrentMaterial(Float_t&, Float_t&, Float_t&, Float_t&, Float_t&) const {StopExecution(); return -1;}
+    virtual Int_t CurrentMedium() const {StopExecution(); return -1;}
+    virtual Int_t CurrentEvent() const {StopExecution(); return -1;}
+    virtual void Gmtod(Float_t*, Float_t*, Int_t) {StopExecution(); return;}
+    virtual void Gmtod(Double_t*, Double_t*, Int_t) {StopExecution(); return;}
+    virtual void Gdtom(Float_t*, Float_t*, Int_t) {StopExecution(); return;}
+    virtual void Gdtom(Double_t*, Double_t*, Int_t) {StopExecution(); return;}
+    virtual Double_t MaxStep() const {StopExecution(); return -1.;}
+    virtual Int_t GetMaxNStep() const {StopExecution(); return -1;}
+    virtual void TrackPosition(TLorentzVector&) const {StopExecution(); return;}
+    virtual void TrackPosition(Double_t&, Double_t&, Double_t&) const {StopExecution(); return;}
+    virtual void TrackMomentum(TLorentzVector&) const {StopExecution(); return;}
+    virtual void TrackMomentum(Double_t&, Double_t&, Double_t&, Double_t&) const {StopExecution(); return;}
+    virtual Double_t TrackStep() const {StopExecution(); return -1.;}
+    virtual Double_t TrackLength() const {StopExecution(); return -1.;}
+    virtual Double_t TrackTime() const {StopExecution(); return -1.;}
+    virtual Double_t Edep() const {StopExecution(); return -1.;}
+    virtual Int_t TrackPid() const {StopExecution(); return -1;}
+    virtual Double_t TrackCharge() const {StopExecution(); return -1.;}
+    virtual Double_t TrackMass() const {StopExecution(); return -1.;}
+    virtual Double_t Etot() const {StopExecution(); return -1.;}
+    virtual Bool_t IsNewTrack() const {StopExecution(); return kFALSE;}
+    virtual Bool_t IsTrackInside() const {StopExecution(); return kFALSE;}
+    virtual Bool_t IsTrackEntering() const {StopExecution(); return kFALSE;}
+    virtual Bool_t IsTrackExiting() const {StopExecution(); return kFALSE;}
+    virtual Bool_t IsTrackOut() const {StopExecution(); return kFALSE;}
+    virtual Bool_t IsTrackDisappeared() const {StopExecution(); return kFALSE;}
+    virtual Bool_t IsTrackStop() const {StopExecution(); return kFALSE;}
+    virtual Bool_t IsTrackAlive() const {StopExecution(); return kFALSE;}
+    virtual Int_t NSecondaries() const {StopExecution(); return -1;}
+    virtual void GetSecondary(Int_t, Int_t&, TLorentzVector&, TLorentzVector&) {StopExecution(); return;}
+    virtual TMCProcess ProdProcess(Int_t) const {StopExecution(); return kPNoProcess;}
+    virtual Int_t StepProcesses(TArrayI&) const {StopExecution(); return -1;}
+    virtual Bool_t SecondariesAreOrdered() const {StopExecution(); return kFALSE;}
+    virtual void Init() {StopExecution(); return;}
+    virtual void BuildPhysics() {StopExecution(); return;}
+    virtual void ProcessEvent() {StopExecution(); return;}
+    virtual Bool_t ProcessRun(Int_t) {StopExecution(); return kFALSE;}
+    virtual void InitLego() {StopExecution(); return;}
+    virtual void SetCollectTracks(Bool_t) {StopExecution(); return;}
+    virtual Bool_t IsCollectTracks() const {StopExecution(); return kFALSE;}
 
   protected:
     TGeoMCGeometry*  fMCGeo;

--- a/test/testlib/CMakeLists.txt
+++ b/test/testlib/CMakeLists.txt
@@ -32,6 +32,6 @@ set(LINK_DIRECTORIES
 link_directories( ${LINK_DIRECTORIES})
 
 ############### build the library #####################
-add_library(FairTest SHARED FairCaptureOutput.cxx FairTestOutputHandler.cxx FairTestNewOutputHandler.cxx FairCaptureOutputNew.cxx )
-  target_link_libraries(FairTest ${Boost_LIBRARIES} )
+add_library(FairTest SHARED FairCaptureOutput.cxx FairTestOutputHandler.cxx FairCaptureOutputNew.cxx )
+target_link_libraries(FairTest ${Boost_LIBRARIES} )
 


### PR DESCRIPTION
Use new output capture class in FairLogger tests to overcome linking problem
when using old fairsoft versions.

Add return statements to all functions of mock class.
Cleanup destructor of mock class.

Correct build system to work with ROOT6.