### PR TITLE
examples: use fer toolkit for Go-based examples

### DIFF
--- a/examples/advanced/GoTutorial/README.md
+++ b/examples/advanced/GoTutorial/README.md
@@ -1,6 +1,6 @@
 # GoTutorial
 
-`GoTutorial` shows how one can mix and mash devices written in `C++` and devices written in `Go`, exchanging data over `nanomsg`.
+`GoTutorial` shows how one can mix and mash devices written in `C++` and devices written in `Go`, exchanging data over `nanomsg` or `ZeroMQ`.
 
 - `go-sink` is a sink, written in `Go`
 - `go-processor` is a processor, written in `Go`

--- a/examples/advanced/GoTutorial/src/go-processor/README.md
+++ b/examples/advanced/GoTutorial/src/go-processor/README.md
@@ -1,6 +1,6 @@
 # go-processor
 
-`go-processor` is a simple `Go` based program using `nanomsg` as a transport facility.
+`go-processor` is a simple `Go` based program using `nanomsg` or `ZeroMQ` as a transport facility.
 It replicates the basic example from [FairRootMQ example 2](https://github.com/FairRootGroup/FairRoot/tree/master/examples/MQ/2-sampler-processor-sink).
 
 ## Manual Build
@@ -86,19 +86,17 @@ q
 - Then, in another terminal:
 
 ```sh
-$> go-processor
-2016/03/11 17:04:53 dialing tcp://localhost:5555 ...
-2016/03/11 17:04:53 dialing tcp://localhost:5555 ... [done]
-2016/03/11 17:04:53 dialing tcp://localhost:5556 ...
-2016/03/11 17:04:53 dialing tcp://localhost:5556 ... [done]
-2016/03/11 17:04:53 recv: Hello
-2016/03/11 17:04:54 recv: Hello
-2016/03/11 17:04:55 recv: Hello
-2016/03/11 17:04:56 recv: Hello
+$> go-processor --id processor \
+	--transport nanomsg \
+	--mq-config /opt/alice/src/fair-root/examples/MQ/2-sampler-processor-sink/ex2-sampler-processor-sink.json
+processor: --- new device: {  processor [{data1 [{pull connect tcp://localhost:5555 1000 1000 0}]    0 0 0} {data2 [{push connect tcp://localhost:5556 1000 1000 0}]    0 0 0}]}
+processor: received: "Hello"
+processor: received: "Hello"
+processor: received: "Hello"
+processor: received: "Hello"
 [...]
-2016/03/11 17:06:07 recv: Hello
-2016/03/11 17:06:08 recv: Hello
-^C
+processor: received: "Hello"
+q
 ```
 
 - And, in yet another terminal:
@@ -150,15 +148,15 @@ $> ex2-sink --id sink1 --config-json-file /opt/alice/src/fair-root/examples/MQ/2
 [17:05:57][INFO] Use keys to control the state machine:
 [17:05:57][INFO] [h] help, [p] pause, [r] run, [s] stop, [t] reset task, [d] reset device, [q] end, [j] init task, [i] init device
 [17:05:57][INFO] DEVICE: Running...
-[17:05:57][INFO] Received message: "HelloHello"
-[17:05:57][INFO] Received message: "HelloHello"
-[17:05:57][INFO] Received message: "HelloHello"
+[17:05:57][INFO] Received message: "Hello (modified by processor)"
+[17:05:57][INFO] Received message: "Hello (modified by processor)"
+[17:05:57][INFO] Received message: "Hello (modified by processor)"
 [...]
-[17:06:04][INFO] Received message: "HelloHello"
-[17:06:05][INFO] Received message: "HelloHello"
-[17:06:06][INFO] Received message: "HelloHello"
-[17:06:07][INFO] Received message: "HelloHello"
-[17:06:08][INFO] Received message: "HelloHello"
+[17:06:04][INFO] Received message: "Hello (modified by processor)"
+[17:06:05][INFO] Received message: "Hello (modified by processor)"
+[17:06:06][INFO] Received message: "Hello (modified by processor)"
+[17:06:07][INFO] Received message: "Hello (modified by processor)"
+[17:06:08][INFO] Received message: "Hello (modified by processor)"
 q
 [17:06:12][INFO] [q] end
 [17:06:12][STATE] Entering EXITING state

--- a/examples/advanced/GoTutorial/src/go-sink/README.md
+++ b/examples/advanced/GoTutorial/src/go-sink/README.md
@@ -83,16 +83,14 @@ q
 - Then, in another terminal:
 
 ```sh
-$> go-sink
-2016/03/11 14:37:28 dialing tcp://localhost:5555 ...
-2016/03/11 14:37:28 dialing tcp://localhost:5555 ... [done]
-2016/03/11 14:37:28 recv: Hello
-2016/03/11 14:37:29 recv: Hello
-2016/03/11 14:37:30 recv: Hello
-2016/03/11 14:37:31 recv: Hello
-2016/03/11 14:37:32 recv: Hello
-2016/03/11 14:37:33 recv: Hello
-2016/03/11 14:37:34 recv: Hello
-^C
+$> go-sink --id sink1 \
+	--tranport nanomsg \
+	--mq-config /opt/alice/src/fair-root/examples/MQ/1-sampler-sink/ex1-sampler-sink.json
+sink1: --- new device: { sink1  [{data [{pull bind tcp://*:5555 1000 1000 0}]    0 0 0}]}
+sink1: received: "Hello"
+sink1: received: "Hello"
+sink1: received: "Hello"
+[...]
+q
 $>
 ```


### PR DESCRIPTION
This CL migrates the Go-based examples to the fer toolkit.
This allows for the produced executables to expose a more FairMQ-like
command-line interface.