### PR TITLE
Offline week follow up

### DIFF
--- a/fairmq/Plugin.h
+++ b/fairmq/Plugin.h
@@ -95,6 +95,8 @@ class Plugin
     auto SubscribeToPropertyChange(std::function<void(const std::string& key, T newValue)> callback) -> void { fPluginServices->SubscribeToPropertyChange<T>(fkName, callback); }
     template<typename T>
     auto UnsubscribeFromPropertyChange() -> void { fPluginServices->UnsubscribeFromPropertyChange<T>(fkName); }
+    auto SubscribeToPropertyChangeAsString(std::function<void(const std::string& key, std::string newValue)> callback) -> void { fPluginServices->SubscribeToPropertyChangeAsString(fkName, callback); }
+    auto UnsubscribeFromPropertyChangeAsString() -> void { fPluginServices->UnsubscribeFromPropertyChangeAsString(fkName); }
 
   private:
     const std::string fkName;

--- a/fairmq/PluginServices.h
+++ b/fairmq/PluginServices.h
@@ -226,6 +226,21 @@ class PluginServices
     template<typename T>
     auto UnsubscribeFromPropertyChange(const std::string& subscriber) -> void { fConfig->Unsubscribe<T>(subscriber); }
 
+    /// @brief Subscribe to property updates
+    /// @param subscriber
+    /// @param callback function
+    ///
+    /// Subscribe to property changes with a callback to monitor property changes in an event based fashion. Will convert the property to string.
+    auto SubscribeToPropertyChangeAsString(const std::string& subscriber, std::function<void(const std::string& key, std::string)> callback) const -> void
+    {
+        fConfig->SubscribeAsString(subscriber, callback);
+    }
+
+    /// @brief Unsubscribe from property updates that convert to string
+    /// @param subscriber
+    auto UnsubscribeFromPropertyChangeAsString(const std::string& subscriber) -> void { fConfig->UnsubscribeAsString(subscriber); }
+
+
     static const std::unordered_map<std::string, DeviceState> fkDeviceStateStrMap;
     static const std::unordered_map<DeviceState, std::string, tools::HashEnum<DeviceState>> fkStrDeviceStateMap;
     static const std::unordered_map<std::string, DeviceStateTransition> fkDeviceStateTransitionStrMap;

--- a/fairmq/options/FairMQProgOptions.h
+++ b/fairmq/options/FairMQProgOptions.h
@@ -34,6 +34,7 @@ namespace mq
 {
 
 struct PropertyChange : Event<std::string> {};
+struct PropertyChangeAsString : Event<std::string> {};
 
 } /* namespace mq */
 } /* namespace fair */
@@ -204,8 +205,10 @@ class FairMQProgOptions : public FairProgOptions
                 }
             }
 
+            lock.unlock();
             //if (std::is_same<T, int>::value || std::is_same<T, std::string>::value)//if one wants to restrict type
             fEvents.Emit<fair::mq::PropertyChange, typename std::decay<T>::type>(key, val);
+            fEvents.Emit<fair::mq::PropertyChangeAsString, std::string>(key, GetStringValue(key));
 
             return 0;
         }
@@ -240,8 +243,11 @@ class FairMQProgOptions : public FairProgOptions
             }
         }
 
+        lock.unlock();
+
         //if (std::is_same<T, int>::value || std::is_same<T, std::string>::value)//if one wants to restrict type
         fEvents.Emit<fair::mq::PropertyChange, typename std::decay<T>::type>(key, val);
+        fEvents.Emit<fair::mq::PropertyChangeAsString, std::string>(key, GetStringValue(key));
 
         return 0;
     }
@@ -265,6 +271,19 @@ class FairMQProgOptions : public FairProgOptions
         fEvents.Unsubscribe<fair::mq::PropertyChange, T>(subscriber);
     }
 
+    void SubscribeAsString(const std::string& subscriber, std::function<void(typename fair::mq::PropertyChange::KeyType, std::string)> func)
+    {
+        std::unique_lock<std::mutex> lock(fConfigMutex);
+
+        fEvents.Subscribe<fair::mq::PropertyChangeAsString, std::string>(subscriber, func);
+    }
+
+    void UnsubscribeAsString(const std::string& subscriber)
+    {
+        std::unique_lock<std::mutex> lock(fConfigMutex);
+
+        fEvents.Unsubscribe<fair::mq::PropertyChangeAsString, std::string>(subscriber);
+    }
     /*
     template <typename F>
     void Subscribe(const std::string& key, F&& func) 
@@ -325,6 +344,7 @@ class FairMQProgOptions : public FairProgOptions
         static_assert(!std::is_same<T,const char*>::value || !std::is_same<T, char*>::value, 
             "In template member FairMQProgOptions::EmitUpdate<T>(key,val) the types const char* or char* for the calback signatures are not supported.");
         fEvents.Emit<fair::mq::PropertyChange, T>(key, val);
+        fEvents.Emit<fair::mq::PropertyChangeAsString, std::string>(key, GetStringValue(key));
     }
 
     int UpdateChannelMap(const std::string& channelName, int index, const std::string& member, const std::string& val);

--- a/fairmq/plugins/DDS/DDS.h
+++ b/fairmq/plugins/DDS/DDS.h
@@ -84,6 +84,8 @@ class DDS : public Plugin
 
     std::set<uint64_t> fHeartbeatSubscribers;
     std::mutex fHeartbeatSubscriberMutex;
+    std::set<uint64_t> fStateChangeSubscribers;
+    std::mutex fStateChangeSubscriberMutex;
 
     boost::asio::io_service fIos;
     boost::asio::io_service::work fIosWork;


### PR DESCRIPTION
The `*AsString` property subscription API, I presented last week, was not yet in the repo - here it is :)

The other two commits are enhancements to the DDS plugin and needed for the O2 DDS workflow executor I showed. Even though, this is not likely to be used as a production implementation (heartbeats won't scale, waiting on FairRootGroup/DDS#180), @rbx and I thought we should still merge it for now and improve it later.