### PR TITLE
add missing link dependency

### DIFF
--- a/fairmq/test/CMakeLists.txt
+++ b/fairmq/test/CMakeLists.txt
@@ -55,7 +55,7 @@ add_testsuite(FairMQ.Parts
     parts/runner.cxx
     parts/_iterator_interface.cxx
 
-    LINKS FairMQ
+    LINKS FairMQ ZeroMQ
     INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/parts
     TIMEOUT 5
 )


### PR DESCRIPTION
Should fix `build/O2/o2-dev-fairroot` check in AliceO2Group/AliceO2#370.