### PR TITLE
Fix compatibility with ZeroMQ 4.2.1

### DIFF
--- a/fairmq/FairMQDevice.cxx
+++ b/fairmq/FairMQDevice.cxx
@@ -320,8 +320,14 @@ bool FairMQDevice::AttachChannel(FairMQChannel& ch)
         ch.fSocket->SetOption("rcv-hwm", &(ch.fRcvBufSize), sizeof(ch.fRcvBufSize));
 
         // set kernel transmit size
-        ch.fSocket->SetOption("snd-size", &(ch.fSndKernelSize), sizeof(ch.fSndKernelSize));
-        ch.fSocket->SetOption("rcv-size", &(ch.fRcvKernelSize), sizeof(ch.fRcvKernelSize));
+        if (ch.fSndKernelSize != 0)
+        {
+            ch.fSocket->SetOption("snd-size", &(ch.fSndKernelSize), sizeof(ch.fSndKernelSize));
+        }
+        if (ch.fRcvKernelSize != 0)
+        {
+            ch.fSocket->SetOption("rcv-size", &(ch.fRcvKernelSize), sizeof(ch.fRcvKernelSize));
+        }
 
         // attach
         bool bind = (ch.fMethod == "bind");


### PR DESCRIPTION
Avoid setting channel values for kernel buffer sizes on the socket if they are default to avoid conflict with changed zmq defaults (0 -> -1, somewhere between version 4.1.3 and 4.2.1).