### PR TITLE
Remove data members / virtual functions from FairMultiLinkedData_Inte…

### DIFF
--- a/base/event/FairMultiLinkedData.h
+++ b/base/event/FairMultiLinkedData.h
@@ -51,6 +51,7 @@ class FairMultiLinkedData : public  TObject
     virtual void SetPersistanceCheck(Bool_t check) {fPersistanceCheck = check;}       ///< Controls if a persistance check of a link is done or not
     virtual void SetVerbose(Int_t level) {fVerbose = level;}                ///< Sets the verbosity level
     virtual void SetInsertHistory(Bool_t val){ fInsertHistory = val;}		///< Toggles if history of a link is inserted or not
+    Bool_t GetInsertHistory() const {return fInsertHistory;}
 
     virtual void SetEntryNr(FairLink entry){ fEntryNr = entry;}
     virtual void SetLinks(FairMultiLinkedData links, Float_t mult = 1.0);           ///< Sets the links as vector of FairLink

--- a/base/event/FairMultiLinkedData_Interface.cxx
+++ b/base/event/FairMultiLinkedData_Interface.cxx
@@ -6,10 +6,7 @@
  */
 
 #include "FairMultiLinkedData_Interface.h"
-
 #include "FairRootManager.h"            // for FairRootManager
-
-#include "TClonesArray.h"               // for TClonesArray
 
 #include <algorithm>                    // for find
 #include <iterator>                     // for distance
@@ -17,35 +14,35 @@
 ClassImp(FairMultiLinkedData_Interface);
 
 FairMultiLinkedData_Interface::FairMultiLinkedData_Interface(FairMultiLinkedData& links, Bool_t)
-  :TObject(), fVerbose(0), fInsertHistory(kTRUE), fLink(NULL)
+  :TObject(), fLink(NULL)
 {
 	SetLinks(links);
 }
 
 FairMultiLinkedData_Interface::FairMultiLinkedData_Interface(TString dataType, std::vector<Int_t> links, Int_t fileId, Int_t evtId, Bool_t persistanceCheck, Bool_t bypass, Float_t mult)
-  :TObject(), fVerbose(0), fInsertHistory(kTRUE), fLink(NULL)
+  :TObject(), fLink(NULL)
 {
 	FairMultiLinkedData data(dataType, links, fileId, evtId, persistanceCheck, bypass, mult);
 	SetLinks(data);
 }
 
 FairMultiLinkedData_Interface::FairMultiLinkedData_Interface( Int_t dataType, std::vector<Int_t> links, Int_t fileId, Int_t evtId, Bool_t persistanceCheck, Bool_t bypass, Float_t mult)
-  :TObject(), fVerbose(0), fInsertHistory(kTRUE), fLink(NULL)
+  :TObject(), fLink(NULL)
 {
 	FairMultiLinkedData data(dataType, links, fileId, evtId, persistanceCheck, bypass, mult);
 	SetLinks(data);
 }
 
 FairMultiLinkedData_Interface::FairMultiLinkedData_Interface(const FairMultiLinkedData_Interface& toCopy)
-  :TObject(toCopy), fVerbose(0), fInsertHistory(kTRUE), fLink(NULL)
+  :TObject(toCopy), fLink(NULL)
 {
 	if (toCopy.GetPointerToLinks() != 0){
-		SetInsertHistory(kFALSE);
+	        SetInsertHistory(kFALSE);
 		SetLinks(*(toCopy.GetPointerToLinks()));
-        SetEntryNr(toCopy.GetEntryNr());
-        fInsertHistory = toCopy.fInsertHistory;
-        SetInsertHistory(fInsertHistory);
-    }
+                SetEntryNr(toCopy.GetEntryNr());
+                // copy history flag information
+                SetInsertHistory(toCopy.GetPointerToLinks()->GetInsertHistory());
+        }
 }
 
 FairMultiLinkedData_Interface& FairMultiLinkedData_Interface::operator=(const FairMultiLinkedData_Interface& rhs)
@@ -66,7 +63,6 @@ FairMultiLinkedData* FairMultiLinkedData_Interface::CreateFairMultiLinkedData()
 			if (fLink == 0){
 				fLink = new FairMultiLinkedData();
 			}
-			fLink->SetInsertHistory(fInsertHistory);
 			return fLink;
 		}
 	}
@@ -184,12 +180,11 @@ void FairMultiLinkedData_Interface::AddInterfaceData(FairMultiLinkedData_Interfa
 	if (data->GetPointerToLinks() != 0) {
 		AddLinks(*data->GetPointerToLinks());
 	}
-	SetInsertHistory(fInsertHistory);
+	SetInsertHistory(GetPointerToLinks()->GetInsertHistory());
 }
 
 void FairMultiLinkedData_Interface::SetInsertHistory(Bool_t val)
 {
-	fInsertHistory = val;
 	if (GetPointerToLinks() != 0) {
 		GetPointerToLinks()->SetInsertHistory(val);
 	}

--- a/base/event/FairMultiLinkedData_Interface.h
+++ b/base/event/FairMultiLinkedData_Interface.h
@@ -44,7 +44,7 @@ class FairMultiLinkedData_Interface : public  TObject
     virtual FairLink        	GetLink(Int_t pos) const;         	///< returns the FairLink at the given position
     virtual FairMultiLinkedData GetLinksWithType(Int_t type) const; ///< returns all FairLinks with the corresponding type
     virtual FairLink            GetEntryNr() const;
-    virtual FairMultiLinkedData* 		GetPointerToLinks() const {	return fLink;}
+    FairMultiLinkedData* 	GetPointerToLinks() const { return fLink;}
 
     virtual std::vector<FairLink> GetSortedMCTracks();
 
@@ -76,11 +76,7 @@ class FairMultiLinkedData_Interface : public  TObject
     }                                                     ///< Output
 
   protected:
-
-    Int_t fVerbose; //!
-    Bool_t fInsertHistory; //!
     FairMultiLinkedData* fLink;
-
     FairMultiLinkedData* CreateFairMultiLinkedData();
 
     ClassDef(FairMultiLinkedData_Interface, 5);
@@ -88,7 +84,7 @@ class FairMultiLinkedData_Interface : public  TObject
 
 inline
 FairMultiLinkedData_Interface::FairMultiLinkedData_Interface()
-  :TObject(), fVerbose(0), fInsertHistory(kTRUE), fLink(NULL)
+  :TObject(), fLink(NULL)
 {
 }
 


### PR DESCRIPTION
…rface

 * remove fVerbose data member which was not used
 * remove fInsertHistory member which is duplicated behind the link pointer
 * make accessor to link pointer not virtual

This PR achieves an 8 byte data reduction for this critical base class.