### PR TITLE
Set FAIRROOT_VERSION in the project command & remove CACHE from manual version set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,9 +29,15 @@ foreach(p
   endif()
 endforeach()
 
-# Set name of our project to "FAIRROOT". Has to be done
-# after check of cmake version
-project(FAIRROOT)
+# Set project version
+SET(FAIRROOT_MAJOR_VERSION 17)
+SET(FAIRROOT_MINOR_VERSION 10)
+SET(FAIRROOT_PATCH_VERSION 02)
+
+# Set name of our project to "FAIRROOT".
+# Has to be done after check of cmake version
+# This also sets ${FAIRROOT_VERSION} to the provided VERSION value, which would be empty if not set here explicitly
+project(FAIRROOT VERSION ${FAIRROOT_MAJOR_VERSION}.${FAIRROOT_MINOR_VERSION}.${FAIRROOT_PATCH_VERSION})
 
 # where to look first for cmake modules, before ${CMAKE_ROOT}/Modules/
 # is checked
@@ -277,12 +283,6 @@ If (Boost_FOUND)
 Else (Boost_FOUND)
   Set(Boost_Avail 0)
 EndIf (Boost_FOUND)
-
-# Set the library version in the main CMakeLists.txt
-SET(FAIRROOT_MAJOR_VERSION 17)
-SET(FAIRROOT_MINOR_VERSION 10)
-SET(FAIRROOT_PATCH_VERSION 02)
-SET(FAIRROOT_VERSION "${FAIRROOT_MAJOR_VERSION}.${FAIRROOT_MINOR_VERSION}.${FAIRROOT_PATCH_VERSION}" CACHE STRING "FairRoot Version")
 
 If(ROOT_FOUND_VERSION LESS 59999)
 #  If(FAIRROOT_MODULAR_BUILD)


### PR DESCRIPTION
Recently added `CACHE` keyword to the setting of custom `FAIRROOT_VERSION` variable was causing all but first cmake runs to fail, because the `project` command also sets `<project name>_VERSION`.

With the `CACHE` keyword, second cmake run evaluated `project` first, set version to empty string and did not update it later because of the way `SET` with `CACHE` keyword work.

This fixes it and sets version via `project`.