### PR TITLE
Refactor FairMQTools

### DIFF
--- a/examples/advanced/Tutorial3/MQ/fileSink/FairTestDetectorFileSink.h
+++ b/examples/advanced/Tutorial3/MQ/fileSink/FairTestDetectorFileSink.h
@@ -27,7 +27,6 @@
 #include "TSystem.h"
 
 #include "FairMQDevice.h"
-#include "FairMQTools.h"
 #include "FairMQLogger.h"
 
 #include "FairTestDetectorPayload.h"

--- a/examples/advanced/Tutorial3/MQ/processorTask/FairTestDetectorMQRecoTask.h
+++ b/examples/advanced/Tutorial3/MQ/processorTask/FairTestDetectorMQRecoTask.h
@@ -28,7 +28,6 @@
 #include "FairMQLogger.h"
 #include "FairMQProcessorTask.h"
 #include "FairMQMessage.h"
-#include "FairMQTools.h"
 
 #include "FairTestDetectorRecoTask.h"
 #include "FairTestDetectorPayload.h"

--- a/examples/advanced/Tutorial3/MQ/samplerTask/FairTestDetectorDigiLoader.h
+++ b/examples/advanced/Tutorial3/MQ/samplerTask/FairTestDetectorDigiLoader.h
@@ -30,7 +30,6 @@
 
 #include "FairMQSamplerTask.h"
 #include "FairMQLogger.h"
-#include "FairMQTools.h"
 
 #include "baseMQtools.h"
 

--- a/fairmq/CMakeLists.txt
+++ b/fairmq/CMakeLists.txt
@@ -55,7 +55,11 @@ endif(DDS_FOUND)
 ##########################
 # libFairMQ header files #
 ##########################
+set(FAIRMQ_DEPRECATED_HEADER_FILES
+    tools/FairMQTools.h
+)
 set(FAIRMQ_HEADER_FILES
+    ${FAIRMQ_DEPRECATED_HEADER_FILES}
     FairMQChannel.h
     FairMQConfigPlugin.h
     FairMQConfigurable.h
@@ -69,6 +73,7 @@ set(FAIRMQ_HEADER_FILES
     FairMQStateMachine.h
     FairMQTransportFactory.h
     FairMQTransports.h
+    Tools.h
     devices/FairMQBenchmarkSampler.h
     devices/FairMQMerger.h
     devices/FairMQMultiplier.h
@@ -90,7 +95,8 @@ set(FAIRMQ_HEADER_FILES
     shmem/FairMQTransportFactorySHM.h
     shmem/FairMQShmMonitor.h
     shmem/FairMQShmDeviceCounter.h
-    tools/FairMQTools.h
+    tools/CppSTL.h
+    tools/Network.h
     tools/runSimpleMQStateMachine.h
     zeromq/FairMQMessageZMQ.h
     zeromq/FairMQPollerZMQ.h
@@ -179,7 +185,9 @@ add_library(FairMQ SHARED
 target_include_directories(FairMQ
     PUBLIC # consumers inherit public include directories
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include/fairmq>
+    $<INSTALL_INTERFACE:include>
 )
 
 ##################

--- a/fairmq/FairMQDevice.cxx
+++ b/fairmq/FairMQDevice.cxx
@@ -30,7 +30,7 @@
 #include "FairMQSocket.h"
 #include "FairMQDevice.h"
 #include "FairMQLogger.h"
-#include "tools/FairMQTools.h"
+#include <fairmq/Tools.h>
 
 #include "options/FairMQProgOptions.h"
 #include "zeromq/FairMQTransportFactoryZMQ.h"
@@ -203,9 +203,9 @@ void FairMQDevice::InitWrapper()
                         // if the configured network interface is default, get its name from the default route
                         if (fNetworkInterface == "default")
                         {
-                            fNetworkInterface = FairMQ::tools::getDefaultRouteNetworkInterface();
+                            fNetworkInterface = fair::mq::tools::getDefaultRouteNetworkInterface();
                         }
-                        vi->fAddress = "tcp://" + FairMQ::tools::getInterfaceIP(fNetworkInterface) + ":1";
+                        vi->fAddress = "tcp://" + fair::mq::tools::getInterfaceIP(fNetworkInterface) + ":1";
                     }
                     // fill the uninitialized list
                     uninitializedBindingChannels.push_back(&(*vi));
@@ -910,16 +910,16 @@ unique_ptr<FairMQTransportFactory> FairMQDevice::MakeTransport(const string& tra
 
     if (transport == "zeromq")
     {
-        tr = FairMQ::tools::make_unique<FairMQTransportFactoryZMQ>();
+        tr = fair::mq::tools::make_unique<FairMQTransportFactoryZMQ>();
     }
     else if (transport == "shmem")
     {
-        tr = FairMQ::tools::make_unique<FairMQTransportFactorySHM>();
+        tr = fair::mq::tools::make_unique<FairMQTransportFactorySHM>();
     }
 #ifdef NANOMSG_FOUND
     else if (transport == "nanomsg")
     {
-        tr = FairMQ::tools::make_unique<FairMQTransportFactoryNN>();
+        tr = fair::mq::tools::make_unique<FairMQTransportFactoryNN>();
     }
 #endif
     else

--- a/fairmq/Tools.h
+++ b/fairmq/Tools.h
@@ -1,0 +1,17 @@
+/********************************************************************************
+ *    Copyright (C) 2017 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+#ifndef FAIR_MQ_TOOLS_H
+#define FAIR_MQ_TOOLS_H
+
+// IWYU pragma: begin_exports
+#include <fairmq/tools/CppSTL.h>
+#include <fairmq/tools/Network.h>
+// IWYU pragma: end_exports
+
+#endif // FAIR_MQ_TOOLS_H

--- a/fairmq/tools/CppSTL.h
+++ b/fairmq/tools/CppSTL.h
@@ -1,0 +1,32 @@
+/********************************************************************************
+ *    Copyright (C) 2017 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+#ifndef FAIR_MQ_TOOLS_CPPSTL_H
+#define FAIR_MQ_TOOLS_CPPSTL_H
+
+#include <memory>
+
+namespace fair
+{
+namespace mq
+{
+namespace tools
+{
+
+// make_unique implementation, until C++14 is default
+template<typename T, typename ...Args>
+std::unique_ptr<T> make_unique(Args&& ...args)
+{
+    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+
+} /* namespace tools */
+} /* namespace mq */
+} /* namespace fair */
+
+#endif /* FAIR_MQ_TOOLS_CPPSTL_H */

--- a/fairmq/tools/FairMQTools.h
+++ b/fairmq/tools/FairMQTools.h
@@ -1,129 +1,21 @@
 #ifndef FAIRMQTOOLS_H_
 #define FAIRMQTOOLS_H_
 
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE // To get defns of NI_MAXSERV and NI_MAXHOST
-#endif
+#warning "This header file is deprecated. Include <fairmq/Tools.h> instead. Note, that the namespace FairMQ::tools has been changed to fair::mq::tools in the new header."
 
-#include "FairMQLogger.h"
-
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <netdb.h>
-#include <ifaddrs.h>
-#include <stdio.h>
-
-#include <boost/algorithm/string.hpp> // trim
-
-#include <map>
-#include <string>
-#include <iostream>
-#include <array>
+#include <fairmq/tools/CppSTL.h>
+#include <fairmq/tools/Network.h>
 
 namespace FairMQ
 {
 namespace tools
 {
 
-// make_unique implementation, until C++14 is default
-template<typename T, typename ...Args>
-std::unique_ptr<T> make_unique(Args&& ...args)
-{
-    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
-}
+using fair::mq::tools::make_unique;
 
-// returns a map with network interface names as keys and their IP addresses as values
-int getHostIPs(std::map<std::string, std::string>& addressMap)
-{
-    struct ifaddrs *ifaddr, *ifa;
-    int s;
-    char host[NI_MAXHOST];
-
-    if (getifaddrs(&ifaddr) == -1)
-    {
-        perror("getifaddrs");
-        return -1;
-    }
-
-    for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next)
-    {
-        if (ifa->ifa_addr == NULL)
-        {
-            continue;
-        }
-
-        if (ifa->ifa_addr->sa_family == AF_INET)
-        {
-            s = getnameinfo(ifa->ifa_addr, sizeof(struct sockaddr_in), host, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
-            if (s != 0)
-            {
-                std::cout << "getnameinfo() failed: " << gai_strerror(s) << std::endl;
-                return -1;
-            }
-
-            addressMap.insert(std::pair<std::string, std::string>(ifa->ifa_name, host));
-        }
-    }
-    freeifaddrs(ifaddr);
-
-    return 0;
-}
-
-// get IP address of a given interface name
-std::string getInterfaceIP(std::string interface)
-{
-    std::map<std::string, std::string> IPs;
-    getHostIPs(IPs);
-    if (IPs.count(interface))
-    {
-        return IPs[interface];
-    }
-    else
-    {
-        LOG(ERROR) << "Could not find provided network interface: \"" << interface << "\"!, exiting.";
-        return "";
-    }
-}
-
-// get name of the default route interface
-std::string getDefaultRouteNetworkInterface()
-{
-    std::array<char, 128> buffer;
-    std::string interfaceName;
-
-#ifdef __APPLE__ // MacOS
-    std::unique_ptr<FILE, decltype(pclose) *> file(popen("route -n get default | grep interface | cut -d \":\" -f 2", "r"), pclose);
-#else // Linux
-    std::unique_ptr<FILE, decltype(pclose) *> file(popen("ip route | grep default | cut -d \" \" -f 5", "r"), pclose);
-#endif
-
-    if (!file)
-    {
-        LOG(ERROR) << "Could not detect default route network interface name - popen() failed!";
-        return "";
-    }
-
-    while (!feof(file.get()))
-    {
-        if (fgets(buffer.data(), 128, file.get()) != NULL)
-        {
-            interfaceName += buffer.data();
-        }
-    }
-
-    boost::algorithm::trim(interfaceName);
-
-    if (interfaceName == "")
-    {
-        LOG(ERROR) << "Could not detect default route network interface name";
-    }
-    else
-    {
-        LOG(DEBUG) << "Detected network interface name for the default route: " << interfaceName;
-    }
-
-    return interfaceName;
-}
+using fair::mq::tools::getHostIPs;
+using fair::mq::tools::getInterfaceIP;
+using fair::mq::tools::getDefaultRouteNetworkInterface;
 
 } // namespace tools
 } // namespace FairMQ

--- a/fairmq/tools/Network.h
+++ b/fairmq/tools/Network.h
@@ -1,0 +1,135 @@
+/********************************************************************************
+ *    Copyright (C) 2017 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+#ifndef FAIR_MQ_TOOLS_NETWORK_H
+#define FAIR_MQ_TOOLS_NETWORK_H
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE // To get defns of NI_MAXSERV and NI_MAXHOST
+#endif
+
+#include "FairMQLogger.h"
+
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <netdb.h>
+#include <ifaddrs.h>
+#include <stdio.h>
+
+#include <boost/algorithm/string.hpp> // trim
+
+#include <map>
+#include <string>
+#include <iostream>
+#include <array>
+
+namespace fair
+{
+namespace mq
+{
+namespace tools
+{
+
+// returns a map with network interface names as keys and their IP addresses as values
+int getHostIPs(std::map<std::string, std::string>& addressMap)
+{
+    struct ifaddrs *ifaddr, *ifa;
+    int s;
+    char host[NI_MAXHOST];
+
+    if (getifaddrs(&ifaddr) == -1)
+    {
+        perror("getifaddrs");
+        return -1;
+    }
+
+    for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next)
+    {
+        if (ifa->ifa_addr == NULL)
+        {
+            continue;
+        }
+
+        if (ifa->ifa_addr->sa_family == AF_INET)
+        {
+            s = getnameinfo(ifa->ifa_addr, sizeof(struct sockaddr_in), host, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
+            if (s != 0)
+            {
+                std::cout << "getnameinfo() failed: " << gai_strerror(s) << std::endl;
+                return -1;
+            }
+
+            addressMap.insert(std::pair<std::string, std::string>(ifa->ifa_name, host));
+        }
+    }
+    freeifaddrs(ifaddr);
+
+    return 0;
+}
+
+// get IP address of a given interface name
+std::string getInterfaceIP(std::string interface)
+{
+    std::map<std::string, std::string> IPs;
+    getHostIPs(IPs);
+    if (IPs.count(interface))
+    {
+        return IPs[interface];
+    }
+    else
+    {
+        LOG(ERROR) << "Could not find provided network interface: \"" << interface << "\"!, exiting.";
+        return "";
+    }
+}
+
+// get name of the default route interface
+std::string getDefaultRouteNetworkInterface()
+{
+    std::array<char, 128> buffer;
+    std::string interfaceName;
+
+#ifdef __APPLE__ // MacOS
+    std::unique_ptr<FILE, decltype(pclose) *> file(popen("route -n get default | grep interface | cut -d \":\" -f 2", "r"), pclose);
+#else // Linux
+    std::unique_ptr<FILE, decltype(pclose) *> file(popen("ip route | grep default | cut -d \" \" -f 5", "r"), pclose);
+#endif
+
+    if (!file)
+    {
+        LOG(ERROR) << "Could not detect default route network interface name - popen() failed!";
+        return "";
+    }
+
+    while (!feof(file.get()))
+    {
+        if (fgets(buffer.data(), 128, file.get()) != NULL)
+        {
+            interfaceName += buffer.data();
+        }
+    }
+
+    boost::algorithm::trim(interfaceName);
+
+    if (interfaceName == "")
+    {
+        LOG(ERROR) << "Could not detect default route network interface name";
+    }
+    else
+    {
+        LOG(DEBUG) << "Detected network interface name for the default route: " << interfaceName;
+    }
+
+    return interfaceName;
+}
+
+} /* namespace tools */
+} /* namespace mq */
+} /* namespace fair */
+
+#endif /* FAIR_MQ_TOOLS_NETWORK_H */

--- a/fairmq/tools/README.md
+++ b/fairmq/tools/README.md
@@ -2,7 +2,7 @@
 
 Contains common tools for use by FairMQ and/or users.
 
-## FairMQ::tools::getHostIPs
+## fair::mq::tools::getHostIPs
 
 Fills a map with the network interfaces and their IP addresses available on the current host.
 
@@ -13,13 +13,13 @@ Fills a map with the network interfaces and their IP addresses available on the 
 #include <string>
 #include <iostream>
 
-#include "FairMQTools.h"
+#include <fairmq/Tools.h>
 
 void main()
 {
     std::map<string,string> IPs;
 
-    FairMQ::tools::getHostIPs(IPs);
+    fair::mq::tools::getHostIPs(IPs);
 
     for (std::map<string,string>::iterator it = IPs.begin(); it != IPs.end(); ++it)
     {


### PR DESCRIPTION
  * Split header, add common header
  * Transform to canonical namespace
  * Deprecate old header
  * Adapt to new Tools.h

---

These changes are a example on how to move declarations to new namespaces while staying backwards compatible with a deprecated header. It also shows how to introduce convenience headers with IWYU support. 