### PR TITLE
Fix broken tests

### DIFF
--- a/examples/MQ/multiple-transports/testMTEx.sh.in
+++ b/examples/MQ/multiple-transports/testMTEx.sh.in
@@ -1,7 +1,7 @@
 #!/bin/bash
 config="@CMAKE_BINARY_DIR@/bin/config/ex-multiple-transports.json"
 
-trap 'kill -TERM $SAMPLER1_PID; kill -TERM $SAMPLER2_PID; kill -TERM $SINK_PID; wait $SAMPLER1_PID; wait $SAMPLER2_PID; wait $SINK_PID; @CMAKE_BINARY_DIR@/bin/shmmonitor --cleanup;' TERM
+trap 'kill -TERM $SAMPLER1_PID; kill -TERM $SAMPLER2_PID; kill -TERM $SINK_PID; wait $SAMPLER1_PID; wait $SAMPLER2_PID; wait $SINK_PID; @CMAKE_BINARY_DIR@/bin/shmmonitor --cleanup; rm ex-mt-*.log;' TERM
 
 @CMAKE_BINARY_DIR@/bin/shmmonitor --cleanup
 
@@ -11,7 +11,7 @@ SINK+=" --max-iterations 1"
 SINK+=" --control static --log-color false"
 SINK+=" --transport shmem"
 SINK+=" --mq-config $config"
-@CMAKE_BINARY_DIR@/bin/examples/MQ/multiple-transports/$SINK &
+@CMAKE_BINARY_DIR@/bin/examples/MQ/multiple-transports/$SINK 2>&1 > ex-mt-sink.log &
 SINK_PID=$!
 
 SAMPLER1="ex-mt-sampler1"
@@ -20,7 +20,7 @@ SAMPLER1+=" --max-iterations 1"
 SAMPLER1+=" --control static --log-color false"
 SAMPLER1+=" --transport shmem"
 SAMPLER1+=" --mq-config $config"
-@CMAKE_BINARY_DIR@/bin/examples/MQ/multiple-transports/$SAMPLER1 &
+@CMAKE_BINARY_DIR@/bin/examples/MQ/multiple-transports/$SAMPLER1 2>&1 > ex-mt-sampler1.log &
 SAMPLER1_PID=$!
 
 SAMPLER2="ex-mt-sampler2"
@@ -29,9 +29,15 @@ SAMPLER2+=" --max-iterations 1"
 SAMPLER2+=" --control static --log-color false"
 SAMPLER2+=" --transport nanomsg"
 SAMPLER2+=" --mq-config $config"
-@CMAKE_BINARY_DIR@/bin/examples/MQ/multiple-transports/$SAMPLER2 &
+@CMAKE_BINARY_DIR@/bin/examples/MQ/multiple-transports/$SAMPLER2 2>&1 > ex-mt-sampler2.log &
 SAMPLER2_PID=$!
 
 wait $SAMPLER1_PID
 wait $SAMPLER2_PID
 wait $SINK_PID
+
+sed -e 's/^/[SAMPLER1]/' ex-mt-sampler1.log
+sed -e 's/^/[SAMPLER2]/' ex-mt-sampler2.log
+sed -e 's/^/[SINK]/' ex-mt-sink.log
+
+rm ex-mt-*.log


### PR DESCRIPTION
Some of the tests produce characterwise interleaved output which breaks
the ctest condition check. This commit serializes the output.