### PR TITLE
Ability to register/retrieve data of any type with IO manager

### DIFF
--- a/base/sim/FairMCApplication.cxx
+++ b/base/sim/FairMCApplication.cxx
@@ -1080,6 +1080,9 @@ void FairMCApplication::InitGeometry()
     rootManager->TruncateBranchNames(outTree, "cbmroot");
     rootManager->SetOutTree(outTree);
 
+    // create other branches not managed by folder
+    rootManager->CreatePersistentBranchesAny();
+
     // Explicit registration of stack in MT mode
     // (should be removed when problem with "Register" is resolved)
     // Create branch in outTree manually

--- a/base/source/FairFileSource.cxx
+++ b/base/source/FairFileSource.cxx
@@ -891,7 +891,7 @@ void FairFileSource::ReadBranchEvent(const char* BrName)
 //_____________________________________________________________________________
 void   FairFileSource::ReadBranchEvent(const char* BrName, Int_t Entry)
 {
-
+    fCurrentEntryNo = Entry;
     if ( fInTree ) {
         fInTree->FindBranch(BrName)->GetEntry(Entry);
         fEventTime = GetEventTime();

--- a/base/source/FairFileSource.cxx
+++ b/base/source/FairFileSource.cxx
@@ -30,6 +30,7 @@
 #include "TRandom.h"                    // for TRandom, gRandom
 #include "TROOT.h"
 #include <list>                         // for _List_iterator, list, etc
+#include <typeinfo>
 using std::map;
 using std::set;
 
@@ -690,6 +691,52 @@ Bool_t   FairFileSource::ActivateObject(TObject** obj, const char* BrName) {
     }
 
     return kTRUE;
+}
+//_____________________________________________________________________________
+
+namespace {
+
+template<typename S>
+bool ActivateObjectAnyImpl(S* source, void **obj, const std::type_info& info, const char* brname) {
+  // we check if the types match at all
+  auto br = source->GetBranch(brname);
+  if(!br) {
+    // branch not found in source
+    return false;
+  }
+
+  // look up the TClass and resulting typeid stored in this branch
+  auto cl = TClass::GetClass(br->GetClassName());
+  if(!cl) {
+    // class not found
+    return false;
+  }
+
+  auto storedtype = cl->GetTypeInfo();
+
+  // check consistency of types
+  if(info.hash_code() != storedtype->hash_code()){
+    LOG(INFO) << "Trying to read from branch " << brname << " with wrong type " << info.name()
+              << " (expected: " << storedtype->name() << " )\n";
+    return false; 
+  }
+  source->SetBranchStatus(brname, 1);
+  // force to use the (void*) interface which is non-checking
+  source->SetBranchAddress(brname, (void*)obj);
+  return true;
+}
+
+}
+
+//_____________________________________________________________________________
+Bool_t  FairFileSource::ActivateObjectAny(void** obj, const std::type_info& info, const char* BrName) {
+    if ( fInTree ) {
+      return ActivateObjectAnyImpl(fInTree, obj, info, BrName);
+    }
+    if ( fInChain ) {
+      return ActivateObjectAnyImpl(fInChain, obj, info, BrName);
+    }
+    return kFALSE;
 }
 //_____________________________________________________________________________
 

--- a/base/source/FairFileSource.h
+++ b/base/source/FairFileSource.h
@@ -98,6 +98,7 @@ public:
     //    virtual void     SetObjectName(const char* ObjName, const char* ObjType);
 
     virtual Bool_t   ActivateObject(TObject** obj, const char* BrName);
+    virtual Bool_t   ActivateObjectAny(void **, const std::type_info &, const char*);
 
     /**Set the status of the EvtHeader
      *@param Status:  True: The header was creatged in this session and has to be filled

--- a/base/source/FairSource.h
+++ b/base/source/FairSource.h
@@ -37,6 +37,7 @@ class FairSource : public TObject
     virtual void Reset() = 0;
 
     virtual Bool_t   ActivateObject(TObject**, const char*)  { return kFALSE; }
+    virtual Bool_t   ActivateObjectAny(void **, const std::type_info &, const char*) { return kFALSE; }
 
     virtual Source_Type GetSourceType() = 0;
 

--- a/base/steer/FairRootManager.cxx
+++ b/base/steer/FairRootManager.cxx
@@ -553,6 +553,19 @@ Int_t  FairRootManager::ReadEvent(Int_t i)
 //_____________________________________________________________________________
 
 //_____________________________________________________________________________
+void FairRootManager::ReadBranchEvent(const char* BrName, Int_t entry)
+{
+  if ( !fSource) return;
+  fSource->Reset();
+  SetEntryNr(entry);
+
+  fSource->ReadBranchEvent(BrName, entry);
+  fSource->FillEventHeader(fEventHeader);
+  fCurrentTime = fEventHeader->GetEventTime();
+}
+//_____________________________________________________________________________
+
+//_____________________________________________________________________________
 Int_t FairRootManager::GetRunId() 
 {
   if ( fSource ) {
@@ -605,6 +618,7 @@ Bool_t FairRootManager::ReadNextEvent(Double_t)
 //_____________________________________________________________________________
 TObject* FairRootManager::GetObject(const char* BrName)
 {
+  fReqBrNames.emplace_back(BrName);
   /**Get Data object by name*/
   TObject* Obj =NULL;
   LOG(DEBUG2) << " Try to find if the object "

--- a/base/steer/FairRunAna.cxx
+++ b/base/steer/FairRunAna.cxx
@@ -290,6 +290,7 @@ void FairRunAna::Init()
   TTree* outTree =new TTree(FairRootManager::GetTreeName(), "/cbmout", 99);
   fRootManager->TruncateBranchNames(outTree, "cbmout");
   fRootManager->SetOutTree(outTree);
+  fRootManager->CreatePersistentBranchesAny();
   fRootManager->WriteFolder();
   fRootManager->WriteFileHeader(fFileHeader);
 }

--- a/examples/simulation/Tutorial2/macros/create_digis.C
+++ b/examples/simulation/Tutorial2/macros/create_digis.C
@@ -53,7 +53,9 @@ void create_digis(){
 
     // add the task
     fRun->AddTask( digi );
-    
+    // add another task (to test reading data from in memory branches)
+    fRun->AddTask( new FairTutorialDet2CustomTask() );    
+
     fRun->Init();
 
     rtdb->getContainer("FairTutorialDet2DigiPar")->print();

--- a/examples/simulation/Tutorial2/src/CMakeLists.txt
+++ b/examples/simulation/Tutorial2/src/CMakeLists.txt
@@ -32,6 +32,7 @@ set(SRCS
   FairTutorialDet2Point.cxx
   FairTutorialDet2DigiPar.cxx
   FairTutorialDet2Digitizer.cxx
+  FairTutorialDet2CustomTask.cxx
 )
 
 Set(HEADERS )

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2.h
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2.h
@@ -12,8 +12,8 @@
 
 #include "TVector3.h"
 #include "TLorentzVector.h"
+#include "FairTutorialDet2Point.h"
 
-class FairTutorialDet2Point;
 class FairVolume;
 class TClonesArray;
 
@@ -96,6 +96,12 @@ class FairTutorialDet2: public FairDetector
     /** container for data points */
 
     TClonesArray*  fFairTutorialDet2PointCollection;
+
+    /** alternative output based on standard containers 
+        just to demonstrate that we can pass non TClonesArray/TObject data
+    */
+    using Det2PointContainer = std::vector<CustomClass>;
+    Det2PointContainer *fCustomData;
 
     FairTutorialDet2(const FairTutorialDet2&);
     FairTutorialDet2& operator=(const FairTutorialDet2&);

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2CustomTask.cxx
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2CustomTask.cxx
@@ -1,0 +1,92 @@
+/********************************************************************************
+ *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             * 
+ *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *  
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+#include "FairTutorialDet2CustomTask.h"
+#include "FairTutorialDet2Point.h"
+#include "FairRootManager.h"
+#include "FairLogger.h"
+
+// we include some unit testing here
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <cassert>
+
+// ---- Default constructor -------------------------------------------
+FairTutorialDet2CustomTask::FairTutorialDet2CustomTask()
+  : FairTask("TutorialDetCustomTask", 0)
+{
+}
+// --------------------------------------------------------------------
+
+// ---- Constructor ----------------------------------------------------
+FairTutorialDet2CustomTask::FairTutorialDet2CustomTask(const char* name, const char* /*title*/)
+  : FairTask(name, 0)
+{
+}
+// --------------------------------------------------------------------
+
+// ---- Destructor ----------------------------------------------------
+FairTutorialDet2CustomTask::~FairTutorialDet2CustomTask()
+{
+}
+// --------------------------------------------------------------------
+
+
+// ---- Init ----------------------------------------------------------
+InitStatus FairTutorialDet2CustomTask::Init()
+{
+  LOG(INFO) << " FairTutorialDet2CustomTask :: Init() " 
+	    << FairLogger::endl;
+
+  FairRootManager* ioman = FairRootManager::Instance();
+  if ( ! ioman ) { 
+    LOG(FATAL) << "No FairRootManager" << FairLogger::endl; 
+    return kERROR;
+  } else {
+    fCustomData=ioman->InitObjectAs<std::vector<CustomClass> const*>("TutorialCustomData");
+    if ( ! fCustomData ) {
+      LOG(ERROR) << "No input data found!" << FairLogger::endl;
+      LOG(ERROR) << "Task will be inactive" << FairLogger::endl;
+      return kERROR;
+    }
+
+    // assert that some other queries are null:
+    // querying existing data under wrong type
+    assert(ioman->InitObjectAs<double const*>("TutorialCustomData") == nullptr);
+    // querying non-existing branch
+    assert(ioman->InitObjectAs<double const*>("WrongName") == nullptr);
+    fCustomData2=ioman->InitObjectAs<std::vector<CustomClass> const*>("InMemory1");
+    assert(fCustomData2);
+  }
+  return kSUCCESS;
+}
+// --------------------------------------------------------------------
+
+// ---- Exec ----------------------------------------------------------
+void FairTutorialDet2CustomTask::Exec(Option_t* /*option*/)
+{
+  // Here we print something
+  LOG(INFO) <<" I am in FairTutorialDet2CustomTask::Exec" 
+	    << FairLogger::endl;
+
+  LOG(INFO) << " The custom data input vector has size" << fCustomData->size() << "\n"; 
+  for(auto& entry : *fCustomData) {
+    LOG(INFO) << " Got entry " << entry.GetX() << " " << entry.GetQ() << "\n";
+  }
+
+  // process data that we got from DigitizerTask
+  LOG(INFO) << " The input vector from DigitizerTask has size" << fCustomData2->size() << "\n"; 
+  for(auto& entry : *fCustomData2) {
+    LOG(INFO) << " Got entry " << entry.GetX() << " " << entry.GetQ() << "\n";
+  }
+
+}
+// --------------------------------------------------------------------
+
+
+ClassImp(FairTutorialDet2CustomTask);

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2CustomTask.h
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2CustomTask.h
@@ -1,0 +1,46 @@
+/********************************************************************************
+ *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             * 
+ *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *  
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+// --------------------------------------------------------------------------
+// -----          Header for the FairTutorialDet2Digizier              ------
+// -----              Created 25.09.17 by S.Wenzel                     ------
+// --------------------------------------------------------------------------
+
+
+#ifndef FAIRTUTORIALDET2CUSTOMTASK_H
+#define FAIRTUTORIALDET2CUSTOMTASK_H
+
+
+#include "FairTask.h"
+#include "FairTutorialDet2Point.h"
+
+class FairTutorialDet2CustomTask : public FairTask
+{
+  public:
+    /** Default constructor **/
+    FairTutorialDet2CustomTask();
+
+    /** Standard constructor **/
+    FairTutorialDet2CustomTask(const char* name, const char* title="FAIR Task");
+
+    /** Destructor **/
+    virtual ~FairTutorialDet2CustomTask();
+
+    /** Initialisation **/
+    virtual InitStatus Init();
+
+    /** Executed task **/
+    virtual void Exec(Option_t* option);
+
+  private:
+    // This task just has input data to be retrieved with InitObjectAs function
+    // note that we are forced to put const on data that we are consuming
+    std::vector<CustomClass> const* fCustomData = nullptr; //!
+    std::vector<CustomClass> const* fCustomData2 = nullptr; //!
+    ClassDef(FairTutorialDet2CustomTask,1)
+};
+#endif //FAIRTUTORIALDETCUSTOMTASK_H

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2Digitizer.cxx
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2Digitizer.cxx
@@ -32,6 +32,7 @@
 FairTutorialDet2Digitizer::FairTutorialDet2Digitizer()
   : FairTask("TutorialDetDigitizer", 0),
     fTutorialDetPoints(NULL),
+    fCustomData2(new std::vector<CustomClass>),
     fDigiPar(NULL)
 {
 }
@@ -41,6 +42,7 @@ FairTutorialDet2Digitizer::FairTutorialDet2Digitizer()
 FairTutorialDet2Digitizer::FairTutorialDet2Digitizer(const char* name, const char* /*title*/)
   : FairTask(name, 0),
     fTutorialDetPoints(NULL),
+    fCustomData2(new std::vector<CustomClass>),
     fDigiPar(NULL)
 {
 }
@@ -110,6 +112,7 @@ InitStatus FairTutorialDet2Digitizer::Init()
     fTutorialDetPoints=static_cast<TClonesArray*>
                        (ioman->GetObject("TutorialDetPoint"));
 
+    fCustomData = ioman->InitObjectAs<std::vector<CustomClass> const*>("TutorialCustomData");
     if ( ! fTutorialDetPoints ) {
       LOG(ERROR) << "No TutorialDetPoints array!" << FairLogger::endl;
       LOG(ERROR) << "Task will be inactive" << FairLogger::endl;
@@ -123,6 +126,9 @@ InitStatus FairTutorialDet2Digitizer::Init()
     // now parameters are filled 
     fDigiPar->printparams();
 
+    // register data output of this task
+    Register();
+    
     return kSUCCESS;
 
   }
@@ -139,6 +145,14 @@ void FairTutorialDet2Digitizer::Exec(Option_t* /*option*/)
   LOG(INFO) <<" I am in FairTutorialDet2Digitizer::Exec" 
 	    << FairLogger::endl;
 
+  LOG(INFO) << " The custom data input vector has size" << fCustomData->size() << "\n"; 
+  for(auto& entry : *fCustomData) {
+    LOG(INFO) << " Got entry " << entry.GetX() << " " << entry.GetQ() << "\n";
+    // process data and fill a structure here, which can be consumed by the next task
+    fCustomData2->emplace_back(entry.GetX()*2, entry.GetQ()*10);
+  }
+
+  
   /*
 
   fNHits = 0;
@@ -217,9 +231,9 @@ void FairTutorialDet2Digitizer::Finish()
 // ---- Register ------------------------------------------------------
 void FairTutorialDet2Digitizer::Register()
 {
-
-  //FairRootManager::Instance()->Register("TrdDigi","Trd Digi", fDigiCollection, kTRUE);
-
+  // testing to transfer a variable to another task via a memory branch
+  LOG(INFO) << "Digitizer::Register\n";
+  FairRootManager::Instance()->RegisterAny("InMemory1", fCustomData2, false);
 }
 // --------------------------------------------------------------------
 

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2Digitizer.h
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2Digitizer.h
@@ -19,6 +19,7 @@
 #include "FairTask.h"
 
 #include "TVector3.h"
+#include "FairTutorialDet2Point.h"
 
 class TClonesArray;
 
@@ -60,6 +61,9 @@ class FairTutorialDet2Digitizer : public FairTask
   private:
 
     TClonesArray* fTutorialDetPoints; //! Tutorial Det MC points
+    std::vector<CustomClass> const* fCustomData = nullptr; //!
+    std::vector<CustomClass>* fCustomData2 = nullptr; //!
+
     //    TClonesArray *fDigiCollection; //! TRD hits
     //TClonesArray *fListStack;         //Tracks
 

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2Point.h
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2Point.h
@@ -46,9 +46,21 @@ class FairTutorialDet2Point : public FairMCPoint
     /** Output to screen **/
     virtual void Print(const Option_t* opt) const;
 
-
     ClassDef(FairTutorialDet2Point,1)
+};
 
+// a custom class holding some data
+// mainly to demonstrate that we don't need TObject inheritance
+class CustomClass {
+public:
+  CustomClass() {}
+  CustomClass(double x, int q) : fX(x), fQ(q) {}
+  double GetX() const {return fX;}
+  int GetQ() const {return fQ;}
+private:
+  double fX = 0.; // x position
+  int    fQ = 0; // charge
+  ClassDefNV(CustomClass, 1);
 };
 
 #endif

--- a/examples/simulation/Tutorial2/src/Tutorial2LinkDef.h
+++ b/examples/simulation/Tutorial2/src/Tutorial2LinkDef.h
@@ -18,5 +18,8 @@
 #pragma link C++ class FairTutorialDet2Point+;
 #pragma link C++ class FairTutorialDet2DigiPar+;
 #pragma link C++ class FairTutorialDet2Digitizer+;
+#pragma link C++ class FairTutorialDet2CustomTask+;
+#pragma link C++ class CustomClass+;
+#pragma link C++ class std::vector<CustomClass>+;
 
 #endif


### PR DESCRIPTION
This commit provides a major extension to the FairRootManager, enabling
the user to register branches based on arbitrary types.
In particular, it is now possible to register stl containers as branch
entries, extending the current TObject* or TCollection* APIs.

Instant gratification:
```
// some source registering data
auto ioman = FairRootManager::Instance();
std::vector<CustomData>* data;
ioman->RegisterAny("mybranch", data, ...);
```

```
// some consumer task asking for the data
auto ioman = FairRootManager::Instance();
auto mydata = ioman->InitObjectAs<std::vector<CustomData> const*>("mybranch");
```

The example "simulation/Tutorial2" was extended accordingly showing use cases
with persistent and non-persistent branches.

The IO to ROOT trees works as before. It was checked that splitting of branches
based on std::vectors still works the same way as for TClonesArrays.

The user has to create dictionaries for any entry she wants to put into
a persistent branch.

Further notes:
  a) the new mechanism does not use folders; Hence the persistent branches
     have to be created explictly (done in FairMCApplication for the moment)
  b) the commit is incompletely in many ways; It demonstrates correct working
     for a simple FileSource
  c) Existing API is fully preserved. The user can use the traditional API as well
     as the new API at the same time.
  d) The new API imposes that input data obtained from InitObjectAs is unmodifiable