### PR TITLE
Make FairLink not inherit from TObject

### DIFF
--- a/base/event/FairLink.cxx
+++ b/base/event/FairLink.cxx
@@ -17,30 +17,9 @@
 
 ClassImp(FairLink);
 
-FairLink::FairLink()
-  :TObject(),
-   fFile(-1),
-   fEntry(-1),
-   fType(-1),
-   fIndex(-1),
-   fWeight(1.0)
-{
-}
-
-FairLink::FairLink(Int_t type, Int_t index, Float_t weight)
-  :TObject(),
-   fFile(-1),
-   fEntry(-1),
-   fType(type),
-   fIndex(index),
-   fWeight(weight)
-{
-}
-
 
 FairLink::FairLink(TString branchName, Int_t index, Float_t weight)
-  :TObject(),
-   fFile(-1),
+  :fFile(-1),
    fEntry(-1),
    fType(FairRootManager::Instance()->GetBranchId(branchName)),
    fIndex(index),
@@ -49,19 +28,8 @@ FairLink::FairLink(TString branchName, Int_t index, Float_t weight)
 }
 
 
-FairLink::FairLink(Int_t file, Int_t entry, Int_t type, Int_t index, Float_t weight)
-  :TObject(),
-   fFile(file),
-   fEntry(entry),
-   fType(type),
-   fIndex(index),
-   fWeight(weight)
-{
-}
-
 FairLink::FairLink(Int_t file, Int_t entry, TString branchName, Int_t index, Float_t weight)
-  :TObject(),
-   fFile(file),
+  :fFile(file),
    fEntry(entry),
    fType(FairRootManager::Instance()->GetBranchId(branchName)),
    fIndex(index),
@@ -75,7 +43,4 @@ void FairLink::PrintLinkInfo(std::ostream& out) const
   out << GetType() << "/" << GetIndex() << "/" << GetWeight() << ")";
 }
 
-FairLink::~FairLink()
-{
-  // TODO Auto-generated destructor stub
-}
+

--- a/base/event/FairLink.h
+++ b/base/event/FairLink.h
@@ -15,7 +15,7 @@
 #ifndef FAIRLINK_H_
 #define FAIRLINK_H_
 
-#include "TObject.h"                    // for TObject
+#include "TObject.h"                    // for TObject; ClassDefNV
 
 #include "Riosfwd.h"                    // for ostream
 #include "Rtypes.h"                     // for Int_t, Float_t, etc
@@ -28,7 +28,7 @@
 #include <boost/serialization/base_object.hpp>
 #endif //__CINT__
 
-class FairLink : public TObject
+class FairLink
 {
   public:
     FairLink();
@@ -36,7 +36,7 @@ class FairLink : public TObject
     FairLink(TString branchName, Int_t index, Float_t weight = 1.);
     FairLink(Int_t file, Int_t entry, Int_t type, Int_t index, Float_t weight = 1.);
     FairLink(Int_t file, Int_t entry, TString branchName, Int_t index, Float_t weight = 1.);
-    virtual ~FairLink();
+    ~FairLink() {};
 
     void SetLink(Int_t file, Int_t entry, Int_t type, Int_t index, Float_t weight = 1.) {
       fFile = file;
@@ -61,9 +61,9 @@ class FairLink : public TObject
     void SetWeight(Float_t weight) {fWeight = weight;}
     void AddWeight(Float_t weight) {fWeight += weight;}
 
-    virtual void PrintLinkInfo(std::ostream& out = std::cout) const;
+    void PrintLinkInfo(std::ostream& out = std::cout) const;
 
-    virtual bool operator==(const FairLink& link) const {
+    bool operator==(const FairLink& link) const {
       if ((fFile == link.GetFile() || link.GetFile() == -1) && (fEntry == link.GetEntry() || link.GetEntry() == -1) && fType == link.GetType() && fIndex == link.GetIndex()) {
         return true;
       } else {
@@ -71,7 +71,7 @@ class FairLink : public TObject
       }
     }
 
-    virtual bool operator<(const FairLink& link) const {
+    bool operator<(const FairLink& link) const {
 	if (fFile != -1 && link.GetFile() != -1){
 		if (fFile < link.GetFile()) 		return true;
 		else if (link.GetFile() < fFile) 	return false;
@@ -104,7 +104,7 @@ class FairLink : public TObject
       return out;
     }
 
-    ClassDef(FairLink, 3);
+    ClassDefNV(FairLink, 4);
 
     template<class Archive>
         void serialize(Archive& ar, const unsigned int)
@@ -125,5 +125,32 @@ class FairLink : public TObject
     Float_t fWeight;
 
 };
+
+inline FairLink::FairLink() :
+   fFile(-1),
+   fEntry(-1),
+   fType(-1),
+   fIndex(-1),
+   fWeight(1.0)
+{
+}
+
+inline FairLink::FairLink(Int_t type, Int_t index, Float_t weight)
+  :fFile(-1),
+   fEntry(-1),
+   fType(type),
+   fIndex(index),
+   fWeight(weight)
+{
+}
+
+inline FairLink::FairLink(Int_t file, Int_t entry, Int_t type, Int_t index, Float_t weight)
+  :fFile(file),
+   fEntry(entry),
+   fType(type),
+   fIndex(index),
+   fWeight(weight)
+{
+}
 
 #endif /* FAIRLINK_H_ */

--- a/datamatch/FairMCDataCrawler.cxx
+++ b/datamatch/FairMCDataCrawler.cxx
@@ -195,7 +195,7 @@ void FairMCDataCrawler::GetNextStage(FairMultiLinkedData& startStage, Int_t stop
       if (fVerbose > 0) {
 //        std::cout << "TempStage Start";
         std::cout << " // ";
-        actualLink.Print();
+	std::cout << actualLink;
         std::cout << " --> " << *tempStage;
       }
       if (tempStage->GetNLinks() == 0) {


### PR DESCRIPTION
 * reduce memory footprint for FairLinks by removing
   inheritance from TObject (which is not needed)
 * remove virtual keyword from operators
 * overall this will gain 24bytes per FairLink
 * other smaller improvements: default destructor, inline trivial constructors