### PR TITLE
Offer important data constructors inline

### DIFF
--- a/base/event/FairMultiLinkedData_Interface.cxx
+++ b/base/event/FairMultiLinkedData_Interface.cxx
@@ -16,11 +16,6 @@
 
 ClassImp(FairMultiLinkedData_Interface);
 
-FairMultiLinkedData_Interface::FairMultiLinkedData_Interface()
-  :TObject(), fVerbose(0), fInsertHistory(kTRUE), fLink(NULL)
-{
-}
-
 FairMultiLinkedData_Interface::FairMultiLinkedData_Interface(FairMultiLinkedData& links, Bool_t)
   :TObject(), fVerbose(0), fInsertHistory(kTRUE), fLink(NULL)
 {

--- a/base/event/FairMultiLinkedData_Interface.h
+++ b/base/event/FairMultiLinkedData_Interface.h
@@ -86,6 +86,13 @@ class FairMultiLinkedData_Interface : public  TObject
     ClassDef(FairMultiLinkedData_Interface, 5);
 };
 
+inline
+FairMultiLinkedData_Interface::FairMultiLinkedData_Interface()
+  :TObject(), fVerbose(0), fInsertHistory(kTRUE), fLink(NULL)
+{
+}
+
+
 /**\fn virtual void FairMultiLinkedData_Interface::SetLinks(Int_t type, std::vector<Int_t> links)
  * \param type as Int_t gives one type of source data for all indices
  * \param links as vector<Int_t> gives the vector of indices at which position in the TClonesArray the source data is stored

--- a/base/event/FairTimeStamp.cxx
+++ b/base/event/FairTimeStamp.cxx
@@ -7,36 +7,6 @@
  ********************************************************************************/
 #include "FairTimeStamp.h"
 
-// -----   Default constructor   -------------------------------------------
-FairTimeStamp::FairTimeStamp()
-  : FairMultiLinkedData_Interface(),
-    fTimeStamp(-1),
-    fTimeStampError(-1),
-    fEntryNr()
-{
-}
-// -----   Standard constructor   ------------------------------------------
-FairTimeStamp::FairTimeStamp(Double_t time)
-  : FairMultiLinkedData_Interface(),
-    fTimeStamp(time),
-    fTimeStampError(-1),
-    fEntryNr()
-{
-}
-
-FairTimeStamp::FairTimeStamp(Double_t time, Double_t timeerror)
-  : FairMultiLinkedData_Interface(),
-    fTimeStamp(time),
-    fTimeStampError(timeerror),
-    fEntryNr()
-{
-}
-
-// -----   Destructor   ----------------------------------------------------
-FairTimeStamp::~FairTimeStamp()
-{
-}
-
 // -------------------------------------------------------------------------
 
 std::ostream& FairTimeStamp::PrintTimeInfo(std::ostream& out) const

--- a/base/event/FairTimeStamp.h
+++ b/base/event/FairTimeStamp.h
@@ -40,7 +40,7 @@ class FairTimeStamp : public FairMultiLinkedData_Interface
     FairTimeStamp(Double_t time, Double_t timeerror);
 
     /** Destructor **/
-    virtual ~FairTimeStamp();
+    virtual ~FairTimeStamp() = default;
     /** Accessors **/
     virtual Double_t GetTimeStamp()             const { return fTimeStamp; };
     virtual Double_t GetTimeStampError()     const { return fTimeStampError;};
@@ -100,5 +100,34 @@ class FairTimeStamp : public FairMultiLinkedData_Interface
 
     ClassDef(FairTimeStamp,3);
 };
+
+// -----   Default constructor   -------------------------------------------
+inline
+FairTimeStamp::FairTimeStamp()
+  : FairMultiLinkedData_Interface(),
+    fTimeStamp(-1),
+    fTimeStampError(-1),
+    fEntryNr()
+{
+}
+
+// -----   Standard constructor   ------------------------------------------
+inline
+FairTimeStamp::FairTimeStamp(Double_t time)
+  : FairMultiLinkedData_Interface(),
+    fTimeStamp(time),
+    fTimeStampError(-1),
+    fEntryNr()
+{
+}
+
+inline
+FairTimeStamp::FairTimeStamp(Double_t time, Double_t timeerror)
+  : FairMultiLinkedData_Interface(),
+    fTimeStamp(time),
+    fTimeStampError(timeerror),
+    fEntryNr()
+{
+}
 
 #endif


### PR DESCRIPTION
 * this commit offers the compiler the chance to inline
   and optimize construction for very important data objects
   (FairTimeStamp, MultiLink_Interface)
 * objects of this kind are potentially created billions of times and should be done
   as fast as possible