### PR TITLE
Fix nanomsg tests

### DIFF
--- a/fairmq/test/pub-sub/runTestPub.cxx
+++ b/fairmq/test/pub-sub/runTestPub.cxx
@@ -15,6 +15,9 @@
 #include "FairMQLogger.h"
 #include "FairMQTestPub.h"
 
+#include <chrono>
+#include <thread>
+
 int main(int argc, char** argv)
 {
     reinit_logger(false);
@@ -66,6 +69,12 @@ int main(int argc, char** argv)
 
     testPub.ChangeState("RUN");
     testPub.WaitForEndOfState("RUN");
+
+    // nanomsg does not implement the LINGER option. Give the sockets some time before their queues are terminated
+    if (transport == "nanomsg")
+    {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
 
     testPub.ChangeState("RESET_TASK");
     testPub.WaitForEndOfState("RESET_TASK");

--- a/fairmq/test/pub-sub/runTestSub.cxx
+++ b/fairmq/test/pub-sub/runTestSub.cxx
@@ -12,10 +12,12 @@
  * @author A. Rybalchenko
  */
 
-#include <string>
-
 #include "FairMQLogger.h"
 #include "FairMQTestSub.h"
+
+#include <string>
+#include <chrono>
+#include <thread>
 
 int main(int argc, char** argv)
 {
@@ -69,6 +71,12 @@ int main(int argc, char** argv)
 
     testSub.ChangeState("RUN");
     testSub.WaitForEndOfState("RUN");
+
+    // nanomsg does not implement the LINGER option. Give the sockets some time before their queues are terminated
+    if (transport == "nanomsg")
+    {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
 
     testSub.ChangeState("RESET_TASK");
     testSub.WaitForEndOfState("RESET_TASK");

--- a/fairmq/test/push-pull/runTestPull.cxx
+++ b/fairmq/test/push-pull/runTestPull.cxx
@@ -15,6 +15,9 @@
 #include "FairMQLogger.h"
 #include "FairMQTestPull.h"
 
+#include <chrono>
+#include <thread>
+
 int main(int argc, char** argv)
 {
     reinit_logger(false);
@@ -58,6 +61,12 @@ int main(int argc, char** argv)
 
     testPull.ChangeState("RUN");
     testPull.WaitForEndOfState("RUN");
+
+    // nanomsg does not implement the LINGER option. Give the sockets some time before their queues are terminated
+    if (transport == "nanomsg")
+    {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
 
     testPull.ChangeState("RESET_TASK");
     testPull.WaitForEndOfState("RESET_TASK");

--- a/fairmq/test/push-pull/runTestPush.cxx
+++ b/fairmq/test/push-pull/runTestPush.cxx
@@ -15,6 +15,9 @@
 #include "FairMQLogger.h"
 #include "FairMQTestPush.h"
 
+#include <chrono>
+#include <thread>
+
 int main(int argc, char** argv)
 {
     reinit_logger(false);
@@ -59,6 +62,12 @@ int main(int argc, char** argv)
 
     testPush.ChangeState("RUN");
     testPush.WaitForEndOfState("RUN");
+
+    // nanomsg does not implement the LINGER option. Give the sockets some time before their queues are terminated
+    if (transport == "nanomsg")
+    {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
 
     testPush.ChangeState("RESET_TASK");
     testPush.WaitForEndOfState("RESET_TASK");

--- a/fairmq/test/req-rep/runTestRep.cxx
+++ b/fairmq/test/req-rep/runTestRep.cxx
@@ -12,10 +12,12 @@
  * @author A. Rybalchenko
  */
 
-#include <iostream>
-
 #include "FairMQLogger.h"
 #include "FairMQTestRep.h"
+
+#include <iostream>
+#include <chrono>
+#include <thread>
 
 int main(int argc, char** argv)
 {
@@ -60,6 +62,12 @@ int main(int argc, char** argv)
 
     testRep.ChangeState("RUN");
     testRep.WaitForEndOfState("RUN");
+
+    // nanomsg does not implement the LINGER option. Give the sockets some time before their queues are terminated
+    if (transport == "nanomsg")
+    {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
 
     testRep.ChangeState("RESET_TASK");
     testRep.WaitForEndOfState("RESET_TASK");

--- a/fairmq/test/req-rep/runTestReq.cxx
+++ b/fairmq/test/req-rep/runTestReq.cxx
@@ -12,10 +12,12 @@
  * @author A. Rybalchenko
  */
 
-#include <iostream>
-
 #include "FairMQLogger.h"
 #include "FairMQTestReq.h"
+
+#include <iostream>
+#include <chrono>
+#include <thread>
 
 int main(int argc, char** argv)
 {
@@ -61,6 +63,12 @@ int main(int argc, char** argv)
 
     testReq.ChangeState("RUN");
     testReq.WaitForEndOfState("RUN");
+
+    // nanomsg does not implement the LINGER option. Give the sockets some time before their queues are terminated
+    if (transport == "nanomsg")
+    {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
 
     testReq.ChangeState("RESET_TASK");
     testReq.WaitForEndOfState("RESET_TASK");

--- a/fairmq/test/runTransferTimeoutTest.cxx
+++ b/fairmq/test/runTransferTimeoutTest.cxx
@@ -15,6 +15,9 @@
 #include "FairMQLogger.h"
 #include "FairMQDevice.h"
 
+#include <chrono>
+#include <thread>
+
 class TransferTimeoutTester : public FairMQDevice
 {
   public:
@@ -110,22 +113,28 @@ int main(int argc, char** argv)
     dataInChannel.UpdateRateLogging(0);
     timeoutTester.fChannels["data-in"].push_back(dataInChannel);
 
-    timeoutTester.ChangeState(TransferTimeoutTester::INIT_DEVICE);
-    timeoutTester.WaitForEndOfState(TransferTimeoutTester::INIT_DEVICE);
+    timeoutTester.ChangeState("INIT_DEVICE");
+    timeoutTester.WaitForEndOfState("INIT_DEVICE");
 
-    timeoutTester.ChangeState(TransferTimeoutTester::INIT_TASK);
-    timeoutTester.WaitForEndOfState(TransferTimeoutTester::INIT_TASK);
+    timeoutTester.ChangeState("INIT_TASK");
+    timeoutTester.WaitForEndOfState("INIT_TASK");
 
-    timeoutTester.ChangeState(TransferTimeoutTester::RUN);
-    timeoutTester.WaitForEndOfState(TransferTimeoutTester::RUN);
+    timeoutTester.ChangeState("RUN");
+    timeoutTester.WaitForEndOfState("RUN");
 
-    timeoutTester.ChangeState(TransferTimeoutTester::RESET_TASK);
-    timeoutTester.WaitForEndOfState(TransferTimeoutTester::RESET_TASK);
+    // nanomsg does not implement the LINGER option. Give the sockets some time before their queues are terminated
+    if (transport == "nanomsg")
+    {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
 
-    timeoutTester.ChangeState(TransferTimeoutTester::RESET_DEVICE);
-    timeoutTester.WaitForEndOfState(TransferTimeoutTester::RESET_DEVICE);
+    timeoutTester.ChangeState("RESET_TASK");
+    timeoutTester.WaitForEndOfState("RESET_TASK");
 
-    timeoutTester.ChangeState(TransferTimeoutTester::END);
+    timeoutTester.ChangeState("RESET_DEVICE");
+    timeoutTester.WaitForEndOfState("RESET_DEVICE");
+
+    timeoutTester.ChangeState("END");
 
     return 0;
 }


### PR DESCRIPTION
nanomsg does not implement the LINGER option that gives the socket some time to finish transfers during shutdown. Adjust nanomsg tests to provide this timeout manually.