### PR TITLE
FairMQProgOptions fixes and cleanup

### DIFF
--- a/fairmq/FairMQDevice.cxx
+++ b/fairmq/FairMQDevice.cxx
@@ -993,7 +993,7 @@ void FairMQDevice::LogSocketRates()
                     bytesOut.at(i) = bytesOutNew.at(i);
                     msgOut.at(i) = msgOutNew.at(i);
 
-                    LOG(debug) << filteredChannelNames.at(i) << ": "
+                    LOG(info) << filteredChannelNames.at(i) << ": "
                                << "in: " << msgPerSecIn.at(i) << " (" << mbPerSecIn.at(i) << " MB) "
                                << "out: " << msgPerSecOut.at(i) << " (" << mbPerSecOut.at(i) << " MB)";
                 }

--- a/fairmq/options/FairMQParser.cxx
+++ b/fairmq/options/FairMQParser.cxx
@@ -14,24 +14,27 @@
 
 #include "FairMQParser.h"
 #include "FairMQLogger.h"
-#include <boost/property_tree/xml_parser.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 using namespace std;
 
-namespace FairMQParser
+namespace fair
+{
+namespace mq
+{
+namespace parser
 {
 
 // TODO : add key-value map<string,string> parameter  for replacing/updating values from keys
-// function that convert property tree (given the xml or json structure) to FairMQMap
-FairMQMap ptreeToMQMap(const boost::property_tree::ptree& pt, const string& id, const string& rootNode, const string& formatFlag)
+// function that convert property tree (given the json structure) to FairMQMap
+FairMQMap ptreeToMQMap(const boost::property_tree::ptree& pt, const string& id, const string& rootNode)
 {
     // Create fair mq map
     FairMQMap channelMap;
     //Helper::PrintPropertyTree(pt);
-    //Helper::PrintDeviceList(pt.get_child(rootNode), formatFlag);
+    //Helper::PrintDeviceList(pt.get_child(rootNode));
     // Extract value from boost::property_tree
-    Helper::DeviceParser(pt.get_child(rootNode), channelMap, id, formatFlag);
+    Helper::DeviceParser(pt.get_child(rootNode), channelMap, id);
 
     if (channelMap.empty())
     {
@@ -56,24 +59,10 @@ FairMQMap JSON::UserParser(stringstream& input, const string& deviceId, const st
     return ptreeToMQMap(pt, deviceId, rootNode);
 }
 
-FairMQMap XML::UserParser(const string& filename, const string& deviceId, const string& rootNode)
-{
-    boost::property_tree::ptree pt;
-    boost::property_tree::read_xml(filename, pt);
-    return ptreeToMQMap(pt, deviceId, rootNode, "xml");
-}
-
-FairMQMap XML::UserParser(stringstream& input, const string& deviceId, const string& rootNode)
-{
-    boost::property_tree::ptree pt;
-    boost::property_tree::read_xml(input, pt);
-    return ptreeToMQMap(pt, deviceId, rootNode, "xml");
-}
-
 namespace Helper
 {
 
-void PrintDeviceList(const boost::property_tree::ptree& tree, const string& formatFlag)
+void PrintDeviceList(const boost::property_tree::ptree& tree)
 {
     string deviceIdKey;
 
@@ -97,35 +86,10 @@ void PrintDeviceList(const boost::property_tree::ptree& tree, const string& form
                 }
             }
         }
-
-        if (p.first == "device")
-        {
-            // get id attribute to choose the device
-            if (formatFlag == "xml")
-            {
-                deviceIdKey = p.second.get<string>("<xmlattr>.id");
-                LOG(debug) << "Found config for '" << deviceIdKey << "' in XML input";
-            }
-
-            if (formatFlag == "json")
-            {
-                string key = p.second.get<string>("key", "");
-                if (key != "")
-                {
-                    deviceIdKey = key;
-                    LOG(debug) << "Found config for device key '" << deviceIdKey << "' in JSON input";
-                }
-                else
-                {
-                    deviceIdKey = p.second.get<string>("id");
-                    LOG(debug) << "Found config for device id '" << deviceIdKey << "' in JSON input";
-                }
-            }
-        }
     }
 }
 
-void DeviceParser(const boost::property_tree::ptree& tree, FairMQMap& channelMap, const string& deviceId, const string& formatFlag)
+void DeviceParser(const boost::property_tree::ptree& tree, FairMQMap& channelMap, const string& deviceId)
 {
     string deviceIdKey;
 
@@ -160,48 +124,13 @@ void DeviceParser(const boost::property_tree::ptree& tree, FairMQMap& channelMap
 
                 LOG(debug) << "Found with following channels:";
 
-                ChannelParser(q.second, channelMap, formatFlag);
+                ChannelParser(q.second, channelMap);
             }
-        }
-
-        if (p.first == "device")
-        {
-            if (formatFlag == "xml")
-            {
-                deviceIdKey = p.second.get<string>("<xmlattr>.id");
-            }
-
-            if (formatFlag == "json")
-            {
-                // check if key is provided, otherwise use id
-                string key = p.second.get<string>("key", "");
-
-                if (key != "")
-                {
-                    deviceIdKey = key;
-                    // LOG(debug) << "Found config for device key '" << deviceIdKey << "' in JSON input";
-                }
-                else
-                {
-                    deviceIdKey = p.second.get<string>("id");
-                    // LOG(debug) << "Found config for device id '" << deviceIdKey << "' in JSON input";
-                }
-            }
-
-            // if not correct device id, do not fill MQMap
-            if (deviceId != deviceIdKey)
-            {
-                continue;
-            }
-
-            LOG(debug) << "Found with following channels:";
-
-            ChannelParser(p.second, channelMap, formatFlag);
         }
     }
 }
 
-void ChannelParser(const boost::property_tree::ptree& tree, FairMQMap& channelMap, const string& formatFlag)
+void ChannelParser(const boost::property_tree::ptree& tree, FairMQMap& channelMap)
 {
     string channelKey;
 
@@ -260,69 +189,6 @@ void ChannelParser(const boost::property_tree::ptree& tree, FairMQMap& channelMa
                 channelMap.insert(make_pair(channelKey, move(channelList)));
             }
         }
-
-        if (p.first == "channel")
-        {
-            // try to get common properties to use for all subChannels
-            FairMQChannel commonChannel;
-            int numSockets = 0;
-
-            // get name attribute to form key
-            if (formatFlag == "xml")
-            {
-                channelKey = p.second.get<string>("<xmlattr>.name");
-            }
-
-            if (formatFlag == "json")
-            {
-                channelKey = p.second.get<string>("name");
-
-                numSockets = p.second.get<int>("numSockets", 0);
-
-                // try to get common properties to use for all subChannels
-                commonChannel.UpdateType(p.second.get<string>("type", commonChannel.GetType()));
-                commonChannel.UpdateMethod(p.second.get<string>("method", commonChannel.GetMethod()));
-                commonChannel.UpdateAddress(p.second.get<string>("address", commonChannel.GetAddress()));
-                commonChannel.UpdateTransport(p.second.get<string>("transport", commonChannel.GetTransport()));
-                commonChannel.UpdateSndBufSize(p.second.get<int>("sndBufSize", commonChannel.GetSndBufSize()));
-                commonChannel.UpdateRcvBufSize(p.second.get<int>("rcvBufSize", commonChannel.GetRcvBufSize()));
-                commonChannel.UpdateSndKernelSize(p.second.get<int>("sndKernelSize", commonChannel.GetSndKernelSize()));
-                commonChannel.UpdateRcvKernelSize(p.second.get<int>("rcvKernelSize", commonChannel.GetRcvKernelSize()));
-                commonChannel.UpdateRateLogging(p.second.get<int>("rateLogging", commonChannel.GetRateLogging()));
-            }
-
-            // temporary FairMQChannel container
-            vector<FairMQChannel> channelList;
-
-            if (numSockets > 0)
-            {
-                LOG(debug) << "" << channelKey << ":";
-                LOG(debug) << "\tnumSockets of " << numSockets << " specified,";
-                LOG(debug) << "\tapplying common settings to each:";
-
-                LOG(debug) << "\ttype          = " << commonChannel.GetType();
-                LOG(debug) << "\tmethod        = " << commonChannel.GetMethod();
-                LOG(debug) << "\taddress       = " << commonChannel.GetAddress();
-                LOG(debug) << "\ttransport     = " << commonChannel.GetTransport();
-                LOG(debug) << "\tsndBufSize    = " << commonChannel.GetSndBufSize();
-                LOG(debug) << "\trcvBufSize    = " << commonChannel.GetRcvBufSize();
-                LOG(debug) << "\tsndKernelSize = " << commonChannel.GetSndKernelSize();
-                LOG(debug) << "\trcvKernelSize = " << commonChannel.GetRcvKernelSize();
-                LOG(debug) << "\trateLogging   = " << commonChannel.GetRateLogging();
-
-                for (int i = 0; i < numSockets; ++i)
-                {
-                    FairMQChannel channel(commonChannel);
-                    channelList.push_back(channel);
-                }
-            }
-            else
-            {
-                SocketParser(p.second.get_child(""), channelList, channelKey, commonChannel);
-            }
-
-            channelMap.insert(make_pair(channelKey, move(channelList)));
-        }
     }
 }
 
@@ -366,37 +232,6 @@ void SocketParser(const boost::property_tree::ptree& tree, vector<FairMQChannel>
                 ++socketCounter;
             }
         }
-
-        if (p.first == "socket")
-        {
-            // create new channel and apply setting from the common channel
-            FairMQChannel channel(commonChannel);
-
-            // if the socket field specifies or overrides something from the common channel, apply those settings
-            channel.UpdateType(p.second.get<string>("type", channel.GetType()));
-            channel.UpdateMethod(p.second.get<string>("method", channel.GetMethod()));
-            channel.UpdateAddress(p.second.get<string>("address", channel.GetAddress()));
-            channel.UpdateTransport(p.second.get<string>("transport", channel.GetTransport()));
-            channel.UpdateSndBufSize(p.second.get<int>("sndBufSize", channel.GetSndBufSize()));
-            channel.UpdateRcvBufSize(p.second.get<int>("rcvBufSize", channel.GetRcvBufSize()));
-            channel.UpdateSndKernelSize(p.second.get<int>("sndKernelSize", channel.GetSndKernelSize()));
-            channel.UpdateRcvKernelSize(p.second.get<int>("rcvKernelSize", channel.GetRcvKernelSize()));
-            channel.UpdateRateLogging(p.second.get<int>("rateLogging", channel.GetRateLogging()));
-
-            LOG(debug) << "" << channelName << "[" << socketCounter << "]:";
-            LOG(debug) << "\ttype          = " << channel.GetType();
-            LOG(debug) << "\tmethod        = " << channel.GetMethod();
-            LOG(debug) << "\taddress       = " << channel.GetAddress();
-            LOG(debug) << "\ttransport     = " << channel.GetTransport();
-            LOG(debug) << "\tsndBufSize    = " << channel.GetSndBufSize();
-            LOG(debug) << "\trcvBufSize    = " << channel.GetRcvBufSize();
-            LOG(debug) << "\tsndKernelSize = " << channel.GetSndKernelSize();
-            LOG(debug) << "\trcvKernelSize = " << channel.GetRcvKernelSize();
-            LOG(debug) << "\trateLogging   = " << channel.GetRateLogging();
-
-            channelList.push_back(channel);
-            ++socketCounter;
-        }
     } // end socket loop
 
     if (socketCounter)
@@ -435,4 +270,6 @@ void PrintPropertyTree(const boost::property_tree::ptree& tree, int level)
 
 } // Helper namespace
 
-} // FairMQParser namespace
+} // namespace parser
+} // namespace mq
+} // namespace fair

--- a/fairmq/options/FairMQParser.h
+++ b/fairmq/options/FairMQParser.h
@@ -17,20 +17,18 @@
 
 #include "FairMQChannel.h"
 
-namespace FairMQParser
+namespace fair
+{
+namespace mq
+{
+namespace parser
 {
 
 using FairMQMap = std::unordered_map<std::string, std::vector<FairMQChannel>>;
 
-FairMQMap ptreeToMQMap(const boost::property_tree::ptree& pt, const std::string& deviceId, const std::string& rootNode, const std::string& formatFlag = "json");
+FairMQMap ptreeToMQMap(const boost::property_tree::ptree& pt, const std::string& deviceId, const std::string& rootNode);
 
 struct JSON
-{
-    FairMQMap UserParser(const std::string& filename, const std::string& deviceId, const std::string& rootNode = "fairMQOptions");
-    FairMQMap UserParser(std::stringstream& input, const std::string& deviceId, const std::string& rootNode = "fairMQOptions");
-};
-
-struct XML
 {
     FairMQMap UserParser(const std::string& filename, const std::string& deviceId, const std::string& rootNode = "fairMQOptions");
     FairMQMap UserParser(std::stringstream& input, const std::string& deviceId, const std::string& rootNode = "fairMQOptions");
@@ -39,14 +37,16 @@ struct XML
 namespace Helper
 {
 
-void PrintDeviceList(const boost::property_tree::ptree& tree, const std::string& formatFlag = "json");
-void DeviceParser(const boost::property_tree::ptree& tree, FairMQMap& channelMap, const std::string& deviceId, const std::string& formatFlag);
-void ChannelParser(const boost::property_tree::ptree& tree, FairMQMap& channelMap, const std::string& formatFlag);
+void PrintDeviceList(const boost::property_tree::ptree& tree);
+void DeviceParser(const boost::property_tree::ptree& tree, FairMQMap& channelMap, const std::string& deviceId);
+void ChannelParser(const boost::property_tree::ptree& tree, FairMQMap& channelMap);
 void SocketParser(const boost::property_tree::ptree& tree, std::vector<FairMQChannel>& channelList, const std::string& channelName, const FairMQChannel& commonChannel);
 void PrintPropertyTree(const boost::property_tree::ptree& tree, int level = 0);
 
 } // Helper namespace
 
-} // FairMQParser namespace
+} // namespace parser
+} // namespace mq
+} // namespace fair
 
 #endif /* FAIRMQPARSER_H */

--- a/fairmq/options/FairMQSuboptParser.h
+++ b/fairmq/options/FairMQSuboptParser.h
@@ -17,11 +17,18 @@
 #include "FairMQParser.h" // for FairMQMap
 #include <boost/program_options.hpp>
 #include <cstring>
+#include <vector>
+#include <string>
 
 namespace po = boost::program_options;
 
-namespace FairMQParser
+namespace fair
 {
+namespace mq
+{
+namespace parser
+{
+
 /**
  * A parser implementation for FairMQ channel properties.
  * The parser handles a comma separated key=value list format by using the
@@ -38,39 +45,42 @@ namespace FairMQParser
  * the concept is extensible by renaming UserParser to ChannelPropertyParser
  * and introducing additional parser functions.
  */
-struct SUBOPT {
-  enum channelOptionKeyIds {
-    NAME = 0,       // name of the channel
-    TYPE,           // push, pull, publish, subscribe, etc
-    METHOD,         // bind or connect
-    ADDRESS,        // host, protocol and port address
-    TRANSPORT,      //
-    SNDBUFSIZE,     // size of the send queue
-    RCVBUFSIZE,     // size of the receive queue
-    SNDKERNELSIZE,
-    RCVKERNELSIZE,
-    RATELOGGING,    // logging rate
-    lastsocketkey
-  };
+struct SUBOPT
+{
+    enum channelOptionKeyIds
+    {
+        NAME = 0,       // name of the channel
+        TYPE,           // push, pull, publish, subscribe, etc
+        METHOD,         // bind or connect
+        ADDRESS,        // host, protocol and port address
+        TRANSPORT,      //
+        SNDBUFSIZE,     // size of the send queue
+        RCVBUFSIZE,     // size of the receive queue
+        SNDKERNELSIZE,
+        RCVKERNELSIZE,
+        RATELOGGING,    // logging rate
+        lastsocketkey
+    };
 
-  constexpr static const char *channelOptionKeys[] = {
-    /*[NAME]          = */ "name",
-    /*[TYPE]          = */ "type",
-    /*[METHOD]        = */ "method",
-    /*[ADDRESS]       = */ "address",
-    /*[TRANSPORT]     = */ "transport",
-    /*[SNDBUFSIZE]    = */ "sndBufSize",
-    /*[RCVBUFSIZE]    = */ "rcvBufSize",
-    /*[SNDKERNELSIZE] = */ "sndKernelSize",
-    /*[RCVKERNELSIZE] = */ "rcvKernelSize",
-    /*[RATELOGGING]   = */ "rateLogging",
-    nullptr
-  };
+    constexpr static const char *channelOptionKeys[] = {
+        /*[NAME]          = */ "name",
+        /*[TYPE]          = */ "type",
+        /*[METHOD]        = */ "method",
+        /*[ADDRESS]       = */ "address",
+        /*[TRANSPORT]     = */ "transport",
+        /*[SNDBUFSIZE]    = */ "sndBufSize",
+        /*[RCVBUFSIZE]    = */ "rcvBufSize",
+        /*[SNDKERNELSIZE] = */ "sndKernelSize",
+        /*[RCVKERNELSIZE] = */ "rcvKernelSize",
+        /*[RATELOGGING]   = */ "rateLogging",
+        nullptr
+    };
 
-  constexpr static const char* OptionKeyChannelConfig = "channel-config";
-
-  FairMQMap UserParser(const po::variables_map& omap, const std::string& deviceId, const std::string& rootNode = "fairMQOptions");
+    FairMQMap UserParser(const std::vector<std::string>& channelConfig, const std::string& deviceId, const std::string& rootNode = "fairMQOptions");
 };
+
+}
+}
 }
 
 #endif /* FAIRMQPARSER_SUBOPT_H */

--- a/fairmq/options/ProgOptionTest/run/testMQoptions2.cxx
+++ b/fairmq/options/ProgOptionTest/run/testMQoptions2.cxx
@@ -35,8 +35,8 @@ int main(int argc, char** argv)
             ("output.file.branch",  po::value<std::string>(), "output branch name")
             ;
 
-        config.AddToCmdLineOptions(format_desc,true);
-        config.AddToCmdLineOptions(io_file_opt_desc,true);
+        config.AddToCmdLineOptions(format_desc);
+        config.AddToCmdLineOptions(io_file_opt_desc);
 
         config.EnableCfgFile();// UseConfigFile (by default config file is not defined)
         config.AddToCfgFileOptions(format_desc,false);//false because already added to visible

--- a/fairmq/run/startMQBenchmark.sh.in
+++ b/fairmq/run/startMQBenchmark.sh.in
@@ -71,9 +71,9 @@ SAMPLER+=" --same-msg $sameMsg"
 # SAMPLER+=" --msg-rate 1000"
 SAMPLER+=" --max-iterations $maxIterations"
 SAMPLER+=" --mq-config @CMAKE_BINARY_DIR@/bin/config/benchmark.json"
-xterm -geometry 90x23+0+0 -hold -e $affinitySamp @CMAKE_BINARY_DIR@/bin/$SAMPLER &
+xterm -geometry 90x50+0+0 -hold -e $affinitySamp @CMAKE_BINARY_DIR@/bin/$SAMPLER &
 echo ""
-echo "started: xterm -geometry 90x23+0+0 -hold -e $affinitySamp @CMAKE_BINARY_DIR@/bin/$SAMPLER"
+echo "started: xterm -geometry 90x50+0+0 -hold -e $affinitySamp @CMAKE_BINARY_DIR@/bin/$SAMPLER"
 echo "pid: $!"
 
 SINK="sink"
@@ -84,8 +84,8 @@ SINK+=" --transport $transport"
 SINK+=" --severity debug"
 SINK+=" --max-iterations $maxIterations"
 SINK+=" --mq-config @CMAKE_BINARY_DIR@/bin/config/benchmark.json"
-xterm -geometry 90x23+550+0 -hold -e $affinitySink @CMAKE_BINARY_DIR@/bin/$SINK &
+xterm -geometry 90x50+550+0 -hold -e $affinitySink @CMAKE_BINARY_DIR@/bin/$SINK &
 echo ""
-echo "started: xterm -geometry 90x23+550+0 -hold -e $affinitySink @CMAKE_BINARY_DIR@/bin/$SINK"
+echo "started: xterm -geometry 90x50+550+0 -hold -e $affinitySink @CMAKE_BINARY_DIR@/bin/$SINK"
 echo "pid: $!"
 echo ""


### PR DESCRIPTION
- Remove singular key names from JSON schema.
- Align the property tree created by `FairMQSuboptParser` with the format required by the main parser (plural names).
- Fix `--print-options` to print all options (not only those that have their value set).
- remove XML parser (outdated and unused).
- various code cleanup.