### PR TITLE
Use <iosfwd> instead of Riosfwd.h

### DIFF
--- a/base/event/FairLink.h
+++ b/base/event/FairLink.h
@@ -25,7 +25,7 @@
 
 #include "TObject.h"                    // for TObject; ClassDefNV
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "Rtypes.h"                     // for Int_t, Float_t, etc
 
 #include <iostream>                     // for ostream, cout

--- a/base/event/FairMesh.cxx
+++ b/base/event/FairMesh.cxx
@@ -13,7 +13,7 @@
 
 #include "FairMesh.h"
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TMath.h"                      // for Sqrt
 #include "TString.h"                    // for TString, operator+
 

--- a/base/event/FairMultiLinkedData.h
+++ b/base/event/FairMultiLinkedData.h
@@ -19,7 +19,7 @@
 
 #include "FairLink.h"                   // for FairLink
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "Rtypes.h"                     // for Int_t, Bool_t, kFALSE, etc
 #include "TString.h"                    // for TString
 

--- a/base/event/FairMultiLinkedData_Interface.h
+++ b/base/event/FairMultiLinkedData_Interface.h
@@ -14,7 +14,7 @@
 #include "FairMultiLinkedData.h"
 #include "FairRootManager.h"
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "Rtypes.h"                     // for Int_t, Bool_t, kFALSE, etc
 #include "TString.h"                    // for TString
 #include "TRef.h"

--- a/base/event/FairTimeStamp.h
+++ b/base/event/FairTimeStamp.h
@@ -12,7 +12,7 @@
 
 #include "FairLink.h"                   // for FairLink
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "Rtypes.h"                     // for Double_t, etc
 
 #include <iostream>                     // for ostream, cout

--- a/base/event/FairTrackParam.cxx
+++ b/base/event/FairTrackParam.cxx
@@ -14,7 +14,7 @@
 
 #include "FairLogger.h"
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TMath.h"                      // for Sqrt
 #include "TMathBase.h"                  // for Abs
 #include "TMatrixTSym.h"                // for TMatrixTSym

--- a/base/field/FairField.h
+++ b/base/field/FairField.h
@@ -30,7 +30,7 @@
 #define FAIRFIELD_H 1
 
 #include "RVersion.h"                   // for ROOT_VERSION_CODE
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "Rtypes.h"                     // for Double_t, Bool_t, etc
 
 #if ROOT_VERSION_CODE < 333824

--- a/base/sim/FairMCApplication.cxx
+++ b/base/sim/FairMCApplication.cxx
@@ -38,7 +38,7 @@
 #include "FairTrajFilter.h"             // for FairTrajFilter
 #include "FairVolume.h"                 // for FairVolume
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TDatabasePDG.h"               // for TDatabasePDG
 #include "TDirectory.h"                 // for TDirectory, gDirectory
 #include "TGeoManager.h"                // for gGeoManager, TGeoManager

--- a/base/sim/FairParticle.cxx
+++ b/base/sim/FairParticle.cxx
@@ -15,7 +15,7 @@
 // particles
 #include "FairParticle.h"
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TDatabasePDG.h"               // for TDatabasePDG
 #include "TMCParticleType.h"            // for TMCParticleType::kPTIon, etc
 #include "TParticle.h"                  // for TParticle

--- a/base/sim/FairPrimaryGenerator.h
+++ b/base/sim/FairPrimaryGenerator.h
@@ -27,7 +27,7 @@ the tracking from the macro (M. Al-Turany)
 
 #include "FairGenerator.h" // for FairGenerator
 
-#include "Riosfwd.h"   // for ostream
+#include <iosfwd>      // for ostream
 #include "Rtypes.h"    // for Double_t, Bool_t, Int_t, etc
 #include "TObjArray.h" // for TObjArray
 #include "TVector3.h"  // for TVector3

--- a/base/source/MRevBuffer.cxx
+++ b/base/source/MRevBuffer.cxx
@@ -26,7 +26,7 @@
 
 #include "MRevBuffer.h"            // class definition
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TSocket.h"                    // for TSocket, etc
 
 #include <iostream>                     // for operator<<, basic_ostream, etc

--- a/base/steer/FairAnaSelector.cxx
+++ b/base/steer/FairAnaSelector.cxx
@@ -22,7 +22,7 @@
 #include "FairRuntimeDb.h"              // for FairRuntimeDb
 #include "FairTask.h"                   // for FairTask
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TFile.h"                      // for TFile
 #include "TList.h"                      // for TList
 #include "TNamed.h"                     // for TNamed

--- a/base/steer/FairRadGridManager.h
+++ b/base/steer/FairRadGridManager.h
@@ -14,7 +14,7 @@
 #define FAIRRADGRIDMANAGER_H 1
 
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "Rtypes.h"                     // for Float_t, Double_t, Int_t, etc
 #include "TLorentzVector.h"             // for TLorentzVector
 #include "TObjArray.h"                  // for TObjArray

--- a/base/steer/FairRadMapManager.cxx
+++ b/base/steer/FairRadMapManager.cxx
@@ -14,7 +14,7 @@
 #include "FairRadMapPoint.h"            // for FairRadMapPoint
 #include "FairRootManager.h"            // for FairRootManager
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TClonesArray.h"               // for TClonesArray
 #include "TGeoManager.h"                // for TGeoManager, gGeoManager
 #include "TGeoVolume.h"                 // for TGeoVolume

--- a/base/steer/FairRingSorter.h
+++ b/base/steer/FairRingSorter.h
@@ -18,7 +18,7 @@
 
 #include "TObject.h"                    // for TObject
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "Rtypes.h"                     // for FairRingSorter::Class, etc
 
 #include <iostream>                     // for operator<<, ostream, etc

--- a/base/steer/FairRingSorterTask.cxx
+++ b/base/steer/FairRingSorterTask.cxx
@@ -15,7 +15,7 @@
 #include "FairRootManager.h"            // for FairRootManager
 #include "FairTimeStamp.h"              // for FairTimeStamp
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TClass.h"                     // for TClass
 #include "TClonesArray.h"               // for TClonesArray
 

--- a/base/steer/FairRootManager.cxx
+++ b/base/steer/FairRootManager.cxx
@@ -26,7 +26,7 @@
 #include "FairTSBufferFunctional.h"     // for FairTSBufferFunctional, etc
 #include "FairWriteoutBuffer.h"         // for FairWriteoutBuffer
 #include "FairLinkManager.h"            // for FairLinkManager
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TArrayI.h"                    // for TArrayI
 #include "TBranch.h"                    // for TBranch
 #include "TChainElement.h"              // for TChainElement

--- a/base/steer/FairRunAna.cxx
+++ b/base/steer/FairRunAna.cxx
@@ -31,7 +31,7 @@
 #include "FairMixedSource.h"            // ONLY TEMPORARILY, FOR COMPABILITY
 
 #include "RVersion.h"                   // for ROOT_VERSION, etc
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TChain.h"                     // for TChain
 #include "TCollection.h"                // for TIter
 #include "TDirectory.h"                 // for TDirectory, gDirectory

--- a/base/steer/FairRunSim.cxx
+++ b/base/steer/FairRunSim.cxx
@@ -29,7 +29,7 @@
 #include "FairTask.h"                   // for FairTask
 #include "FairTrajFilter.h"             // for FairTrajFilter
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TCollection.h"                // for TIter
 #include "TGeoManager.h"                // for gGeoManager
 #include "TList.h"                      // for TList

--- a/base/steer/FairTSBufferFunctional.h
+++ b/base/steer/FairTSBufferFunctional.h
@@ -10,7 +10,7 @@
 
 #include "FairTimeStamp.h"              // for FairTimeStamp
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "Rtypes.h"                     // for Int_t, Bool_t, Double_t, etc
 #include "TObject.h"                    // for TObject
 #include "TString.h"                    // for TString

--- a/base/steer/FairTrajFilter.cxx
+++ b/base/steer/FairTrajFilter.cxx
@@ -14,7 +14,7 @@
 
 #include "FairRootManager.h"            // for FairRootManager
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TClonesArray.h"               // for TClonesArray
 #include "TError.h"                     // for Fatal
 #include "TGeoTrack.h"                  // for TGeoTrack

--- a/base/steer/FairWriteoutBuffer.h
+++ b/base/steer/FairWriteoutBuffer.h
@@ -37,7 +37,7 @@
 #include "FairRootManager.h"            // for FairRootManager
 #include "FairTimeStamp.h"              // for FairTimeStamp
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "Rtypes.h"                     // for Bool_t, Int_t, etc
 #include "TClonesArray.h"               // for TClonesArray
 #include "TString.h"                    // for TString

--- a/datamatch/FairMCDataCrawler.cxx
+++ b/datamatch/FairMCDataCrawler.cxx
@@ -17,7 +17,7 @@
 #include "FairLink.h"                   // for FairLink, operator<<
 #include "FairRootManager.h"            // for FairRootManager
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 
 #include <iostream>                     // for operator<<, ostream, cout, etc
 

--- a/datamatch/FairMCEntry.h
+++ b/datamatch/FairMCEntry.h
@@ -19,7 +19,7 @@
 
 #include "FairLink.h"                   // for FairLink
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "Rtypes.h"                     // for Int_t, FairMCEntry::Class, etc
 
 #include <iostream>                     // for ostream

--- a/datamatch/FairMCMatch.h
+++ b/datamatch/FairMCMatch.h
@@ -23,7 +23,7 @@
 #include "FairMultiLinkedData.h"        // for FairMultiLinkedData
 #include "FairRootManager.h"            // for FairRootManager
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "Rtypes.h"                     // for Int_t, FairMCMatch::Class, etc
 #include "TString.h"                    // for TString
 #include "TClonesArray.h"

--- a/datamatch/FairMCMatchCreatorTask.cxx
+++ b/datamatch/FairMCMatchCreatorTask.cxx
@@ -18,7 +18,7 @@
 #include "FairMultiLinkedData.h"        // for FairMultiLinkedData
 #include "FairRootManager.h"            // for FairRootManager
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TClonesArray.h"               // for TClonesArray
 
 #include <stddef.h>                     // for NULL

--- a/datamatch/FairMCMatchLoaderTask.cxx
+++ b/datamatch/FairMCMatchLoaderTask.cxx
@@ -14,7 +14,7 @@
 #include "FairMCMatch.h"                // for FairMCMatch
 #include "FairRootManager.h"            // for FairRootManager
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TClonesArray.h"               // for TClonesArray
 
 #include <stddef.h>                     // for NULL

--- a/datamatch/FairMCMatchSelectorTask.cxx
+++ b/datamatch/FairMCMatchSelectorTask.cxx
@@ -16,7 +16,7 @@
 #include "FairMCStage.h"                // for FairMCStage
 #include "FairRootManager.h"            // for FairRootManager
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 
 #include <stddef.h>                     // for NULL
 #include <iostream>                     // for operator<<, ostream, etc

--- a/datamatch/FairMCObject.h
+++ b/datamatch/FairMCObject.h
@@ -21,7 +21,7 @@
 #include "FairMCEntry.h"                // for FairMCEntry
 #include "FairMultiLinkedData.h"        // for FairMultiLinkedData
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "Rtypes.h"                     // for Int_t, FairMCObject::Class, etc
 
 #include <iostream>                     // for ostream, etc

--- a/datamatch/FairMCResult.h
+++ b/datamatch/FairMCResult.h
@@ -19,7 +19,7 @@
 
 #include "FairMCEntry.h"                // for FairMCEntry
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "Rtypes.h"                     // for Int_t, FairMCResult::Class, etc
 
 #include <iostream>                     // for operator<<, ostream, etc

--- a/datamatch/FairMCStage.h
+++ b/datamatch/FairMCStage.h
@@ -17,7 +17,7 @@
 
 #include "FairMCObject.h"               // for FairMCObject
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "Rtypes.h"                     // for Bool_t, Double_t, etc
 
 #include <iostream>                     // for ostream, basic_ostream, etc

--- a/eventdisplay/FairBoxSetDraw.cxx
+++ b/eventdisplay/FairBoxSetDraw.cxx
@@ -18,7 +18,7 @@
 #include "FairTSBufferFunctional.h"     // for StopTime
 #include "FairTimeStamp.h"              // for FairTimeStamp
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TClonesArray.h"               // for TClonesArray
 #include "TEveBoxSet.h"
 #include "TEveManager.h"                // for TEveManager, gEve

--- a/eventdisplay/FairBoxSetEditor.cxx
+++ b/eventdisplay/FairBoxSetEditor.cxx
@@ -10,7 +10,7 @@
 #include "FairEventManager.h"           // for FairEventManager
 #include "FairRootManager.h"            // for FairRootManager
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TGLabel.h"                    // for TGLabel
 #include "TGLayout.h"                   // for TGLayoutHints, etc
 #include "TGNumberEntry.h"              // for TGNumberEntry, etc

--- a/eventdisplay/FairHitPointSetDraw.cxx
+++ b/eventdisplay/FairHitPointSetDraw.cxx
@@ -16,7 +16,7 @@
 
 #include "FairHit.h"                    // for FairHit
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TVector3.h"                   // for TVector3
 
 #include <iostream>                     // for operator<<, basic_ostream, etc

--- a/eventdisplay/FairMCTracks.cxx
+++ b/eventdisplay/FairMCTracks.cxx
@@ -15,7 +15,7 @@
 #include "FairRootManager.h"            // for FairRootManager
 #include "FairLogger.h"
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TClonesArray.h"               // for TClonesArray
 #include "TEveManager.h"                // for TEveManager, gEve
 #include "TEvePathMark.h"               // for TEvePathMark

--- a/eventdisplay/FairPointSetDraw.cxx
+++ b/eventdisplay/FairPointSetDraw.cxx
@@ -14,7 +14,7 @@
 #include "FairEventManager.h"           // for FairEventManager
 #include "FairRootManager.h"            // for FairRootManager
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TClonesArray.h"               // for TClonesArray
 #include "TEveManager.h"                // for TEveManager, gEve
 #include "TEvePointSet.h"               // for TEvePointSet

--- a/examples/MQ/9-PixelDetector/src/Pixel.cxx
+++ b/examples/MQ/9-PixelDetector/src/Pixel.cxx
@@ -27,7 +27,7 @@
 
 
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TClonesArray.h"               // for TClonesArray
 #include "TList.h"                      // for TListIter, TList (ptr only)
 #include "TObjArray.h"                  // for TObjArray

--- a/examples/MQ/serialization/data_struct/MyDigi.h
+++ b/examples/MQ/serialization/data_struct/MyDigi.h
@@ -18,7 +18,7 @@
 
 #include "FairTimeStamp.h" // for FairTimeStamp
 
-#include "Riosfwd.h" // for ostream
+#include <iosfwd>    // for ostream
 #include "Rtypes.h"  // for Int_t, etc
 
 #include <iostream> // for operator<<, basic_ostream, etc

--- a/examples/MQ/serialization/data_struct/MyPodData.h
+++ b/examples/MQ/serialization/data_struct/MyPodData.h
@@ -17,7 +17,7 @@
 #define	MYPODDATA_H
 
 // for root types
-#include "Riosfwd.h"
+#include <iosfwd>   
 #include "Rtypes.h" 
 
 // for boost serialization (must be hidden from CINT)

--- a/examples/advanced/Tutorial3/data/FairTestDetectorDigi.h
+++ b/examples/advanced/Tutorial3/data/FairTestDetectorDigi.h
@@ -17,7 +17,7 @@
 
 #include "FairTimeStamp.h" // for FairTimeStamp
 
-#include "Riosfwd.h" // for ostream
+#include <iosfwd>    // for ostream
 #include "Rtypes.h"  // for Int_t, etc
 
 #include <iostream> // for operator<<, basic_ostream, etc

--- a/examples/advanced/Tutorial3/digitization/FairTestDetectorDigiTask.cxx
+++ b/examples/advanced/Tutorial3/digitization/FairTestDetectorDigiTask.cxx
@@ -12,7 +12,7 @@
 #include "FairTestDetectorDigi.h"  // for FairTestDetectorDigi
 #include "FairTestDetectorPoint.h" // for FairTestDetectorPoint
 
-#include "Riosfwd.h"      // for ostream
+#include <iosfwd>         // for ostream
 #include "TClonesArray.h" // for TClonesArray
 #include "TMath.h"        // for Sqrt
 #include "TRandom.h"      // for TRandom, gRandom

--- a/examples/advanced/Tutorial3/reconstruction/FairTestDetectorRecoTask.cxx
+++ b/examples/advanced/Tutorial3/reconstruction/FairTestDetectorRecoTask.cxx
@@ -11,7 +11,7 @@
 #include "FairRootManager.h"      // for FairRootManager
 #include "FairTestDetectorDigi.h" // for FairTestDetectorDigi
 #include "FairTestDetectorHit.h"  // for FairTestDetectorHit
-#include "Riosfwd.h"              // for ostream
+#include <iosfwd>                 // for ostream
 #include "TClonesArray.h"         // for TClonesArray
 #include "TMath.h"                // for Sqrt
 #include "TVector3.h"             // for TVector3

--- a/examples/advanced/Tutorial3/simulation/FairConstField.cxx
+++ b/examples/advanced/Tutorial3/simulation/FairConstField.cxx
@@ -16,7 +16,7 @@
 #include "FairRuntimeDb.h" // for FairRuntimeDb
 #include "FairLogger.h"    // for logging
 
-#include "Riosfwd.h" // for ostream
+#include <iosfwd>    // for ostream
 #include "TString.h" // for operator<<, TString
 
 #include <iomanip>  // for operator<<, setw

--- a/examples/advanced/Tutorial3/timeBasedSimulation/FairTestDetectorDigiWriteoutBuffer.cxx
+++ b/examples/advanced/Tutorial3/timeBasedSimulation/FairTestDetectorDigiWriteoutBuffer.cxx
@@ -18,7 +18,7 @@
 #include "FairTestDetectorDigi.h" // for FairTestDetectorDigi, etc
 #include "FairLogger.h"           // for logging
 
-#include "Riosfwd.h"      // for ostream
+#include <iosfwd>         // for ostream
 #include "TClonesArray.h" // for TClonesArray
 
 #include <utility>  // for pair

--- a/examples/common/mcstack/FairStack.cxx
+++ b/examples/common/mcstack/FairStack.cxx
@@ -18,7 +18,7 @@
 #include "FairRootManager.h"            // for FairRootManager
 #include "FairLogger.h"                 // for FairLogger, MESSAGE_ORIGIN
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TClonesArray.h"               // for TClonesArray
 #include "TIterator.h"                  // for TIterator
 #include "TLorentzVector.h"             // for TLorentzVector

--- a/examples/common/passive/FairGeoCave.h
+++ b/examples/common/passive/FairGeoCave.h
@@ -10,7 +10,7 @@
 
 #include "FairGeoSet.h"                 // for FairGeoSet
 
-#include "Riosfwd.h"                    // for fstream
+#include <iosfwd>                       // for fstream
 #include "Rtypes.h"                     // for FairGeoCave::Class, Bool_t, etc
 #include "TString.h"                    // for TString
 

--- a/examples/common/passive/FairMagnet.cxx
+++ b/examples/common/passive/FairMagnet.cxx
@@ -18,7 +18,7 @@
 
 #include "FairRun.h"                    // for FairRun
 #include "FairRuntimeDb.h"              // for FairRuntimeDb
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TList.h"                      // for TListIter, TList (ptr only)
 #include "TObjArray.h"                  // for TObjArray
 #include "TString.h"                    // for TString

--- a/examples/simulation/Tutorial1/src/FairTutorialDet1.cxx
+++ b/examples/simulation/Tutorial1/src/FairTutorialDet1.cxx
@@ -22,7 +22,7 @@
 #include "FairVolume.h"                 // for FairVolume
 #include "FairLogger.h"                 // for logging
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TClonesArray.h"               // for TClonesArray
 #include "TList.h"                      // for TListIter, TList (ptr only)
 #include "TObjArray.h"                  // for TObjArray

--- a/examples/simulation/Tutorial4/src/display/FairTutorialDet4PointDraw.cxx
+++ b/examples/simulation/Tutorial4/src/display/FairTutorialDet4PointDraw.cxx
@@ -15,7 +15,7 @@
 #include "FairRuntimeDb.h"              // for FairRuntimeDb
 #include "FairLogger.h"
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TClonesArray.h"               // for TClonesArray
 #include "TEvePointSet.h"                 // for TEveBoxSet, etc
 #include "TEveManager.h"                // for TEveManager, gEve

--- a/examples/simulation/Tutorial4/src/mc/FairTutorialDet4.cxx
+++ b/examples/simulation/Tutorial4/src/mc/FairTutorialDet4.cxx
@@ -23,7 +23,7 @@
 #include "FairTutorialDet4MisalignPar.h"
 #include "FairTutorialDet4Point.h"      // for FairTutorialDet4Point
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TClonesArray.h"               // for TClonesArray
 #include "TGeoManager.h"                // for TGeoManager, gGeoManager
 #include "TGeoMatrix.h"                 // for TGeoHMatrix, TGeoCombiTrans, etc

--- a/examples/simulation/rutherford/src/FairRutherfordPoint.cxx
+++ b/examples/simulation/rutherford/src/FairRutherfordPoint.cxx
@@ -7,7 +7,7 @@
  ********************************************************************************/
 #include "FairRutherfordPoint.h"
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 
 #include <iostream>                     // for operator<<, basic_ostream, etc
 

--- a/fairtools/FairLogger.cxx
+++ b/fairtools/FairLogger.cxx
@@ -14,7 +14,7 @@
 
 #include "FairLogger.h"
 
-#include "Riosfwd.h"                    // for ostream, ofstream
+#include <iosfwd>                       // for ostream, ofstream
 #include "TString.h"                    // for TString, operator==, etc
 #include "TSystem.h"                    // for gSystem, TSystem
 

--- a/geane/FairGeane.cxx
+++ b/geane/FairGeane.cxx
@@ -15,7 +15,7 @@
 #include "FairGeaneApplication.h"       // for FairGeaneApplication
 #include "FairRunAna.h"                 // for FairRunAna
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TGeoManager.h"                // for TGeoManager
 #include "TROOT.h"                      // for TROOT, gROOT
 #include "TString.h"                    // for TString, operator!=, etc

--- a/geane/FairGeanePro.cxx
+++ b/geane/FairGeanePro.cxx
@@ -17,7 +17,7 @@
 #include "FairTrackParH.h"              // for FairTrackParH
 #include "FairTrackParP.h"              // for FairTrackParP
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TDatabasePDG.h"               // for TDatabasePDG
 #include "TGeant3.h"                    // for TGeant3, Ertrio_t
 #include "TGeoTorus.h"                  // for TGeoTorus

--- a/generators/FairAsciiGenerator.h
+++ b/generators/FairAsciiGenerator.h
@@ -31,7 +31,7 @@
 
 #include "FairGenerator.h"              // for FairGenerator
 
-#include "Riosfwd.h"                    // for ifstream
+#include <iosfwd>                       // for ifstream
 #include "Rtypes.h"                     // for FairAsciiGenerator::Class, etc
 
 #include <fstream>                      // for ifstream

--- a/generators/FairEvtGenGenerator.cxx
+++ b/generators/FairEvtGenGenerator.cxx
@@ -14,7 +14,7 @@
 #include "FairPrimaryGenerator.h"       // for FairPrimaryGenerator
 #include "FairLogger.h"
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TF1.h"                        // for TF1
 #include "TRandom.h"                    // for TRandom, gRandom
 

--- a/generators/FairIonGenerator.cxx
+++ b/generators/FairIonGenerator.cxx
@@ -17,7 +17,7 @@
 #include "FairRunSim.h"                 // for FairRunSim
 #include "FairLogger.h"                 // for logging
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TDatabasePDG.h"               // for TDatabasePDG
 #include "TObjArray.h"                  // for TObjArray
 #include "TParticle.h"                  // for TParticle

--- a/generators/FairShieldGenerator.h
+++ b/generators/FairShieldGenerator.h
@@ -31,7 +31,7 @@
 
 #include "FairGenerator.h"              // for FairGenerator
 
-#include "Riosfwd.h"                    // for ifstream
+#include <iosfwd>                       // for ifstream
 #include "Rtypes.h"                     // for FairShieldGenerator::Class, etc
 #include "TString.h"                    // for TString
 

--- a/generators/FairUrqmdGenerator.cxx
+++ b/generators/FairUrqmdGenerator.cxx
@@ -15,7 +15,7 @@
 #include "FairPrimaryGenerator.h"       // for FairPrimaryGenerator
 #include "FairLogger.h"                 // for logging
 
-#include "Riosfwd.h"                    // for ostream, ifstream
+#include <iosfwd>                       // for ostream, ifstream
 #include "TDatabasePDG.h"               // for TDatabasePDG
 #include "TLorentzVector.h"             // for TLorentzVector
 #include "TMath.h"                      // for Sqrt, sqrt

--- a/geobase/FairGeoAsciiIo.h
+++ b/geobase/FairGeoAsciiIo.h
@@ -10,7 +10,7 @@
 
 #include "FairGeoIo.h"                  // for FairGeoIo
 
-#include "Riosfwd.h"                    // for fstream
+#include <iosfwd>                       // for fstream
 #include "Rtypes.h"                     // for Bool_t, etc
 #include "TString.h"                    // for TString
 

--- a/geobase/FairGeoAssembly.h
+++ b/geobase/FairGeoAssembly.h
@@ -10,7 +10,7 @@
 
 #include "FairGeoBasicShape.h"          // for FairGeoBasicShape
 
-#include "Riosfwd.h"                    // for fstream
+#include <iosfwd>                       // for fstream
 #include "Rtypes.h"                     // for FairGeoAssembly::Class, etc
 
 #include <iosfwd>                       // for fstream

--- a/geobase/FairGeoBasicShape.h
+++ b/geobase/FairGeoBasicShape.h
@@ -10,7 +10,7 @@
 
 #include "TNamed.h"                     // for TNamed
 
-#include "Riosfwd.h"                    // for fstream
+#include <iosfwd>                       // for fstream
 #include "Rtypes.h"                     // for Int_t, etc
 
 #include <fstream>                      // for fstream

--- a/geobase/FairGeoCone.h
+++ b/geobase/FairGeoCone.h
@@ -10,7 +10,7 @@
 
 #include "FairGeoBasicShape.h"          // for FairGeoBasicShape
 
-#include "Riosfwd.h"                    // for fstream
+#include <iosfwd>                       // for fstream
 #include "Rtypes.h"                     // for FairGeoCone::Class, Bool_t, etc
 
 #include <iosfwd>                       // for fstream

--- a/geobase/FairGeoCons.h
+++ b/geobase/FairGeoCons.h
@@ -10,7 +10,7 @@
 
 #include "FairGeoBasicShape.h"          // for FairGeoBasicShape
 
-#include "Riosfwd.h"                    // for fstream
+#include <iosfwd>                       // for fstream
 #include "Rtypes.h"                     // for FairGeoCons::Class, Bool_t, etc
 
 #include <iosfwd>                       // for fstream

--- a/geobase/FairGeoEltu.h
+++ b/geobase/FairGeoEltu.h
@@ -10,7 +10,7 @@
 
 #include "FairGeoBasicShape.h"          // for FairGeoBasicShape
 
-#include "Riosfwd.h"                    // for fstream
+#include <iosfwd>                       // for fstream
 #include "Rtypes.h"                     // for FairGeoEltu::Class, Bool_t, etc
 
 #include <iosfwd>                       // for fstream

--- a/geobase/FairGeoInterface.cxx
+++ b/geobase/FairGeoInterface.cxx
@@ -30,7 +30,7 @@
 #include "FairGeoSet.h"                 // for FairGeoSet
 #include "FairGeoShapes.h"              // for FairGeoShapes
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TClass.h"                     // for TClass
 #include "TList.h"                      // for TList
 #include "TObjArray.h"                  // for TObjArray

--- a/geobase/FairGeoLoader.cxx
+++ b/geobase/FairGeoLoader.cxx
@@ -17,7 +17,7 @@
 #include "FairGeoInterface.h"           // for FairGeoInterface
 #include "FairGeoRootBuilder.h"         // for FairGeoRootBuilder
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TGeoManager.h"                // for TGeoManager
 
 #include <string.h>                     // for strncmp

--- a/geobase/FairGeoMedia.h
+++ b/geobase/FairGeoMedia.h
@@ -10,7 +10,7 @@
 
 #include "TNamed.h"                     // for TNamed
 
-#include "Riosfwd.h"                    // for fstream
+#include <iosfwd>                       // for fstream
 #include "Rtypes.h"                     // for FairGeoMedia::Class, etc
 #include "TString.h"                    // for TString
 

--- a/geobase/FairGeoMedium.h
+++ b/geobase/FairGeoMedium.h
@@ -10,7 +10,7 @@
 
 #include "TNamed.h"                     // for TNamed
 
-#include "Riosfwd.h"                    // for fstream
+#include <iosfwd>                       // for fstream
 #include "Rtypes.h"                     // for Double_t, Int_t, Bool_t, etc
 
 #include <fstream>                      // for fstream

--- a/geobase/FairGeoNode.h
+++ b/geobase/FairGeoNode.h
@@ -14,7 +14,7 @@
 #include "FairGeoMedium.h"              // for FairGeoMedium
 #include "FairGeoTransform.h"           // for FairGeoTransform
 
-#include "Riosfwd.h"                    // for fstream
+#include <iosfwd>                       // for fstream
 #include "Rtypes.h"                     // for Bool_t, FairGeoNode::Class, etc
 #include "TObjArray.h"                  // for TObjArray
 #include "TString.h"                    // for TString

--- a/geobase/FairGeoOldAsciiIo.h
+++ b/geobase/FairGeoOldAsciiIo.h
@@ -10,7 +10,7 @@
 
 #include "FairGeoIo.h"                  // for FairGeoIo
 
-#include "Riosfwd.h"                    // for fstream
+#include <iosfwd>                       // for fstream
 #include "Rtypes.h"                     // for Bool_t, kFALSE, etc
 #include "TString.h"                    // for TString
 

--- a/geobase/FairGeoPcon.h
+++ b/geobase/FairGeoPcon.h
@@ -10,7 +10,7 @@
 
 #include "FairGeoBasicShape.h"          // for FairGeoBasicShape
 
-#include "Riosfwd.h"                    // for fstream
+#include <iosfwd>                       // for fstream
 #include "Rtypes.h"                     // for FairGeoPcon::Class, Bool_t, etc
 
 #include <iosfwd>                       // for fstream

--- a/geobase/FairGeoPgon.h
+++ b/geobase/FairGeoPgon.h
@@ -10,7 +10,7 @@
 
 #include "FairGeoBasicShape.h"          // for FairGeoBasicShape
 
-#include "Riosfwd.h"                    // for fstream
+#include <iosfwd>                       // for fstream
 #include "Rtypes.h"                     // for FairGeoPcon::Class, Bool_t, etc
 
 #include <iosfwd>                       // for fstream

--- a/geobase/FairGeoRotation.h
+++ b/geobase/FairGeoRotation.h
@@ -12,7 +12,7 @@
 
 #include "FairGeoVector.h"              // for FairGeoVector
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "Rtypes.h"                     // for Double_t, Int_t, Bool_t, etc
 
 #include <iostream>                     // for operator<<, cout, ostream, etc

--- a/geobase/FairGeoSet.h
+++ b/geobase/FairGeoSet.h
@@ -12,7 +12,7 @@
 
 #include "FairGeoNode.h"
 
-#include "Riosfwd.h"                    // for fstream
+#include <iosfwd>                       // for fstream
 #include "Rtypes.h"                     // for Int_t, Bool_t, etc
 #include "TList.h"                      // for TList
 #include "TString.h"                    // for TString

--- a/geobase/FairGeoShapes.h
+++ b/geobase/FairGeoShapes.h
@@ -10,7 +10,7 @@
 
 #include "TObject.h"                    // for TObject
 
-#include "Riosfwd.h"                    // for fstream
+#include <iosfwd>                       // for fstream
 #include "Rtypes.h"                     // for FairGeoShapes::Class, etc
 #include "TString.h"                    // for TString
 

--- a/geobase/FairGeoSphe.h
+++ b/geobase/FairGeoSphe.h
@@ -10,7 +10,7 @@
 
 #include "FairGeoBasicShape.h"          // for FairGeoBasicShape
 
-#include "Riosfwd.h"                    // for fstream
+#include <iosfwd>                       // for fstream
 #include "Rtypes.h"                     // for FairGeoPcon::Class, Bool_t, etc
 
 #include <iosfwd>                       // for fstream

--- a/geobase/FairGeoTorus.h
+++ b/geobase/FairGeoTorus.h
@@ -10,7 +10,7 @@
 
 #include "FairGeoBasicShape.h"          // for FairGeoBasicShape
 
-#include "Riosfwd.h"                    // for fstream
+#include <iosfwd>                       // for fstream
 #include "Rtypes.h"                     // for FairGeoPcon::Class, Bool_t, etc
 
 #include <iosfwd>                       // for fstream

--- a/geobase/FairGeoTrap.cxx
+++ b/geobase/FairGeoTrap.cxx
@@ -34,7 +34,7 @@
 #include "FairGeoVector.h"              // for FairGeoVector
 #include "FairGeoVolume.h"              // for FairGeoVolume
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TArrayD.h"                    // for TArrayD
 #include "TMath.h"                      // for ATan, Pi, Sqrt, atan
 #include "TMathBase.h"                  // for Abs

--- a/geobase/FairGeoTube.h
+++ b/geobase/FairGeoTube.h
@@ -10,7 +10,7 @@
 
 #include "FairGeoBasicShape.h"          // for FairGeoBasicShape
 
-#include "Riosfwd.h"                    // for fstream
+#include <iosfwd>                       // for fstream
 #include "Rtypes.h"                     // for FairGeoPcon::Class, Bool_t, etc
 
 #include <iosfwd>                       // for fstream

--- a/geobase/FairGeoTubs.h
+++ b/geobase/FairGeoTubs.h
@@ -10,7 +10,7 @@
 
 #include "FairGeoBasicShape.h"          // for FairGeoBasicShape
 
-#include "Riosfwd.h"                    // for fstream
+#include <iosfwd>                       // for fstream
 #include "Rtypes.h"                     // for FairGeoPcon::Class, Bool_t, etc
 
 #include <iosfwd>                       // for fstream

--- a/geobase/FairGeoVector.h
+++ b/geobase/FairGeoVector.h
@@ -10,7 +10,7 @@
 
 #include "TObject.h"                    // for TObject
 
-#include "Riosfwd.h"                    // for ostream, istream
+#include <iosfwd>                       // for ostream, istream
 #include "Rtypes.h"                     // for Double_t, Bool_t, Int_t, etc
 #include "TMath.h"                      // for pow, floor, sqrt
 #include "TMathBase.h"                  // for Abs

--- a/geobase/FairGeoVolume.cxx
+++ b/geobase/FairGeoVolume.cxx
@@ -28,7 +28,7 @@
 /////////////////////////////////////////////////////////////
 #include "FairGeoVolume.h"
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 
 #include <iostream>                     // for operator<<, basic_ostream, etc
 

--- a/parbase/FairContFact.cxx
+++ b/parbase/FairContFact.cxx
@@ -21,7 +21,7 @@
 #include "FairLogger.h"                 // for FairLogger
 #include "FairRuntimeDb.h"              // for FairRuntimeDb
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TCollection.h"                // for TIter
 #include "TObjString.h"                 // for TObjString
 

--- a/parbase/FairDetParAsciiFileIo.h
+++ b/parbase/FairDetParAsciiFileIo.h
@@ -10,7 +10,7 @@
 
 #include "FairDetParIo.h"               // for FairDetParIo
 
-#include "Riosfwd.h"                    // for fstream
+#include <iosfwd>                       // for fstream
 #include "Rtypes.h"                     // for Text_t, Bool_t, etc
 #include "TString.h"                    // for TString
 

--- a/parbase/FairDetParRootFileIo.cxx
+++ b/parbase/FairDetParRootFileIo.cxx
@@ -27,7 +27,7 @@
 #include "FairRtdbRun.h"       // for FairParVersion, FairRtdbRun
 #include "FairRuntimeDb.h"     // for FairRuntimeDb
 
-#include "Riosfwd.h"    // for ostream
+#include <iosfwd>       // for ostream
 #include "TDirectory.h" // for TDirectory, gDirectory
 #include "TKey.h"       // for TKey
 #include "TROOT.h"      // for TROOT, gROOT

--- a/parbase/FairGenericParAsciiFileIo.h
+++ b/parbase/FairGenericParAsciiFileIo.h
@@ -10,7 +10,7 @@
 
 #include "FairDetParAsciiFileIo.h"      // for FairDetParAsciiFileIo
 
-#include "Riosfwd.h"                    // for fstream
+#include <iosfwd>                       // for fstream
 #include "Rtypes.h"                     // for Int_t, Bool_t, etc
 
 #include <fstream>                      // for fstream

--- a/parbase/FairParAsciiFileIo.h
+++ b/parbase/FairParAsciiFileIo.h
@@ -10,7 +10,7 @@
 
 #include "FairParIo.h"                  // for FairParIo
 
-#include "Riosfwd.h"                    // for fstream
+#include <iosfwd>                       // for fstream
 #include "Rtypes.h"                     // for Bool_t, Text_t, etc
 
 #include <fstream>                      // for fstream, etc

--- a/parbase/FairParGenericSet.cxx
+++ b/parbase/FairParGenericSet.cxx
@@ -32,7 +32,7 @@
 #include "FairParIo.h"                  // for FairParIo
 #include "FairParamList.h"              // for FairParamList
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TString.h"                    // for operator<<, TString
 
 #include <iostream>                     // for operator<<, ostream, cout, etc

--- a/parbase/FairParRootFileIo.cxx
+++ b/parbase/FairParRootFileIo.cxx
@@ -26,7 +26,7 @@
 #include "FairDetParIo.h"               // for FairDetParIo
 #include "FairRtdbRun.h"                // for FairRtdbRun
 #include "FairRuntimeDb.h"              // for FairRuntimeDb
-#include "Riosfwd.h"                    // for ostream, fstream
+#include <iosfwd>                       // for ostream, fstream
 #include "TCollection.h"                // for TIter
 #include "TDatime.h"                    // for TDatime
 #include "TKey.h"                       // for TKey

--- a/parbase/FairParSet.cxx
+++ b/parbase/FairParSet.cxx
@@ -18,7 +18,7 @@
 #include "FairLogger.h"                 // for FairLogger, MESSAGE_ORIGIN
 #include "FairRuntimeDb.h"              // for FairRuntimeDb
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 
 #include <iostream>                     // for operator<<, ostream, etc
 

--- a/parbase/FairParamList.cxx
+++ b/parbase/FairParamList.cxx
@@ -12,7 +12,7 @@
 
 #include "FairLogger.h"                 // for FairLogger, MESSAGE_ORIGIN
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TArrayD.h"                    // for TArrayD
 #include "TArrayF.h"                    // for TArrayF
 #include "TArrayI.h"                    // for TArrayI

--- a/parbase/FairRtdbRun.h
+++ b/parbase/FairRtdbRun.h
@@ -10,7 +10,7 @@
 
 #include "TNamed.h"                     // for TNamed
 
-#include "Riosfwd.h"                    // for fstream
+#include <iosfwd>                       // for fstream
 #include "Rtypes.h"                     // for Int_t, Text_t, UInt_t, etc
 #include "TString.h"                    // for TString
 

--- a/parbase/FairRuntimeDb.cxx
+++ b/parbase/FairRuntimeDb.cxx
@@ -29,7 +29,7 @@
 #include "FairParSet.h"                 // for FairParSet
 #include "FairRtdbRun.h"                // for FairRtdbRun, FairParVersion
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TClass.h"                     // for TClass
 #include "TCollection.h"                // for TIter
 #include "TFile.h"                      // for TFile, gFile

--- a/templates/NewDetector/NewDetector.cxx
+++ b/templates/NewDetector/NewDetector.cxx
@@ -20,7 +20,7 @@
 #include "FairVolume.h"                 // for FairVolume
 #include "FairLogger.h"                 // for logging
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TClonesArray.h"               // for TClonesArray
 #include "TList.h"                      // for TListIter, TList (ptr only)
 #include "TObjArray.h"                  // for TObjArray

--- a/templates/project_template/MyProjData/MyProjStack.cxx
+++ b/templates/project_template/MyProjData/MyProjStack.cxx
@@ -20,7 +20,7 @@
 #include "FairRootManager.h"            // for FairRootManager
 #include "FairLogger.h"                 // for FairLogger, MESSAGE_ORIGIN
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TClonesArray.h"               // for TClonesArray
 #include "TIterator.h"                  // for TIterator
 #include "TLorentzVector.h"             // for TLorentzVector

--- a/templates/project_template/passive/MyGeoCave.h
+++ b/templates/project_template/passive/MyGeoCave.h
@@ -17,7 +17,7 @@
 #define MYGEOCAVE_H
 
 #include "FairGeoSet.h"                 // for FairGeoSet
-#include "Riosfwd.h"                    // for fstream
+#include <iosfwd>                       // for fstream
 #include "Rtypes.h"                     // for MyGeoCave::Class, Bool_t, etc
 #include "TString.h"                    // for TString
 

--- a/templates/project_template/passive/MyMagnet.cxx
+++ b/templates/project_template/passive/MyMagnet.cxx
@@ -16,7 +16,7 @@
 #include "TGeoManager.h"
 #include "FairRun.h"                    // for FairRun
 #include "FairRuntimeDb.h"              // for FairRuntimeDb
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TList.h"                      // for TListIter, TList (ptr only)
 #include "TObjArray.h"                  // for TObjArray
 #include "TString.h"                    // for TString

--- a/trackbase/FairTrackParH.cxx
+++ b/trackbase/FairTrackParH.cxx
@@ -19,7 +19,7 @@
 #include "FairGeaneUtil.h"              // for FairGeaneUtil
 #include "FairRunAna.h"                 // for FairRunAna
 #include "FairTrackParP.h"              // for FairTrackParP
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TMath.h"                      // for pow, Sqrt, sqrt, Sin, Cos, etc
 #include "TMathBase.h"                  // for Abs, Sign
 

--- a/trackbase/FairTrackParP.cxx
+++ b/trackbase/FairTrackParP.cxx
@@ -21,7 +21,7 @@
 #include "FairRunAna.h"                 // for FairRunAna
 #include "FairTrackParH.h"              // for FairTrackParH
 
-#include "Riosfwd.h"                    // for ostream
+#include <iosfwd>                       // for ostream
 #include "TMath.h"                      // for Sqrt
 #include "TMathBase.h"                  // for Abs, Sign
 


### PR DESCRIPTION
ROOT is deprecating the Riosfwd.h soon (in version 6.12) and suggests to switch
to standard iosfwd.