### PR TITLE
Adding FairMQ channel property parser implementation for key-value subopt format

### DIFF
--- a/fairmq/CMakeLists.txt
+++ b/fairmq/CMakeLists.txt
@@ -94,6 +94,7 @@ Set(SRCS
   "options/FairProgOptions.cxx"
   "options/FairMQProgOptions.cxx"
   "options/FairMQParser.cxx"
+  "options/FairMQSuboptParser.cxx"
 )
 
 If(NANOMSG_FOUND)

--- a/fairmq/options/FairMQParser.cxx
+++ b/fairmq/options/FairMQParser.cxx
@@ -28,7 +28,8 @@ FairMQMap ptreeToMQMap(const boost::property_tree::ptree& pt, const string& id, 
 {
     // Create fair mq map
     FairMQMap channelMap;
-    // helper::PrintDeviceList(pt.get_child(rootNode));
+    //Helper::PrintPropertyTree(pt);
+    //Helper::PrintDeviceList(pt.get_child(rootNode), formatFlag);
     // Extract value from boost::property_tree
     Helper::DeviceParser(pt.get_child(rootNode), channelMap, id, formatFlag);
 
@@ -431,6 +432,14 @@ void SocketParser(const boost::property_tree::ptree& tree, vector<FairMQChannel>
 
         channelList.push_back(channel);
     }
+}
+
+void PrintPropertyTree(const boost::property_tree::ptree& tree, int level)
+{
+  for (const auto& p : tree) {
+    std::cout << std::setw(level+1) << level << ": " << p.first << " " << p.second.get_value<string>() << std::endl;
+    PrintPropertyTree(p.second.get_child(""), level + 1);
+  }
 }
 
 } // Helper namespace

--- a/fairmq/options/FairMQParser.h
+++ b/fairmq/options/FairMQParser.h
@@ -43,6 +43,7 @@ void PrintDeviceList(const boost::property_tree::ptree& tree, const std::string&
 void DeviceParser(const boost::property_tree::ptree& tree, FairMQMap& channelMap, const std::string& deviceId, const std::string& formatFlag);
 void ChannelParser(const boost::property_tree::ptree& tree, FairMQMap& channelMap, const std::string& formatFlag);
 void SocketParser(const boost::property_tree::ptree& tree, std::vector<FairMQChannel>& channelList, const std::string& channelName, const FairMQChannel& commonChannel);
+void PrintPropertyTree(const boost::property_tree::ptree& tree, int level = 0);
 
 } // Helper namespace
 

--- a/fairmq/options/FairMQSuboptParser.cxx
+++ b/fairmq/options/FairMQSuboptParser.cxx
@@ -1,0 +1,70 @@
+/********************************************************************************
+ *    Copyright (C) 2017 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *         GNU Lesser General Public License version 3 (LGPL) version 3,        *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+/// @file   FairMQSuboptParser.cxx
+/// @author Matthias.Richter@scieq.net
+/// @since  2017-03-30
+/// @brief  Parser implementation for key-value subopt format
+
+#include "FairMQSuboptParser.h"
+#include <boost/property_tree/ptree.hpp>
+#include <cstring>
+
+using boost::property_tree::ptree;
+
+namespace FairMQParser
+{
+
+constexpr const char* SUBOPT::channelOptionKeys[];
+
+FairMQMap SUBOPT::UserParser(const po::variables_map& omap, const std::string& deviceId, const std::string& rootNode)
+{
+  std::string nodeKey = rootNode + ".device";
+  ptree pt;
+
+  pt.put(nodeKey + ".id", deviceId.c_str());
+  nodeKey += ".channels";
+
+  // parsing of channel properties is the only implemented method right now
+  if (omap.count(OptionKeyChannelConfig) > 0) {
+    std::map<std::string, ptree> channelProperties;
+    auto tokens = omap[OptionKeyChannelConfig].as<std::vector<std::string>>();
+    for (auto token : tokens) {
+      std::map<std::string, ptree>::iterator channelProperty = channelProperties.end();
+      ptree socketProperty;
+      std::string channelName;
+      std::string argString(token);
+      char* subopts = &argString[0];
+      char* value = nullptr;
+      while (subopts && *subopts != 0 && *subopts != ' ') {
+        char* saved = subopts;
+        int subopt=getsubopt(&subopts, (char**)channelOptionKeys, &value);
+        if (subopt == NAME) {
+          channelName = value;
+          channelProperties[channelName].put("name", channelName);
+        } else
+        if (subopt>=0 && value != nullptr) {
+          socketProperty.put(channelOptionKeys[subopt], value);
+        }
+      }
+      if (channelName != "") {
+        channelProperties[channelName].add_child("sockets.socket", socketProperty);
+      } else {
+        // TODO: what is the error policy here, should we abort?
+        LOG(ERROR) << "missing channel name in argument of option --channel-config";
+      }
+    }
+    for (auto channelProperty : channelProperties) {
+      pt.add_child(nodeKey + ".channel", channelProperty.second);
+    }
+  }
+
+  return ptreeToMQMap(pt, deviceId, rootNode);
+}
+
+} // namespace FairMQMap

--- a/fairmq/options/FairMQSuboptParser.h
+++ b/fairmq/options/FairMQSuboptParser.h
@@ -1,0 +1,71 @@
+/********************************************************************************
+ *    Copyright (C) 2017 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *         GNU Lesser General Public License version 3 (LGPL) version 3,        *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+/// @file   FairMQSuboptParser.h
+/// @author Matthias.Richter@scieq.net
+/// @since  2017-03-30
+/// @brief  Parser implementation for key-value subopt format
+
+#include "FairMQParser.h" // for FairMQMap
+#include <boost/program_options.hpp>
+#include <cstring>
+
+namespace po = boost::program_options;
+
+namespace FairMQParser
+{
+/**
+ * A parser implementation for FairMQ channel properties.
+ * The parser handles a comma separated key=value list format by using the
+ * getsubopt function of the standard library.
+ *
+ * The option key '--channel-config' can be used with the list of key/value
+ * pairs like e.g.
+ * <pre>
+ * --channel-config name=output,type=push,method=bind
+ * </pre>
+ *
+ * The FairMQ option parser defines a 'UserParser' function for different
+ * formats. Currently it is strictly parsing channel options, but in general
+ * the concept is extensible by renaming UserParser to ChannelPropertyParser
+ * and introducing additional parser functions.
+ */
+struct SUBOPT {
+  enum channelOptionKeyIds {
+    NAME = 0,       // name of the channel
+    TYPE,           // push, pull, publish, subscribe, etc
+    METHOD,         // bind or connect
+    ADDRESS,        // host, protocol and port address
+    TRANSPORT,      //
+    SNDBUFSIZE,     // size of the send queue
+    RCVBUFSIZE,     // size of the receive queue
+    SNDKERNELSIZE,
+    RCVKERNELSIZE,
+    RATELOGGING,    // logging rate
+    lastsocketkey
+  };
+
+  constexpr static const char *channelOptionKeys[] = {
+    /*[NAME]          = */ "name",
+    /*[TYPE]          = */ "type",
+    /*[METHOD]        = */ "method",
+    /*[ADDRESS]       = */ "address",
+    /*[TRANSPORT]     = */ "transport",
+    /*[SNDBUFSIZE]    = */ "sndBufSize",
+    /*[RCVBUFSIZE]    = */ "rcvBufSize",
+    /*[SNDKERNELSIZE] = */ "sndKernelSize",
+    /*[RCVKERNELSIZE] = */ "rcvKernelSize",
+    /*[RATELOGGING]   = */ "rateLogging",
+    nullptr
+  };
+
+  constexpr static const char* OptionKeyChannelConfig = "channel-config";
+
+  FairMQMap UserParser(const po::variables_map& omap, const std::string& deviceId, const std::string& rootNode = "fairMQOptions");
+};
+}


### PR DESCRIPTION
This allows to configure FairMQDevice channels via a simple command line syntax like
```
--channel-config name=output,type=push,method=bind
```

It's an alternative to `--mq-config` or `--config-json-string`

@rbx please have a look if that can be merged without creating any side effect.