### PR TITLE
Fix confusing message about "dynamic_cast fails"

### DIFF
--- a/base/sim/FairMCApplication.cxx
+++ b/base/sim/FairMCApplication.cxx
@@ -142,8 +142,9 @@ FairMCApplication::FairMCApplication(const char* name, const char* title,
         fActiveDetectors->Add(detector);
         listActiveDetectors.push_back(detector);
       }
-    } else {
-        LOG(ERROR) << "Dynamic cast fails." << FairLogger::endl;
+    }
+    else if(!dynamic_cast<FairModule*>(obj)) {
+        LOG(ERROR) << "Dynamic cast fails. Object neither FairDetector nor FairModule in module list" << FairLogger::endl;
     }
   }
   


### PR DESCRIPTION
The FairMCApplication issued error messages about failing dynamic casts.
These were probably no real errors but occurances of FairModule instances in the list.
Modified the check accordingly.