### PR TITLE
Less string work to retrieve branchID; special cached branchID for MC…

### DIFF
--- a/base/event/FairMultiLinkedData.cxx
+++ b/base/event/FairMultiLinkedData.cxx
@@ -132,7 +132,8 @@ void FairMultiLinkedData::AddLink(FairLink link, Bool_t bypass, Float_t mult)
 
   if (fPersistanceCheck == kFALSE ||
       link.GetIndex() < 0 ||
-      ioman->CheckBranch(ioman->GetBranchName(link.GetType())) == 0) {
+      ( link.GetType() != ioman->GetMCTrackBranchId() &&
+	ioman->CheckBranch(ioman->GetBranchName(link.GetType())) == 0) ) {
     InsertLink(link);
     if (fInsertHistory == kTRUE)
     	InsertHistory(link);

--- a/base/event/FairMultiLinkedData.cxx
+++ b/base/event/FairMultiLinkedData.cxx
@@ -143,7 +143,7 @@ void FairMultiLinkedData::AddLink(FairLink link, Bool_t bypass, Float_t mult)
     if (fVerbose > 1) {
       std::cout << "BranchName " << ioman->GetBranchName(link.GetType()) << " checkStatus: " <<  ioman->CheckBranch(ioman->GetBranchName(link.GetType())) << std::endl;
     }
-    if (link.GetType() > ioman->GetBranchId("MCTrack") && ioman->CheckBranch(ioman->GetBranchName(link.GetType())) != 1) {
+    if (link.GetType() > ioman->GetMCTrackBranchId() && ioman->CheckBranch(ioman->GetBranchName(link.GetType())) != 1) {
       if (fVerbose > 1) {
         std::cout << "BYPASS!" << std::endl;
       }
@@ -153,7 +153,7 @@ void FairMultiLinkedData::AddLink(FairLink link, Bool_t bypass, Float_t mult)
 
   if (bypass == kTRUE) {
     //FairRootManager* ioman = FairRootManager::Instance();
-    if (link.GetType() > ioman->GetBranchId("MCTrack")) {
+    if (link.GetType() > ioman->GetMCTrackBranchId()) {
       TClonesArray* array = static_cast<TClonesArray*>(ioman->GetObject(ioman->GetBranchName(link.GetType())));
       if (fVerbose > 1) {
         std::cout << "Entries in " << ioman->GetBranchName(link.GetType()) << " Array: " << array->GetEntries() << std::endl;
@@ -206,7 +206,7 @@ void FairMultiLinkedData::InsertHistory(FairLink link)
 
         if (link.GetType() < 0)
                 return;
-        if (link.GetType() == ioman->GetBranchId("MCTrack"))
+        if (link.GetType() == ioman->GetMCTrackBranchId())
                 return;
         if(ioman->GetBranchName(link.GetType()).Contains("."))
         	return;
@@ -278,7 +278,7 @@ bool LargerWeight(FairLink val1, FairLink val2){
 }
 
 std::vector<FairLink> FairMultiLinkedData::GetSortedMCTracks(){
-	FairMultiLinkedData mcLinks = GetLinksWithType(FairRootManager::Instance()->GetBranchId("MCTrack"));
+	FairMultiLinkedData mcLinks = GetLinksWithType(FairRootManager::Instance()->GetMCTrackBranchId());
 	std::set<FairLink> mcSet = mcLinks.GetLinks();
 	std::vector<FairLink> mcVector(mcSet.begin(), mcSet.end());
 	//std::sort(begin(mcVector), end(mcVector), [](FairLink& val1, FairLink& val2){ return val1.GetWeight() > val2.GetWeight();});

--- a/base/steer/FairRootManager.h
+++ b/base/steer/FairRootManager.h
@@ -83,7 +83,11 @@ class FairRootManager : public TObject
     /**Return branch name by Id*/
     TString             GetBranchName(Int_t id);
     /**Return Id of a branch named */
-    Int_t               GetBranchId(TString BrName);
+    Int_t               GetBranchId(TString const &BrName);
+
+    /**The MCTrack branch stands out since it is required by the framework algorithms**/
+    Int_t GetMCTrackBranchId() const { return fMCTrackBranchId; }
+
     /**Return a TList of TObjString of branch names available in this session*/
     TList*              GetBranchNameList() {return fBranchNameList;}
     /** Return a pointer to the output Tree of type TTree */
@@ -281,9 +285,12 @@ class FairRootManager : public TObject
 #endif
 
     /**Branch id for this run */
-    Int_t                               fBranchSeqId;
+    Int_t                                fBranchSeqId;
     /**List of branch names as TObjString*/
     TList*                               fBranchNameList; //!
+    /**The branch ID for the special (required) MCTrack branch**/
+    Int_t                                fMCTrackBranchId; //!
+
     /**List of Time based branchs names as TObjString*/
     TList*                               fTimeBasedBranchNameList; //!
     /** Internally used to compress empty slots in data buffer*/


### PR DESCRIPTION
…Track

 * The FairLink management uses a lot of string queries/operations which
   have visible effects on the CPU performance

 * This commit achieves 3 separate things:
   - it makes the query string->branchID faster
   - it makes the query avoidable in many cases by introducing
     a special branchId for MCTrack (since MCTrack has a special meaning
     in the framework and is used/required in many places)
   - The new caching mechanism of the MCTrack branchID is used in FairMultiLinkedData