### PR TITLE
Avoid InheritsFrom function from ROOT

### DIFF
--- a/base/sim/FairMCApplication.cxx
+++ b/base/sim/FairMCApplication.cxx
@@ -134,18 +134,16 @@ FairMCApplication::FairMCApplication(const char* name, const char* title,
   TObject* obj;
  
   while((obj=fModIter->Next())) {
-    if(obj->InheritsFrom("FairDetector")) {
-      detector=dynamic_cast<FairDetector*>(obj);
-      if(detector) {
-        fDetectors->Add(detector);
-        listDetectors.push_back(detector);
-        if(detector->IsActive()) {
-          fActiveDetectors->Add(detector);
-          listActiveDetectors.push_back(detector);
-	      }
-      } else {
-        LOG(ERROR) << "Dynamic cast fails." << FairLogger::endl;
+    detector=dynamic_cast<FairDetector*>(obj);
+    if(detector) {
+      fDetectors->Add(detector);
+      listDetectors.push_back(detector);
+      if(detector->IsActive()) {
+        fActiveDetectors->Add(detector);
+        listActiveDetectors.push_back(detector);
       }
+    } else {
+        LOG(ERROR) << "Dynamic cast fails." << FairLogger::endl;
     }
   }
   


### PR DESCRIPTION
 * This seemingly cosmetic change saves a lot of CPU
   time because ROOT triggered a lot of internal TClass generation stuff
 * It is also not needed since the dynamic cast does the same job