### PR TITLE
Add alfa-ci build jobs

### DIFF
--- a/Dart.sh
+++ b/Dart.sh
@@ -69,14 +69,16 @@ chip=$(uname -m | tr '[A-Z]' '[a-z]')
 # environment variables used by ctest
 SYSTEM=$arch-$chip
 if test -z $CXX ; then
-  COMPILER=gcc;
-  GCC_VERSION=$(gcc -dumpversion)
+  if [ "$arch" == "darwin" ]; then
+    COMPILER=$(clang --version | head -n 1 | cut -d' ' -f1,2,4 | tr -d ' ')
+  else
+    COMPILER=gcc$(gcc -dumpversion)
+  fi
 else
-  COMPILER=$CXX;
-  GCC_VERSION=$($CXX -dumpversion)
+  COMPILER=$CXX$($CXX -dumpversion)
 fi
 
-export LABEL1=${LINUX_FLAVOUR}-$SYSTEM-$COMPILER$GCC_VERSION-fairroot_$GIT_BRANCH-fairsoft_$FAIRSOFT_VERSION
+export LABEL1=${LINUX_FLAVOUR}-$chip-$COMPILER-FairRoot_$GIT_BRANCH-FairSoft_$FAIRSOFT_VERSION
 export LABEL=$(echo $LABEL1 | sed -e 's#/#_#g')
 
 # get the number of processors

--- a/FairBase_test.cmake
+++ b/FairBase_test.cmake
@@ -86,8 +86,6 @@ EndIf()
 
 Ctest_Submit()
  
-if (${CTEST_SITE} MATCHES "Travis")
-  if (_ctest_test_ret_val)
-    Message(FATAL_ERROR "Some tests failed.")
-  endif()
+if (_ctest_test_ret_val)
+  Message(FATAL_ERROR "Some tests failed.")
 endif()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,59 @@
+#!groovy
+
+def specToLabel(Map spec) {
+  return "${spec.os}-${spec.arch}-${spec.compiler}-FairSoft_${spec.fairsoft}"
+}
+
+def buildMatrix(List specs, Closure callback) {
+  def nodes = [:]
+  for (spec in specs) {
+    def label = specToLabel(spec)
+    def cdashUrl = 'https://cdash.gsi.de/index.php?project=FairRoot#!#Experimental'
+    nodes[label] = { 
+      node(label) {
+        githubNotify(context: "alfa-ci/${label}", description: 'Building ...', status: 'PENDING')
+        try {
+          deleteDir()
+          checkout scm
+
+          callback.call(spec, label)
+
+          deleteDir()
+          githubNotify(context: "alfa-ci/${label}", description: 'Success', status: 'SUCCESS', targetUrl: cdashUrl)
+        } catch (e) {
+          deleteDir()
+          githubNotify(context: "alfa-ci/${label}", description: 'Error', status: 'ERROR', targetUrl: cdashUrl)
+          throw e
+        }
+      }
+    }
+  }
+  return nodes
+}
+
+pipeline{
+  agent none
+  stages {
+    stage("Run Build/Test Matrix") {
+      steps{
+        script {
+          parallel(buildMatrix([
+            [os: 'Debian8',    arch: 'x86_64', compiler: 'gcc4.9',         fairsoft: 'oct17'],
+            [os: 'MacOS10.11', arch: 'x86_64', compiler: 'AppleLLVM8.0.0', fairsoft: 'oct17'],
+            [os: 'MacOS10.13', arch: 'x86_64', compiler: 'AppleLLVM9.0.0', fairsoft: 'oct17'],
+          ]) { spec, label ->
+            sh '''\
+              echo "export BUILDDIR=$PWD/build" >> Dart.cfg
+              echo "export SOURCEDIR=$PWD" >> Dart.cfg
+              echo "export PATH=$SIMPATH/bin:$PATH" >> Dart.cfg
+              echo "export GIT_BRANCH=$JOB_BASE_NAME" >> Dart.cfg
+            '''
+            sh 'cmake --version'
+            sh 'env'
+            sh './Dart.sh Experimental Dart.cfg'
+          })
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
In principle this is how it could look like. What do you think?

Note: When a requested label in the build matrix is not available on any online build agent, the build job will be queued indefinitely by jenkins.

TODO
* [x] Make sure the build stages fails, if one of the unit tests failed. As one can [see here](https://alfa-ci.gsi.de/blue/organizations/jenkins/FairRootGroup%2FFairRoot/detail/PR-663/71/pipeline/12) or in the yellow box below, all build agents had failing tests, but some reported success.
* [x] Observe agent disk usage. I believe builds are currently not cleaned up. This could lead to excessive disk usage over time. Find a plugin or a config option to add cleanup.
* [x] ~Find out, if one can retrieve the submit id of cdash. Would be nicer to have the github links directly point to the right cdash page instead of just the dashboard.~ It is not possible, see https://cmake.org/pipermail/cmake/2014-September/058538.html