### PR TITLE
Adding rate control for ConditionalRun function

### DIFF
--- a/fairmq/FairMQDevice.cxx
+++ b/fairmq/FairMQDevice.cxx
@@ -64,7 +64,6 @@ FairMQDevice::FairMQDevice()
     , fVersion({0, 0, 0})
     , fRate(0.)
     , fLastTime(0)
-
 {
 }
 
@@ -94,6 +93,8 @@ FairMQDevice::FairMQDevice(const fair::mq::tools::Version version)
     , fMultitransportProceed(false)
     , fExternalConfig(false)
     , fVersion(version)
+    , fRate(0.)
+    , fLastTime(0)
 {
 }
 

--- a/fairmq/FairMQDevice.cxx
+++ b/fairmq/FairMQDevice.cxx
@@ -514,19 +514,19 @@ void FairMQDevice::RunWrapper()
         }
         else
         {
+            using Clock = std::chrono::steady_clock;
+            using TimeScale = std::chrono::microseconds;
+            const TimeScale::rep period = TimeScale::period::den / fRate;
+            const auto reftime = Clock::now();
             while (CheckCurrentState(RUNNING) && ConditionalRun())
             {
-              using TimeScale = std::chrono::microseconds;
-              static const auto reftime = std::chrono::system_clock::now();
               if (fRate > 0.001) {
-                auto timeSinceRef = std::chrono::duration_cast<TimeScale>(std::chrono::system_clock::now() - reftime);
-                auto timespan = timeSinceRef.count() - fLastTime;
-                TimeScale::rep period = static_cast<float>(TimeScale::period::den) / fRate;
+                auto timespan = std::chrono::duration_cast<TimeScale>(Clock::now() - reftime).count() - fLastTime;
                 if (timespan < period) {
                   TimeScale sleepfor(period - timespan);
                   std::this_thread::sleep_for(sleepfor);
                 }
-                fLastTime = std::chrono::duration_cast<TimeScale>(std::chrono::system_clock::now() - reftime).count();
+                fLastTime = std::chrono::duration_cast<TimeScale>(Clock::now() - reftime).count();
               }
             }
 

--- a/fairmq/FairMQDevice.cxx
+++ b/fairmq/FairMQDevice.cxx
@@ -520,7 +520,7 @@ void FairMQDevice::RunWrapper()
               if (fRate > 0.001) {
                 auto timeSinceRef = std::chrono::duration_cast<TimeScale>(std::chrono::system_clock::now() - reftime);
                 auto timespan = timeSinceRef.count() - fLastTime;
-                TimeScale::rep period = (float)TimeScale::period::den / fRate;
+                TimeScale::rep period = static_cast<float>(TimeScale::period::den) / fRate;
                 if (timespan < period) {
                   TimeScale sleepfor(period - timespan);
                   std::this_thread::sleep_for(sleepfor);
@@ -909,7 +909,7 @@ void FairMQDevice::SetConfig(FairMQProgOptions& config)
     fNetworkInterface = config.GetValue<string>("network-interface");
     fNumIoThreads = config.GetValue<int>("io-threads");
     fInitializationTimeoutInS = config.GetValue<int>("initialization-timeout");
-    std::stringstream(fConfig->GetValue<string>("rate")) >> fRate;
+    fRate = fConfig->GetValue<float>("rate");
 }
 
 void FairMQDevice::LogSocketRates()

--- a/fairmq/FairMQDevice.h
+++ b/fairmq/FairMQDevice.h
@@ -535,6 +535,8 @@ class FairMQDevice : public FairMQStateMachine
     bool fExternalConfig;
 
     const fair::mq::tools::Version fVersion;
+    float fRate;
+    size_t fLastTime;
 };
 
 #endif /* FAIRMQDEVICE_H_ */

--- a/fairmq/options/FairMQProgOptions.cxx
+++ b/fairmq/options/FairMQProgOptions.cxx
@@ -336,7 +336,7 @@ void FairMQProgOptions::FillOptionDescription(boost::program_options::options_de
             ("print-channels",         po::value<bool  >()->implicit_value(true),               "Print registered channel endpoints in a machine-readable format (<channel name>:<min num subchannels>:<max num subchannels>)")
             ("shm-segment-size",       po::value<size_t>()->default_value(2000000000),          "shmem transport: size of the shared memory segment (in bytes).")
             ("shm-segment-name",       po::value<string>()->default_value("fairmq_shmem_main"), "shmem transport: name of the shared memory segment.")
-            ("rate",                   po::value<string>()->default_value(""),                  "rate for conditional run loop (Hz)")
+            ("rate",                   po::value<float>()->default_value(0.),                   "rate for conditional run loop (Hz)")
             ;
 
 }

--- a/fairmq/options/FairMQProgOptions.cxx
+++ b/fairmq/options/FairMQProgOptions.cxx
@@ -319,63 +319,40 @@ int FairMQProgOptions::NotifySwitchOption()
     return 0;
 }
 
+void FairMQProgOptions::FillOptionDescription(boost::program_options::options_description& options)
+{
+        options.add_options()
+            ("id",                     po::value<string>(),                                     "Device ID (required argument).")
+            ("io-threads",             po::value<int   >()->default_value(1),                   "Number of I/O threads.")
+            ("transport",              po::value<string>()->default_value("zeromq"),            "Transport ('zeromq'/'nanomsg').")
+            ("config",                 po::value<string>()->default_value("static"),            "Config source ('static'/<config library filename>).")
+            ("network-interface",      po::value<string>()->default_value("default"),           "Network interface to bind on (e.g. eth0, ib0..., default will try to detect the interface of the default route).")
+            ("config-key",             po::value<string>(),                                     "Use provided value instead of device id for fetching the configuration from the config file.")
+            ("catch-signals",          po::value<int   >()->default_value(1),                   "Enable signal handling (1/0).")
+            ("initialization-timeout", po::value<int   >()->default_value(120),                 "Timeout for the initialization in seconds (when expecting dynamic initialization).")
+            ("port-range-min",         po::value<int   >()->default_value(22000),               "Start of the port range for dynamic initialization.")
+            ("port-range-max",         po::value<int   >()->default_value(32000),               "End of the port range for dynamic initialization.")
+            ("log-to-file",            po::value<string>()->default_value(""),                  "Log output to a file.")
+            ("print-channels",         po::value<bool  >()->implicit_value(true),               "Print registered channel endpoints in a machine-readable format (<channel name>:<min num subchannels>:<max num subchannels>)")
+            ("shm-segment-size",       po::value<size_t>()->default_value(2000000000),          "shmem transport: size of the shared memory segment (in bytes).")
+            ("shm-segment-name",       po::value<string>()->default_value("fairmq_shmem_main"), "shmem transport: name of the shared memory segment.")
+            ("rate",                   po::value<string>()->default_value(""),                  "rate for conditional run loop (Hz)")
+            ;
+
+}
+
 void FairMQProgOptions::InitOptionDescription()
 {
     // Id required in command line if config txt file not enabled
     if (fUseConfigFile)
     {
-        fMQOptionsInCmd.add_options()
-            ("id",                     po::value<string>(),                                     "Device ID (required argument).")
-            ("io-threads",             po::value<int   >()->default_value(1),                   "Number of I/O threads.")
-            ("transport",              po::value<string>()->default_value("zeromq"),            "Transport ('zeromq'/'nanomsg').")
-            ("config",                 po::value<string>()->default_value("static"),            "Config source ('static'/<config library filename>).")
-            ("network-interface",      po::value<string>()->default_value("default"),           "Network interface to bind on (e.g. eth0, ib0..., default will try to detect the interface of the default route).")
-            ("config-key",             po::value<string>(),                                     "Use provided value instead of device id for fetching the configuration from the config file.")
-            ("catch-signals",          po::value<int   >()->default_value(1),                   "Enable signal handling (1/0).")
-            ("initialization-timeout", po::value<int   >()->default_value(120),                 "Timeout for the initialization in seconds (when expecting dynamic initialization).")
-            ("port-range-min",         po::value<int   >()->default_value(22000),               "Start of the port range for dynamic initialization.")
-            ("port-range-max",         po::value<int   >()->default_value(32000),               "End of the port range for dynamic initialization.")
-            ("log-to-file",            po::value<string>()->default_value(""),                  "Log output to a file.")
-            ("print-channels",         po::value<bool  >()->implicit_value(true),               "Print registered channel endpoints in a machine-readable format (<channel name>:<min num subchannels>:<max num subchannels>)")
-            ("shm-segment-size",       po::value<size_t>()->default_value(2000000000),          "shmem transport: size of the shared memory segment (in bytes).")
-            ("shm-segment-name",       po::value<string>()->default_value("fairmq_shmem_main"), "shmem transport: name of the shared memory segment.")
-            ;
+        FillOptionDescription(fMQOptionsInCmd);
 
-        fMQOptionsInCfg.add_options()
-            ("id",                     po::value<string>(),                                     "Device ID (required argument).")
-            ("io-threads",             po::value<int   >()->default_value(1),                   "Number of I/O threads.")
-            ("transport",              po::value<string>()->default_value("zeromq"),            "Transport ('zeromq'/'nanomsg').")
-            ("config",                 po::value<string>()->default_value("static"),            "Config source ('static'/<config library filename>).")
-            ("network-interface",      po::value<string>()->default_value("default"),           "Network interface to bind on (e.g. eth0, ib0..., default will try to detect the interface of the default route).")
-            ("config-key",             po::value<string>(),                                     "Use provided value instead of device id for fetching the configuration from the config file.")
-            ("catch-signals",          po::value<int   >()->default_value(1),                   "Enable signal handling (1/0).")
-            ("initialization-timeout", po::value<int   >()->default_value(120),                 "Timeout for the initialization in seconds (when expecting dynamic initialization).")
-            ("port-range-min",         po::value<int   >()->default_value(22000),               "Start of the port range for dynamic initialization.")
-            ("port-range-max",         po::value<int   >()->default_value(32000),               "End of the port range for dynamic initialization.")
-            ("log-to-file",            po::value<string>()->default_value(""),                  "Log output to a file.")
-            ("print-channels",         po::value<bool  >()->implicit_value(true),               "Print registered channel endpoints in a machine-readable format (<channel name>:<min num subchannels>:<max num subchannels>)")
-            ("shm-segment-size",       po::value<size_t>()->default_value(2000000000),          "shmem transport: size of the shared memory segment (in bytes).")
-            ("shm-segment-name",       po::value<string>()->default_value("fairmq_shmem_main"), "shmem transport: name of the shared memory segment.")
-            ;
+        FillOptionDescription(fMQOptionsInCfg);
     }
     else
     {
-        fMQOptionsInCmd.add_options()
-            ("id",                     po::value<string>(),                                     "Device ID (required argument).")
-            ("io-threads",             po::value<int   >()->default_value(1),                   "Number of I/O threads.")
-            ("transport",              po::value<string>()->default_value("zeromq"),            "Transport ('zeromq'/'nanomsg').")
-            ("config",                 po::value<string>()->default_value("static"),            "Config source ('static'/<config library filename>).")
-            ("network-interface",      po::value<string>()->default_value("default"),           "Network interface to bind on (e.g. eth0, ib0..., default will try to detect the interface of the default route).")
-            ("config-key",             po::value<string>(),                                     "Use provided value instead of device id for fetching the configuration from the config file.")
-            ("catch-signals",          po::value<int   >()->default_value(1),                   "Enable signal handling (1/0).")
-            ("initialization-timeout", po::value<int   >()->default_value(120),                 "Timeout for the initialization in seconds (when expecting dynamic initialization).")
-            ("port-range-min",         po::value<int   >()->default_value(22000),               "Start of the port range for dynamic initialization.")
-            ("port-range-max",         po::value<int   >()->default_value(32000),               "End of the port range for dynamic initialization.")
-            ("log-to-file",            po::value<string>()->default_value(""),                  "Log output to a file.")
-            ("print-channels",         po::value<bool  >()->implicit_value(true),               "Print registered channel endpoints in a machine-readable format (<channel name>:<min num subchannels>:<max num subchannels>)")
-            ("shm-segment-size",       po::value<size_t>()->default_value(2000000000),          "shmem transport: size of the shared memory segment (in bytes).")
-            ("shm-segment-name",       po::value<string>()->default_value("fairmq_shmem_main"), "shmem transport: name of the shared memory segment.")
-            ;
+        FillOptionDescription(fMQOptionsInCmd);
     }
 
     fMQParserOptions.add_options()

--- a/fairmq/options/FairMQProgOptions.h
+++ b/fairmq/options/FairMQProgOptions.h
@@ -299,6 +299,9 @@ class FairMQProgOptions : public FairProgOptions
     virtual int NotifySwitchOption(); // for custom help & version printing
     void InitOptionDescription();
 
+    // fill boost option description with the standard options
+    static void FillOptionDescription(po::options_description& options);
+
     // read FairMQChannelMap and insert/update corresponding values in variable map
     // create key for variable map as follow : channelName.index.memberName
     void UpdateMQValues();


### PR DESCRIPTION
Devices implementing the conditional run method are typically source
devices and a rate control can be desireable. New option '--rate' with
a float number argument in Hz can be used to configure rate control.
By default it is switched off.

There has been a good fraction of identical code for the boost options description in `FairMQProgOptions` which is now in one single function.