### PR TITLE
fix rpath generation on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,12 @@ before_install:
         env;
         brew update;
         if test "${_system_version}" = "10.11"; then
-          brew install gcc;
+          brew install --force-bottle gcc@6;
+          sudo ln -s $(brew --prefix gcc@6)/bin/gfortran-6 /usr/local/bin/gfortran;
+          target=$(dirname $(greadlink -f $(gfortran -print-file-name=libgfortran.dylib)));
+          link=/usr/local/opt/gcc/lib/gcc/6;
+          sudo mkdir -p $(dirname $link);
+          sudo ln -s $target $link;
         fi;
         if test "${_system_version}" = "10.9"; then
           brew tap homebrew/versions;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,6 @@ foreach(p
   endif()
 endforeach()
 
-
 # Set name of our project to "FAIRROOT". Has to be done
 # after check of cmake version
 project(FAIRROOT)
@@ -38,6 +37,16 @@ project(FAIRROOT)
 # is checked
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/cuda" ${CMAKE_MODULE_PATH})
+
+if(APPLE)
+  # Configure RPATH entries on macOS
+  # https://cmake.org/Wiki/CMake_RPATH_handling#Always_full_RPATH
+  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+  list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
+  if("${isSystemDir}" STREQUAL "-1")
+    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+  endif()
+endif()
 
 SET(VMCWORKDIR ${CMAKE_SOURCE_DIR}/examples)
 


### PR DESCRIPTION
This is part of the resolution of AliceO2Group/AliceO2#343.

The code is copied from DDS, I tested it on a `10.11.6` mac. It basically adds the `LC_RPATH` entries for the dylib itself and for all dependencies, that have an install name based on `@rpath` themselves.

This issue became visible after I have cleaned up the overlinking of `libFairMQ`. It can still be masked by CMake and `DYLD_LIBRARY_PATH`, but essentially the rpath entries were missing for all the libraries in FairRoot, at least when built with `aliBuild`.