### PR TITLE
Allow simulation setup via compiled library hook

### DIFF
--- a/base/steer/FairRunSim.cxx
+++ b/base/steer/FairRunSim.cxx
@@ -285,6 +285,12 @@ void FairRunSim::CheckFlukaExec()
 //_____________________________________________________________________________
 void FairRunSim::SetMCConfig()
 {
+  // Either setup the simulation with the provided user hook
+  if (fUseSimSetupFunction) {
+    fSimSetup();
+  }
+  else {
+    // or use the conventional method of loading configuration macros
   /** Private method for setting simulation and/or Geane configuration and cuts*/
 
   TString work = getenv("VMCWORKDIR");
@@ -417,8 +423,9 @@ void FairRunSim::SetMCConfig()
 
   gROOT->LoadMacro(cuts);
   gROOT->ProcessLine("SetCuts()");
+  }
 
-  fApp->InitMC(ConfigMacro.Data(), cuts.Data());
+  fApp->InitMC("foo", "bar");
 }
 
 //_____________________________________________________________________________

--- a/base/steer/FairRunSim.h
+++ b/base/steer/FairRunSim.h
@@ -18,6 +18,7 @@
 #include "TObjArray.h"                  // for TObjArray
 #include "TString.h"                    // for TString
 #include "TMCtls.h"                     // for multi-threading
+#include <functional>
 
 class FairField;
 class FairMCEventHeader;
@@ -151,6 +152,9 @@ class FairRunSim : public FairRun
     /**Get beam energy flag */
     Bool_t UseBeamMom() {return fUseBeamMom;}
     void SetFieldContainer();
+
+    void SetSimSetup(std::function<void()> f) { fSimSetup = f; fUseSimSetupFunction = true; }
+    
   private:
     FairRunSim(const FairRunSim& M);
     FairRunSim& operator= (const  FairRunSim&) {return *this;}
@@ -184,7 +188,9 @@ class FairRunSim : public FairRun
     TString                fUserConfig; //!                        /** Macro for geant configuration*/
     TString                fUserCuts; //!                          /** Macro for geant cuts*/
 
-
+    std::function<void()>    fSimSetup; //!         /** A user provided function to do sim setup / instead of using macros **/ 
+    bool                     fUseSimSetupFunction = false;
+    
     ClassDef(FairRunSim ,2)
 
 };


### PR DESCRIPTION
Allow for the possibility to setup the simulation
without interpreting macros at runtime;

The user can now simply register a hook which is supposed
to call into compiled library code that sets up the simulation

The change is fully backward compatible and the hook
is not used by default