### PR TITLE
Update AttachChannel()

### DIFF
--- a/fairmq/FairMQChannel.cxx
+++ b/fairmq/FairMQChannel.cxx
@@ -14,6 +14,8 @@
 
 #include <set>
 
+#include <boost/algorithm/string.hpp> // join/split
+
 #include "FairMQChannel.h"
 #include "FairMQLogger.h"
 
@@ -784,13 +786,5 @@ FairMQChannel::~FairMQChannel()
 
 void FairMQChannel::Tokenize(vector<string>& output, const string& input, const string delimiters)
 {
-    size_t start = 0;
-    size_t end = input.find_first_of(delimiters);
-    while (end != string::npos)
-    {
-        output.push_back(input.substr(start, end-start));
-        start = ++end;
-        end = input.find_first_of(delimiters, start);
-    }
-    output.push_back(input.substr(start));
+    boost::algorithm::split(output, input, boost::algorithm::is_any_of(delimiters));
 }

--- a/fairmq/FairMQDevice.cxx
+++ b/fairmq/FairMQDevice.cxx
@@ -26,6 +26,8 @@
 #include <termios.h> // for the InteractiveStateLoop
 #include <poll.h>
 
+#include <boost/algorithm/string.hpp> // join/split
+
 #include "FairMQSocket.h"
 #include "FairMQDevice.h"
 #include "FairMQLogger.h"
@@ -348,6 +350,10 @@ bool FairMQDevice::AttachChannel(FairMQChannel& ch)
     // after the book keeping is done, exit in case of errors
     if (!rc) return rc;
   }
+
+  // put the (possibly) modified address back in the config
+  ch.UpdateAddress(boost::algorithm::join(endpoints, ","));
+
   return true;
 }
 


### PR DESCRIPTION
- AttachChannel() must update the channel config after it's done (bind could modify the port).
- Use boost::split for tokenizing.