### PR TITLE
FairMQProgOptions: initialize defaults in the constructor

### DIFF
--- a/fairmq/options/FairMQProgOptions.cxx
+++ b/fairmq/options/FairMQProgOptions.cxx
@@ -30,6 +30,8 @@ FairMQProgOptions::FairMQProgOptions()
     , fChannelInfo()
     , fMQKeyMap()
 {
+    InitOptionDescription();
+    ParseDefaults(fCmdLineOptions);
 }
 
 FairMQProgOptions::~FairMQProgOptions()
@@ -50,8 +52,6 @@ int FairMQProgOptions::ParseAll(const vector<string>& cmdLineArgs, bool allowUnr
 
 int FairMQProgOptions::ParseAll(const int argc, char const* const* argv, bool allowUnregistered)
 {
-    InitOptionDescription();
-
     if (FairProgOptions::ParseCmdLine(argc, argv, fCmdLineOptions, fVarMap, allowUnregistered))
     {
         // ParseCmdLine returns 0 if no immediate switches found.

--- a/fairmq/options/FairMQProgOptions.cxx
+++ b/fairmq/options/FairMQProgOptions.cxx
@@ -24,8 +24,8 @@ using namespace std;
 
 FairMQProgOptions::FairMQProgOptions()
     : FairProgOptions()
-    , fMQParserOptions("FairMQ config parser options")
     , fMQCmdOptions("FairMQ device options")
+    , fMQParserOptions("FairMQ config parser options")
     , fFairMQMap()
     , fChannelInfo()
     , fMQKeyMap()

--- a/fairmq/options/FairProgOptions.cxx
+++ b/fairmq/options/FairProgOptions.cxx
@@ -16,6 +16,7 @@
 
 #include <iomanip>
 #include <sstream>
+#include <algorithm>
 
 using namespace std;
 
@@ -85,6 +86,21 @@ int FairProgOptions::ParseCmdLine(const int argc, char const* const* argv, const
 int FairProgOptions::ParseCmdLine(const int argc, char const* const* argv, const po::options_description& desc, bool allowUnregistered)
 {
     return ParseCmdLine(argc, argv, desc, fVarMap, allowUnregistered);
+}
+
+void FairProgOptions::ParseDefaults(const po::options_description& desc)
+{
+    vector<string> emptyArgs;
+    emptyArgs.push_back("dummy");
+
+    vector<const char*> argv(emptyArgs.size());
+
+    transform(emptyArgs.begin(), emptyArgs.end(), argv.begin(), [](const string& str)
+    {
+        return str.c_str();
+    });
+
+    po::store(po::parse_command_line(argv.size(), const_cast<char**>(argv.data()), desc), fVarMap);
 }
 
 int FairProgOptions::PrintOptions()

--- a/fairmq/options/FairProgOptions.h
+++ b/fairmq/options/FairProgOptions.h
@@ -161,6 +161,7 @@ class FairProgOptions
     // boost prog options parsers
     int ParseCmdLine(const int argc, char const* const* argv, const po::options_description& desc, po::variables_map& varmap, bool allowUnregistered = false);
     int ParseCmdLine(const int argc, char const* const* argv, const po::options_description& desc, bool allowUnregistered = false);
+    void ParseDefaults(const po::options_description& desc);
 
     virtual int ParseAll(const int argc, char const* const* argv, bool allowUnregistered = false) = 0;// TODO change return type to bool and propagate to executable
 

--- a/fairmq/plugins/Control.cxx
+++ b/fairmq/plugins/Control.cxx
@@ -37,10 +37,10 @@ Control::Control(const string name, const Plugin::Version version, const string 
     : Plugin(name, version, maintainer, homepage, pluginServices)
     , fControllerThread()
     , fSignalHandlerThread()
-    , fDeviceTerminationRequested{false}
     , fEvents()
     , fEventsMutex()
     , fNewEvent()
+    , fDeviceTerminationRequested{false}
 {
     try
     {

--- a/fairmq/shmem/FairMQSocketSHM.cxx
+++ b/fairmq/shmem/FairMQSocketSHM.cxx
@@ -21,8 +21,8 @@ atomic<bool> FairMQSocketSHM::fInterrupted(false);
 
 FairMQSocketSHM::FairMQSocketSHM(Manager& manager, const string& type, const string& name, const string& id /*= ""*/, void* context)
     : FairMQSocket(ZMQ_SNDMORE, ZMQ_RCVMORE, ZMQ_DONTWAIT)
-    , fManager(manager)
     , fSocket(nullptr)
+    , fManager(manager)
     , fId()
     , fBytesTx(0)
     , fBytesRx(0)

--- a/fairmq/shmem/FairMQTransportFactorySHM.cxx
+++ b/fairmq/shmem/FairMQTransportFactorySHM.cxx
@@ -35,7 +35,7 @@ FairMQ::Transport FairMQTransportFactorySHM::fTransportType = FairMQ::Transport:
 
 FairMQTransportFactorySHM::FairMQTransportFactorySHM(const string& id, const FairMQProgOptions* config)
     : FairMQTransportFactory(id)
-    , fSessionName()
+    , fSessionName("default")
     , fContext(nullptr)
     , fHeartbeatSocket(nullptr)
     , fHeartbeatThread()
@@ -62,14 +62,14 @@ FairMQTransportFactorySHM::FairMQTransportFactorySHM(const string& id, const Fai
     {
         numIoThreads = config->GetValue<int>("io-threads");
         fSessionName = config->GetValue<string>("session");
-        fSessionName.resize(8, '_'); // shorten the session name, to accommodate for name size limit on some systems (MacOS)
-        // fSegmentName = "fmq_shm_" + fSessionName + "_main";
         segmentSize = config->GetValue<size_t>("shm-segment-size");
     }
     else
     {
         LOG(warn) << "FairMQProgOptions not available! Using defaults.";
     }
+
+    fSessionName.resize(8, '_'); // shorten the session name, to accommodate for name size limit on some systems (MacOS)
 
     try
     {

--- a/fairmq/test/message_resize/_message_resize.cxx
+++ b/fairmq/test/message_resize/_message_resize.cxx
@@ -27,8 +27,6 @@ auto RunPushPullWithMsgResize(string transport, string address) -> void {
 
     FairMQProgOptions config;
     config.SetValue<string>("session", to_string(session));
-    config.SetValue<int>("io-threads", 1);
-    config.SetValue<size_t>("shm-segment-size", 20000000);
 
     auto factory = FairMQTransportFactory::CreateTransportFactory(transport, fair::mq::tools::Uuid(), &config);
 

--- a/fairmq/test/protocols/_push_pull_multipart.cxx
+++ b/fairmq/test/protocols/_push_pull_multipart.cxx
@@ -31,8 +31,6 @@ auto RunSingleThreadedMultipart(string transport, string address) -> void {
 
     FairMQProgOptions config;
     config.SetValue<string>("session", std::to_string(session));
-    config.SetValue<int>("io-threads", 1);
-    config.SetValue<size_t>("shm-segment-size", 20000000);
     auto factory = FairMQTransportFactory::CreateTransportFactory(transport, fair::mq::tools::Uuid(), &config);
     auto push = FairMQChannel{"Push", "push", factory};
     ASSERT_TRUE(push.Bind(address));


### PR DESCRIPTION
- FairMQProgOptions: initialize defaults in the constructor, not in ParseAll.
- shmem: Fix missing session name resize if running without FairMQProgOptions.
- Fix reorder warnings.