### PR TITLE
Changes in FairLogger.

### DIFF
--- a/fairtools/FairLogger.cxx
+++ b/fairtools/FairLogger.cxx
@@ -333,12 +333,13 @@ FairLogger& FairLogger::GetOutputStream(FairLogLevel level, const char* file, co
 
   fLevel = level;
 
+  /*
   if (level == FATAL) {
     fLogToScreen = true;
     fLogVerbosityLevel = verbosityHIGH;
     fLogColored = true;
   }
-
+  */
 
   if (fIsNewLine) {
     if ( (fLogToScreen && level <= fLogScreenLevel) ) {
@@ -395,12 +396,9 @@ FairLogger& FairLogger::GetFATALOutputStream(const char* file, const char* line,
   fLevel = FATAL;
   FairLogLevel level = FATAL;
 
-//  if (level == FATAL) {
-    fLogToScreen = true;
-    fLogVerbosityLevel = verbosityHIGH;
-    fLogColored = true;
-//  }
-
+  fLogToScreen = true;
+  fLogVerbosityLevel = verbosityHIGH;
+  fLogColored = true;
 
   if (fIsNewLine) {
     if ( (fLogToScreen && level <= fLogScreenLevel) ) {
@@ -450,29 +448,33 @@ FairLogger& FairLogger::GetFATALOutputStream(const char* file, const char* line,
   return *this;
 }
 
-
-#if (__GNUC__ >= 3)
 FairLogger& FairLogger::operator<<(std::ios_base& (*manip) (std::ios_base&))
 {
-  if (fLogToScreen && (fLevel <= fLogScreenLevel || fLevel <= fLogFileLevel) ) {
+//  if (fLogToScreen && (fLevel <= fLogScreenLevel || fLevel <= fLogFileLevel) ) {
+  if (fLogToScreen && (fLevel <= fLogScreenLevel) ) {
     *(fScreenStream) << manip;
   }
 
-  if (fLogToFile && !fLogToScreen && (fLevel <= fLogScreenLevel || fLevel <= fLogFileLevel) ) {
+  //if (fLogToFile && !fLogToScreen && (fLevel <= fLogScreenLevel || fLevel <= fLogFileLevel) ) {
+  if (fLogToFile && (fLevel <= fLogFileLevel) ) {
     *(fFileStream) << manip;
   }
 
   return *this;
 }
-#endif
 
 FairLogger& FairLogger::operator<<(std::ostream& (*manip) (std::ostream&))
 {
-  if (fLogToScreen && (fLevel <= fLogScreenLevel || fLevel <= fLogFileLevel) ) {
+  //if (fLogToScreen && (fLevel <= fLogScreenLevel || fLevel <= fLogFileLevel) ) {
+  if (fLogToScreen && fLevel <= fLogScreenLevel) {
     *(fScreenStream) << manip;
   }
-
-  if (fLogToFile && !fLogToScreen && (fLevel <= fLogScreenLevel || fLevel <= fLogFileLevel) ) {
+  
+  //if (fLogToFile && !fLogToScreen && (fLevel <= fLogScreenLevel || fLevel <= fLogFileLevel) ) {
+  // Second option looks more clear but when used one gets an extra newline when using FairLogger::endl
+  // so use the first option since  no problems in the file are detected so far 
+  if (fLogToFile && !fLogToScreen && (fLevel <= fLogFileLevel) ) {
+  // if (fLogToFile && fLevel <= fLogFileLevel) {
     *(fFileStream) << manip;
   }
 
@@ -492,9 +494,8 @@ std::ostream&  FairLogger::endl(std::ostream& strm)
     }
   }
 
-  if (gLogger->fLogToFile &&
-      gLogger->fLevel <= gLogger->fLogFileLevel) {
-    *(gLogger->fFileStream) << std::endl;
+  if ( (gLogger->fLogToFile && gLogger->fLevel <= gLogger->fLogFileLevel) ) {
+      *(gLogger->fFileStream) << std::endl;
   }
 
   if (gLogger->fLevel == FATAL) {
@@ -574,9 +575,9 @@ void FairLogger::LogFatalMessage(std::ostream& strm)
     freopen(corefile, "w", stderr);
     gSystem->StackTrace();
     fclose(stderr);
-    gSystem->Abort(1);
+    exit(1);
   } else {
-    abort();
+    exit(1);
   }
 
 }

--- a/fairtools/FairLogger.h
+++ b/fairtools/FairLogger.h
@@ -169,9 +169,7 @@ class FairLogger : public std::ostream
 
     /*! \brief Pass the ios_base manipulators
      */
-#if (__GNUC__ >= 3)
     FairLogger&                      operator<<(std::ios_base & (*manip) (std::ios_base&));
-#endif
     FairLogger&                      operator<<(std::ostream & (*manip) (std::ostream&));
 
     /*! \brief End of the line


### PR DESCRIPTION
Properly handle c++ stream manipulators for file output.
In case of FATAL error use exit intead of abort.
Clean the code.