### PR TITLE
Remove unneeded if when deleting NULL / 0 / nullptr

### DIFF
--- a/base/MQ/devices/FairMQUnpacker.h
+++ b/base/MQ/devices/FairMQUnpacker.h
@@ -43,10 +43,7 @@ class FairMQUnpacker : public FairMQDevice
 
     virtual ~FairMQUnpacker()
     {
-        if (fUnpacker)
-        {
-            delete fUnpacker;
-        }
+        delete fUnpacker;
     }
 
     void AddSubEvtKey(short type, short subType, short procid, short subCrate, short control, const std::string& channelName)

--- a/base/MQ/policies/Sampler/FairSourceMQInterface.h
+++ b/base/MQ/policies/Sampler/FairSourceMQInterface.h
@@ -52,22 +52,13 @@ class FairSourceMQInterface : public BaseSourcePolicy<FairSourceMQInterface<Fair
 
     virtual ~FairSourceMQInterface()
     {
-        if (fInput)
-        {
-            delete fInput;
-        }
+        delete fInput;
         fInput = nullptr;
 
-        if (fSource)
-        {
-            delete fSource;
-        }
+        delete fSource;
         fSource = nullptr;
 
-        if (fRunAna)
-        {
-            delete fRunAna;
-        }
+        delete fRunAna;
         fRunAna = nullptr;
     }
 

--- a/base/MQ/policies/Serialization/MQPolicyDef.h
+++ b/base/MQ/policies/Serialization/MQPolicyDef.h
@@ -173,11 +173,8 @@ struct RawPtrDeleter
     template<typename T>
     static void Destroy_impl(T* input)
     {
-        if (input)
-        {
-            delete input;
-            input = nullptr;
-        }
+        delete input;
+        input = nullptr;
     }
 };
 

--- a/base/MQ/policies/Serialization/RootSerializer.h
+++ b/base/MQ/policies/Serialization/RootSerializer.h
@@ -76,7 +76,7 @@ struct RootDeserializer
     template<typename T>
     void deserialize_impl(const std::unique_ptr<FairMQMessage>& msg, T*& output)
     {
-        if(output) delete output;
+        delete output;
         FairTMessage tm(msg->GetData(), msg->GetSize());
         output = static_cast<T*>(tm.ReadObject(tm.GetClass()));
     }
@@ -91,7 +91,7 @@ struct RootDeserializer
     template<typename T>
     void Deserialize(FairMQMessage& msg, T*& output)
     {
-        if(output) delete output;
+        delete output;
         FairTMessage tm(msg.GetData(), msg.GetSize());
         output = static_cast<T*>(tm.ReadObject(tm.GetClass()));
     }

--- a/base/MQ/policies/Storage/RootOutFileManager.tpl
+++ b/base/MQ/policies/Storage/RootOutFileManager.tpl
@@ -47,8 +47,7 @@ RootOutFileManager<DataType>::~RootOutFileManager()
     if (fFlowMode && fWrite)
         fTree->Write("", TObject::kOverwrite);
 
-    if (fTree)
-        delete fTree;
+    delete fTree;
 
     if (fOutFile)
     {
@@ -56,9 +55,8 @@ RootOutFileManager<DataType>::~RootOutFileManager()
             fOutFile->Close();
         delete fOutFile;
     }
-    
-    if (fFolder)
-        delete fFolder;
+ 
+    delete fFolder;
 }
 
 template <typename DataType>

--- a/base/sim/FairDetector.cxx
+++ b/base/sim/FairDetector.cxx
@@ -53,9 +53,7 @@ FairDetector::FairDetector(const FairDetector& rhs)
 
 FairDetector::~FairDetector()
 {
-
-  if ( flGeoPar ) { delete flGeoPar; }
-
+  delete flGeoPar;
 }
 // -------------------------------------------------------------------------
 

--- a/base/sim/FairGenericStack.cxx
+++ b/base/sim/FairGenericStack.cxx
@@ -36,7 +36,7 @@ FairGenericStack::FairGenericStack(Int_t)
 // -----   Destructor   ----------------------------------------------------
 FairGenericStack::~FairGenericStack()
 {
-  if (fDetIter) delete fDetIter;
+  delete fDetIter;
 }
 // -------------------------------------------------------------------------
 // -----   Copy constructor   ----------------------------------------------

--- a/base/sim/FairGeoParSet.cxx
+++ b/base/sim/FairGeoParSet.cxx
@@ -33,8 +33,8 @@ FairGeoParSet::~FairGeoParSet(void)
 
 void FairGeoParSet::clear(void)
 {
-  //if(fGeoNodes) { delete fGeoNodes; }
-// if(fGeom ) delete fGeom;
+  //delete fGeoNodes;
+// delete fGeom;
 
 }
 

--- a/base/sim/FairModule.cxx
+++ b/base/sim/FairModule.cxx
@@ -406,7 +406,7 @@ void FairModule::ConstructRootGeometry()
        *  produce TGeoVolumes with materials that have only names and no properties
        */
       ExpandNode(n);
-      if(NewGeo!=0) { delete NewGeo; }
+      delete NewGeo;
       delete f;
     } else {
       LOG(FATAL)<<"Could not find the given mother volume "<< fMotherVolumeName.Data() << " where the geomanger should be added."<<FairLogger::endl;

--- a/base/steer/FairRingSorterTask.h
+++ b/base/steer/FairRingSorterTask.h
@@ -79,7 +79,7 @@ class FairRingSorterTask : public FairTask
 
     /** Destructor **/
     virtual ~FairRingSorterTask() {
-      if (fSorter!= 0) { delete fSorter; }
+      delete fSorter;
     }
 
     /** Virtual method Init **/

--- a/base/steer/FairRootManager.cxx
+++ b/base/steer/FairRootManager.cxx
@@ -126,9 +126,7 @@ FairRootManager::~FairRootManager()
 {
 //
   LOG(DEBUG) << "Enter Destructor of FairRootManager" << FairLogger::endl;
-  if(fOutTree) {
-    delete fOutTree;
-  }
+  delete fOutTree;
   if(fOutFile) {
     fOutFile->cd();
     delete fOutFile;
@@ -139,10 +137,8 @@ FairRootManager::~FairRootManager()
   fgInstance = 0;
   LOG(DEBUG) << "Leave Destructor of FairRootManager" << FairLogger::endl;
 
-  if (fEventHeader)
-	  delete fEventHeader;
-  if (fSourceChain)
-	  delete fSourceChain;
+  delete fEventHeader;
+  delete fSourceChain;
 }
 //_____________________________________________________________________________
 

--- a/base/steer/FairRun.cxx
+++ b/base/steer/FairRun.cxx
@@ -65,20 +65,12 @@ FairRun::FairRun(Bool_t isMaster)
 FairRun::~FairRun()
 {
   LOG(DEBUG) << "Enter Destructor of FairRun" << FairLogger::endl;
-  if (fTask) {
-    delete fTask;  // There is another tasklist in MCApplication,
-  }
+  delete fTask;  // There is another tasklist in MCApplication,
   // but this should be independent
-  if (fRtdb) {
-    delete fRtdb;  // who is responsible for the RuntimeDataBase
-  }
-  if (fRootManager) {
-    delete fRootManager; // who is responsible
-    fRootManager=0;
-  }
-  if (fEvtHeader) {
-    delete fEvtHeader;
-  }
+  delete fRtdb;  // who is responsible for the RuntimeDataBase
+  delete fRootManager; // who is responsible
+  fRootManager=0;
+  delete fEvtHeader;
   LOG(DEBUG) << "Leave Destructor of FairRun" << FairLogger::endl;
 }
 //_____________________________________________________________________________
@@ -114,7 +106,7 @@ void FairRun::AddTask(FairTask* t)
 //_____________________________________________________________________________
 void FairRun::SetTask(FairTask* t)
 {
-  if ( fTask ) { delete fTask; }
+  delete fTask;
   fTask = t;
   fFileHeader->AddTaskClassName(t->ClassName());
 }

--- a/base/steer/FairRunAna.cxx
+++ b/base/steer/FairRunAna.cxx
@@ -107,9 +107,7 @@ FairRunAna::FairRunAna()
 FairRunAna::~FairRunAna()
 {
   //  delete fFriendFileList;
-  if (fField) {
-    delete fField;
-  }
+  delete fField;
   if (gGeoManager) {
     if (gROOT->GetVersionInt() >= 60602) {
       gGeoManager->GetListOfVolumes()->Delete();

--- a/base/steer/FairRunOnline.cxx
+++ b/base/steer/FairRunOnline.cxx
@@ -110,9 +110,7 @@ FairRunOnline::FairRunOnline(FairSource* source)
 FairRunOnline::~FairRunOnline()
 {
   //  delete fFriendFileList;
-  if (fField) {
-    delete fField;
-  }
+  delete fField;
   if (gGeoManager) {
     if (gROOT->GetVersionInt() >= 60602) {
       gGeoManager->GetListOfVolumes()->Delete();
@@ -124,10 +122,7 @@ FairRunOnline::~FairRunOnline()
     fFolder->Delete();
     delete fFolder;
   }
-  if(fServer)
-  {
-    delete fServer;
-  }
+  delete fServer;
 }
 //_____________________________________________________________________________
 

--- a/base/steer/FairRunSim.cxx
+++ b/base/steer/FairRunSim.cxx
@@ -444,7 +444,7 @@ void FairRunSim::SetMaterials(const char* MatFileName)
 void FairRunSim::SetGeoModel( char* name )
 {
   if ( strncmp(fName,"TGeant3",7) == 0 ) {
-    if (fLoaderName) { delete fLoaderName; }
+    delete fLoaderName;
     fLoaderName = new TString(name);
     LOG(INFO) << "FairRun::SetGeoModel(): G3 native geometry model used "
 	      << FairLogger::endl;

--- a/examples/MQ/9-PixelDetector/src/PixelDigitize.cxx
+++ b/examples/MQ/9-PixelDetector/src/PixelDigitize.cxx
@@ -85,7 +85,7 @@ PixelDigitize::PixelDigitize(const char* name, Int_t iVerbose)
 // -----   Destructor   ----------------------------------------------------
 PixelDigitize::~PixelDigitize() { 
   Reset();
-  if ( fDigiPar)   delete fDigiPar;
+  delete fDigiPar;
   if ( fDigis ) {
     fDigis->Delete();
     delete fDigis;

--- a/examples/MQ/9-PixelDetector/src/PixelFindHits.cxx
+++ b/examples/MQ/9-PixelDetector/src/PixelFindHits.cxx
@@ -92,7 +92,7 @@ PixelFindHits::PixelFindHits(const char* name, Int_t iVerbose)
 // -----   Destructor   ----------------------------------------------------
 PixelFindHits::~PixelFindHits() { 
   Reset();
-  if ( fDigiPar)   delete fDigiPar;
+  delete fDigiPar;
   if ( fHits ) {
     fHits->Delete();
     delete fHits;

--- a/examples/MQ/9-PixelDetector/src/PixelFindTracks.cxx
+++ b/examples/MQ/9-PixelDetector/src/PixelFindTracks.cxx
@@ -81,7 +81,7 @@ PixelFindTracks::PixelFindTracks(const char* name, Int_t iVerbose)
 // -----   Destructor   ----------------------------------------------------
 PixelFindTracks::~PixelFindTracks() { 
   Reset();
-  if ( fDigiPar)   delete fDigiPar;
+  delete fDigiPar;
   if ( fTracks ) {
     fTracks->Delete();
     delete fTracks;

--- a/examples/MQ/9-PixelDetector/src/PixelFitTracks.cxx
+++ b/examples/MQ/9-PixelDetector/src/PixelFitTracks.cxx
@@ -80,7 +80,7 @@ PixelFitTracks::PixelFitTracks(const char* name, Int_t iVerbose)
 // -----   Destructor   ----------------------------------------------------
 PixelFitTracks::~PixelFitTracks() { 
   Reset();
-  if ( fDigiPar)   delete fDigiPar;
+  delete fDigiPar;
   if ( fFitTracks ) {
     fFitTracks->Delete();
     delete fFitTracks;

--- a/examples/MQ/9-PixelDetector/src/PixelGeoPar.cxx
+++ b/examples/MQ/9-PixelDetector/src/PixelGeoPar.cxx
@@ -30,8 +30,8 @@ PixelGeoPar::~PixelGeoPar(void)
 
 void PixelGeoPar::clear(void)
 {
-  if(fGeoSensNodes) { delete fGeoSensNodes; }
-  if(fGeoPassNodes) { delete fGeoPassNodes; }
+  delete fGeoSensNodes;
+  delete fGeoPassNodes;
 }
 
 void PixelGeoPar::putParams(FairParamList* l)

--- a/examples/MQ/9-PixelDetector/src/devices/FairMQEx9Processor.cxx
+++ b/examples/MQ/9-PixelDetector/src/devices/FairMQEx9Processor.cxx
@@ -63,24 +63,14 @@ FairMQEx9Processor::FairMQEx9Processor()
 
 FairMQEx9Processor::~FairMQEx9Processor()
 {
-    if(fDigiPar)
-    {
-        delete fDigiPar;
-        fDigiPar=nullptr;
-    }
+    delete fDigiPar;
+    fDigiPar=nullptr;
 
-    if(fGeoPar)
-    {
-        delete fGeoPar;
-        fGeoPar=nullptr;
-    }
+    delete fGeoPar;
+    fGeoPar=nullptr;
 
-    if(fOutput)
-    {
-        delete fOutput;
-        fOutput=nullptr;
-    }
-
+    delete fOutput;
+    fOutput=nullptr;
 
 }
 
@@ -187,17 +177,11 @@ void FairMQEx9Processor::CustomCleanup(void* /*data*/, void* hint)
 void FairMQEx9Processor::UpdateParameters()
 {
     //*
-    if(fDigiPar)
-    {
-        delete fDigiPar;
-        fDigiPar=nullptr;
-    }
+    delete fDigiPar;
+    fDigiPar=nullptr;
 
-    if(fGeoPar)
-    {
-        delete fGeoPar;
-        fGeoPar=nullptr;
-    }
+    delete fGeoPar;
+    fGeoPar=nullptr;
 
     fDigiPar = new PixelDigiPar();
     fGeoPar = new FairGeoParSet();

--- a/examples/MQ/9-PixelDetector/src/devices/FairMQEx9TaskProcessor.tpl
+++ b/examples/MQ/9-PixelDetector/src/devices/FairMQEx9TaskProcessor.tpl
@@ -40,24 +40,12 @@ FairMQEx9TaskProcessor<T>::FairMQEx9TaskProcessor()
 template <typename T>
 FairMQEx9TaskProcessor<T>::~FairMQEx9TaskProcessor()
 {
-  if(fGeoPar)
-    {
-      delete fGeoPar;
-      fGeoPar=nullptr;
-    }
-  
-  if(fInput)
-    {
-      delete fInput;
-      fInput=nullptr;
-    }
-  
-  if(fOutput)
-    {
-      delete fOutput;
-      fOutput=nullptr;
-    }
-
+  delete fGeoPar;
+  fGeoPar=nullptr;
+  delete fInput;
+  fInput=nullptr;
+  delete fOutput;
+  fOutput=nullptr;
   delete fFairTask;
 }
 

--- a/examples/MQ/9-PixelDetector/src/devices/FairMQEx9TaskProcessorBin.tpl
+++ b/examples/MQ/9-PixelDetector/src/devices/FairMQEx9TaskProcessorBin.tpl
@@ -49,39 +49,24 @@ template <typename T>
 FairMQEx9TaskProcessorBin<T>::~FairMQEx9TaskProcessorBin()
 {
   LOG(INFO) << "deteling fGeoPar"; 
- if(fGeoPar)
-    {
-      delete fGeoPar;
-      fGeoPar=nullptr;
-    }
-   
+  delete fGeoPar;
+  fGeoPar=nullptr;
+
   LOG(INFO) << "deteling fInput";
- if(fInput)
-    {
-      delete fInput;
-      fInput=nullptr;
-    }
-  
+  delete fInput;
+  fInput=nullptr;
+
   LOG(INFO) << "deteling fOutput";
-  if(fOutput)
-    {
-      delete fOutput;
-      fOutput=nullptr;
-    }
+  delete fOutput;
+  fOutput=nullptr;
 
   LOG(INFO) << "deteling fInputArray";
-  if(fInputArray)
-    {
-      delete fInputArray;
-      fInputArray=nullptr;
-    }
-  
+  delete fInputArray;
+  fInputArray=nullptr;
+
   LOG(INFO) << "deteling fOutputArray";
-  if(fOutputArray)
-    {
-      delete fOutputArray;
-      fOutputArray=nullptr;
-    }
+  delete fOutputArray;
+  fOutputArray=nullptr;
 
   delete fFairTask;
 }

--- a/examples/MQ/9a-PixelDetector/src/PixelAltFindHits.cxx
+++ b/examples/MQ/9a-PixelDetector/src/PixelAltFindHits.cxx
@@ -92,7 +92,7 @@ PixelAltFindHits::PixelAltFindHits(const char* name, Int_t iVerbose)
 // -----   Destructor   ----------------------------------------------------
 PixelAltFindHits::~PixelAltFindHits() { 
   Reset();
-  if ( fDigiPar)   delete fDigiPar;
+  delete fDigiPar;
   if ( fHits ) {
     fHits->Delete();
     delete fHits;

--- a/examples/MQ/9a-PixelDetector/src/devices/FairMQEx9aTaskProcessorBin.tpl
+++ b/examples/MQ/9a-PixelDetector/src/devices/FairMQEx9aTaskProcessorBin.tpl
@@ -39,12 +39,8 @@ template <typename T>
 FairMQEx9aTaskProcessorBin<T>::~FairMQEx9aTaskProcessorBin()
 {
   LOG(INFO) << "deteling fGeoPar"; 
-  if(fGeoPar)
-    {
-      delete fGeoPar;
-      fGeoPar=nullptr;
-    }
-  
+  delete fGeoPar;
+  fGeoPar=nullptr;
   delete fFairTask;
 }
 

--- a/examples/MQ/serialization/src/1-simple/devices/SerializerExample.h
+++ b/examples/MQ/serialization/src/1-simple/devices/SerializerExample.h
@@ -40,7 +40,7 @@ struct MyDeserializer
 {
     void Deserialize(FairMQMessage& msg, TClonesArray*& output)
     {
-        if(output) delete output;
+        delete output;
         FairTMessage tm(msg.GetData(), msg.GetSize());
         output = static_cast<TClonesArray*>(tm.ReadObject(tm.GetClass()));
     }

--- a/examples/MQ/serialization/src/2-multi-part/devices/SerializerExample2.h
+++ b/examples/MQ/serialization/src/2-multi-part/devices/SerializerExample2.h
@@ -54,7 +54,7 @@ struct SerializerEx2
 
     void Deserialize(FairMQMessage& msg, TClonesArray*& output)
     {
-        if (output) delete output;
+        delete output;
         FairTMessage tm(msg.GetData(), msg.GetSize());
         output = static_cast<TClonesArray*>(tm.ReadObject(tm.GetClass()));
     }

--- a/examples/advanced/Tutorial3/MQ/fileSink/FairTestDetectorFileSink.h
+++ b/examples/advanced/Tutorial3/MQ/fileSink/FairTestDetectorFileSink.h
@@ -76,14 +76,8 @@ class FairTestDetectorFileSink : public FairMQDevice
     {
         fTree->Write();
         fOutFile->Close();
-        if (fHitVector.size() > 0)
-        {
-            fHitVector.clear();
-        }
-        if (fOutput)
-        {
-            delete fOutput;
-        }
+        fHitVector.clear();
+        delete fOutput;
         delete fOutFile;
     }
 

--- a/examples/advanced/Tutorial3/simulation/FairTestDetectorGeoPar.cxx
+++ b/examples/advanced/Tutorial3/simulation/FairTestDetectorGeoPar.cxx
@@ -24,14 +24,8 @@ FairTestDetectorGeoPar::~FairTestDetectorGeoPar(void)
 
 void FairTestDetectorGeoPar::clear(void)
 {
-    if (fGeoSensNodes)
-    {
-        delete fGeoSensNodes;
-    }
-    if (fGeoPassNodes)
-    {
-        delete fGeoPassNodes;
-    }
+    delete fGeoSensNodes;
+    delete fGeoPassNodes;
 }
 
 void FairTestDetectorGeoPar::putParams(FairParamList* l)

--- a/examples/common/passive/FairGeoPassivePar.cxx
+++ b/examples/common/passive/FairGeoPassivePar.cxx
@@ -31,8 +31,8 @@ FairGeoPassivePar::~FairGeoPassivePar(void)
 
 void FairGeoPassivePar::clear(void)
 {
-  if(fGeoSensNodes) { delete fGeoSensNodes; }
-  if(fGeoPassNodes) { delete fGeoPassNodes; }
+  delete fGeoSensNodes;
+  delete fGeoPassNodes;
 }
 
 void FairGeoPassivePar::putParams(FairParamList* l)

--- a/examples/simulation/Tutorial1/src/FairTutorialDet1GeoPar.cxx
+++ b/examples/simulation/Tutorial1/src/FairTutorialDet1GeoPar.cxx
@@ -28,8 +28,8 @@ FairTutorialDet1GeoPar::~FairTutorialDet1GeoPar(void)
 
 void FairTutorialDet1GeoPar::clear(void)
 {
-  if(fGeoSensNodes) { delete fGeoSensNodes; }
-  if(fGeoPassNodes) { delete fGeoPassNodes; }
+  delete fGeoSensNodes;
+  delete fGeoPassNodes;
 }
 
 void FairTutorialDet1GeoPar::putParams(FairParamList* l)

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2GeoPar.cxx
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2GeoPar.cxx
@@ -30,8 +30,8 @@ FairTutorialDet2GeoPar::~FairTutorialDet2GeoPar(void)
 
 void FairTutorialDet2GeoPar::clear(void)
 {
-  if(fGeoSensNodes) { delete fGeoSensNodes; }
-  if(fGeoPassNodes) { delete fGeoPassNodes; }
+  delete fGeoSensNodes;
+  delete fGeoPassNodes;
 }
 
 void FairTutorialDet2GeoPar::putParams(FairParamList* l)

--- a/examples/simulation/Tutorial4/src/param/FairTutorialDet4GeoPar.cxx
+++ b/examples/simulation/Tutorial4/src/param/FairTutorialDet4GeoPar.cxx
@@ -29,8 +29,8 @@ FairTutorialDet4GeoPar::~FairTutorialDet4GeoPar(void)
 
 void FairTutorialDet4GeoPar::clear(void)
 {
-  if(fGeoSensNodes) { delete fGeoSensNodes; }
-  if(fGeoPassNodes) { delete fGeoPassNodes; }
+  delete fGeoSensNodes;
+  delete fGeoPassNodes;
 }
 
 void FairTutorialDet4GeoPar::putParams(FairParamList* l)

--- a/examples/simulation/rutherford/src/FairRutherfordGeoPar.cxx
+++ b/examples/simulation/rutherford/src/FairRutherfordGeoPar.cxx
@@ -28,8 +28,8 @@ FairRutherfordGeoPar::~FairRutherfordGeoPar(void)
 
 void FairRutherfordGeoPar::clear(void)
 {
-  if(fGeoSensNodes) { delete fGeoSensNodes; }
-  if(fGeoPassNodes) { delete fGeoPassNodes; }
+  delete fGeoSensNodes;
+  delete fGeoPassNodes;
 }
 
 void FairRutherfordGeoPar::putParams(FairParamList* l)

--- a/fairmq/nanomsg/FairMQPollerNN.cxx
+++ b/fairmq/nanomsg/FairMQPollerNN.cxx
@@ -231,8 +231,5 @@ bool FairMQPollerNN::CheckOutput(const string channelKey, const int index)
 
 FairMQPollerNN::~FairMQPollerNN()
 {
-    if (items != NULL)
-    {
-        delete[] items;
-    }
+    delete[] items;
 }

--- a/fairmq/shmem/FairMQPollerSHM.cxx
+++ b/fairmq/shmem/FairMQPollerSHM.cxx
@@ -234,8 +234,5 @@ bool FairMQPollerSHM::CheckOutput(const string channelKey, const int index)
 
 FairMQPollerSHM::~FairMQPollerSHM()
 {
-    if (items != NULL)
-    {
-        delete[] items;
-    }
+    delete[] items;
 }

--- a/fairmq/zeromq/FairMQPollerZMQ.cxx
+++ b/fairmq/zeromq/FairMQPollerZMQ.cxx
@@ -234,8 +234,5 @@ bool FairMQPollerZMQ::CheckOutput(const string channelKey, const int index)
 
 FairMQPollerZMQ::~FairMQPollerZMQ()
 {
-    if (items != NULL)
-    {
-        delete[] items;
-    }
+    delete[] items;
 }

--- a/generators/FairEvtGenGenerator.cxx
+++ b/generators/FairEvtGenGenerator.cxx
@@ -80,7 +80,7 @@ FairEvtGenGenerator::FairEvtGenGenerator(const char* fileName, Double_t Rsigma, 
 // -----   Destructor   ---------------------------------------------------
 FairEvtGenGenerator::~FairEvtGenGenerator()
 {
-  if(fDensityFunction) { delete fDensityFunction; }
+  delete fDensityFunction;
   if(fInputFile) { fclose(fInputFile); }
 }
 // ------------------------------------------------------------------------

--- a/geobase/FairGeoAsciiIo.cxx
+++ b/geobase/FairGeoAsciiIo.cxx
@@ -45,10 +45,8 @@ FairGeoAsciiIo::~FairGeoAsciiIo()
 {
   // Destructor
   close();
-  if (file) {
-    delete file;
-    file=0;
-  }
+  delete file;
+  file=0;
 }
 
 Bool_t FairGeoAsciiIo::open(const char* fname,const Text_t* status)
@@ -208,10 +206,8 @@ Bool_t FairGeoAsciiIo::readDetectorSetup(FairGeoInterface* interface)
     if (strlen(buf)>=3 && buf[1]!='/') {
       if (buf[0]=='[') {
         set=0;
-        if (mod) {
-          delete [] mod;
-          mod=0;
-        }
+        delete [] mod;
+        mod=0;
         s=buf;
         Ssiz_t n=s.First(']');
         det=s(1,n-1);
@@ -219,7 +215,7 @@ Bool_t FairGeoAsciiIo::readDetectorSetup(FairGeoInterface* interface)
         set=interface->findSet(det);
         if (!set) {
           Error("readDetectorSetup","Detector %s not found",det.Data());
-          if (mod) { delete [] mod; }
+          delete [] mod;
           return kFALSE;
         }
         maxModules=set->getMaxModules();
@@ -236,12 +232,12 @@ Bool_t FairGeoAsciiIo::readDetectorSetup(FairGeoInterface* interface)
             set->setModules(secNo,mod);
           }
         } else {
-          if (mod) { delete [] mod; }
+          delete [] mod;
           return kFALSE;
         }
       }
     }
   }
-  if (mod) { delete [] mod; }
+  delete [] mod;
   return kTRUE;
 }

--- a/geobase/FairGeoInterface.cxx
+++ b/geobase/FairGeoInterface.cxx
@@ -66,18 +66,13 @@ FairGeoInterface::FairGeoInterface()
 FairGeoInterface::~FairGeoInterface()
 {
   // Destructor
-  if (fileInput) {
-    delete fileInput;
-    fileInput=0;
-  }
-  if (oraInput) {
-    delete oraInput;
-    oraInput=0;
-  }
-  if (output) {
-    delete output;
-    output=0;
-  }
+  delete fileInput;
+  fileInput=0;
+  delete oraInput;
+  oraInput=0;
+  delete output;
+  output=0;
+
 //  if (geoBuilder) {
 //    delete geoBuilder;
 //    geoBuilder=0;

--- a/geobase/FairGeoPcon.cxx
+++ b/geobase/FairGeoPcon.cxx
@@ -57,18 +57,12 @@ FairGeoPcon::FairGeoPcon()
 FairGeoPcon::~FairGeoPcon()
 {
   // default destructor
-  if (param) {
-    delete param;
-    param=0;
-  }
-  if (center) {
-    delete center;
-    center=0;
-  }
-  if (position) {
-    delete position;
-    position=0;
-  }
+  delete param;
+  param=0;
+  delete center;
+  center=0;
+  delete position;
+  position=0;
 }
 
 

--- a/geobase/FairGeoPgon.cxx
+++ b/geobase/FairGeoPgon.cxx
@@ -57,18 +57,12 @@ FairGeoPgon::FairGeoPgon()
 FairGeoPgon::~FairGeoPgon()
 {
   // default destructor
-  if (param) {
-    delete param;
-    param=0;
-  }
-  if (center) {
-    delete center;
-    center=0;
-  }
-  if (position) {
-    delete position;
-    position=0;
-  }
+  delete param;
+  param=0;
+  delete center;
+  center=0;
+  delete position;
+  position=0;
 }
 
 

--- a/geobase/FairGeoSet.cxx
+++ b/geobase/FairGeoSet.cxx
@@ -58,15 +58,10 @@ FairGeoSet::FairGeoSet()
 FairGeoSet::~FairGeoSet()
 {
   // Destructor
-  if (volumes) {
-//    volumes->Delete("slow");
-    delete volumes;
-    volumes=0;
-  }
-  if (modules) {
-    delete modules;
-    modules=0;
-  }
+  delete volumes;
+  volumes=0;
+  delete modules;
+  modules=0;
 }
 
 void FairGeoSet::setModules(Int_t s,Int_t* m)

--- a/geobase/FairGeoSphe.cxx
+++ b/geobase/FairGeoSphe.cxx
@@ -56,18 +56,12 @@ FairGeoSphe::FairGeoSphe()
 FairGeoSphe::~FairGeoSphe()
 {
   // default destructor
-  if (param) {
-    delete param;
-    param=0;
-  }
-  if (center) {
-    delete center;
-    center=0;
-  }
-  if (position) {
-    delete position;
-    position=0;
-  }
+  delete param;
+  param=0;
+  delete center;
+  center=0;
+  delete position;
+  position=0;
 }
 
 

--- a/geobase/FairGeoTrap.cxx
+++ b/geobase/FairGeoTrap.cxx
@@ -63,18 +63,12 @@ FairGeoTrap::FairGeoTrap()
 FairGeoTrap::~FairGeoTrap()
 {
   // destructor
-  if (param) {
-    delete param;
-    param=0;
-  }
-  if (center) {
-    delete center;
-    center=0;
-  }
-  if (position) {
-    delete position;
-    position=0;
-  }
+  delete param;
+  param=0;
+  delete center;
+  center=0;
+  delete position;
+  position=0;
 }
 
 

--- a/geobase/FairGeoTrd1.cxx
+++ b/geobase/FairGeoTrd1.cxx
@@ -59,18 +59,12 @@ FairGeoTrd1::FairGeoTrd1()
 FairGeoTrd1::~FairGeoTrd1()
 {
   // destructor
-  if (param) {
-    delete param;
-    param=0;
-  }
-  if (center) {
-    delete center;
-    center=0;
-  }
-  if (position) {
-    delete position;
-    position=0;
-  }
+  delete param;
+  param=0;
+  delete center;
+  center=0;
+  delete position;
+  position=0;
 }
 
 

--- a/geobase/FairGeoTube.cxx
+++ b/geobase/FairGeoTube.cxx
@@ -58,18 +58,12 @@ FairGeoTube::FairGeoTube()
 FairGeoTube::~FairGeoTube()
 {
   // default destructor
-  if (param) {
-    delete param;
-    param=0;
-  }
-  if (center) {
-    delete center;
-    center=0;
-  }
-  if (position) {
-    delete position;
-    position=0;
-  }
+  delete param;
+  param=0;
+  delete center;
+  center=0;
+  delete position;
+  position=0;
 }
 
 

--- a/geobase/FairGeoTubs.cxx
+++ b/geobase/FairGeoTubs.cxx
@@ -61,18 +61,12 @@ FairGeoTubs::FairGeoTubs()
 FairGeoTubs::~FairGeoTubs()
 {
   // default destructor
-  if (param) {
-    delete param;
-    param=0;
-  }
-  if (center) {
-    delete center;
-    center=0;
-  }
-  if (position) {
-    delete position;
-    position=0;
-  }
+  delete param;
+  param=0;
+  delete center;
+  center=0;
+  delete position;
+  position=0;
 }
 
 

--- a/parbase/FairGenericParAsciiFileIo.cxx
+++ b/parbase/FairGenericParAsciiFileIo.cxx
@@ -253,9 +253,7 @@ Bool_t FairGenericParAsciiFileIo::readGenericSet(FairParGenericSet *pPar) {
           UChar_t *pValue = obj->setLength(length);
           memcpy(pValue, val, length);
           paramList->getList()->Add(obj);
-          if (val) {
-            delete[] val;
-          }
+          delete[] val;
         }
       }
     }

--- a/parbase/FairParIo.cxx
+++ b/parbase/FairParIo.cxx
@@ -77,8 +77,6 @@ void FairParIo::removeDetParIo(Text_t* detName)
 {
   // removes input/output class for a detector
   TObject* p=detParIoList->FindObject(detName);
-  if (p) {
-    delete p;
-    p=0;
-  }
+  delete p;
+  p=0;
 }

--- a/parbase/FairParRootFileIo.cxx
+++ b/parbase/FairParRootFileIo.cxx
@@ -77,9 +77,7 @@ FairParRootFile::FairParRootFile(TFile* f)
 FairParRootFile::~FairParRootFile()
 {
   // destructor
-  if (run) {
-    delete run;
-  }
+  delete run;
   run=0;
   //TODO: What about the file? Should it be closed or not
 }
@@ -90,9 +88,7 @@ void FairParRootFile::readVersions(FairRtdbRun* currentRun)
 {
   // finds the current run containing the parameter container versions
   // in the ROOT file
-  if (run) {
-    delete run;
-  }
+  delete run;
 
   run=static_cast<FairRtdbRun*>(RootFile->Get((const_cast<char*>(currentRun->GetName()))));
   //cout << "-I- FairParRootFile :: readversions " << currentRun->GetName() << " : " << run << endl;

--- a/parbase/FairParamList.cxx
+++ b/parbase/FairParamList.cxx
@@ -324,14 +324,10 @@ FairParamObj::FairParamObj(const Text_t* name,const UChar_t* value,const Int_t n
 FairParamObj::~FairParamObj()
 {
   // Destructor
-  if (paramValue) {
-    delete [] paramValue;
-    paramValue=0;
-  }
-  if (streamerInfo) {
-    delete [] streamerInfo;
-    streamerInfo=0;
-  }
+  delete [] paramValue;
+  paramValue=0;
+  delete [] streamerInfo;
+  streamerInfo=0;
 }
 
 void FairParamObj::setParamType(const Text_t* t)
@@ -374,7 +370,7 @@ void FairParamObj::setParamType(const Text_t* t)
 UChar_t* FairParamObj::setLength(Int_t l)
 {
   // Sets the length of the binary array
-  if (paramValue) { delete [] paramValue; }
+  delete [] paramValue;
   arraySize=l;
   if (l>0) {
     paramValue=new UChar_t[arraySize];
@@ -387,7 +383,7 @@ UChar_t* FairParamObj::setLength(Int_t l)
 void FairParamObj::setParamValue(UChar_t* value,const Int_t length)
 {
   // Sets the parameter value (the array is not copied!)
-  if (paramValue) { delete [] paramValue; }
+  delete [] paramValue;
   arraySize=length;
   paramValue=value;
 }
@@ -395,7 +391,7 @@ void FairParamObj::setParamValue(UChar_t* value,const Int_t length)
 UChar_t* FairParamObj::setStreamerInfoSize(Int_t l)
 {
   // Sets the length of the streamer info
-  if (streamerInfo) { delete [] streamerInfo; }
+  delete [] streamerInfo;
   streamerInfoSize=l;
   if (l>0) {
     streamerInfo=new UChar_t[streamerInfoSize];
@@ -408,7 +404,7 @@ UChar_t* FairParamObj::setStreamerInfoSize(Int_t l)
 void FairParamObj::setStreamerInfo(UChar_t* array,const Int_t length)
 {
   // Sets the streamer info of ROOT classes (the array is not copied!)
-  if (streamerInfo) { delete [] streamerInfo; }
+  delete [] streamerInfo;
   streamerInfoSize=length;
   streamerInfo=array;
 }

--- a/parmq/ParameterMQServer.cxx
+++ b/parmq/ParameterMQServer.cxx
@@ -224,8 +224,5 @@ int ParameterMQServer::GetProperty(const int key, const int default_ /*= 0*/)
 
 ParameterMQServer::~ParameterMQServer()
 {
-    if (fRtdb)
-    {
-        delete fRtdb;
-    }
+    delete fRtdb;
 }

--- a/templates/NewDetector/NewDetectorGeoPar.cxx
+++ b/templates/NewDetector/NewDetectorGeoPar.cxx
@@ -30,8 +30,8 @@ NewDetectorGeoPar::~NewDetectorGeoPar(void)
 
 void NewDetectorGeoPar::clear(void)
 {
-  if(fGeoSensNodes) { delete fGeoSensNodes; }
-  if(fGeoPassNodes) { delete fGeoPassNodes; }
+  delete fGeoSensNodes;
+  delete fGeoPassNodes;
 }
 
 void NewDetectorGeoPar::putParams(FairParamList* l)

--- a/templates/project_template/NewDetector/NewDetectorGeoPar.cxx
+++ b/templates/project_template/NewDetector/NewDetectorGeoPar.cxx
@@ -30,8 +30,8 @@ NewDetectorGeoPar::~NewDetectorGeoPar(void)
 
 void NewDetectorGeoPar::clear(void)
 {
-  if(fGeoSensNodes) { delete fGeoSensNodes; }
-  if(fGeoPassNodes) { delete fGeoPassNodes; }
+  delete fGeoSensNodes;
+  delete fGeoPassNodes;
 }
 
 void NewDetectorGeoPar::putParams(FairParamList* l)


### PR DESCRIPTION
C++ standard dictates that NULL / 0 / nullptr is a valid argument for
delete which then simply has no effect:

"The value of the first argument supplied to a deallocation function may
be a null pointer value; if so, and if the deallocation function is one
supplied in the standard library, the call has no effect."

I therefore think in these particular case it's safe to remove the ifs.