### PR TITLE
Updated FairGenericStack interface and clean-up:

### DIFF
--- a/base/sim/FairGenericStack.h
+++ b/base/sim/FairGenericStack.h
@@ -87,6 +87,9 @@ class FairGenericStack : public TVirtualMCStack
     /** Set the list of detectors to be used for filltering the stack*/
     void SetDetArrayList(TRefArray* detArray);
 
+    /** Allow a stack to perform a clean-up after a primary particle is finished **/
+    virtual void FinishPrimary() {}
+
     /** Resets arrays and stack and deletes particles and tracks **/
     virtual void Reset() {}
 

--- a/base/sim/FairMCApplication.cxx
+++ b/base/sim/FairMCApplication.cxx
@@ -795,6 +795,7 @@ void FairMCApplication::FinishPrimary()
     (*listIter)->FinishPrimary();
   }
 
+  fStack->FinishPrimary();
 }
 
 //_____________________________________________________________________________
@@ -1086,15 +1087,6 @@ void FairMCApplication::InitGeometry()
 
     // create other branches not managed by folder
     fRootManager->CreatePersistentBranchesAny();
-
-    // Explicit registration of stack in MT mode
-    // (should be removed when problem with "Register" is resolved)
-    // Create branch in outTree manually
-    if (  gMC->IsMT() ) {
-      LOG(WARNING) << "Create branch explicitly " << FairLogger::endl;
-      TClonesArray* tracks = fStack->GetListOfParticles();
-      outTree->Bronch("MCTrack", "TClonesArray", &tracks, 3200, 99);
-    }
   }
 
   // Get static thread local svList


### PR DESCRIPTION
- Added FairGenericStack::FinishPrimary() function and it call
  in FairMCApplication (to allow a clean-up in ALICE use case)
- Removed obsolete code prforming an sxplicit registration of stack
  in MT mode