### PR TITLE
Ask FairRunSim if TGeo should be imported to VMC

### DIFF
--- a/base/sim/FairMCApplication.cxx
+++ b/base/sim/FairMCApplication.cxx
@@ -968,7 +968,13 @@ void FairMCApplication::ConstructGeometry()
                << "This almost certainly means inconsistent lookup structures used in simulation/stepping.\n";
   }
   
-  TVirtualMC::GetMC()->SetRootGeometry();         // notify VMC about Root geometry
+  if (fRun->IsImportTGeoToVMC() ) {
+    TVirtualMC::GetMC()->SetRootGeometry();         // notify VMC about Root geometry
+    LOG(info) << "TGeometry will be imported to VMC" << "\n";
+  }
+  else {
+    LOG(info) << "TGeometry will not be imported to VMC" << "\n";
+  }
   Int_t Counter=0;
   TDatabasePDG* pdgDatabase = TDatabasePDG::Instance();
   const THashList *list=pdgDatabase->ParticleList();

--- a/base/steer/FairRunSim.cxx
+++ b/base/steer/FairRunSim.cxx
@@ -73,7 +73,8 @@ FairRunSim::FairRunSim(Bool_t isMaster)
    fMeshList( new TObjArray() ),
    fUserConfig(""),
    fUserCuts("SetCuts.C"),
-   fIsMT(kFALSE)
+   fIsMT(kFALSE),
+   fImportTGeoToVMC(kTRUE)
 
 {
   if (fginstance) {

--- a/base/steer/FairRunSim.h
+++ b/base/steer/FairRunSim.h
@@ -158,6 +158,9 @@ class FairRunSim : public FairRun
     void SetIsMT(Bool_t isMT) { fIsMT = isMT; }
     Bool_t IsMT() const { return fIsMT; }
 
+    void SetImportTGeoToVMC(Bool_t v) { fImportTGeoToVMC = v; }
+    Bool_t IsImportTGeoToVMC() const { return fImportTGeoToVMC; }
+    
   private:
     FairRunSim(const FairRunSim& M);
     FairRunSim& operator= (const  FairRunSim&) {return *this;}
@@ -191,7 +194,7 @@ class FairRunSim : public FairRun
     TString                fUserConfig; //!                        /** Macro for geant configuration*/
     TString                fUserCuts; //!                          /** Macro for geant cuts*/
     Bool_t                 fIsMT; //!                              /** MT mode option (Geant4 only)*/
-
+    Bool_t                 fImportTGeoToVMC; //!                   /** Allow importing TGeometry to VMC */
     std::function<void()>    fSimSetup; //!         /** A user provided function to do sim setup / instead of using macros **/ 
     bool                     fUseSimSetupFunction = false;
     


### PR DESCRIPTION
FairMCApplication.cxx unconditionally calls TVirtualMC::GetMC()->SetRootGeometry()
Materials/Media created via VMC are added both to TGeo and VMC geometry, so that
the importing the TGeo to VMC in the e.g. TGeant3TGeo::FinishGeometry() leads to
materials duplication and the loss of special (e.g. optical) properties set directly
on VMC materials 1st copy. This patch introduces a flag in the AliRunSim, which tells
to FairMCApplication if the TGeo should be imported to VMC. The flag is set to TRUE
in the constructor, therefore default behaviour of FairRoot is not altered. Those
applications which do not importing of TGeo (e.g. O2 always created the geometry
for the simulation on the fly) can set FairRunSim::SetImportTGeoToVMC(false)
BEFORE building the geometry