### PR TITLE
Multiple endpoints per socket

### DIFF
--- a/examples/MQ/8-multipart/ex8-multipart.json
+++ b/examples/MQ/8-multipart/ex8-multipart.json
@@ -9,8 +9,8 @@
                         "sockets": [
                             {
                                 "type": "push",
-                                "method": "bind",
-                                "address": "tcp://*:5555",
+                                "method": "connect",
+                                "address": "tcp://localhost:5555,tcp://localhost:5556",
                                 "sndBufSize": 1000,
                                 "rcvBufSize": 1000,
                                 "rateLogging": 0
@@ -27,8 +27,26 @@
                         "sockets": [
                             {
                                 "type": "pull",
+                                "method": "bind",
+                                "address": "tcp://*:5555",
+                                "sndBufSize": 1000,
+                                "rcvBufSize": 1000,
+                                "rateLogging": 0
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "sink2",
+                "channels": [
+                    {
+                        "name": "data-in",
+                        "sockets": [
+                            {
+                                "type": "pull",
                                 "method": "connect",
-                                "address": "tcp://localhost:5555",
+                                "address": "@tcp://*:5556",
                                 "sndBufSize": 1000,
                                 "rcvBufSize": 1000,
                                 "rateLogging": 0

--- a/fairmq/FairMQChannel.cxx
+++ b/fairmq/FairMQChannel.cxx
@@ -791,19 +791,12 @@ void FairMQChannel::Tokenize(std::vector<std::string>& output,
   using namespace std;
   size_t start = 0;
   size_t end = input.find_first_of(delimiters);
-  if (end == string::npos)
-  {
-    output.push_back(input.substr(start, input.length()));
-  }
-  else do
+  while (end != string::npos)
   {
     output.push_back(input.substr(start, end-start));
     start = ++end;
     end = input.find_first_of(delimiters, start);
-    if (end == string::npos)
-    {
-      output.push_back(input.substr(start, input.length()));
-    }
-  } while (end != string::npos);
+  }
+  output.push_back(input.substr(start));
 }
 

--- a/fairmq/FairMQChannel.cxx
+++ b/fairmq/FairMQChannel.cxx
@@ -390,17 +390,6 @@ bool FairMQChannel::ValidateChannel()
             exit(EXIT_FAILURE);
         }
 
-        // validate socket method
-        const string socketMethodNames[] = { "bind", "connect" };
-        const set<string> socketMethods(socketMethodNames, socketMethodNames + sizeof(socketMethodNames) / sizeof(string));
-        if (socketMethods.find(fMethod) == socketMethods.end())
-        {
-            ss << "INVALID";
-            LOG(DEBUG) << ss.str();
-            LOG(ERROR) << "Invalid channel method: \"" << fMethod << "\"";
-            exit(EXIT_FAILURE);
-        }
-
         // validate socket address
         if (fAddress == "unspecified" || fAddress == "")
         {
@@ -421,7 +410,17 @@ bool FairMQChannel::ValidateChannel()
                 if (endpoint[0]=='@'||endpoint[0]=='+'||endpoint[0]=='>') {
                   address = endpoint.substr(1);
                 } else {
-                  address = endpoint;
+                    // we don't have a method modifier, check if the default method is set
+                    const string socketMethodNames[] = { "bind", "connect" };
+                    const set<string> socketMethods(socketMethodNames, socketMethodNames + sizeof(socketMethodNames) / sizeof(string));
+                    if (socketMethods.find(fMethod) == socketMethods.end())
+                    {
+                        ss << "INVALID";
+                        LOG(DEBUG) << ss.str();
+                        LOG(ERROR) << "Invalid endpoint connection method: \"" << fMethod << "\" for " << endpoint;
+                        exit(EXIT_FAILURE);
+                    }
+                    address = endpoint;
                 }
                 // check if address is a tcp or ipc address
                 if (address.compare(0, 6, "tcp://") == 0)

--- a/fairmq/FairMQChannel.h
+++ b/fairmq/FairMQChannel.h
@@ -248,6 +248,11 @@ class FairMQChannel
     int Receive(FairMQMessage* msg, const std::string& flag = "", int rcvTimeoutInMs = -1) const;
     int Receive(FairMQMessage* msg, const int flags, int rcvTimeoutInMs = -1) const;
 
+    // TODO: this might go to some base utility library
+    static void Tokenize(std::vector<std::string>& output,
+                         const std::string& input,
+                         const std::string delimiters = ",");
+
   private:
     std::string fType;
     std::string fMethod;

--- a/fairmq/FairMQDevice.cxx
+++ b/fairmq/FairMQDevice.cxx
@@ -208,6 +208,15 @@ void FairMQDevice::InitWrapper()
                 // fill the uninitialized list
                 uninitializedConnectingChannels.push_back(&(*vi));
             }
+            else if (vi->fAddress.find_first_of("@+>") != string::npos)
+            {
+                // set channel name: name + vector index
+                stringstream ss;
+                ss << mi->first << "[" << vi - (mi->second).begin() << "]";
+                vi->fChannelName = ss.str();
+                // fill the uninitialized list
+                uninitializedConnectingChannels.push_back(&(*vi));
+            }
             else
             {
                 LOG(ERROR) << "Cannot update configuration. Socket method (bind/connect) not specified.";

--- a/fairmq/FairMQDevice.h
+++ b/fairmq/FairMQDevice.h
@@ -400,6 +400,16 @@ class FairMQDevice : public FairMQStateMachine, public FairMQConfigurable
     /// Connects a single channel (used in InitWrapper)
     bool ConnectChannel(FairMQChannel& ch);
 
+    /// Sets up and connects/binds a socket to an endpoint
+    /// return a string with the actual endpoint if it happens
+    //to stray from default.
+    bool ConnectEndpoint(FairMQSocket& socket, std::string& endpoint);
+    bool BindEndpoint(FairMQSocket& socket, std::string& endpoint);
+    /// Attaches the channel to all listed endpoints
+    /// the list is comma separated; the default method (bind/connect) is used.
+    /// to override default: prepend "@" to bind, "+" or ">" to connect endpoint.
+    bool AttachChannel(FairMQChannel& ch);
+
     /// Signal handler
     void SignalHandler(int signal);
     bool fCatchingSignals;

--- a/fairmq/FairMQSocket.cxx
+++ b/fairmq/FairMQSocket.cxx
@@ -13,6 +13,7 @@
  */
 
 #include "FairMQSocket.h"
+#include <cstring>
 
 bool FairMQSocket::Attach(const std::string& config, bool serverish)
 {

--- a/fairmq/FairMQSocket.cxx
+++ b/fairmq/FairMQSocket.cxx
@@ -11,3 +11,53 @@
  * @since 2012-12-05
  * @author D. Klein, A. Rybalchenko
  */
+
+#include "FairMQSocket.h"
+
+bool FairMQSocket::Attach(const std::string& config, bool serverish)
+{
+  if (config.empty())
+    return false;
+  if (config.size()<2)
+    return false;
+
+  const char* endpoints = config.c_str();
+
+  //  We hold each individual endpoint here
+  char endpoint [256];
+  while (*endpoints) {
+    const char *delimiter = strchr (endpoints, ',');
+    if (!delimiter)
+      delimiter = endpoints + strlen (endpoints);
+    if (delimiter - endpoints > 255)
+      return false;
+    memcpy (endpoint, endpoints, delimiter - endpoints);
+    endpoint [delimiter - endpoints] = 0;
+
+    bool rc;
+    if (endpoint [0] == '@') {
+      rc = Bind(endpoint + 1);
+    }
+    else if (endpoint [0] == '>' || endpoint [0] == '-' || endpoint [0] == '+' ) {
+      Connect(endpoint + 1);
+    }
+    else if (serverish) {
+      rc = Bind(endpoint);
+    }
+    else {
+      Connect(endpoint);
+    }
+
+    if (!rc) {
+      return false;
+    }
+
+    if (*delimiter == 0) {
+      break;
+    }
+
+    endpoints = delimiter + 1;
+  }
+
+  return true;
+}

--- a/fairmq/FairMQSocket.h
+++ b/fairmq/FairMQSocket.h
@@ -37,6 +37,7 @@ class FairMQSocket
 
     virtual bool Bind(const std::string& address) = 0;
     virtual void Connect(const std::string& address) = 0;
+    virtual bool Attach(const std::string& address, bool serverish = false);
 
     virtual int Send(FairMQMessage* msg, const std::string& flag = "") = 0;
     virtual int Send(FairMQMessage* msg, const int flags = 0) = 0;


### PR DESCRIPTION
Hi, this contains the feature we discussed about - attaching many endpoints to a socket, specified with a list of addresses, optionally with specifiers to overrid default bind/connect method. See the commit for more documentation.