### PR TITLE
Disallow compilation of FairRoot with old versions of C++ and ROOT.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,24 +5,7 @@ matrix:
         - os: osx
           compiler: clang
           osx_image: xcode7.3
-          env: FAIRSOFT_VERSION=may16p1_root5
-        - os: osx
-          compiler: clang
-          osx_image: xcode7.3
           env: FAIRSOFT_VERSION=may16p1_root6
-#        - os: osx
-#          compiler: clang
-#          osx_image: beta-xcode6.2
-#          env: FAIRSOFT_VERSION=nov15p7_root5
-#        - os: osx
-#          compiler: clang
-#          osx_image: beta-xcode6.2
-#          env: FAIRSOFT_VERSION=nov15p7_root6
-        - os: linux
-          compiler: gcc
-          dist: trusty
-          sudo: required
-          env: FAIRSOFT_VERSION=mar17_root5
         - os: linux
           compiler: gcc
           dist: trusty

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,13 @@ SET(VMCWORKDIR ${CMAKE_SOURCE_DIR}/examples)
 Set(CheckSrcDir "${CMAKE_SOURCE_DIR}/cmake/checks")
 include(CheckCXX11Features)
 
+# FairRoot only uses C++11 or later, so we need an compiler which supports C++11
+# Check if the used compiler support C++11. If not stop with an error message
+If(NOT _HAS_CXX11_FLAG)
+  Message(FATAL_ERROR "The used C++ compiler (${CMAKE_CXX_COMPILER}) does not support C++11. CbmRoot can only be compiled with compilers supporting C++11. Please install such a compiler.")
+EndIf()
+
+
 # Load some basic macros which are needed later on
 include(FairMacros)
 include(WriteConfigFile)
@@ -75,6 +82,20 @@ include(cotire)
 
 #Check the compiler and set the compile and link flags
 Check_Compiler()
+
+# Check also if FairSoft has been compiled with C++11 or C++14 support
+# If FairSoft is used the compiler flags provided by fairsoft-config
+# are added to the variable CMAKE_CXX_FLAGS.
+# If alibuild is used the compiler flags are passed on the command line
+# and are also added to CMAKE_CXX_FLAGS.
+# So check if CMAKE_CXX_FLAGS has the compiler flags -std=c++11 or -std=c++14
+String(FIND ${CMAKE_CXX_FLAGS} "-std=c++11" POS_C++11)
+If(${POS_C++11} EQUAL -1)
+  String(FIND ${CMAKE_CXX_FLAGS} "-std=c++14" POS_C++11)
+  If(${POS_C++11} EQUAL -1)
+    Message(FATAL_ERROR "FairSoft wasn't compiled with c++11 or c++14 support. Please recompile FairSoft with a compiler which supports at least c++11.")
+  EndIf()
+EndIf()
 
 set(LIBRARY_OUTPUT_PATH "${CMAKE_BINARY_DIR}/lib")
 set(EXECUTABLE_OUTPUT_PATH "${CMAKE_BINARY_DIR}/bin")
@@ -110,14 +131,15 @@ ENDIF(NOT UNIX)
 
 #Check if necessary environment variables are set
 #If not stop execution unless modular build is activated
-Option(FAIRROOT_MODULAR_BUILD "Modular build without environment variables" OFF)
-IF(NOT FAIRROOT_MODULAR_BUILD)
+#Option(FAIRROOT_MODULAR_BUILD "Modular build without environment variables" OFF)
+#IF(NOT FAIRROOT_MODULAR_BUILD)
+If(FAIRSOFT_CONFIG)
   IF(NOT DEFINED ENV{SIMPATH})
     MESSAGE(FATAL_ERROR "You did not define the environment variable SIMPATH which is nedded to find the external packages. Please set this variable and execute cmake again.")
   ENDIF(NOT DEFINED ENV{SIMPATH})
   STRING(REGEX MATCHALL "[^:]+" PATH $ENV{PATH})
   SET(SIMPATH $ENV{SIMPATH})
-endif(NOT FAIRROOT_MODULAR_BUILD)
+endif()
 
 # Check if the external packages are installed into a separate install
 # directory
@@ -128,7 +150,8 @@ CHECK_EXTERNAL_PACKAGE_INSTALL_DIR()
 # For example the framework can run without GEANT4, but ROOT is
 # mandatory
 
-find_package(ROOT 5.32.00 REQUIRED)
+# FairRoot only supports ROOT6, so check which version is available 
+find_package(ROOT 6.00.00 REQUIRED)
 find_package(Pythia6)
 find_package(Pythia8)
 

--- a/base/FairLinkDef.h
+++ b/base/FairLinkDef.h
@@ -85,8 +85,4 @@
 #pragma link C++ class REvent;
 #endif
 
-#if ROOT_VERSION_CODE < 333824
-#pragma link C++ class TVirtualMagField+;
-#endif
-
 #endif

--- a/base/event/FairHit.h
+++ b/base/event/FairHit.h
@@ -13,10 +13,8 @@
 #include "Rtypes.h"                     // for Double_t, Int_t, Double32_t, etc
 #include "TVector3.h"                   // for TVector3
 
-#ifndef __CINT__
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/base_object.hpp>
-#endif //__CINT__
 
 /**
  * Abstract base class for reconstructed hits in the FAIR detectors.
@@ -87,9 +85,7 @@ class FairHit : public FairTimeStamp
     }
 
   protected:
-#ifndef __CINT__ // for BOOST serialization
     friend class boost::serialization::access;
-#endif // for BOOST serialization
 
     Double32_t fDx, fDy, fDz;   ///< Errors of position [cm]
     Int_t      fRefIndex;       ///< Index of FairMCPoint for this hit

--- a/base/event/FairLink.h
+++ b/base/event/FairLink.h
@@ -30,10 +30,8 @@
 
 #include <iostream>                     // for ostream, cout
 
-#ifndef __CINT__
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/base_object.hpp>
-#endif //__CINT__
 
 class FairLink
 {

--- a/base/event/FairMCPoint.h
+++ b/base/event/FairMCPoint.h
@@ -21,10 +21,8 @@
 #include "TVector3.h"                   // for TVector3
 
 
-#ifndef __CINT__
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/base_object.hpp>
-#endif //__CINT__
 
 class FairMCPoint : public FairMultiLinkedData_Interface
 {
@@ -111,11 +109,8 @@ class FairMCPoint : public FairMultiLinkedData_Interface
 
   protected:
 
-    #ifndef __CINT__ // for BOOST serialization
     friend class boost::serialization::access;
 
-    #endif // for BOOST serialization
-    
     Int_t fTrackID;               ///< Track index
     UInt_t fEventId;              ///< MC Event id
     Double32_t fPx, fPy, fPz;     ///< Momentum components [GeV]

--- a/base/event/FairTimeStamp.h
+++ b/base/event/FairTimeStamp.h
@@ -17,10 +17,8 @@
 
 #include <iostream>                     // for ostream, cout
 
-#ifndef __CINT__ // for BOOST serialization
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/base_object.hpp>
-#endif //__CINT__
 
 class TObject;
 
@@ -86,9 +84,7 @@ class FairTimeStamp : public FairMultiLinkedData_Interface
     }
 
   protected:
-#ifndef __CINT__ // for BOOST serialization
     friend class boost::serialization::access;
-#endif // for BOOST serialization
 
     Double_t fTimeStamp;        /** Time of digit or Hit  [ns] */
     Double_t fTimeStampError;     /** Error on time stamp */

--- a/base/field/FairField.h
+++ b/base/field/FairField.h
@@ -29,35 +29,9 @@
 #ifndef FAIRFIELD_H
 #define FAIRFIELD_H 1
 
-#include "RVersion.h"                   // for ROOT_VERSION_CODE
 #include <iosfwd>                       // for ostream
 #include "Rtypes.h"                     // for Double_t, Bool_t, etc
-
-#if ROOT_VERSION_CODE < 333824
-
-#ifndef ROOT_TVirtualMagField
-#define ROOT_TVirtualMagField
-// copied from ROOT for backward compatibility with ROOT versions before 5.24
-#include "TNamed.h"
-
-class TVirtualMagField : public TNamed
-{
-  public:
-    TVirtualMagField()                 : TNamed() {}
-    TVirtualMagField(const char* name) : TNamed(name,"") {}
-    virtual ~TVirtualMagField() {}
-    virtual void Field(const Double_t* x, Double_t* B) = 0;
-    ClassDef(TVirtualMagField, 1)              // Abstract base field class
-};
-ClassImp(TVirtualMagField)
-#endif
-
-
-#else
-
 #include "TVirtualMagField.h"
-
-#endif
 
 #include <stdio.h>                      // for printf
 #include <iostream>                     // for operator<<, basic_ostream, etc

--- a/base/sim/FairGeaneApplication.h
+++ b/base/sim/FairGeaneApplication.h
@@ -15,7 +15,6 @@
 
 #include "TVirtualMCApplication.h"      // for TVirtualMCApplication
 
-#include "RVersion.h"                   // for ROOT_VERSION_CODE
 #include "Rtypes.h"                     // for Bool_t, etc
 #include "TLorentzVector.h"             // for TLorentzVector
 
@@ -38,10 +37,6 @@ class FairGeaneApplication : public TVirtualMCApplication
     FairGeaneApplication(Bool_t Debug);
     /** default destructor */
     virtual ~FairGeaneApplication();
-#if ROOT_VERSION_CODE < 333824
-    /** Calculate user field  b at point x */
-    void          Field(const Double_t* x, Double_t* b) const;      // MC Application
-#endif
     /** Return Field used in simulation*/
     FairField*             GetField() {return fxField;}
     /** Initialize MC engine */

--- a/base/sim/FairMCApplication.h
+++ b/base/sim/FairMCApplication.h
@@ -17,7 +17,6 @@
 
 #include "FairRunInfo.h"                // for FairRunInfo
 
-#include "RVersion.h"                   // for ROOT_VERSION_CODE
 #include "Rtypes.h"                     // for Int_t, Bool_t, Double_t, etc
 #include "TLorentzVector.h"             // for TLorentzVector
 #include "TString.h"                    // for TString
@@ -89,10 +88,6 @@ class FairMCApplication : public TVirtualMCApplication
     virtual void          ConstructGeometry();                              // MC Application
     /** Define parameters for optical processes (optional) */
     virtual void          ConstructOpGeometry();                            // MC Application
-#if ROOT_VERSION_CODE < 333824
-    /** Calculate user field  b at point x */
-    virtual void          Field(const Double_t* x, Double_t* b) const;      // MC Application
-#endif
     /** Define actions at the end of event */
     virtual void          FinishEvent();                                    // MC Application
     /** Define actions at the end of primary track */

--- a/base/steer/FairLinkManager.h
+++ b/base/steer/FairLinkManager.h
@@ -45,11 +45,7 @@ class FairLinkManager : public TObject
     Bool_t fIgnoreSetting;
 
     /**Singleton instance*/
-#if !defined(__CINT__)
     static TMCThreadLocal FairLinkManager* fgInstance;
-#else
-    static                FairLinkManager* fgInstance;
-#endif
 
     FairLogger*                         fLogger;//!
 

--- a/base/steer/FairRootManager.h
+++ b/base/steer/FairRootManager.h
@@ -279,11 +279,7 @@ class FairRootManager : public TObject
     std::map < TString , TObject* >     fMap;  //!
 
     /**Singleton instance*/
-#if !defined(__CINT__)
     static TMCThreadLocal FairRootManager*  fgInstance;
-#else
-    static                FairRootManager*  fgInstance;
-#endif
 
     /**Branch id for this run */
     Int_t                                fBranchSeqId;

--- a/base/steer/FairRun.h
+++ b/base/steer/FairRun.h
@@ -175,11 +175,7 @@ class FairRun : public TNamed
 
   protected:
     /** static pointer to this run*/
-#if !defined(__CINT__)
     static TMCThreadLocal FairRun* fRunInstance;
-#else
-    static                FairRun* fRunInstance;
-#endif
     /** RuntimeDb*/
     FairRuntimeDb*           fRtdb;
     /** Tasks used*/

--- a/base/steer/FairRunAna.cxx
+++ b/base/steer/FairRunAna.cxx
@@ -30,7 +30,6 @@
 #include "FairFileSource.h"             // ONLY TEMPORARILY, FOR COMPABILITY
 #include "FairMixedSource.h"            // ONLY TEMPORARILY, FOR COMPABILITY
 
-#include "RVersion.h"                   // for ROOT_VERSION, etc
 #include <iosfwd>                       // for ostream
 #include "TChain.h"                     // for TChain
 #include "TCollection.h"                // for TIter
@@ -653,16 +652,12 @@ void FairRunAna::Reinit(UInt_t runId)
 
 void  FairRunAna::RunWithTimeStamps()
 {
-  if (ROOT_VERSION_CODE >= ROOT_VERSION(5,29,1)) {
-    if (fIsInitialized) {
-      LOG(WARNING) << "RunWithTimeStamps has to be set before Run::Init !" << FairLogger::endl;
-      exit(-1);
-    } else {
-      fTimeStamps=kTRUE;
-      fRootManager->RunWithTimeStamps();
-    }
+  if (fIsInitialized) {
+    LOG(WARNING) << "RunWithTimeStamps has to be set before Run::Init !" << FairLogger::endl;
+    exit(-1);
   } else {
-    LOG(FATAL) << "RunWithTimeStamps need at least ROOT version 5.29.1" << FairLogger::endl;
+    fTimeStamps=kTRUE;
+    fRootManager->RunWithTimeStamps();
   }
 }
 //_____________________________________________________________________________

--- a/base/steer/FairRunOnline.cxx
+++ b/base/steer/FairRunOnline.cxx
@@ -418,12 +418,8 @@ void FairRunOnline::RegisterHttpCommand(TString name, TString command)
 {
   if(fServer)
   {
-#if ROOT_VERSION_CODE > 336416
-      TString path = "/Objects/HISTO";
-      fServer->RegisterCommand(name, path + command);
-#else
-      LOG(WARNING)<<"THttp->RegisterCommand() only implemented in ROOT above version 5.34/26. Skip call of this function." << FairLogger::endl;
-#endif      
+    TString path = "/Objects/HISTO";
+    fServer->RegisterCommand(name, path + command);
   }
 }
 //_____________________________________________________________________________

--- a/base/steer/FairRunSim.h
+++ b/base/steer/FairRunSim.h
@@ -164,11 +164,7 @@ class FairRunSim : public FairRun
     Bool_t                 fUseBeamMom; //!                        /** flag for use Beam Energy  */
     FairPrimaryGenerator*  fGen; //!                               /** Primary Event Generator */
     FairMCEventHeader*     fMCEvHead; //!                          /** MC Event Header */
-#if !defined(__CINT__)
     static TMCThreadLocal FairRunSim*  fginstance;//!              /** Singleton Instance */
-#else
-    static                FairRunSim*  fginstance;//!              /** Singleton Instance */
-#endif
     FairField*             fField;                                 /** Magnetic Field */
     const char*            fMapName; //!                           /** Input file name map*/
     TObjArray*             fIons; //!                              /** Array of user defined ions */

--- a/examples/MQ/9-PixelDetector/src/PixelEventHeader.h
+++ b/examples/MQ/9-PixelDetector/src/PixelEventHeader.h
@@ -17,10 +17,8 @@
 
 #include "FairEventHeader.h"     // for FairEventHeader
 
-#ifndef __CINT__
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/base_object.hpp>
-#endif //__CINT__
 
 class PixelEventHeader : public FairEventHeader
 {
@@ -43,9 +41,7 @@ class PixelEventHeader : public FairEventHeader
   private:
     Int_t fPartNo;
 
-#ifndef __CINT__ // for BOOST serialization
     friend class boost::serialization::access;
-#endif // for BOOST serialization
 
     ClassDef(PixelEventHeader, 1);
 };

--- a/examples/MQ/9-PixelDetector/src/PixelHit.h
+++ b/examples/MQ/9-PixelDetector/src/PixelHit.h
@@ -19,10 +19,8 @@
 #include "Rtypes.h"      // for PixelHit::Class, ClassDef, PixelHit::Streamer
 class TVector3;  // lines 27-27
 
-#ifndef __CINT__
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/base_object.hpp>
-#endif //__CINT__
 
 class TVector3;
 
@@ -45,9 +43,7 @@ class PixelHit : public FairHit
     }
 
   private:
-#ifndef __CINT__ // for BOOST serialization
     friend class boost::serialization::access;
-#endif // for BOOST serialization
 
     ClassDef(PixelHit, 1);
 };

--- a/examples/MQ/9-PixelDetector/src/PixelTrack.h
+++ b/examples/MQ/9-PixelDetector/src/PixelTrack.h
@@ -18,11 +18,8 @@
 #include "FairTimeStamp.h"  // for FairTimeStamp
 #include "Rtypes.h"         // for PixelTrack::Class, ClassDef, PixelTrack::...
 
-#ifndef __CINT__
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/base_object.hpp>
-#endif //__CINT__
-
 
 class PixelTrack : public FairTimeStamp
 {
@@ -67,9 +64,7 @@ class PixelTrack : public FairTimeStamp
     }
 
   private:
-#ifndef __CINT__ // for BOOST serialization
     friend class boost::serialization::access;
-#endif // for BOOST serialization
 
     Double_t fX0;
     Double_t fAX;

--- a/examples/MQ/serialization/data_generator/RooDataGenerator.h
+++ b/examples/MQ/serialization/data_generator/RooDataGenerator.h
@@ -12,9 +12,7 @@
 #include "TDatime.h"
 
 // roofit
-#ifndef __CINT__
 #include "RooGlobalFunc.h"
-#endif
 #include "RooConstVar.h"
 #include "RooRealVar.h"
 #include "RooDataSet.h"

--- a/examples/MQ/serialization/data_struct/MyDigi.h
+++ b/examples/MQ/serialization/data_struct/MyDigi.h
@@ -23,10 +23,8 @@
 
 #include <iostream> // for operator<<, basic_ostream, etc
 
-#ifndef __CINT__
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/base_object.hpp>
-#endif //__CINT__
 
 class MyDigi : public FairTimeStamp
 {
@@ -130,10 +128,7 @@ class MyDigi : public FairTimeStamp
     }
 
   private:
-#ifndef __CINT__ // for BOOST serialization
     friend class boost::serialization::access;
-
-#endif // for BOOST serialization
 
     Int_t fX;
     Int_t fY;

--- a/examples/MQ/serialization/data_struct/MyHit.h
+++ b/examples/MQ/serialization/data_struct/MyHit.h
@@ -20,10 +20,8 @@
 
 #include "Rtypes.h" // for MyHit::Class, etc
 
-#ifndef __CINT__
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/base_object.hpp>
-#endif //__CINT__
 
 class TVector3;
 
@@ -47,10 +45,7 @@ class MyHit : public FairHit
     }
 
   private:
-#ifndef __CINT__ // for BOOST serialization
     friend class boost::serialization::access;
-
-#endif // for BOOST serialization
 
     ClassDef(MyHit, 1);
 };

--- a/examples/MQ/serialization/data_struct/MyPodData.h
+++ b/examples/MQ/serialization/data_struct/MyPodData.h
@@ -20,11 +20,8 @@
 #include <iosfwd>   
 #include "Rtypes.h" 
 
-// for boost serialization (must be hidden from CINT)
-#ifndef __CINT__
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/base_object.hpp>
-#endif //__CINT__
 
 #if defined(__GNUC__) || defined(__GNUG__)
 #pragma GCC diagnostic push
@@ -41,7 +38,6 @@ namespace MyPodData
         Double_t fTimeStampError;
         
         // method to use boost serialization
-        #ifndef __CINT__
         template<class Archive>
         void serialize(Archive & ar, const unsigned int /*version*/) 
         {
@@ -49,7 +45,6 @@ namespace MyPodData
             ar & fTimeStampError;
         }
         friend class boost::serialization::access;
-        #endif //__CINT__
         
     };
 
@@ -61,7 +56,6 @@ namespace MyPodData
         Int_t fZ;
         
         // method to use boost serialization
-        #ifndef __CINT__
         template<class Archive>
         void serialize(Archive & ar, const unsigned int /*version*/) 
         {
@@ -71,7 +65,6 @@ namespace MyPodData
             ar & fZ;
         }
         friend class boost::serialization::access;
-        #endif //__CINT__
         
     };
 
@@ -88,7 +81,6 @@ namespace MyPodData
         Double_t dposZ;
         
         // method to use boost serialization
-        #ifndef __CINT__
         template<class Archive>
         void serialize(Archive & ar, const unsigned int /*version*/) 
         {
@@ -103,7 +95,6 @@ namespace MyPodData
             ar & dposZ;
         }
         friend class boost::serialization::access;
-        #endif //__CINT__
     };
 }
 

--- a/examples/advanced/Tutorial3/MQ/fileSink/FairTestDetectorFileSink.h
+++ b/examples/advanced/Tutorial3/MQ/fileSink/FairTestDetectorFileSink.h
@@ -36,12 +36,10 @@
 
 #include "TMessage.h"
 
-#ifndef __CINT__
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/serialization/vector.hpp>
 #include <boost/serialization/binary_object.hpp>
-#endif //__CINT__
 
 template <typename TIn, typename TPayloadIn>
 class FairTestDetectorFileSink : public FairMQDevice
@@ -125,9 +123,7 @@ class FairTestDetectorFileSink : public FairMQDevice
     std::string fInChannelName;
     std::string fAckChannelName;
 
-#ifndef __CINT__ // for BOOST serialization
     std::vector<TIn> fHitVector;
-#endif // for BOOST serialization
 };
 
 // Template implementation of Run() in FairTestDetectorFileSink.tpl :

--- a/examples/advanced/Tutorial3/MQ/processorTask/FairTestDetectorMQRecoTask.h
+++ b/examples/advanced/Tutorial3/MQ/processorTask/FairTestDetectorMQRecoTask.h
@@ -12,14 +12,12 @@
 #include <sstream>
 #include <array>
 
-#ifndef __CINT__ // Boost serialization
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/serialization/vector.hpp>
 #include <boost/serialization/binary_object.hpp>
-#endif //__CINT__
 
 #include "TMath.h"
 #include "TClonesArray.h"
@@ -139,10 +137,8 @@ class FairTestDetectorMQRecoTask : public FairMQProcessorTask
 
   private:
     FairTestDetectorRecoTask* fRecoTask;
-#ifndef __CINT__ // for BOOST serialization
     std::vector<TIn> fDigiVector;
     std::vector<TOut> fHitVector;
-#endif // for BOOST serialization
 };
 
 // Template implementation of exec in FairTestDetectorMQRecoTask.tpl :

--- a/examples/advanced/Tutorial3/MQ/samplerTask/FairTestDetectorDigiLoader.h
+++ b/examples/advanced/Tutorial3/MQ/samplerTask/FairTestDetectorDigiLoader.h
@@ -64,9 +64,7 @@ class FairTestDetectorDigiLoader : public FairMQSamplerTask
     virtual void Exec(Option_t* opt);
 
   private:
-#ifndef __CINT__ // for BOOST serialization
     std::vector<TOut> fDigiVector;
-#endif // for BOOST serialization
 };
 
 // Template implementation is in FairTestDetectorDigiLoader.tpl :

--- a/examples/advanced/Tutorial3/data/FairTestDetectorDigi.h
+++ b/examples/advanced/Tutorial3/data/FairTestDetectorDigi.h
@@ -24,10 +24,8 @@
 #include <string>
 #include <sstream>
 
-#ifndef __CINT__
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/base_object.hpp>
-#endif //__CINT__
 
 class FairTestDetectorDigi : public FairTimeStamp
 {
@@ -148,9 +146,7 @@ class FairTestDetectorDigi : public FairTimeStamp
     }
 
   private:
-#ifndef __CINT__ // for BOOST serialization
     friend class boost::serialization::access;
-#endif // for BOOST serialization
 
     Int_t fX;
     Int_t fY;

--- a/examples/advanced/Tutorial3/data/FairTestDetectorHit.h
+++ b/examples/advanced/Tutorial3/data/FairTestDetectorHit.h
@@ -12,10 +12,8 @@
 
 #include "Rtypes.h" // for FairTestDetectorHit::Class, etc
 
-#ifndef __CINT__
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/base_object.hpp>
-#endif //__CINT__
 
 class TVector3;
 
@@ -38,9 +36,7 @@ class FairTestDetectorHit : public FairHit
     }
 
   private:
-#ifndef __CINT__ // for BOOST serialization
     friend class boost::serialization::access;
-#endif // for BOOST serialization
 
     ClassDef(FairTestDetectorHit, 1);
 };

--- a/fairtools/FairLogger.h
+++ b/fairtools/FairLogger.h
@@ -181,11 +181,7 @@ class FairLogger : public std::ostream
     static std::ostream&        flush(std::ostream&);
 
   private:
-#if !defined(__CINT__)
     static TMCThreadLocal FairLogger* instance;
-#else
-    static                FairLogger* instance;
-#endif
 
     FairLogger();
     FairLogger(const FairLogger&);

--- a/templates/project_template/MyProjGenerators/Pythia6Generator.h
+++ b/templates/project_template/MyProjGenerators/Pythia6Generator.h
@@ -61,11 +61,6 @@
 #ifndef PND_PYTHIAGENERATOR_H
 #define PND_PYTHIAGENERATOR_H
 
-#ifdef __CINT__
-#define _DLFCN_H_
-#define _DLFCN_H
-#endif
-
 #include <stdio.h>          // for FILE
 #include "FairGenerator.h"  // for FairGenerator
 #include "Rtypes.h"         // for Int_t, Pythia6Generator::Class, Bool_t, etc

--- a/templates/project_template/MyProjGenerators/Pythia8Generator.h
+++ b/templates/project_template/MyProjGenerators/Pythia8Generator.h
@@ -13,12 +13,6 @@
 #ifndef PNDP8GENERATOR_H
 #define PNDP8GENERATOR_H 1
 
-// Avoid the inclusion of dlfcn.h by Pyhtia.h that CINT is not able to process (avoid compile error on GCC > 5)
-#ifdef __CINT__
-#define _DLFCN_H_
-#define _DLFCN_H
-#endif
-
 #include "Basics.h"          // for RndmEngine
 #include "FairGenerator.h"   // for FairGenerator
 #include "Pythia8/Pythia.h"  // for Pythia

--- a/trackbase/FairTrackPar.h
+++ b/trackbase/FairTrackPar.h
@@ -13,10 +13,8 @@
 #include "Rtypes.h"                     // for Double_t, Int_t, etc
 #include "TVector3.h"                   // for TVector3
 
-#ifndef __CINT__
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/base_object.hpp>
-#endif //__CINT__
 
 class FairTrackPar : public TObject
 {


### PR DESCRIPTION
Stop CMake run when using ROOT5.
Stop CMake run when using C++ versions prior C++11.
Make tests generic to work with FairSoft and aliBuild.

Remove code which runs only with ROOT5 because this code is now obsolete.