### PR TITLE
FairTask - added new member variable (fStreamProcessing).

### DIFF
--- a/base/steer/FairTask.cxx
+++ b/base/steer/FairTask.cxx
@@ -30,6 +30,7 @@ FairTask::FairTask()
     fVerbose(0),
     fInputPersistance(-1),
     fLogger(FairLogger::GetLogger()),
+    fStreamProcessing(kFALSE),
     fOutputPersistance()
 {
 }

--- a/base/steer/FairTask.h
+++ b/base/steer/FairTask.h
@@ -99,11 +99,14 @@ class FairTask : public TTask
     **/  
     Bool_t IsOutputBranchPersistent(TString);
 
+    void SetStreamProcessing(Bool_t val=kTRUE) {fStreamProcessing=val;}
+
   protected:
 
     Int_t        fVerbose;  //  Verbosity level
     Int_t        fInputPersistance; ///< Indicates if input branch is persistant
     FairLogger*  fLogger; //!
+    Bool_t       fStreamProcessing;
 
     /** Intialisation at begin of run. To be implemented in the derived class.
     *@value  Success   If not kSUCCESS, task will be set inactive.
@@ -153,7 +156,7 @@ class FairTask : public TTask
     FairTask(const FairTask&);
     FairTask& operator=(const FairTask&);
 
-    ClassDef(FairTask,3);
+    ClassDef(FairTask,4);
 
 };
 

--- a/examples/MQ/9-PixelDetector/src/devices/FairMQEx9TaskProcessor.tpl
+++ b/examples/MQ/9-PixelDetector/src/devices/FairMQEx9TaskProcessor.tpl
@@ -59,6 +59,7 @@ void FairMQEx9TaskProcessor<T>::Init()
   fParamChannelName  = fConfig->GetValue<std::string>("par-channel");
   
   fFairTask = new T();
+  fFairTask->SetStreamProcessing(kTRUE);
   fGeoPar = new FairGeoParSet("FairGeoParSet");
   fParCList = new TList();
   fParCList->Add(fGeoPar);

--- a/examples/MQ/9-PixelDetector/src/devices/FairMQEx9TaskProcessorBin.tpl
+++ b/examples/MQ/9-PixelDetector/src/devices/FairMQEx9TaskProcessorBin.tpl
@@ -82,6 +82,7 @@ void FairMQEx9TaskProcessorBin<T>::Init()
 
     //fHitFinder->InitMQ(fRootParFileName,fAsciiParFileName);
   fFairTask = new T();
+  fFairTask->SetStreamProcessing(kTRUE);
   fGeoPar = new FairGeoParSet("FairGeoParSet");
   fParCList = new TList();
   fParCList->Add(fGeoPar);

--- a/examples/MQ/9a-PixelDetector/src/devices/FairMQEx9aTaskProcessorBin.tpl
+++ b/examples/MQ/9a-PixelDetector/src/devices/FairMQEx9aTaskProcessorBin.tpl
@@ -55,6 +55,7 @@ void FairMQEx9aTaskProcessorBin<T>::Init()
 
     //fHitFinder->InitMQ(fRootParFileName,fAsciiParFileName);
   fFairTask = new T();
+  fFairTask->SetStreamProcessing(kTRUE);
   fGeoPar = new FairGeoParSet("FairGeoParSet");
   fParCList = new TList();
   fParCList->Add(fGeoPar);

--- a/examples/advanced/Tutorial3/MQ/processorTask/FairTestDetectorMQRecoTask.h
+++ b/examples/advanced/Tutorial3/MQ/processorTask/FairTestDetectorMQRecoTask.h
@@ -128,6 +128,7 @@ class FairTestDetectorMQRecoTask : public FairMQProcessorTask
     virtual InitStatus Init()
     {
         fRecoTask = new FairTestDetectorRecoTask();
+        fRecoTask->SetStreamProcessing(kTRUE);
         fRecoTask->fDigiArray = new TClonesArray("FairTestDetectorDigi");
         fRecoTask->fHitArray = new TClonesArray("FairTestDetectorHit");
 

--- a/examples/advanced/Tutorial3/reconstruction/FairTestDetectorRecoTask.cxx
+++ b/examples/advanced/Tutorial3/reconstruction/FairTestDetectorRecoTask.cxx
@@ -97,7 +97,8 @@ void FairTestDetectorRecoTask::Exec(Option_t* /*opt*/)
         TVector3 dpos(1 / TMath::Sqrt(12), 1 / TMath::Sqrt(12), 1 / TMath::Sqrt(12));
 
         FairTestDetectorHit* hit = new ((*fHitArray)[ipnt]) FairTestDetectorHit(-1, -1, pos, dpos);
-        hit->AddLink(FairLink(-1, FairRootManager::Instance()->GetEntryNr(), FairRootManager::Instance()->GetBranchId("FairTestDetectorDigi"), ipnt));
+        if ( fStreamProcessing == kFALSE )
+          hit->AddLink(FairLink(-1, FairRootManager::Instance()->GetEntryNr(), FairRootManager::Instance()->GetBranchId("FairTestDetectorDigi"), ipnt));
         hit->SetTimeStamp(digi->GetTimeStamp());
         hit->SetTimeStampError(digi->GetTimeStampError());
     }


### PR DESCRIPTION
It is set by default to kFALSE.
When running in FairMQ, it should be SetStreamProcesssing(kTRUE).

Modified:
examples/advanced/Tutorial3,
examples/MQ/9-PixelDetector,
examples/MQ/9a-PixelDetector
accordingly.