### PR TITLE
Clean the dtor of FairBaseParSet, and solve the problem of double delete

### DIFF
--- a/base/sim/FairBaseParSet.cxx
+++ b/base/sim/FairBaseParSet.cxx
@@ -33,18 +33,15 @@ FairBaseParSet::FairBaseParSet(const char* name,const char* title,const char* co
 
 FairBaseParSet::~FairBaseParSet(void)
 {
-  clear();
-}
-
-void FairBaseParSet::clear(void)
-{
-  if(fPriGen) { delete fPriGen; }
-  if(fDetList) { delete fDetList; }
   if(fContNameList) {
     fContNameList->Delete();
     delete fContNameList;
   }
+}
 
+void FairBaseParSet::clear(void)
+{
+  fContNameList->Delete();
 }
 
 void FairBaseParSet::putParams(FairParamList* l)


### PR DESCRIPTION
fpriGen and fDetList are deleted in FairRunSim where they are created. Only the container list should be deleted in the dtor of FairBaseParSet