### PR TITLE
Fix crash when calling TGeoManager destructor in FairRunAna and FairRunOnline

### DIFF
--- a/base/steer/FairRunAna.cxx
+++ b/base/steer/FairRunAna.cxx
@@ -111,6 +111,10 @@ FairRunAna::~FairRunAna()
     delete fField;
   }
   if (gGeoManager) {
+    if (gROOT->GetVersionInt() >= 60602) {
+      gGeoManager->GetListOfVolumes()->Delete();
+      gGeoManager->GetListOfShapes()->Delete();
+    }
     delete gGeoManager;
   }
 }

--- a/base/steer/FairRunOnline.cxx
+++ b/base/steer/FairRunOnline.cxx
@@ -114,6 +114,10 @@ FairRunOnline::~FairRunOnline()
     delete fField;
   }
   if (gGeoManager) {
+    if (gROOT->GetVersionInt() >= 60602) {
+      gGeoManager->GetListOfVolumes()->Delete();
+      gGeoManager->GetListOfShapes()->Delete();
+    }
     delete gGeoManager;
   }
   if(fFolder) {


### PR DESCRIPTION
- Clear volumes and shapes before deleting gGeoManager. "delete run;" has to be called at the end of macro.