### PR TITLE
Make members of FairMCApplication protected

### DIFF
--- a/base/sim/FairMCApplication.h
+++ b/base/sim/FairMCApplication.h
@@ -191,6 +191,7 @@ class FairMCApplication : public TVirtualMCApplication
 
     void UndoGeometryModifications();
 
+  protected:
     // data members
     /**List of active detector */
     TRefArray*           fActiveDetectors;


### PR DESCRIPTION
This allows to inherit from FairMCApplication and access
the data members directly (as not accessible through getters).