### PR TITLE
Add Support for externally specified MessagePack location

### DIFF
--- a/cmake/modules/FindMsgpack.cmake
+++ b/cmake/modules/FindMsgpack.cmake
@@ -10,16 +10,19 @@ MESSAGE(STATUS "Looking for MessagePack...")
 
 find_path(MSGPACK_INCLUDE_DIR msgpack.hpp PATHS
   ${SIMPATH}/include
+  ${MSGPACK_ROOT}/include
   NO_DEFAULT_PATH
 )
 
 find_path(MSGPACK_LIBRARY_DIR NAMES libmsgpackc.dylib libmsgpackc.so PATHS
   ${SIMPATH}/lib
+  ${MSGPACK_ROOT}/lib
   NO_DEFAULT_PATH
 )
 
 find_library(MSGPACK_LIBRARY_SHARED NAMES libmsgpackc.dylib libmsgpackc.so
   PATHS ${SIMPATH}/lib
+  ${MSGPACK_ROOT}/lib
   NO_DEFAULT_PATH
 )
 


### PR DESCRIPTION
This commit enables the use of a MessagePack installation outside of $SIMPATH. This will be needed for aliBuild.