### PR TITLE
shmmonitor update

### DIFF
--- a/fairmq/FairMQDevice.cxx
+++ b/fairmq/FairMQDevice.cxx
@@ -892,13 +892,13 @@ void FairMQDevice::SetConfig(FairMQProgOptions& config)
             LOG(warn) << "did not insert channel '" << c.first << "', it is already in the device.";
         }
     }
-    fDefaultTransport = config.GetValue<string>("transport");
-    SetTransport(fDefaultTransport);
     fId = config.GetValue<string>("id");
     fNetworkInterface = config.GetValue<string>("network-interface");
     fNumIoThreads = config.GetValue<int>("io-threads");
     fInitializationTimeoutInS = config.GetValue<int>("initialization-timeout");
     fRate = fConfig->GetValue<float>("rate");
+    fDefaultTransport = config.GetValue<string>("transport");
+    SetTransport(fDefaultTransport);
 }
 
 void FairMQDevice::LogSocketRates()

--- a/fairmq/options/FairMQProgOptions.cxx
+++ b/fairmq/options/FairMQProgOptions.cxx
@@ -240,6 +240,7 @@ void FairMQProgOptions::InitOptionDescription()
         ("port-range-max",         po::value<int   >()->default_value(32000),      "End of the port range for dynamic initialization.")
         ("print-channels",         po::value<bool  >()->implicit_value(true),      "Print registered channel endpoints in a machine-readable format (<channel name>:<min num subchannels>:<max num subchannels>)")
         ("shm-segment-size",       po::value<size_t>()->default_value(2000000000), "Shared memory: size of the shared memory segment (in bytes).")
+        ("shm-monitor",            po::value<bool  >()->default_value(false),      "Shared memory: run monitor daemon.")
         ("rate",                   po::value<float >()->default_value(0.),         "Rate for conditional run loop (Hz).")
         ("session",                po::value<string>()->default_value("default"),  "Session name.")
         ;

--- a/fairmq/shmem/FairMQTransportFactorySHM.h
+++ b/fairmq/shmem/FairMQTransportFactorySHM.h
@@ -56,6 +56,7 @@ class FairMQTransportFactorySHM : public FairMQTransportFactory
     void StartMonitor();
 
     static FairMQ::Transport fTransportType;
+    std::string fDeviceId;
     std::string fSessionName;
     void* fContext;
     std::thread fHeartbeatThread;

--- a/fairmq/shmem/Monitor.h
+++ b/fairmq/shmem/Monitor.h
@@ -14,6 +14,7 @@
 #include <chrono>
 #include <atomic>
 #include <string>
+#include <unordered_map>
 
 namespace fair
 {
@@ -25,7 +26,7 @@ namespace shmem
 class Monitor
 {
   public:
-    Monitor(const std::string& sessionName, bool selfDestruct, bool interactive, unsigned int timeoutInMS);
+    Monitor(const std::string& sessionName, bool selfDestruct, bool interactive, unsigned int timeoutInMS, bool runAsDaemon, bool cleanOnExit);
 
     Monitor(const Monitor&) = delete;
     Monitor operator=(const Monitor&) = delete;
@@ -51,6 +52,8 @@ class Monitor
     bool fSelfDestruct; // will self-destruct after the memory has been closed
     bool fInteractive; // running in interactive mode
     bool fSeenOnce; // true is segment has been opened successfully at least once
+    bool fIsDaemon;
+    bool fCleanOnExit;
     unsigned int fTimeoutInMS;
     std::string fSessionName;
     std::string fSegmentName;
@@ -61,6 +64,7 @@ class Monitor
     std::chrono::high_resolution_clock::time_point fLastHeartbeat;
     std::thread fSignalThread;
     boost::interprocess::managed_shared_memory fManagementSegment;
+    std::unordered_map<std::string, std::chrono::high_resolution_clock::time_point> fDeviceHeartbeats;
 };
 
 } // namespace shmem

--- a/fairmq/shmem/runMonitor.cxx
+++ b/fairmq/shmem/runMonitor.cxx
@@ -9,11 +9,59 @@
 
 #include <boost/program_options.hpp>
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
 #include <iostream>
 #include <string>
 
 using namespace std;
 using namespace boost::program_options;
+
+static void daemonize()
+{
+    // already a daemon?
+    // if (getppid() == 1) return;
+
+    // Fork off the parent process
+    // pid_t pid = fork();
+    // if (pid < 0) exit(1);
+
+    // If we got a good PID, then we can exit the parent process.
+    // if (pid > 0) exit(0);
+
+    // Change the file mode mask
+    umask(0);
+
+    // Create a new SID for the child process
+    if (setsid() < 0)
+    {
+        exit(1);
+    }
+
+    // Change the current working directory. This prevents the current directory from being locked; hence not being able to remove it.
+    if ((chdir("/")) < 0)
+    {
+        exit(1);
+    }
+
+    // Redirect standard files to /dev/null
+    if (!freopen("/dev/null", "r", stdin))
+    {
+        cout << "could not redirect stdin to /dev/null" << endl;
+    }
+    if (!freopen("/dev/null", "w", stdout))
+    {
+        cout << "could not redirect stdout to /dev/null" << endl;
+    }
+    if (!freopen("/dev/null", "w", stderr))
+    {
+        cout << "could not redirect stderr to /dev/null" << endl;
+    }
+}
 
 int main(int argc, char** argv)
 {
@@ -24,15 +72,19 @@ int main(int argc, char** argv)
         bool selfDestruct = false;
         bool interactive = false;
         unsigned int timeoutInMS;
+        bool runAsDaemon = false;
+        bool cleanOnExit = false;
 
         options_description desc("Options");
         desc.add_options()
-            ("session", value<string>(&sessionName)->default_value("default"), "Name of the session which to monitor")
-            ("cleanup", value<bool>(&cleanup)->implicit_value(true), "Perform cleanup and quit")
-            ("self-destruct", value<bool>(&selfDestruct)->implicit_value(true), "Quit after first closing of the memory")
-            ("interactive", value<bool>(&interactive)->implicit_value(true), "Interactive run")
-            ("timeout", value<unsigned int>(&timeoutInMS)->default_value(5000), "Heartbeat timeout in milliseconds")
-            ("help", "Print help");
+            ("session,s", value<string>(&sessionName)->default_value("default"), "Name of the session which to monitor")
+            ("cleanup,c", value<bool>(&cleanup)->implicit_value(true), "Perform cleanup and quit")
+            ("self-destruct,x", value<bool>(&selfDestruct)->implicit_value(true), "Quit after first closing of the memory")
+            ("interactive,i", value<bool>(&interactive)->implicit_value(true), "Interactive run")
+            ("timeout,t", value<unsigned int>(&timeoutInMS)->default_value(5000), "Heartbeat timeout in milliseconds")
+            ("daemonize,d", value<bool>(&runAsDaemon)->implicit_value(true), "Daemonize the monitor")
+            ("clean-on-exit,e", value<bool>(&cleanOnExit)->implicit_value(true), "Perform cleanup on exit")
+            ("help,h", "Print help");
 
         variables_map vm;
         store(parse_command_line(argc, argv, desc), vm);
@@ -47,6 +99,11 @@ int main(int argc, char** argv)
 
         sessionName.resize(8, '_'); // shorten the session name, to accommodate for name size limit on some systems (MacOS)
 
+        if (runAsDaemon)
+        {
+            daemonize();
+        }
+
         if (cleanup)
         {
             cout << "Cleaning up \"" << sessionName << "\"..." << endl;
@@ -57,7 +114,7 @@ int main(int argc, char** argv)
 
         cout << "Starting shared memory monitor for session: \"" << sessionName << "\"..." << endl;
 
-        fair::mq::shmem::Monitor monitor{sessionName, selfDestruct, interactive, timeoutInMS};
+        fair::mq::shmem::Monitor monitor{sessionName, selfDestruct, interactive, timeoutInMS, runAsDaemon, cleanOnExit};
 
         monitor.CatchSignals();
         monitor.Run();


### PR DESCRIPTION
- add `--clean-on-exit`.
- Use boost::process to optionally autostart the monitor.
- Add monitor command to see a list of devices that use shared memory.