### PR TITLE
Migration of simulation code to multi-threading:

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -95,6 +95,9 @@ sim/FairMCApplication.cxx
 sim/FairModule.cxx
 sim/FairParticle.cxx
 sim/FairPrimaryGenerator.cxx
+sim/FairGenericRootManager.cxx
+sim/FairRootManagerSim.cxx
+sim/FairRootManagerSimMT.cxx
 sim/FairRunIdGenerator.cxx
 sim/FairVolume.cxx
 sim/FairVolumeList.cxx

--- a/base/sim/FairGenericRootManager.cxx
+++ b/base/sim/FairGenericRootManager.cxx
@@ -1,0 +1,64 @@
+/********************************************************************************
+ *    Copyright (C) 2017 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             * 
+ *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *  
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+//------------------------------------------------
+// The Geant4 Virtual Monte Carlo package
+// Copyright (C) 2013, 2014 Ivana Hrivnacova
+// All rights reserved.
+//
+// For the licensing terms see geant4_vmc/LICENSE.
+// Contact: root-vmc@cern.ch
+//-------------------------------------------------
+
+/// \file FairGenericRootManager.cxx
+/// \brief Implementation of the FairGenericRootManager class
+///
+/// TVirtualMCRootManager class adapted for FairRoot.
+///
+/// \author I. Hrivnacova; IPN Orsay
+
+#include "FairGenericRootManager.h"
+#include "TError.h"
+
+
+                                Bool_t  FairGenericRootManager::fgDebug = false;
+TMCThreadLocal FairGenericRootManager*  FairGenericRootManager::fgInstance = 0;
+
+//_____________________________________________________________________________
+FairGenericRootManager* FairGenericRootManager::Instance()
+{
+/// \return The singleton instance.
+
+  return fgInstance;
+}  
+
+//
+// ctors, dtor
+//
+
+//_____________________________________________________________________________
+FairGenericRootManager::FairGenericRootManager()
+{
+/// Default constructor
+
+  if ( fgInstance ) {
+      Fatal("FairGenericRootManager",
+            "Attempt to create two instances of singleton.");
+    return;
+  }  
+
+  fgInstance = this;
+}
+
+//_____________________________________________________________________________
+FairGenericRootManager::~FairGenericRootManager() 
+{
+/// Destructor
+
+  fgInstance = 0;
+}

--- a/base/sim/FairGenericRootManager.h
+++ b/base/sim/FairGenericRootManager.h
@@ -1,0 +1,93 @@
+/********************************************************************************
+ *    Copyright (C) 2017 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             * 
+ *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *  
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+//------------------------------------------------
+// The Geant4 Virtual Monte Carlo package
+// Copyright (C) 2013, 2014 Ivana Hrivnacova
+// All rights reserved.
+//
+// For the licensing terms see geant4_vmc/LICENSE.
+// Contact: root-vmc@cern.ch
+//-------------------------------------------------
+
+/// \file FairGenericRootManager.h
+/// \brief Definition of the FairGenericRootManager class
+///
+/// TVirtualMCRootManager class adapted for FairRoot.
+///
+/// \author I. Hrivnacova; IPN Orsay
+
+#ifndef ROOT_FairGenericRootManager
+#define ROOT_FairGenericRootManager
+
+#include "TObject.h"
+#include "TMCtls.h"
+
+class FairWriteoutBuffer;
+class FairRootManager;
+class TClonesArray; 
+
+/// \brief The interface to the Root IO manager for FairRoot multi-threaded applications.
+///
+/// Implemented according to TVirtualMCRootManager from Geant4 VMC.
+
+class FairGenericRootManager : public TObject
+{
+  public:
+    FairGenericRootManager();
+    virtual ~FairGenericRootManager();     
+  
+    // static access method
+    static FairGenericRootManager* Instance(); 
+    
+    // static method for activating debug mode
+    static void SetDebug(Bool_t debug); 
+    static Bool_t GetDebug();
+
+    // methods
+    virtual void                Register(const char* name, const char* folderName, TNamed* obj, Bool_t toFile) = 0;
+    virtual void                Register(const char* name,const char* folderName ,TCollection* obj, Bool_t toFile) = 0;
+    virtual void                RegisterInputObject(const char* name, TObject* obj) = 0;
+    virtual TClonesArray*       Register(TString branchName, TString className, TString folderName, Bool_t toFile) = 0;
+    virtual FairWriteoutBuffer* RegisterWriteoutBuffer(TString branchName, FairWriteoutBuffer* buffer) = 0;
+
+    virtual void  Fill() = 0;
+    virtual void  Write() = 0;
+    virtual void  CloseOutFile() = 0;
+    // virtual void  WriteAndClose() = 0;
+
+    // access to the implementation class
+    virtual FairRootManager*    GetFairRootManager() const = 0;
+    virtual Int_t  GetId() const = 0;
+    
+    // static data members
+    static  Bool_t  fgDebug; // Option to activate debug printings
+
+  private:
+    // not implemented
+    FairGenericRootManager(const FairGenericRootManager& rhs);
+    FairGenericRootManager& operator=(const FairGenericRootManager& rhs);
+    
+#if !defined(__CINT__)
+    static  TMCThreadLocal FairGenericRootManager* fgInstance; // singleton instance
+#else
+    static                 FairGenericRootManager* fgInstance; // singleton instance
+#endif 
+};
+
+// inline functions
+
+inline void FairGenericRootManager::SetDebug(Bool_t debug) {
+  fgDebug = debug;
+}  
+  
+inline Bool_t FairGenericRootManager::GetDebug() {
+  return fgDebug;
+}  
+
+#endif //ROOT_FairGenericRootManager

--- a/base/sim/FairGenericStack.cxx
+++ b/base/sim/FairGenericStack.cxx
@@ -42,8 +42,8 @@ FairGenericStack::~FairGenericStack()
 // -----   Copy constructor   ----------------------------------------------
 FairGenericStack::FairGenericStack(const FairGenericStack& rhs)
   : TVirtualMCStack(rhs),
-    fLogger(0),
-    fDetList(0),
+    fLogger(FairLogger::GetLogger()),
+    fDetList(rhs.fDetList),
     fDetIter(0),
     fVerbose(rhs.fVerbose)
 {

--- a/base/sim/FairMCApplication.h
+++ b/base/sim/FairMCApplication.h
@@ -34,10 +34,11 @@ class FairPrimaryGenerator;
 class FairRadGridManager;
 class FairRadLenManager;
 class FairRadMapManager;
-class FairRootManager;
+class FairGenericRootManager;
 class FairTask;
 class FairTrajFilter;
 class FairVolume;
+class FairRunSim;
 class TChain;
 class TIterator;
 class TObjArray;
@@ -124,11 +125,11 @@ class FairMCApplication : public TVirtualMCApplication
     /** Clone for worker (used in MT mode only) */
     virtual TVirtualMCApplication* CloneForWorker() const;
 
-    /** Init worker run (used in MT mode only) */
-    virtual void InitForWorker() const;
+    /** Init application on worker (used in MT mode only) */
+    virtual void InitOnWorker();
 
-    /** Finish worker run (used in MT mode only) */
-    virtual void FinishWorkerRun() const;
+    /** Finish run on worker (used in MT mode only) */
+    virtual void FinishRunOnWorker();
 
     /** Run the MC engine
      * @param nofEvents : number of events to simulate
@@ -191,8 +192,6 @@ class FairMCApplication : public TVirtualMCApplication
 
   private:
     // methods
-    void RegisterStack();
-
     Int_t GetIonPdg(Int_t z, Int_t a) const;
 
     void UndoGeometryModifications();
@@ -219,7 +218,7 @@ class FairMCApplication : public TVirtualMCApplication
     /** Simulation Stack  */
     FairGenericStack*     fStack; //!
     /**Pointer to thr I/O Manager */
-    FairRootManager*      fRootManager; //!
+    FairGenericRootManager*  fRootManager; //!
     /**List of sensetive volumes in all detectors*/
     TRefArray*           fSenVolumes; //!
     /**Magnetic Field Pointer*/
@@ -273,9 +272,9 @@ class FairMCApplication : public TVirtualMCApplication
     std::list <FairDetector *> listDetectors;  //!
     /** Pointer to the current MC engine //!
      */
-    TVirtualMC* fMC;
-
-   
+    TVirtualMC*  fMC;
+    /** Pointer to FairRunSim //! */
+    FairRunSim*  fRun;
     
     ClassDef(FairMCApplication,4)  //Interface to MonteCarlo application
 
@@ -287,6 +286,8 @@ class FairMCApplication : public TVirtualMCApplication
 
     FairRunInfo fRunInfo;//!
     Bool_t      fGeometryIsInitialized;
+
+    static FairMCApplication* fgMasterInstance;
 };
 
 // inline functions

--- a/base/sim/FairRootManagerSim.cxx
+++ b/base/sim/FairRootManagerSim.cxx
@@ -1,0 +1,151 @@
+/********************************************************************************
+ *    Copyright (C) 2017 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             * 
+ *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *  
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+//------------------------------------------------
+// The Geant4 Virtual Monte Carlo package
+// Copyright (C) 2013, 2014 Ivana Hrivnacova
+// All rights reserved.
+//
+// For the licensing terms see geant4_vmc/LICENSE.
+// Contact: root-vmc@cern.ch
+//-------------------------------------------------
+
+/// \file FairRootManagerSim.cxx
+/// \brief Implementation of the FairRootManagerSim class
+///
+/// TMCRootManager class adapted for FairRoot.
+///
+/// \author I. Hrivnacova; IPN Orsay
+
+#include "FairRootManagerSim.h"
+#include "FairRootManager.h"
+#include "FairWriteoutBuffer.h"
+#include "TClonesArray.h"
+#include "TError.h"
+
+#include <cstdio>
+
+//
+// ctors, dtor
+//
+
+//_____________________________________________________________________________
+FairRootManagerSim::FairRootManagerSim()
+  : FairGenericRootManager(),
+    fRootManager(0)
+{
+/// Standard constructor
+  if ( fgDebug ) printf("FairRootManagerSim::FairRootManagerSim %p \n", this);
+  fRootManager = FairRootManager::Instance();
+  if ( ! fRootManager ) {
+    std::cout << "Creating FairRootManager" << std::endl;
+    fRootManager = new FairRootManager();
+  } else {
+    std::cout << "Got FairRootManager existing" << std::endl;
+  }
+  if ( fgDebug ) printf("Done FairRootManagerSim::FairRootManagerSim %p \n", this);
+}
+
+//_____________________________________________________________________________
+FairRootManagerSim::~FairRootManagerSim() 
+{
+/// Destructor
+
+  // Delete Root manager
+  if ( fgDebug ) printf("Going to Delete fRootManager in  %p \n", this);
+  delete fRootManager;
+  if ( fgDebug ) printf("Done Delete fRootManager in %p \n", this);
+}
+
+//
+// public methods
+//
+
+//_____________________________________________________________________________
+void FairRootManagerSim::Register(const char* name, const char* folderName, TNamed* obj, Bool_t toFile)
+{
+  fRootManager->Register(name, folderName, obj, toFile);
+}
+
+//_____________________________________________________________________________
+void FairRootManagerSim::Register(const char* name, const char* folderName, TCollection* obj, Bool_t toFile)
+{
+  fRootManager->Register(name, folderName, obj, toFile);
+}
+
+//_____________________________________________________________________________
+void FairRootManagerSim::RegisterInputObject(const char* name, TObject* obj)
+{
+  fRootManager->RegisterInputObject(name,obj);
+}
+
+//_____________________________________________________________________________
+TClonesArray*  FairRootManagerSim::Register(TString branchName, TString className, TString folderName, Bool_t toFile)
+{
+  return fRootManager->Register(branchName, className, folderName, toFile);
+}
+
+//_____________________________________________________________________________
+FairWriteoutBuffer* FairRootManagerSim::RegisterWriteoutBuffer(TString branchName, FairWriteoutBuffer* buffer)
+{
+  return fRootManager->RegisterWriteoutBuffer(branchName, buffer);
+}
+
+//_____________________________________________________________________________
+void  FairRootManagerSim::Fill()
+{
+/// Fill the Root tree.
+
+  fRootManager->Fill();
+}  
+
+//_____________________________________________________________________________
+void FairRootManagerSim:: Write()
+{
+/// Write the Root tree in the file.
+
+  fRootManager->Write();
+}  
+
+//_____________________________________________________________________________
+void FairRootManagerSim:: CloseOutFile()
+{
+/// Close the Root file.
+
+  fRootManager->CloseOutFile();
+}  
+
+// //_____________________________________________________________________________
+// void FairRootManagerSim:: WriteAndClose()
+// {
+// /// Write the Root tree in the file and close the file.
+
+//   fRootManager->Write();
+//   fRootManager->CloseOutFile();
+// }  
+
+// //_____________________________________________________________________________
+// TObject*  FairRootManagerSim::GetObject(const char* branchName)
+// {
+//   return fRootManager->GetObject(branchName);
+// }
+
+// //_____________________________________________________________________________
+// TClonesArray*  FairRootManagerSim::GetTClonesArray(TString branchName)
+// {
+//   return fRootManager->GetTClonesArray(branchName);
+// }
+
+// //_____________________________________________________________________________
+// void  FairRootManagerSim::ReadEvent(Int_t i)
+// {
+// /// Read the event data for \em i -th event for all connected branches.
+// /// \param i  The event to be read
+
+//   fRootManager->ReadEvent(i);
+// }

--- a/base/sim/FairRootManagerSim.h
+++ b/base/sim/FairRootManagerSim.h
@@ -1,0 +1,72 @@
+/********************************************************************************
+ *    Copyright (C) 2017 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             * 
+ *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *  
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+//------------------------------------------------
+// The Geant4 Virtual Monte Carlo package
+// Copyright (C) 2013, 2014 Ivana Hrivnacova
+// All rights reserved.
+//
+// For the licensing terms see geant4_vmc/LICENSE.
+// Contact: root-vmc@cern.ch
+//-------------------------------------------------
+
+/// \file FairRootManagerSim.h
+/// \brief Definition of the FairRootManagerSim class
+///
+/// TMCRootManager class adapted for FairRoot.
+///
+/// \author I. Hrivnacova; IPN Orsay
+
+#ifndef ROOT_FairRootManagerSim
+#define ROOT_FairRootManagerSim
+
+#include "FairGenericRootManager.h"
+
+#include <vector>
+
+class FairRootManager;
+class FairWriteoutBuffer;
+class TClonesArray; 
+
+/// \brief The Root IO manager for FairRoot multi-threaded applications.
+///
+/// Implemented according to TMCRootManager from Geant4 VMC.
+/// It implements the FairGenericRootManager interface.
+
+class FairRootManagerSim : public FairGenericRootManager
+{
+  public:
+    FairRootManagerSim();
+    virtual ~FairRootManagerSim();     
+  
+    // methods
+    // virtual void  Register(const char* name, const char* className, void* objAddress);
+    // virtual void  Register(const char* name, const char* className, const void* objAddress);
+    virtual void                Register(const char* name, const char* folderName, TNamed* obj, Bool_t toFile);
+    virtual void                Register(const char* name,const char* folderName ,TCollection* obj, Bool_t toFile);
+    virtual void                RegisterInputObject(const char* name, TObject* obj);
+    virtual TClonesArray*       Register(TString branchName, TString className, TString folderName, Bool_t toFile);
+    virtual FairWriteoutBuffer* RegisterWriteoutBuffer(TString branchName, FairWriteoutBuffer* buffer);
+
+    virtual void  Fill();
+    virtual void  Write();
+    virtual void  CloseOutFile();
+
+    virtual FairRootManager*    GetFairRootManager() const { return fRootManager; }
+    virtual Int_t  GetId() const { return 0; }
+
+  private:
+    // not implemented
+    FairRootManagerSim(const FairRootManagerSim& rhs);
+    FairRootManagerSim& operator=(const FairRootManagerSim& rhs);
+
+    // data members 
+    FairRootManager*  fRootManager;  // The Root manager
+};
+
+#endif //ROOT_FairRootManagerSim

--- a/base/sim/FairRootManagerSimMT.cxx
+++ b/base/sim/FairRootManagerSimMT.cxx
@@ -1,0 +1,397 @@
+/********************************************************************************
+ *    Copyright (C) 2017 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             * 
+ *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *  
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+//------------------------------------------------
+// The Geant4 Virtual Monte Carlo package
+// Copyright (C) 2013, 2014 Ivana Hrivnacova
+// All rights reserved.
+//
+// For the licensing terms see geant4_vmc/LICENSE.
+// Contact: root-vmc@cern.ch
+//-------------------------------------------------
+
+/// \file FairRootManagerSimMT.cxx
+/// \brief Implementation of the FairRootManagerSimMT class
+///
+/// Implemented according to TMCRootManagerMT from Geant4 VMC.
+///
+/// \author I. Hrivnacova; IPN Orsay
+
+#include "FairRootManagerSimMT.h"
+#include "FairRootManager.h"
+#include "FairWriteoutBuffer.h"
+#include "TClonesArray.h"
+#if ( ROOT_VERSION_CODE >= ROOT_VERSION(6,9,3) )
+#include "TMCAutoLock.h"
+#endif
+#include "TMCtls.h"
+#include "TThread.h"
+#include "TError.h"
+#include "RVersion.h"
+
+#include <cstdio>
+
+#if ( ROOT_VERSION_CODE >= ROOT_VERSION(6,9,3) )
+namespace {
+  TMCMutex createMutex = TMCMUTEX_INITIALIZER;
+  TMCMutex deleteMutex = TMCMUTEX_INITIALIZER;
+  TMCMutex registerMutex = TMCMUTEX_INITIALIZER;
+  TMCMutex fillMutex  = TMCMUTEX_INITIALIZER;
+  TMCMutex tmpFillMutex  = TMCMUTEX_INITIALIZER;
+  TMCMutex writeMutex = TMCMUTEX_INITIALIZER;
+  TMCMutex closeMutex = TMCMUTEX_INITIALIZER;
+  TMCMutex getMutex =  TMCMUTEX_INITIALIZER;
+}  
+#endif
+
+pthread_mutex_t counter_mutex;
+pthread_mutex_t fill_lock_mutex;
+
+//
+// static data, methods
+//
+
+Int_t   FairRootManagerSimMT::fgCounter = 0; 
+Bool_t  FairRootManagerSimMT::fgIsFillLock = true; 
+std::vector<Bool_t>* FairRootManagerSimMT::fgIsFillLocks = 0;
+
+//
+// ctors, dtor
+//
+
+//_____________________________________________________________________________
+FairRootManagerSimMT::FairRootManagerSimMT()
+  : FairGenericRootManager(),
+    fId(0),
+    fRootManager(0)
+{
+/// Standard constructor
+
+  // Check if TThread was initialized
+  //if ( ! TThread::IsInitialized() ) {
+  //   Fatal("FairRootManagerSimMT", "TThread::Initialize() must be called first.");
+  //}
+
+  if ( fgDebug ) {
+    LOG(INFO) << "FairRootManagerSimMT::FairRootManagerSimMT: going to lock " 
+      << this << FairLogger::endl;
+  }
+#if ( ROOT_VERSION_CODE >= ROOT_VERSION(6,9,3) )
+  TMCAutoLock lk(&createMutex);
+#endif
+
+  // Set Id
+  fId = fgCounter;
+
+  // Get  FairRootManager (created via FairRun object)
+  fRootManager = FairRootManager::Instance();
+  if ( ! fRootManager ) {
+    LOG(ERROR) << "FairRootManager::Instance() does not exist, creating new instance in " 
+      << fId << " " << this << FairLogger::endl;
+    fRootManager = new FairRootManager();
+  }
+
+  if ( fgDebug ) {
+    LOG(INFO) << "Done get fRootManager " << fRootManager << " in " 
+      << fId << " " << this << FairLogger::endl;
+  }
+
+  // Increment counter
+  if ( ! fgCounter ) {
+    fgIsFillLocks = new std::vector<Bool_t>();
+  } 
+  ++fgCounter;
+  fgIsFillLocks->push_back(true);  
+
+#if ( ROOT_VERSION_CODE >= ROOT_VERSION(6,9,3) )
+  lk.unlock();
+#endif
+  if ( fgDebug ) {
+    LOG(INFO) << "Released lock and done FairRootManagerSimMT::FairRootManagerSimMT in "
+      << fId << " " << this << FairLogger::endl;
+  }
+}
+
+//_____________________________________________________________________________
+FairRootManagerSimMT::~FairRootManagerSimMT() 
+{
+/// Destructor
+
+  if ( fgDebug ) {
+    LOG(INFO) << "FairRootManagerSimMT::~FairRootManagerSimMT: going to lock " 
+      << fId << " " << this << FairLogger::endl;
+  }
+#if ( ROOT_VERSION_CODE >= ROOT_VERSION(6,9,3) )
+  TMCAutoLock lk(&deleteMutex);
+#endif
+
+  // Delete Root manager
+  if ( fgDebug ) {
+    LOG(INFO) << "Going to Delete fRootManager in " 
+      << fId << " " << this << FairLogger::endl;
+  }
+  delete fRootManager;
+  if ( fgDebug ) {
+    LOG(INFO) << "Done Delete fRootManager in " 
+      << fId << " " << this << FairLogger::endl;
+  }
+
+  // Global cleanup 
+  --fgCounter;
+  if ( ! fgCounter ) {
+    delete fgIsFillLocks;
+    fgIsFillLocks = 0;
+  } 
+
+  //  
+#if ( ROOT_VERSION_CODE >= ROOT_VERSION(6,9,3) )
+  lk.unlock();
+#endif
+  if ( fgDebug ) {
+    LOG(INFO) << "Released lock and done FairRootManagerSimMT::~FairRootManagerSimMT in "
+      << fId << " " << this << FairLogger::endl;
+  }
+}
+
+//
+// private methods
+//
+
+//_____________________________________________________________________________
+void  FairRootManagerSimMT::LogMessage(const TString& message)
+{
+/// Output one line log message followed with the instance Id and pointer
+
+  if ( fgDebug ) {
+    LOG(INFO) << message << " in " << fId << " " << this << FairLogger::endl;
+  }
+}
+
+
+//_____________________________________________________________________________
+void  FairRootManagerSimMT::FillWithTmpLock()
+{
+/// Fill the Root tree.
+
+  LogMessage("Going to lock for Fill");
+#if ( ROOT_VERSION_CODE >= ROOT_VERSION(6,9,3) )
+  TMCAutoLock lk(&tmpFillMutex);
+#endif
+
+  LogMessage("Fill");
+  fRootManager->Fill();
+  LogMessage("Done Fill");
+  
+  if ( fgIsFillLock ) {
+    // the access to TFile and TTree needs to be locked only until 
+    // __after__ the first Fill
+    (*fgIsFillLocks)[fId] = false;
+    Bool_t isDoneAll = true;
+    Int_t counter = 0;
+    while ( isDoneAll && counter < fgCounter ) {
+      isDoneAll = ! (*fgIsFillLocks)[counter++];
+    }
+    if ( isDoneAll ) {
+      LogMessage("... Switching off locking of Fill()");
+      fgIsFillLock = false;
+    }
+  }
+
+  LogMessage("Exiting Fill");
+
+#if ( ROOT_VERSION_CODE >= ROOT_VERSION(6,9,3) )
+  lk.unlock();
+#endif
+  LogMessage("Released lock for Fill");
+}  
+
+//_____________________________________________________________________________
+void  FairRootManagerSimMT::FillWithLock()
+{
+/// Fill the Root tree.
+
+  LogMessage("Going to lock for Fill");
+#if ( ROOT_VERSION_CODE >= ROOT_VERSION(6,9,3) )
+  TMCAutoLock lk(&fillMutex);
+#endif
+
+  LogMessage("Fill");
+  fRootManager->Fill();
+  LogMessage("Done Fill");
+  
+#if ( ROOT_VERSION_CODE >= ROOT_VERSION(6,9,3) )
+  lk.unlock();
+#endif
+  LogMessage("Released lock for Fill");
+}  
+
+//_____________________________________________________________________________
+
+void  FairRootManagerSimMT::FillWithoutLock()
+{
+  LogMessage("Fill");
+  fRootManager->Fill();
+  LogMessage("Done Fill");
+}
+
+//
+// public methods
+//
+
+//_____________________________________________________________________________
+void FairRootManagerSimMT::Register(const char* name, const char* folderName, TNamed* obj, Bool_t toFile)
+{
+  LogMessage("Going to lock for Register (1)");
+#if ( ROOT_VERSION_CODE >= ROOT_VERSION(6,9,3) )
+  TMCAutoLock lk(&registerMutex);
+#endif
+
+  LogMessage(TString("Register ") + name);
+  fRootManager->Register(name, folderName, obj, toFile);
+  LogMessage(TString("Done Register") + name);
+
+#if ( ROOT_VERSION_CODE >= ROOT_VERSION(6,9,3) )
+  lk.unlock();
+#endif
+  LogMessage("Released lock for Register");
+}
+
+//_____________________________________________________________________________
+void FairRootManagerSimMT::Register(const char* name, const char* folderName, TCollection* obj, Bool_t toFile)
+{
+  LogMessage("Going to lock for Register (2)");
+#if ( ROOT_VERSION_CODE >= ROOT_VERSION(6,9,3) )
+  TMCAutoLock lk(&registerMutex);
+#endif
+
+  LogMessage(TString("Register ") + name);
+  fRootManager->Register(name, folderName, obj, toFile);
+  LogMessage(TString("Done Register") + name);
+
+#if ( ROOT_VERSION_CODE >= ROOT_VERSION(6,9,3) )
+  lk.unlock();
+#endif
+  LogMessage("Released lock for Register (2)");
+}
+
+//_____________________________________________________________________________
+void FairRootManagerSimMT::RegisterInputObject(const char* name, TObject* obj)
+{
+  LogMessage("Going to lock for Register (3)");
+#if ( ROOT_VERSION_CODE >= ROOT_VERSION(6,9,3) )
+  TMCAutoLock lk(&registerMutex);
+#endif
+
+  LogMessage(TString("Register ") + name);
+  fRootManager->RegisterInputObject(name,obj);
+  LogMessage(TString("Done Register") + name);
+
+#if ( ROOT_VERSION_CODE >= ROOT_VERSION(6,9,3) )
+  lk.unlock();
+#endif
+  LogMessage("Released lock for Register (3)");
+}
+
+//_____________________________________________________________________________
+TClonesArray*  FairRootManagerSimMT::Register(TString branchName, TString className, TString folderName, Bool_t toFile)
+{
+  LogMessage("Going to lock for Register (4)");
+#if ( ROOT_VERSION_CODE >= ROOT_VERSION(6,9,3) )
+  TMCAutoLock lk(&registerMutex);
+#endif
+
+  LogMessage(TString("Register ") + branchName);
+  TClonesArray* result
+    = fRootManager->Register(branchName, className, folderName, toFile);
+  LogMessage(TString("Done Register") + branchName);
+
+#if ( ROOT_VERSION_CODE >= ROOT_VERSION(6,9,3) )
+  lk.unlock();
+#endif
+  LogMessage("Released lock for Register (4)");
+
+  return result;
+}
+
+//_____________________________________________________________________________
+FairWriteoutBuffer* FairRootManagerSimMT::RegisterWriteoutBuffer(TString branchName, FairWriteoutBuffer* buffer)
+{
+  LogMessage("Going to lock for RegisterWriteoutBuffer");
+#if ( ROOT_VERSION_CODE >= ROOT_VERSION(6,9,3) )
+  TMCAutoLock lk(&registerMutex);
+#endif
+
+  LogMessage("RegisterWriteoutBuffer");
+  FairWriteoutBuffer* result
+    = fRootManager->RegisterWriteoutBuffer(branchName, buffer);
+  LogMessage("Done RegisterWriteoutBuffer");
+
+#if ( ROOT_VERSION_CODE >= ROOT_VERSION(6,9,3) )
+  lk.unlock();
+#endif
+  LogMessage("Released lock for RegisterWriteoutBuffer");
+
+  return result;
+}
+
+//_____________________________________________________________________________
+void  FairRootManagerSimMT::Fill()
+{
+/// Fill the Root tree.
+
+  // Fill with lack untill first call on all threads
+  if ( fgIsFillLock ) {
+    FillWithTmpLock();
+  }  
+  else {
+    FillWithoutLock();
+  }
+
+  // Fill with lock during the whole run
+  // FillWithLock();
+}  
+
+//_____________________________________________________________________________
+void FairRootManagerSimMT:: Write()
+{
+/// Write the Root tree in the file.
+
+  LogMessage("Going to lock for Write");
+#if ( ROOT_VERSION_CODE >= ROOT_VERSION(6,9,3) )
+  TMCAutoLock lk(&writeMutex);
+#endif
+
+  LogMessage("Write");
+  fRootManager->Write();
+  LogMessage("Done Write");
+
+#if ( ROOT_VERSION_CODE >= ROOT_VERSION(6,9,3) )
+  lk.unlock();
+#endif
+  LogMessage("Released lock for Write");
+}  
+
+//_____________________________________________________________________________
+void FairRootManagerSimMT:: CloseOutFile()
+{
+/// Close the Root file.
+
+  LogMessage("Going to lock for CloseOutFile");
+#if ( ROOT_VERSION_CODE >= ROOT_VERSION(6,9,3) )
+  TMCAutoLock lk(&closeMutex);
+#endif
+
+  LogMessage("CloseOutFile");
+  fRootManager->CloseOutFile();
+  LogMessage("Done CloseOutFile");
+
+#if ( ROOT_VERSION_CODE >= ROOT_VERSION(6,9,3) )
+  lk.unlock();
+#endif
+  LogMessage("Released lock for CloseOutFile");
+}  

--- a/base/sim/FairRootManagerSimMT.h
+++ b/base/sim/FairRootManagerSimMT.h
@@ -1,0 +1,84 @@
+/********************************************************************************
+ *    Copyright (C) 2017 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             * 
+ *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *  
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+//------------------------------------------------
+// The Geant4 Virtual Monte Carlo package
+// Copyright (C) 2013, 2014 Ivana Hrivnacova
+// All rights reserved.
+//
+// For the licensing terms see geant4_vmc/LICENSE.
+// Contact: root-vmc@cern.ch
+//-------------------------------------------------
+
+/// \file FairRootManagerSimMT.h
+/// \brief Definition of the FairRootManagerSimMT class
+///
+/// TMCRootManagerMT class adapted for FairRoot.
+///
+/// \author I. Hrivnacova; IPN Orsay
+
+#ifndef ROOT_FairRootManagerSimMT
+#define ROOT_FairRootManagerSimMT
+
+#include "FairGenericRootManager.h"
+
+#include <vector>
+
+class FairRootManager;
+class FairWriteoutBuffer;
+class TClonesArray; 
+
+/// \brief The Root IO manager for VMC examples for multi-threaded applications.
+///
+/// Implemented according to TMCRootManager from Geant4 VMC.
+/// It implements the FairGenericRootManager interface.
+
+class FairRootManagerSimMT : public FairGenericRootManager
+{
+  public:
+    FairRootManagerSimMT();
+    virtual ~FairRootManagerSimMT();     
+  
+    // methods
+    // virtual void  Register(const char* name, const char* className, void* objAddress);
+    // virtual void  Register(const char* name, const char* className, const void* objAddress);
+    virtual void                Register(const char* name, const char* folderName, TNamed* obj, Bool_t toFile);
+    virtual void                Register(const char* name,const char* folderName ,TCollection* obj, Bool_t toFile);
+    virtual void                RegisterInputObject(const char* name, TObject* obj);
+    virtual TClonesArray*       Register(TString branchName, TString className, TString folderName, Bool_t toFile);
+    virtual FairWriteoutBuffer* RegisterWriteoutBuffer(TString branchName, FairWriteoutBuffer* buffer);
+
+    virtual void  Fill();
+    virtual void  Write();
+    virtual void  CloseOutFile();
+
+    virtual FairRootManager*    GetFairRootManager() const { return fRootManager; }
+    virtual Int_t  GetId() const { return fId; }
+
+  private:
+    // not implemented
+    FairRootManagerSimMT(const FairRootManagerSimMT& rhs);
+    FairRootManagerSimMT& operator=(const FairRootManagerSimMT& rhs);
+    
+    // methods
+    void  LogMessage(const TString& message);
+    void  FillWithLock();
+    void  FillWithTmpLock();
+    void  FillWithoutLock();
+
+    // global static data members
+    static  Int_t    fgCounter;         // The counter of instances
+    static  Bool_t   fgIsFillLock;      // The if the Fill should be locked 
+    static  std::vector<Bool_t>* fgIsFillLocks; // The info per thread if the Fill should be locked
+
+    // data members 
+    Int_t             fId;           // This manager ID 
+    FairRootManager*  fRootManager;  // The Root manager
+};
+
+#endif //ROOT_FairRootManagerSimMT

--- a/base/steer/FairRootManager.cxx
+++ b/base/steer/FairRootManager.cxx
@@ -126,10 +126,13 @@ FairRootManager::~FairRootManager()
 {
 //
   LOG(DEBUG) << "Enter Destructor of FairRootManager" << FairLogger::endl;
-  delete fOutTree;
+  // delete fOutTree;
   if(fOutFile) {
     fOutFile->cd();
     delete fOutFile;
+  } else {
+    // if fOutFile exists, fOutTree is deleted with the file
+    delete fOutTree;
   }
   delete fObj2;
   fBranchNameList->Delete();
@@ -199,6 +202,8 @@ TFile* FairRootManager::OpenOutFile(const char* fname)
   }
   LOG(INFO) << "FairRootManager::OpenOutFile(\"" << fname << "\")" << FairLogger::endl;
   fOutFile = TFile::Open(fname, "recreate");
+  LOG(DEBUG) << "FairRootManager::OpenOutFile(\"" << fname << "\") " << this << " "
+    << fOutFile << FairLogger::endl;
   return OpenOutFile(fOutFile);
 }
 //_____________________________________________________________________________
@@ -478,12 +483,13 @@ void FairRootManager::LastFill()
     Fill();
   }
 }
-//_____________________________________________________________________________
 
 //_____________________________________________________________________________
 Int_t FairRootManager::Write(const char*, Int_t, Int_t)
 {
   /** Writes the tree in the file.*/
+
+    LOG(DEBUG) << "FairRootManager::Write "  << this << FairLogger::endl ;
 
   if(fOutTree!=0) {
     /** Get the file handle to the current output file from the tree.
@@ -491,7 +497,11 @@ Int_t FairRootManager::Write(const char*, Int_t, Int_t)
       * handle fOutFile is lost and the program crash while writing the
       * last part of the last file.
     */
+
+    // fOutTree->Print();
+
     fOutFile = fOutTree->GetCurrentFile();
+    LOG(DEBUG) << "FairRootManager::Write to file: "  << fOutFile->GetName()  << FairLogger::endl ;
     fOutFile->cd();
     fOutTree->Write();
   } else {

--- a/base/steer/FairRun.cxx
+++ b/base/steer/FairRun.cxx
@@ -56,9 +56,8 @@ FairRun::FairRun(Bool_t isMaster)
   }
   fRunInstance=this;
 
-  if ( isMaster ) {
-    fRootManager = new FairRootManager();
-  }
+  fRootManager = new FairRootManager();
+
   new FairLinkManager();
 }
 //_____________________________________________________________________________
@@ -79,7 +78,7 @@ FairRun::~FairRun()
 void FairRun::SetOutputFile(const char* fname)
 {
   fOutname=fname;
-  if (fRootManager) fOutFile = fRootManager->OpenOutFile(fOutname);
+  if (fRootManager) fOutFile = fRootManager->OpenOutFile(fOutname.Data());
 
 }
 //_____________________________________________________________________________

--- a/base/steer/FairRun.h
+++ b/base/steer/FairRun.h
@@ -82,10 +82,22 @@ class FairRun : public TNamed
       return fRtdb;
     }
     /**
+     * Set the  output file name without creating the file
+     */
+    void SetOutputFileName(const TString& name) {
+      fOutname = name;
+    }
+    /**
      * return a pointer to the output file
      */
     TFile* GetOutputFile() {
       return fOutFile;
+    }
+    /**
+     * return a pointer to the output file
+     */
+    TString GetOutputFileName() {
+      return fOutname;
     }
     /**
      * return the run ID for the actul run
@@ -173,7 +185,7 @@ class FairRun : public TNamed
     /** Tasks used*/
     FairTask*                fTask;
     /**Output file name*/
-    const char*              fOutname;
+    TString                  fOutname;
     /**IO manager */
     FairRootManager*         fRootManager;
     /**Output file*/

--- a/base/steer/FairRunAnaProof.cxx
+++ b/base/steer/FairRunAnaProof.cxx
@@ -369,14 +369,12 @@ void FairRunAnaProof::RunOnProof(Int_t NStart,Int_t NStop)
 
   TString outDir = (fOutputDirectory.Length()>1?fOutputDirectory.Data():gSystem->WorkingDirectory());
 
-  TString outFile = Form("%s",fOutname);
-
   fProof->AddInput(fTask);
 
   fProof->AddInput(new TNamed("FAIRRUNANA_fContainerStatic",(fStatic?"kTRUE":"kFALSE")));
   fProof->AddInput(new TNamed("FAIRRUNANA_fProofOutputStatus",fProofOutputStatus.Data()));
   fProof->AddInput(new TNamed("FAIRRUNANA_fOutputDirectory",outDir.Data()));
-  fProof->AddInput(new TNamed("FAIRRUNANA_fOutputFileName",outFile.Data()));
+  fProof->AddInput(new TNamed("FAIRRUNANA_fOutputFileName",fOutname.Data()));
   fProof->AddInput(new TNamed("FAIRRUNANA_fParInput1FName",par1File.Data()));
   fProof->AddInput(new TNamed("FAIRRUNANA_fParInput2FName",par2File.Data()));
 

--- a/base/steer/FairRunSim.cxx
+++ b/base/steer/FairRunSim.cxx
@@ -87,11 +87,18 @@ FairRunSim::FairRunSim(Bool_t isMaster)
 //_____________________________________________________________________________
 FairRunSim::~FairRunSim()
 {
+
   LOG(DEBUG) << "Enter Destructor of FairRunSim " << FairLogger::endl;
+
+  delete fApp;
+
   /** List of Modules is filled via AddModule from the macro, but it
    is the responsibility of FairRunSim to call the destructors of
    the modules-
   */
+/*
+  // TO DO: to be fixed
+  // breaks
   LOG(DEBUG) << "Start deleting all registered modules" 
 	     << FairLogger::endl;
   ListOfModules->Delete();
@@ -104,10 +111,11 @@ FairRunSim::~FairRunSim()
   fParticles->Delete();
   delete fParticles;
 
-  delete fApp;
+  // delete fApp;
   delete fField;
   delete fGen;
   delete fMCEvHead;
+*/
 }
 //_____________________________________________________________________________
 FairRunSim* FairRunSim::Instance()

--- a/base/steer/FairRunSim.cxx
+++ b/base/steer/FairRunSim.cxx
@@ -90,32 +90,29 @@ FairRunSim::~FairRunSim()
 
   LOG(DEBUG) << "Enter Destructor of FairRunSim " << FairLogger::endl;
 
-  delete fApp;
+  // delete fApp;
 
   /** List of Modules is filled via AddModule from the macro, but it
    is the responsibility of FairRunSim to call the destructors of
    the modules-
   */
-/*
-  // TO DO: to be fixed
-  // breaks
   LOG(DEBUG) << "Start deleting all registered modules" 
-	     << FairLogger::endl;
+       << FairLogger::endl;
   ListOfModules->Delete();
   delete ListOfModules;
   LOG(DEBUG) << "Finish deleting all registered modules"
-	     << FairLogger::endl;
+       << FairLogger::endl;
 
   fIons->Delete();
   delete fIons;
   fParticles->Delete();
   delete fParticles;
 
-  // delete fApp;
-  delete fField;
+  delete fApp;
+  // delete fField;
+      // Not owner of the field
   delete fGen;
   delete fMCEvHead;
-*/
 }
 //_____________________________________________________________________________
 FairRunSim* FairRunSim::Instance()


### PR DESCRIPTION
- Added new RootManager classes which allow to use ROOT IO with
  Geant4 multi-threading, according to the implementation in geant4_vmc/mtroot:
  FairRootGenericManager, FairRootManagerSim, FairRootManagerSimMT
  which use the FairRootManager methods implementation
- Updated the following classes for multi-threading:
  FairGenericStack, FairMCApplication

- Not yet migrated data:
  FairMCApplication::fRunInfo
  FairMCApplication::fFairTaskList, fRadGridMan - are these used in O2?
- Left problems - see "TO DO"