### PR TITLE
Always have access to FairMQProgOptions from device

### DIFF
--- a/fairmq/FairMQDevice.h
+++ b/fairmq/FairMQDevice.h
@@ -472,6 +472,8 @@ class FairMQDevice : public FairMQStateMachine, public FairMQConfigurable
     bool HandleMsgInput(const std::string& chName, const InputMsgCallback& callback, int i) const;
     bool HandleMultipartInput(const std::string& chName, const InputMultipartCallback& callback, int i) const;
 
+    void CreateOwnConfig();
+
     /// Signal handler
     void SignalHandler(int signal);
     bool fCatchingSignals;
@@ -486,6 +488,8 @@ class FairMQDevice : public FairMQStateMachine, public FairMQConfigurable
     std::vector<std::string> fInputChannelKeys;
     std::mutex fMultitransportMutex;
     std::atomic<bool> fMultitransportProceed;
+
+    bool fExternalConfig;
 };
 
 #endif /* FAIRMQDEVICE_H_ */

--- a/fairmq/docs/Device.md
+++ b/fairmq/docs/Device.md
@@ -45,4 +45,8 @@ Without the interactive mode, for example for a run in background, two other con
  - static (`--control static`) - device goes through a simple init -> run -> reset -> exit chain.
  - dds (`--control dds`) - device is controled by external command, in this case using dds commands (fairmq-dds-command-ui).
 
+## 1.4 Multiple devices in the same process
+
+Technically one can create two or more devices within the same process without any conflicts. However the configuration (FairMQProgOptions) currently assumes the supplied configuration values are for one device/process.
+
 ← [Back](../README.md)

--- a/fairmq/options/FairMQProgOptions.cxx
+++ b/fairmq/options/FairMQProgOptions.cxx
@@ -110,14 +110,12 @@ void FairMQProgOptions::ParseAll(const int argc, char** argv, bool allowUnregist
 
     if (!optionExists)
     {
-        LOG(WARN) << "Options to configure FairMQ channels are not provided.";
-        LOG(WARN) << "Please provide the value for one of the following keys:";
+        LOG(WARN) << "FairMQProgOptions: no channels configuration provided via neither of:";
         for (const auto& p : MQParserKeys)
         {
-            LOG(WARN) << p;
+            LOG(WARN) << " --" << p;
         }
         LOG(WARN) << "No channels will be created (You can create them manually).";
-        // return 1;
     }
     else
     {

--- a/fairmq/test/CMakeLists.txt
+++ b/fairmq/test/CMakeLists.txt
@@ -64,6 +64,19 @@ add_testsuite(FairMQ.Parts
     TIMEOUT 5
 )
 
+add_testsuite(FairMQ.Device
+    SOURCES
+    device/TestSender.h
+    device/TestReceiver.h
+    device/runner.cxx
+    device/_multiple_devices.cxx
+
+    LINKS FairMQ
+    INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/device
+    TIMEOUT 5
+    RUN_SERIAL ON
+)
+
 ##############################
 # Aggregate all test targets #
 ##############################

--- a/fairmq/test/device/TestReceiver.h
+++ b/fairmq/test/device/TestReceiver.h
@@ -1,0 +1,62 @@
+/********************************************************************************
+ * Copyright (C) 2015-2017 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+#ifndef FAIR_MQ_TEST_TESTRECEIVER_H
+#define FAIR_MQ_TEST_TESTRECEIVER_H
+
+#include <FairMQDevice.h>
+#include <FairMQLogger.h>
+
+#include <string>
+
+namespace fair
+{
+namespace mq
+{
+namespace test
+{
+
+class Receiver : public FairMQDevice
+{
+  public:
+    Receiver(const std::string& channelName)
+        : fChannelName(channelName)
+    {}
+
+  protected:
+    auto Init() -> void override
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    }
+
+    auto Reset() -> void override
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    auto Run() -> void override
+    {
+        auto msg = FairMQMessagePtr{NewMessage()};
+        if (Receive(msg, fChannelName) >= 0)
+        {
+            LOG(INFO) << "received empty message";
+        }
+        else
+        {
+            LOG(ERROR) << "fair::mq::test::Receiver::Run(): Receive(msg, fChannelName) < 0";
+        }
+    };
+
+    std::string fChannelName;
+};
+
+} // namespace test
+} // namespace mq
+} // namespace fair
+
+#endif // FAIR_MQ_TEST_TESTRECEIVER_H

--- a/fairmq/test/device/TestSender.h
+++ b/fairmq/test/device/TestSender.h
@@ -1,0 +1,62 @@
+/********************************************************************************
+ * Copyright (C) 2015-2017 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+#ifndef FAIR_MQ_TEST_TESTSENDER_H
+#define FAIR_MQ_TEST_TESTSENDER_H
+
+#include <FairMQDevice.h>
+#include <FairMQLogger.h>
+
+#include <string>
+
+namespace fair
+{
+namespace mq
+{
+namespace test
+{
+
+class Sender : public FairMQDevice
+{
+  public:
+    Sender(const std::string& channelName)
+        : fChannelName(channelName)
+    {}
+
+  protected:
+    auto Init() -> void override
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    }
+
+    auto Reset() -> void override
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    auto Run() -> void override
+    {
+        auto msg = FairMQMessagePtr{NewMessage()};
+        if (Send(msg, fChannelName) >= 0)
+        {
+            LOG(INFO) << "sent empty message";
+        }
+        else
+        {
+            LOG(ERROR) << "fair::mq::test::Sender::Run(): Send(msg, fChannelName) < 0";
+        }
+    };
+
+    std::string fChannelName;
+};
+
+} // namespace test
+} // namespace mq
+} // namespace fair
+
+#endif // FAIR_MQ_TEST_TESTSENDER_H

--- a/fairmq/test/device/_multiple_devices.cxx
+++ b/fairmq/test/device/_multiple_devices.cxx
@@ -1,0 +1,96 @@
+/********************************************************************************
+ *    Copyright (C) 2017 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+#include "TestSender.h"
+#include "TestReceiver.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <future> // std::async, std::future
+
+namespace
+{
+
+using namespace std;
+
+class MultipleDevices : public ::testing::Test {
+  public:
+    MultipleDevices()
+    {}
+
+    bool TestFirst()
+    {
+        fair::mq::test::Sender sender("data");
+
+        sender.SetTransport("zeromq");
+
+        FairMQChannel channel("push", "connect", "ipc://multiple-devices-test");
+        channel.UpdateRateLogging(0);
+        sender.fChannels["data"].push_back(channel);
+
+        sender.ChangeState("INIT_DEVICE");
+        sender.WaitForEndOfState("INIT_DEVICE");
+        sender.ChangeState("INIT_TASK");
+        sender.WaitForEndOfState("INIT_TASK");
+
+        sender.ChangeState("RUN");
+        sender.WaitForEndOfState("RUN");
+
+        sender.ChangeState("RESET_TASK");
+        sender.WaitForEndOfState("RESET_TASK");
+        sender.ChangeState("RESET_DEVICE");
+        sender.WaitForEndOfState("RESET_DEVICE");
+
+        sender.ChangeState("END");
+
+        return true;
+    }
+
+    bool TestSecond()
+    {
+        fair::mq::test::Receiver receiver("data");
+
+        receiver.SetTransport("zeromq");
+
+        FairMQChannel channel("pull", "bind", "ipc://multiple-devices-test");
+        channel.UpdateRateLogging(0);
+        receiver.fChannels["data"].push_back(channel);
+
+        receiver.ChangeState("INIT_DEVICE");
+        receiver.WaitForEndOfState("INIT_DEVICE");
+        receiver.ChangeState("INIT_TASK");
+        receiver.WaitForEndOfState("INIT_TASK");
+
+        receiver.ChangeState("RUN");
+        receiver.WaitForEndOfState("RUN");
+
+        receiver.ChangeState("RESET_TASK");
+        receiver.WaitForEndOfState("RESET_TASK");
+        receiver.ChangeState("RESET_DEVICE");
+        receiver.WaitForEndOfState("RESET_DEVICE");
+
+        receiver.ChangeState("END");
+
+        return true;
+    }
+};
+
+TEST_F(MultipleDevices, TwoInSameProcess)
+{
+    std::future<bool> fut1 = std::async(std::launch::async, &MultipleDevices::TestFirst, this);
+    std::future<bool> fut2 = std::async(std::launch::async, &MultipleDevices::TestSecond, this);
+
+    bool first = fut1.get();
+    bool second = fut2.get();
+
+    ASSERT_EQ(first, true);
+    ASSERT_EQ(second, true);
+}
+
+} // namespace

--- a/fairmq/test/device/runner.cxx
+++ b/fairmq/test/device/runner.cxx
@@ -1,0 +1,16 @@
+/********************************************************************************
+ *    Copyright (C) 2017 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+#include <gtest/gtest.h>
+
+auto main(int argc, char** argv) -> int
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
- Create FairMQProgOptions within a device if it has been started without access to one.
- Test devices without supplied config & two in a process.