### PR TITLE
remove "cmake --version" call from Jenkins file 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,8 +47,6 @@ pipeline{
               echo "export PATH=$SIMPATH/bin:$PATH" >> Dart.cfg
               echo "export GIT_BRANCH=$JOB_BASE_NAME" >> Dart.cfg
             '''
-            sh 'cmake --version'
-            sh 'env'
             sh './Dart.sh alfa_ci Dart.cfg'
           })
         }


### PR DESCRIPTION
remove cmake --version call from jenkins file as it is called before setting the enviroment from Dart.cfg which could stop the build if cmake was not installed in the system but in our packages