### PR TITLE
Stability fixes

### DIFF
--- a/base/sim/FairMCApplication.cxx
+++ b/base/sim/FairMCApplication.cxx
@@ -311,6 +311,7 @@ FairMCApplication::~FairMCApplication()
   delete fModIter;
   //  LOG(DEBUG3) << "Leave Destructor of FairMCApplication"
   //              << FairLogger::endl;
+  delete fMC;
 }
 
 //_____________________________________________________________________________

--- a/base/steer/FairRootManager.cxx
+++ b/base/steer/FairRootManager.cxx
@@ -127,7 +127,8 @@ FairRootManager::~FairRootManager()
   LOG(DEBUG) << "Enter Destructor of FairRootManager" << FairLogger::endl;
   // delete fOutTree;
   if(fOutFile) {
-    CloseOutFile();
+    // the following line lead to a segfault:
+    // CloseOutFile();
   } else {
     // if fOutFile exists, fOutTree is deleted with the file
     delete fOutTree;


### PR DESCRIPTION
Two stability fixes:

a) proper cleanup of vmc instance (solves part of https://github.com/AliceO2Group/AliceO2/issues/640)

b) temporary removal of a line (in a singleton destructor) identified as source of a segfault.