### PR TITLE
Reduce size of FairLink to 15 byte

### DIFF
--- a/base/event/FairLink.cxx
+++ b/base/event/FairLink.cxx
@@ -19,22 +19,23 @@ ClassImp(FairLink);
 
 
 FairLink::FairLink(TString branchName, Int_t index, Float_t weight)
-  :fFile(-1),
+  :fFile(0),
+   fType(0),
    fEntry(-1),
-   fType(FairRootManager::Instance()->GetBranchId(branchName)),
    fIndex(index),
    fWeight(weight)
 {
+	SetType(FairRootManager::Instance()->GetBranchId(branchName));
 }
 
 
 FairLink::FairLink(Int_t file, Int_t entry, TString branchName, Int_t index, Float_t weight)
-  :fFile(file),
-   fEntry(entry),
-   fType(FairRootManager::Instance()->GetBranchId(branchName)),
+  :fEntry(entry),
    fIndex(index),
    fWeight(weight)
 {
+	SetFile(file);
+	SetType(FairRootManager::Instance()->GetBranchId(branchName));
 }
 
 void FairLink::PrintLinkInfo(std::ostream& out) const

--- a/base/event/FairLink.h
+++ b/base/event/FairLink.h
@@ -10,6 +10,14 @@
  *
  *  Created on: Dec 23, 2009
  *      Author: stockman
+ *      "Pointer" to any data structure inside a root file with a tree structure
+ *      Contains four information:
+ *      	File : in which file is the data written (-1 : actual number; 254 : maximum number)
+ *      	Entry: entry number in branch of a tree (-1 : actual entry)
+ *      	Type : branch inside the tree (-1 : FairLink not set; 65534 : maximum number)
+ *      	Index: position inside a container stored in the given branch and entry
+ *      	Weight: weighting factor to describe probabilities of a MC truth match
+ *
  */
 
 #ifndef FAIRLINK_H_
@@ -19,7 +27,6 @@
 
 #include "Riosfwd.h"                    // for ostream
 #include "Rtypes.h"                     // for Int_t, Float_t, etc
-#include "TString.h"                    // for TString
 
 #include <iostream>                     // for ostream, cout
 
@@ -39,32 +46,40 @@ class FairLink
     ~FairLink() {};
 
     void SetLink(Int_t file, Int_t entry, Int_t type, Int_t index, Float_t weight = 1.) {
-      fFile = file;
-      fEntry = entry;
-      fType = type;
-      fIndex = index;
-      fWeight = weight;
+      SetFile(file);
+      SetEntry(entry);
+      SetType(type);
+      SetIndex(index);
+      SetWeight(weight);
     };
     void SetLink(Int_t type, Int_t index, Float_t weight = 1.) {
-      fFile = -1;
-      fEntry = -1;
-      fType = type;
-      fIndex = index;
-      fWeight = weight;
+      SetFile(-1);
+      SetEntry(-1);
+      SetType(type);
+      SetIndex(index);
+      SetWeight(weight);
     };
-    Int_t GetFile() const {return fFile;}
-    Int_t GetEntry() const {return fEntry;}
-    Int_t GetType() const {return fType;}
-    Int_t GetIndex() const {return fIndex;}
-    Float_t GetWeight() const {return fWeight;}
+    int GetFile() const;
+    int GetEntry() const {return fEntry;}
+    int GetType() const;
+    int GetIndex() const {return fIndex;}
+    float GetWeight() const {return fWeight;}
+
+    void SetFile(int file);
+    void SetEntry(int entry){fEntry = entry;};
+    void SetType(int type);
+    void SetIndex(int index){fIndex = index;};
 
     void SetWeight(Float_t weight) {fWeight = weight;}
     void AddWeight(Float_t weight) {fWeight += weight;}
 
+
     void PrintLinkInfo(std::ostream& out = std::cout) const;
 
     bool operator==(const FairLink& link) const {
-      if ((fFile == link.GetFile() || link.GetFile() == -1) && (fEntry == link.GetEntry() || link.GetEntry() == -1) && fType == link.GetType() && fIndex == link.GetIndex()) {
+      if ((GetFile() == link.GetFile() || link.GetFile() == -1) &&
+		  (GetEntry() == link.GetEntry() || link.GetEntry() == -1) &&
+			  GetType() == link.GetType() && GetIndex() == link.GetIndex()) {
         return true;
       } else {
         return false;
@@ -72,31 +87,20 @@ class FairLink
     }
 
     bool operator<(const FairLink& link) const {
-	if (fFile != -1 && link.GetFile() != -1){
-		if (fFile < link.GetFile()) 		return true;
-		else if (link.GetFile() < fFile) 	return false;
-	}
-	if (fEntry != -1 && link.GetEntry() != -1){
-		if(fEntry < link.GetEntry())		return true;
-		else if (link.GetEntry() < fEntry)	return false;
-	}
-	if (fType < link.GetType())				return true;
-	else if (link.GetType() < fType)		return false;
-	if (fIndex < link.GetIndex())			return true;
-	else if (link.GetIndex() < fIndex)		return false;
+		if (GetFile() != -1 && link.GetFile() != -1){
+			if (GetFile() < link.GetFile()) 		return true;
+			else if (link.GetFile() < GetFile()) 	return false;
+		}
+		if (GetEntry() != -1 && link.GetEntry() != -1){
+			if(GetEntry() < link.GetEntry())		return true;
+			else if (link.GetEntry() < GetEntry())	return false;
+		}
+		if (GetType() < link.GetType())				return true;
+		else if (link.GetType() < GetType())		return false;
+		if (GetIndex() < link.GetIndex())			return true;
+		else if (link.GetIndex() < GetIndex())		return false;
 
-	return false;
-//      if (fFile != -1 && fFile < link.GetFile()) {
-//        return true;
-//      } else if ((fFile == link.GetFile() || link.GetFile() == -1) && fEntry < link.GetEntry()) {
-//        return true;
-//      } else if ((fFile == link.GetFile() || link.GetFile() == -1)  && (fEntry == link.GetEntry() || link.GetEntry() == -1) && fType < link.GetType()) {
-//        return true;
-//      } else if ((fFile == link.GetFile() || link.GetFile() == -1)  && (fEntry == link.GetEntry() || link.GetEntry() == -1) && fType == link.GetType() && fIndex < link.GetIndex()) {
-//        return true;
-//      } else {
-//        return false;
-//      }
+		return false;
     }
 
     friend std::ostream& operator<< (std::ostream& out, const FairLink& link) {
@@ -104,53 +108,78 @@ class FairLink
       return out;
     }
 
-    ClassDefNV(FairLink, 4);
+    ClassDefNV(FairLink, 5);
 
     template<class Archive>
         void serialize(Archive& ar, const unsigned int)
         {
             ar& fFile;
+			ar& fType;
             ar& fEntry;
-            ar& fType;
             ar& fIndex;
             ar& fWeight;
         }
 
 
   private:
-    Int_t fFile;
-    Int_t fEntry;
-    Int_t fType;
-    Int_t fIndex;
-    Float_t fWeight;
+    unsigned char fFile;
+    unsigned short fType;
+    int fEntry;
+    int fIndex;
+    float fWeight;
+
 
 };
 
 inline FairLink::FairLink() :
-   fFile(-1),
+   fFile(0),
+   fType(0),
    fEntry(-1),
-   fType(-1),
    fIndex(-1),
    fWeight(1.0)
 {
 }
 
 inline FairLink::FairLink(Int_t type, Int_t index, Float_t weight)
-  :fFile(-1),
+  :fFile(0),
    fEntry(-1),
-   fType(type),
    fIndex(index),
    fWeight(weight)
 {
+	SetType(type);
 }
 
 inline FairLink::FairLink(Int_t file, Int_t entry, Int_t type, Int_t index, Float_t weight)
-  :fFile(file),
-   fEntry(entry),
-   fType(type),
+  :fEntry(entry),
    fIndex(index),
    fWeight(weight)
 {
+	SetFile(file);
+	SetType(type);
+}
+
+inline void FairLink::SetType(int type)
+{
+	if (type < -1) return;
+	fType = type + 1;
+}
+
+inline int FairLink::GetType() const
+{
+	int type = fType;
+	return type - 1;
+}
+
+inline void FairLink::SetFile(int file)
+{
+	if (file < -1) return;
+	fFile = file + 1;
+}
+
+inline int FairLink::GetFile() const
+{
+	int file = fFile;
+	return file - 1;
 }
 
 #endif /* FAIRLINK_H_ */


### PR DESCRIPTION
Reducing the size of FairLink down to 15 byte.
This limits the number of file links down to 254 and for types to 65534.
At the moment I do not check if values larger than that are given due to performance concerns.