### PR TITLE
Allow custom definition of Boost_NO_SYSTEM_PATHS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,7 +257,9 @@ Else(FAIRSOFT_EXTERN)
   set(GSL_DIR ${SIMPATH}/basics/gsl)
 EndIf(FAIRSOFT_EXTERN)
 
-Set(Boost_NO_SYSTEM_PATHS TRUE)
+if(NOT DEFINED Boost_NO_SYSTEM_PATHS)
+  Set(Boost_NO_SYSTEM_PATHS TRUE)
+endif()
 Set(Boost_NO_BOOST_CMAKE TRUE)
 Message("-- Looking for Boost ...")
 # If an older version of boost is found both of the variables below are


### PR DESCRIPTION
This patch defaults `Boost_NO_SYSTEM_PATH` to `TRUE` only if it wasn't explicitly defined otherwise. This allows us in O2 to build FairRoot using system's boost (which is currently prevented by current FairRoot's dev).