### PR TITLE
Better encapsulate Device config: Offer a getter method

### DIFF
--- a/fairmq/FairMQDevice.h
+++ b/fairmq/FairMQDevice.h
@@ -342,6 +342,7 @@ class FairMQDevice : public FairMQStateMachine, public FairMQConfigurable
     void SetTransport(const std::string& transport = "zeromq");
 
     void SetConfig(FairMQProgOptions& config);
+    const FairMQProgOptions* GetConfig() const {return fConfig;}
 
     /// Implements the sort algorithm used in SortChannel()
     /// @param lhs Right hand side value for comparison


### PR DESCRIPTION
So far devices inheriting from FairMQDevice needed to access the `fConfig` variable.
This is bad encapsulation and might be in conflict with coding conventions.

This simple getter is an evident improvement.