### PR TITLE
FairMQ: Support Apple Compiler 8.0

### DIFF
--- a/fairmq/StateMachine.h
+++ b/fairmq/StateMachine.h
@@ -95,7 +95,7 @@ class StateMachine
     struct StateQueued : Event<State> {};
     auto SubscribeToStateChange(const std::string& subscriber, std::function<void(typename StateChange::KeyType newState, State lastState)> callback) -> void { fCallbacks.Subscribe<StateChange, State>(subscriber, callback); }
     auto UnsubscribeFromStateChange(const std::string& subscriber) -> void { fCallbacks.Unsubscribe<StateChange, State>(subscriber); }
-    auto SubscribeToStateQueued(const std::string& subscriber, std::function<void(typename StateChange::KeyType newState, State lastState)> callback) -> void { fCallbacks.Subscribe<StateQueued, State>(subscriber, callback); }
+    auto SubscribeToStateQueued(const std::string& subscriber, std::function<void(typename StateQueued::KeyType newState, State lastState)> callback) -> void { fCallbacks.Subscribe<StateQueued, State>(subscriber, callback); }
     auto UnsubscribeFromStateQueued(const std::string& subscriber) -> void { fCallbacks.Unsubscribe<StateQueued, State>(subscriber); }
 
     auto GetCurrentState() const -> State { std::lock_guard<std::mutex> lock{fMutex}; return fState; }

--- a/fairmq/test/event_manager/_event_manager.cxx
+++ b/fairmq/test/event_manager/_event_manager.cxx
@@ -16,7 +16,7 @@ namespace
 using namespace std;
 using namespace fair::mq;
 
-struct TestEvent : fair::mq::Event<std::string> {};
+struct TestEvent : fair::mq::Event<const std::string&> {};
 
 TEST(EventManager, Basics)
 {
@@ -26,14 +26,14 @@ TEST(EventManager, Basics)
     int value = 0;
     string value2;
 
-    EventManager::Callback<TestEvent, int> callback{
-        [&](TestEvent::KeyType& key, int newValue){
+    std::function<void(typename TestEvent::KeyType, int)> callback{
+        [&](TestEvent::KeyType key, int newValue){
             ++call_counter;
             if (key == "test") value = newValue;
         }
     };
-    EventManager::Callback<TestEvent, string> callback2{
-        [&](TestEvent::KeyType& key, string newValue){
+    std::function<void(typename TestEvent::KeyType, string)> callback2{
+        [&](TestEvent::KeyType key, string newValue){
             ++call_counter2;
             if (key == "test") value2 = newValue;
         }


### PR DESCRIPTION
In fact, this commit will workaround a bug with template alias compilation
from Clang 3.4 to Clang 3.8.