### PR TITLE
Migration of simulation examples to MT + minor fixes:

### DIFF
--- a/base/sim/FairDetector.cxx
+++ b/base/sim/FairDetector.cxx
@@ -23,6 +23,7 @@
 #include "TROOT.h"                      // for TROOT, gROOT
 #include "TRefArray.h"                  // for TRefArray
 #include "TString.h"                    // for TString
+#include "TGeoManager.h"                // for gGeoManager
 #include "TVirtualMC.h"                 // for TVirtualMC
 
 #include <stddef.h>                     // for NULL
@@ -80,6 +81,22 @@ FairDetector::FairDetector()
 {
 
 }
+
+// -------------------------------------------------------------------------
+
+void FairDetector::DefineSensitiveVolumes()
+{
+  TObjArray* volumes = gGeoManager->GetListOfVolumes();
+  TIter next(volumes);
+  TGeoVolume* volume;
+  while ( ( volume = static_cast<TGeoVolume*>(next()) ) ) {
+    if ( CheckIfSensitive(volume->GetName()) ) {
+      LOG(debug2)<<"Sensitive Volume "<< volume->GetName();
+      AddSensitiveVolume(volume);
+    }
+  }
+}
+
 // -------------------------------------------------------------------------
 
 void   FairDetector::Initialize()
@@ -87,6 +104,13 @@ void   FairDetector::Initialize()
 // Registers hits collection in Root manager;
 // sets sensitive volumes.
 // ---
+
+  // Define sensitive volumes if in MT
+  if ( gMC->IsMT() ) {
+    std::cout << "Define sensitive volume " << std::endl;
+    DefineSensitiveVolumes();
+  }
+
   Int_t NoOfEntries=svList->GetEntries();
   Int_t fMCid;
   FairGeoNode* fN;

--- a/base/sim/FairDetector.h
+++ b/base/sim/FairDetector.h
@@ -108,6 +108,8 @@ class FairDetector : public FairModule
     /** Assignment operator */
     FairDetector& operator= (const FairDetector&);
 
+    virtual void DefineSensitiveVolumes();
+
     Int_t fDetId; // Detector Id has to be set from ctr.
     FairLogger* fLogger;  //! /// FairLogger
 

--- a/base/sim/FairMCApplication.cxx
+++ b/base/sim/FairMCApplication.cxx
@@ -610,6 +610,12 @@ TVirtualMCApplication* FairMCApplication::CloneForWorker() const
   workerRun->SetName(fRun->GetName()); // Transport engine
   workerRun->SetOutputFileName(fRun->GetOutputFileName());
 
+  // Trajectories filter is created explicitly as we do not call
+  // FairRunSim::Init on workers
+  if ( fRun->GetStoreTraj() ) {
+    new FairTrajFilter();
+  }
+
   // Create new  FairMCApplication object on worker
   FairMCApplication* workerApplication = new FairMCApplication(*this);
   workerApplication->SetGenerator(fEvGen->ClonePrimaryGenerator());
@@ -1048,10 +1054,6 @@ void FairMCApplication::InitGeometry()
   fMCEventHeader->SetRunID(runId);
   if (fRootManager) {
     fMCEventHeader->Register();
-  }
-
-  if(NULL !=fRadGridMan) {
-    fRadGridMan->Init();
   }
 
   if(fEvGen) {

--- a/base/sim/FairModule.cxx
+++ b/base/sim/FairModule.cxx
@@ -107,8 +107,19 @@ FairModule::FairModule(const FairModule& rhs)
    fGeoSaved(rhs.fGeoSaved),
    fMC(0)
 {
-  if(!svList) { svList=new TRefArray(); }
-  if(!vList) { vList=new FairVolumeList(); }
+  if(!svList) {
+    svList=new TRefArray();
+    for (Int_t i=0; i < rhs.svList->GetEntries(); i++) {
+      svList->Add(rhs.svList->At(i));
+    }
+  }
+
+  if(!vList) {
+    vList=new FairVolumeList();
+    for (Int_t i=0; i < rhs.vList->getEntries(); i++) {
+      vList->addVolume(rhs.vList->At(i));
+    }
+  }
 
   // Initialize cached pointer to MC (on worker)
   fMC = TVirtualMC::GetMC();
@@ -687,6 +698,3 @@ FairModule* FairModule::CloneModule() const
 
 //__________________________________________________________________________
 ClassImp(FairModule)
-
-
-

--- a/base/steer/FairRunSim.h
+++ b/base/steer/FairRunSim.h
@@ -91,6 +91,9 @@ class FairRunSim : public FairRun
     /**switch On/Off the track visualisation */
     void SetStoreTraj(Bool_t storeTraj=kTRUE) {fStoreTraj = storeTraj;}
 
+    /**Return the switch for the track visualisation */
+    Bool_t GetStoreTraj() const {return fStoreTraj;}
+
     /**switch On/Off the debug mode */
     void SetTrackingDebugMode( Bool_t set ) { if (fApp) { fApp->SetTrackingDebugMode( set ); } }
 

--- a/base/steer/FairTrajFilter.cxx
+++ b/base/steer/FairTrajFilter.cxx
@@ -35,7 +35,7 @@ ClassImp(FairTrajFilter)
 
 
 
-FairTrajFilter* FairTrajFilter::fgInstance = NULL;
+TMCThreadLocal FairTrajFilter* FairTrajFilter::fgInstance = NULL;
 
 FairTrajFilter* FairTrajFilter::Instance()
 {
@@ -94,8 +94,7 @@ FairTrajFilter::~FairTrajFilter()
 void FairTrajFilter::Init(TString brName, TString folderName)
 {
 
-  FairRootManager::Instance()->Register(brName.Data(), folderName.Data(), fTrackCollection, kTRUE);
-
+  FairRootManager::Instance()->RegisterAny(brName, fTrackCollection, kTRUE);
 }
 
 void FairTrajFilter::Reset()

--- a/base/steer/FairTrajFilter.h
+++ b/base/steer/FairTrajFilter.h
@@ -17,6 +17,7 @@
 #include "TGeoTrack.h"                  // IWYU pragma: keep needed by cint
 #include "TMath.h"                      // for Pi, TwoPi
 #include "TString.h"                    // for TString
+#include "TMCtls.h"                     // for multi-threading
 
 class TClonesArray;
 class TParticle;
@@ -67,7 +68,7 @@ class FairTrajFilter
     FairTrajFilter(const FairTrajFilter&);
     FairTrajFilter& operator=(const FairTrajFilter&);
 
-    static FairTrajFilter* fgInstance;
+    static TMCThreadLocal FairTrajFilter* fgInstance;
 
     Double_t fVxMin;
     Double_t fVxMax;

--- a/examples/common/gconfig/g4config.in
+++ b/examples/common/gconfig/g4config.in
@@ -38,8 +38,6 @@
 #/control/manual   
 #/control/createHTML  
 
-/run/particle/dumpCutValues
-
 # Limit max number of Cerenkov photons per step
 # (Needed as Cerenkov process does not limit step itself)
 #

--- a/examples/common/mcstack/FairStack.cxx
+++ b/examples/common/mcstack/FairStack.cxx
@@ -24,6 +24,7 @@
 #include "TLorentzVector.h"             // for TLorentzVector
 #include "TParticle.h"                  // for TParticle
 #include "TRefArray.h"                  // for TRefArray
+#include "TVirtualMC.h"                 // for gMC
 
 #include <stddef.h>                     // for NULL
 #include <iostream>                     // for operator<<, etc
@@ -346,7 +347,11 @@ void FairStack::Reset()
 // -----   Public method Register   ----------------------------------------
 void FairStack::Register()
 {
-  FairRootManager::Instance()->Register("MCTrack", "Stack", fTracks,kTRUE);
+  if ( gMC && ( ! gMC->IsMT() ) ) {
+    FairRootManager::Instance()->Register("MCTrack", "Stack", fTracks,kTRUE);
+  } else {
+    FairRootManager::Instance()->RegisterAny("MCTrack",fTracks,kTRUE);
+  }
 }
 // -------------------------------------------------------------------------
 

--- a/examples/common/passive/FairCave.cxx
+++ b/examples/common/passive/FairCave.cxx
@@ -58,6 +58,15 @@ void FairCave::ConstructGeometry()
   par->setInputVersion(fRun->GetRunId(),1);
 
 }
+
+FairCave::FairCave(const FairCave& rhs)
+ : FairModule(rhs)
+{
+  world[0] = rhs.world[0];
+  world[1] = rhs.world[1];
+  world[2] = rhs.world[2];
+}
+
 FairCave::FairCave()
 {
 }
@@ -72,4 +81,9 @@ FairCave::FairCave(const char* name,  const char* Title)
   world[0] = 0;
   world[1] = 0;
   world[2] = 0;
+}
+
+FairModule* FairCave::CloneModule() const
+{
+  return new FairCave(*this);
 }

--- a/examples/common/passive/FairCave.h
+++ b/examples/common/passive/FairCave.h
@@ -20,8 +20,10 @@ class FairCave : public FairModule
     virtual ~FairCave();
     virtual void ConstructGeometry();
 
+    virtual FairModule* CloneModule() const;
 
   private:
+    FairCave(const FairCave& rhs);
     Double_t world[3];
     ClassDef(FairCave,1) //PNDCaveSD
 };

--- a/examples/common/passive/FairMagnet.cxx
+++ b/examples/common/passive/FairMagnet.cxx
@@ -39,6 +39,11 @@ FairMagnet::FairMagnet(const char* name, const char* Title)
 {
 }
 
+FairMagnet::FairMagnet(const FairMagnet& rhs)
+ : FairModule(rhs)
+{
+}
+
 void FairMagnet::ConstructGeometry()
 {
 
@@ -91,6 +96,11 @@ void FairMagnet::ConstructASCIIGeometry()
   ProcessNodes( volList );
   par->setChanged();
   par->setInputVersion(fRun->GetRunId(),1);
+}
+
+FairModule* FairMagnet::CloneModule() const
+{
+  return new FairMagnet(*this);
 }
 
 ClassImp(FairMagnet)

--- a/examples/common/passive/FairMagnet.h
+++ b/examples/common/passive/FairMagnet.h
@@ -23,8 +23,12 @@ class FairMagnet : public FairModule
     void ConstructGeometry();
     void ConstructASCIIGeometry();
     Bool_t CheckIfSensitive(std::string name);
-    ClassDef(FairMagnet,1)
 
+    virtual FairModule* CloneModule() const;
+
+  private:
+    FairMagnet(const FairMagnet& rhs);
+    ClassDef(FairMagnet,1)
 };
 
 #endif //MAGNET_H

--- a/examples/common/passive/FairPipe.cxx
+++ b/examples/common/passive/FairPipe.cxx
@@ -38,6 +38,11 @@ FairPipe::FairPipe(const char* name, const char* title)
 {
 }
 
+FairPipe::FairPipe(const FairPipe& rhs)
+ : FairModule(rhs)
+{
+}
+
 void FairPipe::ConstructGeometry()
 {
 
@@ -216,6 +221,11 @@ void FairPipe::ConstructGeometry()
   TGeoVolume* cave = gGeoManager->GetTopVolume();
   cave->AddNode(beamPipe, 1);
 
+}
+
+FairModule* FairPipe::CloneModule() const
+{
+  return new FairPipe(*this);
 }
 
 ClassImp(FairPipe)

--- a/examples/common/passive/FairPipe.h
+++ b/examples/common/passive/FairPipe.h
@@ -21,6 +21,10 @@ class FairPipe : public FairModule
     virtual ~FairPipe();
     virtual void ConstructGeometry();
 
+    virtual FairModule* CloneModule() const;
+
+  private:
+    FairPipe(const FairPipe& rhs);
     ClassDef(FairPipe,1) //PNDPIPE
 
 };

--- a/examples/common/passive/FairTarget.cxx
+++ b/examples/common/passive/FairTarget.cxx
@@ -35,6 +35,12 @@ FairTarget::FairTarget(const char* name,  const char* title)
   : FairModule(name ,title)
 {
 }
+
+FairTarget::FairTarget(const FairTarget& rhs)
+ : FairModule(rhs)
+{
+}
+
 void FairTarget::ConstructGeometry()
 {
   FairGeoLoader* loader=FairGeoLoader::Instance();
@@ -70,6 +76,12 @@ void FairTarget::ConstructGeometry()
   par->setInputVersion(fRun->GetRunId(),1);
 
 }
+
+FairModule* FairTarget::CloneModule() const
+{
+  return new FairTarget(*this);
+}
+
 ClassImp(FairTarget)
 
 

--- a/examples/common/passive/FairTarget.h
+++ b/examples/common/passive/FairTarget.h
@@ -19,8 +19,12 @@ class FairTarget : public FairModule
     FairTarget();
     virtual ~FairTarget();
     virtual void ConstructGeometry();
-    ClassDef(FairTarget,1)
 
+    virtual FairModule* CloneModule() const;
+
+  private:
+    FairTarget(const FairTarget& rhs);
+    ClassDef(FairTarget,1)
 };
 
 #endif //Target_H

--- a/examples/simulation/Tutorial1/macros/run_tutorial1.C
+++ b/examples/simulation/Tutorial1/macros/run_tutorial1.C
@@ -5,7 +5,7 @@
  *              GNU Lesser General Public Licence (LGPL) version 3,             *  
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
-void run_tutorial1(Int_t nEvents = 10, TString mcEngine = "TGeant3")
+void run_tutorial1(Int_t nEvents = 10, TString mcEngine = "TGeant3", Bool_t isMT=false)
 {
   
   TString dir = getenv("VMCWORKDIR");
@@ -60,6 +60,7 @@ void run_tutorial1(Int_t nEvents = 10, TString mcEngine = "TGeant3")
   // -----   Create simulation run   ----------------------------------------
   FairRunSim* run = new FairRunSim();
   run->SetName(mcEngine);              // Transport engine
+  run->SetIsMT(isMT);                  // Multi-threading mode (Geant4 only)
   run->SetOutputFile(outFile);          // Output file
   FairRuntimeDb* rtdb = run->GetRuntimeDb();
   // ------------------------------------------------------------------------

--- a/examples/simulation/Tutorial1/src/FairTutorialDet1.h
+++ b/examples/simulation/Tutorial1/src/FairTutorialDet1.h
@@ -15,6 +15,7 @@
 #include "TVector3.h"                   // for TVector3
 
 class FairTutorialDet1Point;
+class FairTutorialDet1Geo;
 class FairVolume;
 class TClonesArray;
 
@@ -80,8 +81,12 @@ class FairTutorialDet1: public FairDetector
     virtual void   PreTrack() {;}
     virtual void   BeginEvent() {;}
 
+    virtual FairModule* CloneModule() const;
 
   private:
+    void SetSensitiveVolumes();
+
+    static FairTutorialDet1Geo* fgGeo;   //!
 
     /** Track information to be stored until the track leaves the
     active volume.

--- a/examples/simulation/Tutorial2/macros/run_tutorial2.C
+++ b/examples/simulation/Tutorial2/macros/run_tutorial2.C
@@ -5,7 +5,7 @@
  *              GNU Lesser General Public Licence (LGPL) version 3,             *  
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
-void run_tutorial2(Int_t nEvents = 10)
+void run_tutorial2(Int_t nEvents = 10, TString mcEngine = "TGeant3", Bool_t isMT=false)
 {
   
   TString dir = getenv("VMCWORKDIR");
@@ -60,7 +60,8 @@ void run_tutorial2(Int_t nEvents = 10)
 
   // -----   Create simulation run   ----------------------------------------
   FairRunSim* run = new FairRunSim();
-  run->SetName("TGeant3");              // Transport engine
+  run->SetName(mcEngine);              // Transport engine
+  run->SetIsMT(isMT);                  // Multi-threading mode (Geant4 only)
   run->SetOutputFile(outFile);          // Output file
   FairRuntimeDb* rtdb = run->GetRuntimeDb();
   // ------------------------------------------------------------------------

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2.h
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2.h
@@ -15,6 +15,7 @@
 #include "FairTutorialDet2Point.h"
 
 class FairVolume;
+class FairTutorialDet2Geo;
 class TClonesArray;
 
 class FairTutorialDet2: public FairDetector
@@ -79,8 +80,12 @@ class FairTutorialDet2: public FairDetector
     virtual void   PreTrack() {;}
     virtual void   BeginEvent() {;}
 
+    virtual FairModule* CloneModule() const;
 
   private:
+    void SetSensitiveVolumes();
+
+    static FairTutorialDet2Geo* fgGeo;   //!
 
     /** Track information to be stored until the track leaves the
     active volume.

--- a/examples/simulation/Tutorial4/gconfig/g4Config.C
+++ b/examples/simulation/Tutorial4/gconfig/g4Config.C
@@ -56,8 +56,8 @@ void Config()
 /// Customise Geant4 setting
 /// (verbose level, global range cut, ..)
 
-   TString configm(gSystem->Getenv("VMCWORKDIR"));
-   TString configm1 = configm + "/gconfig/g4config.in";
+   TString configm(gSystem->Getenv("CONFIG_DIR"));
+   TString configm1 = configm + "/g4config.in";
    cout << " -I g4Config() using g4conf  macro: " << configm1 << endl;
 
    //set geant4 specific stuff

--- a/examples/simulation/Tutorial4/gconfig/g4config.in
+++ b/examples/simulation/Tutorial4/gconfig/g4config.in
@@ -38,8 +38,6 @@
 #/control/manual   
 #/control/createHTML  
 
-/run/particle/dumpCutValues
-
 # Limit max number of Cerenkov photons per step
 # (Needed as Cerenkov process does not limit step itself)
 #

--- a/examples/simulation/Tutorial4/macros/run_tutorial4.C
+++ b/examples/simulation/Tutorial4/macros/run_tutorial4.C
@@ -5,7 +5,7 @@
  *              GNU Lesser General Public Licence (LGPL) version 3,             *  
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
-void run_tutorial4(Int_t nEvents = 10, TString mcEngine="TGeant3")
+void run_tutorial4(Int_t nEvents = 10, TString mcEngine="TGeant3",  Bool_t isMT=false)
 {
   
   TString dir = getenv("VMCWORKDIR");
@@ -56,6 +56,7 @@ void run_tutorial4(Int_t nEvents = 10, TString mcEngine="TGeant3")
   // -----   Create simulation run   ----------------------------------------
   FairRunSim* run = new FairRunSim();
   run->SetName(mcEngine);              // Transport engine
+  run->SetIsMT(isMT);                  // Multi-threading mode (Geant4 only)
   run->SetOutputFile(outFile);          // Output file
   FairRuntimeDb* rtdb = run->GetRuntimeDb();
   // ------------------------------------------------------------------------
@@ -71,7 +72,10 @@ void run_tutorial4(Int_t nEvents = 10, TString mcEngine="TGeant3")
 
   FairTutorialDet4* tutdet = new FairTutorialDet4("TUTDET", kTRUE);
   tutdet->SetGeometryFileName("tutorial4.root"); 
-  tutdet->SetModifyGeometry(kTRUE);
+  if ( ! isMT ) {
+    // This mode does not yet work with MT
+    tutdet->SetModifyGeometry(kTRUE);
+  }
   run->AddModule(tutdet);
   // ------------------------------------------------------------------------
 

--- a/examples/simulation/Tutorial4/src/mc/FairTutorialDet4.h
+++ b/examples/simulation/Tutorial4/src/mc/FairTutorialDet4.h
@@ -21,6 +21,7 @@
 class FairTutorialDet4Point;
 class FairTutorialDet4GeoHandler;
 class FairTutorialDet4MisalignPar;
+class FairTutorialDet4Geo;
 class FairVolume;
 class TClonesArray;
 
@@ -95,7 +96,13 @@ class FairTutorialDet4: public FairDetector
     void SetModifyGeometry(Bool_t val) { fModifyGeometry=val; }
     void SetGlobalCoordinates(Bool_t val) { fGlobalCoordinates=val; }
 
+    virtual FairModule* CloneModule() const;
+
   private:
+    void SetSensitiveVolumes();
+
+    static FairTutorialDet4Geo* fgGeo;   //!
+
 
     /** Track information to be stored until the track leaves the
     active volume.

--- a/examples/simulation/rutherford/macros/run_rutherford.C
+++ b/examples/simulation/rutherford/macros/run_rutherford.C
@@ -5,7 +5,7 @@
  *              GNU Lesser General Public Licence (LGPL) version 3,             *  
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
-void run_rutherford(Int_t nEvents = 10, TString mcEngine="TGeant4")
+void run_rutherford(Int_t nEvents = 10, TString mcEngine="TGeant4", Bool_t isMT=false)
 {
   
   TString dir = gSystem->Getenv("VMCWORKDIR");
@@ -50,6 +50,7 @@ void run_rutherford(Int_t nEvents = 10, TString mcEngine="TGeant4")
   // -----   Create simulation run   ----------------------------------------
   FairRunSim* run = new FairRunSim();
   run->SetName(mcEngine);              // Transport engine
+  run->SetIsMT(isMT);                  // Multi-threading mode (Geant4 only)
   run->SetOutputFile(outFile);          // Output file
   FairRuntimeDb* rtdb = run->GetRuntimeDb();
   // ------------------------------------------------------------------------

--- a/examples/simulation/rutherford/src/FairRutherford.h
+++ b/examples/simulation/rutherford/src/FairRutherford.h
@@ -15,6 +15,7 @@
 #include "TVector3.h"                   // for TVector3
 
 class FairRutherfordPoint;
+class FairRutherfordGeo;
 class FairVolume;
 class TClonesArray;
 
@@ -80,10 +81,14 @@ class FairRutherford: public FairDetector
     virtual void   PreTrack() {;}
     virtual void   BeginEvent() {;}
 
+    virtual FairModule* CloneModule() const;
 
   private:
+    void SetSensitiveVolumes();
 
-    /** Track information to be stored until the track leaves the
+    static FairRutherfordGeo* fgGeo;   //!
+
+   /** Track information to be stored until the track leaves the
     active volume.
     */
     Int_t          fTrackID;           //!  track index

--- a/generators/FairIonGenerator.cxx
+++ b/generators/FairIonGenerator.cxx
@@ -126,7 +126,22 @@ FairIonGenerator::FairIonGenerator(Int_t z, Int_t a, Int_t q, Int_t mult,
 }
 //_________________________________________________________________________
 
-
+FairIonGenerator::FairIonGenerator(const FairIonGenerator& rhs)
+  :FairGenerator(rhs),
+   fMult(rhs.fMult),
+   fPx(rhs.fPx), fPy(rhs.fPy), fPz(rhs.fPz),
+   fVx(rhs.fVx), fVy(rhs.fVy), fVz(rhs.fVz),
+   fIon(rhs.fIon), // CHECK
+   fQ(0)
+{
+  // fIon= new FairIon(buffer, z, a, q);
+  FairRunSim* run = FairRunSim::Instance();
+  if ( ! run ) {
+    LOG(error) << "No FairRun instantised!";
+  } else {
+    run->AddNewIon(fIon);
+  }
+}
 
 // -----   Destructor   ---------------------------------------------------
 FairIonGenerator::~FairIonGenerator()
@@ -190,5 +205,14 @@ Bool_t FairIonGenerator::ReadEvent(FairPrimaryGenerator* primGen)
 
 //_____________________________________________________________________________
 
+// ------------------------------------------------------------------------
+FairGenerator* FairIonGenerator::CloneGenerator() const
+{
+  // Clone for worker (used in MT mode only)
+
+  return new FairIonGenerator(*this);
+}
+
+//_____________________________________________________________________________
 
 ClassImp(FairIonGenerator)

--- a/generators/FairIonGenerator.h
+++ b/generators/FairIonGenerator.h
@@ -80,6 +80,8 @@ class FairIonGenerator : public FairGenerator
      **/
     virtual Bool_t ReadEvent(FairPrimaryGenerator* primGen);
 
+    /** Clone this object (used in MT mode only) */
+    virtual FairGenerator* CloneGenerator() const;
 
   private:
 


### PR DESCRIPTION
- Implemented CloneModule() in the examples detectors
- Separation of code for definition of sensitive volumes from modules ConstructGeometry()
  in a new DefineSensitiveVolumes() function called from Initialize()
- Migration of FairTrajFilter to MT
- Removed /run/particle/dumpCutValues from g4config.in: the command is not available
  in PreInit phase
- Fixed path to g4config.in in Tutorial4/gconfig/g4Config.C