### PR TITLE
Merge channels from FairMQProgOptions to device, instead of replacing

### DIFF
--- a/fairmq/FairMQDevice.cxx
+++ b/fairmq/FairMQDevice.cxx
@@ -966,7 +966,13 @@ void FairMQDevice::SetConfig(FairMQProgOptions& config)
 {
     fExternalConfig = true;
     fConfig = &config;
-    fChannels = config.GetFairMQMap();
+    for (auto& c : config.GetFairMQMap())
+    {
+        if (!fChannels.insert(c).second)
+        {
+            LOG(WARN) << "FairMQDevice::SetConfig: did not insert channel '" << c.first << "', it is already in the device.";
+        }
+    }
     fDefaultTransport = config.GetValue<string>("transport");
     SetTransport(fDefaultTransport);
     fId = config.GetValue<string>("id");


### PR DESCRIPTION
This avoids conflicts if some channels were created grammatically, while also using FairMQProgOptions/FairMQParser.