### PR TITLE
use relative path for data file and add the example to the installation

### DIFF
--- a/examples/advanced/MbsTutorial/CMakeLists.txt
+++ b/examples/advanced/MbsTutorial/CMakeLists.txt
@@ -1,11 +1,11 @@
  ################################################################################
  #    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    #
  #                                                                              #
- #              This software is distributed under the terms of the             # 
- #         GNU Lesser General Public Licence version 3 (LGPL) version 3,        #  
+ #              This software is distributed under the terms of the             #
+ #         GNU Lesser General Public Licence version 3 (LGPL) version 3,        #
  #                  copied verbatim in the file "LICENSE"                       #
  ################################################################################
-# Create a library called "libMbsTutorial" 
+# Create a library called "libMbsTutorial"
 
 set(INCLUDE_DIRECTORIES
     ${BASE_INCLUDE_DIRECTORIES}
@@ -24,7 +24,7 @@ include_directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
 
 set(LINK_DIRECTORIES
     ${ROOT_LIBRARY_DIR}
-) 
+)
 
 link_directories(${LINK_DIRECTORIES})
 
@@ -44,6 +44,7 @@ Set(DEPENDENCIES
 )
 
 GENERATE_LIBRARY()
-
+Install(DIRECTORY data
+           DESTINATION share/fairbase/examples/advanced/MbsTutorial
+          )
 add_subdirectory(macros)
-

--- a/examples/advanced/MbsTutorial/macros/CMakeLists.txt
+++ b/examples/advanced/MbsTutorial/macros/CMakeLists.txt
@@ -1,5 +1,8 @@
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_SOURCE_DIR}/examples/advanced/MbsTutorial/macros/unpack_mbs.C)
 add_test(unpack_mbs ${CMAKE_BINARY_DIR}/examples/advanced/MbsTutorial/macros/unpack_mbs.sh)
+configure_file(${CMAKE_SOURCE_DIR}/examples/advanced/MbsTutorial/data/sample_data_2.lmd  ${CMAKE_BINARY_DIR}/examples/advanced/MbsTutorial/data/sample_data_2.lmd COPYONLY)
 SET_TESTS_PROPERTIES(unpack_mbs PROPERTIES TIMEOUT "30")
 SET_TESTS_PROPERTIES(unpack_mbs PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished successfully")
-
+Install(FILES unpack_mbs.C
+         DESTINATION share/fairbase/examples/advanced/MbsTutorial/macros
+         )

--- a/examples/advanced/MbsTutorial/macros/unpack_mbs.C
+++ b/examples/advanced/MbsTutorial/macros/unpack_mbs.C
@@ -9,7 +9,7 @@ void unpack_mbs()
     TString tutdir = dir + "/advanced/MbsTutorial";
 
     FairLmdSource* source = new FairLmdSource();
-    source->AddFile(tutdir + "/data/sample_data_2.lmd");
+    source->AddFile("../data/sample_data_2.lmd");
 
     // NeuLAND MBS parameters -------------------------------
     Short_t type = 94;
@@ -62,4 +62,3 @@ void unpack_mbs()
         cout << "Real time " << rtime << " s, CPU time " << ctime << "s" << endl << endl;
     }
 }
-


### PR DESCRIPTION
1. Use the relative file name for the data file as the full path can get very long with Jenkins  
2. Install the mbs tutorial  (was not in the installation!)
3. copy the data file to the build directory