### PR TITLE
Extend parameter list in FairPrimaryGenerator::AddTrack

### DIFF
--- a/base/sim/FairPrimaryGenerator.cxx
+++ b/base/sim/FairPrimaryGenerator.cxx
@@ -16,7 +16,6 @@
 #include "TDatabasePDG.h" // for TDatabasePDG
 #include "TF1.h"          // for TF1
 #include "TIterator.h"    // for TIterator
-#include "TMCProcess.h"   // for TMCProcess::kPPrimary
 #include "TMath.h"        // for Sqrt
 #include "TObject.h"      // for TObject
 #include "TParticlePDG.h" // for TParticlePDG
@@ -234,7 +233,8 @@ void FairPrimaryGenerator::AddTrack(Int_t pdgid, Double_t px_raw,
                                     Double_t py_raw, Double_t pz_raw,
                                     Double_t vx, Double_t vy, Double_t vz,
                                     Int_t parent, Bool_t wanttracking,
-                                    Double_t e, Double_t tof, Double_t weight) {
+                                    Double_t e, Double_t tof,
+                                    Double_t weight, TMCProcess proc) {
 
   // ---> Add event vertex to track vertex
   vx += fVertex.X();
@@ -315,7 +315,7 @@ void FairPrimaryGenerator::AddTrack(Int_t pdgid, Double_t px_raw,
   } // correct for tracks which are in list before generator is called
   // Add track to stack
   fStack->PushTrack(doTracking, dummyparent, pdgid, mom.X(), mom.Y(), mom.Z(),
-                    e, vx, vy, vz, tof, polx, poly, polz, kPPrimary, ntr,
+                    e, vx, vy, vz, tof, polx, poly, polz, proc, ntr,
                     weight, status, parent);
   fNTracks++;
 }

--- a/base/sim/FairPrimaryGenerator.h
+++ b/base/sim/FairPrimaryGenerator.h
@@ -31,6 +31,7 @@ the tracking from the macro (M. Al-Turany)
 #include "Rtypes.h"    // for Double_t, Bool_t, Int_t, etc
 #include "TObjArray.h" // for TObjArray
 #include "TVector3.h"  // for TVector3
+#include "TMCProcess.h"
 
 #include <iostream> // for operator<<, basic_ostream, etc
 
@@ -83,7 +84,7 @@ public:
                         Double_t vx, Double_t vy, Double_t vz,
                         Int_t parent = -1, Bool_t wanttracking = true,
                         Double_t e = -9e9, Double_t tof = 0.,
-                        Double_t weight = 0.);
+                        Double_t weight = 0., TMCProcess proc = kPPrimary);
 
   /** Clone this object (used in MT mode only) */
   virtual FairPrimaryGenerator* ClonePrimaryGenerator() const;


### PR DESCRIPTION
- added TMCProcess. By default kPPrimary
- Propagate this parameter to the stack
Changes do not influence the existing generators.