### PR TITLE
Correct mapping of volume number to module id

### DIFF
--- a/base/sim/FairMCApplication.cxx
+++ b/base/sim/FairMCApplication.cxx
@@ -942,7 +942,8 @@ void FairMCApplication::ConstructGeometry()
     ModId=Mod->GetModId();
     NoOfVolumes=tgeovolumelist->GetEntriesFast();
     for (Int_t n=NoOfVolumesBefore; n < NoOfVolumes; n++) {
-      fModVolMap.insert(pair<Int_t, Int_t >(n,ModId));
+      TGeoVolume* v = (TGeoVolume*) tgeovolumelist->At(n);
+      fModVolMap.insert(pair<Int_t, Int_t >(v->GetNumber(),ModId));
     }
   }
   fSenVolumes=FairModule::svList;


### PR DESCRIPTION
Use the VMC volume id which corresponds to TGeoVolume::GetNumber
rather than the index in the TGeoVolume list to construct the mapping
of volumes to modules