### PR TITLE
Missing explicit reference to lib boost_signals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,7 +269,8 @@ Message("-- Looking for Boost ...")
 # for boost.
 Unset(Boost_INCLUDE_DIR CACHE)
 Unset(Boost_LIBRARY_DIRS CACHE)
-find_package(Boost 1.64 COMPONENTS thread system timer program_options random filesystem chrono exception regex serialization log log_setup atomic date_time)
+find_package(Boost 1.64 COMPONENTS thread system timer program_options random filesystem chrono exception regex
+    serialization log log_setup atomic date_time signals)
 If (Boost_FOUND)
   Set(Boost_Avail 1)
   Set(LD_LIBRARY_PATH ${LD_LIBRARY_PATH} ${Boost_LIBRARY_DIR})

--- a/fairmq/CMakeLists.txt
+++ b/fairmq/CMakeLists.txt
@@ -228,6 +228,7 @@ target_link_libraries(FairMQ
     Boost::filesystem
     Boost::regex
     Boost::date_time
+    Boost::signals
     $<$<PLATFORM_ID:Linux>:rt>
 
     PRIVATE # only libFairMQ links against private dependencies


### PR DESCRIPTION
Hi, 

(not so sure the PR should be made to master, I'm a bit unclear on how to work with the alisw/FairRoot vs this repo...)

After a long and painful debugging session on my Mac which was refusing to build FairRoot (using alibuild or using "direct" cmake) (tag alice-dev-20171027)...

```
> aliBuild --defaults o2 build FairRoot
...snip...
[ 63%] Building CXX object fairmq/test/CMakeFiles/testsuite_FairMQ.PluginServices.dir/plugin_services/runner.cxx.o
[ 63%] Building CXX object fairmq/test/CMakeFiles/testsuite_FairMQ.StateMachine.dir/state_machine/_state_machine.cxx.o
[ 63%] Building CXX object fairmq/test/CMakeFiles/testsuite_FairMQ.PluginServices.dir/plugin_services/_config.cxx.o
[ 63%] Linking CXX shared library ../../../lib/libFairMQPlugin_dds.dylib
ld: file not found: libboost_signals.dylib for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

...I think I've found a bug in a couple of CMakeLists.txt files. As far as I can tell the lib boost signals is an actual dependency of fairmq and so should be stated as such. 

For the record, note that some colleagues of mine with Macs did not observe the issue at all. That's because they have a boost version (1.65) installed with brew. Even if that's not the required version (1.64) and that alibuild is indeed building 1.64, it seems the "missing" libboost_signals issue is somehow shadowed in this case.

Anyway with this commit, I'm able to build FairRoot.

