### PR TITLE
Removing virtuality of methods in FairMultiLinkedData_Interface

### DIFF
--- a/base/event/FairMultiLinkedData_Interface.h
+++ b/base/event/FairMultiLinkedData_Interface.h
@@ -33,34 +33,34 @@ class FairMultiLinkedData_Interface : public  TObject
     FairMultiLinkedData_Interface(Int_t dataType, std::vector<Int_t> links, Int_t fileId = -1, Int_t evtId = -1, Bool_t persistanceCheck = kTRUE, Bool_t bypass = kFALSE, Float_t mult = 1.0);///< Constructor
     FairMultiLinkedData_Interface(const FairMultiLinkedData_Interface& toCopy);
 
-    virtual ~FairMultiLinkedData_Interface() {
+    ~FairMultiLinkedData_Interface() {
     	delete(fLink);
     };
 
     FairMultiLinkedData_Interface& operator=(const FairMultiLinkedData_Interface& rhs);
 
-    virtual std::set<FairLink>  GetLinks() const;           		///< returns stored links as FairLinks
-    virtual Int_t           	GetNLinks() const;                	///< returns the number of stored links
-    virtual FairLink        	GetLink(Int_t pos) const;         	///< returns the FairLink at the given position
-    virtual FairMultiLinkedData GetLinksWithType(Int_t type) const; ///< returns all FairLinks with the corresponding type
-    virtual FairLink            GetEntryNr() const;
+    std::set<FairLink>  GetLinks() const;           		///< returns stored links as FairLinks
+    Int_t           	GetNLinks() const;                	///< returns the number of stored links
+    FairLink        	GetLink(Int_t pos) const;         	///< returns the FairLink at the given position
+    FairMultiLinkedData GetLinksWithType(Int_t type) const; ///< returns all FairLinks with the corresponding type
+    FairLink            GetEntryNr() const;
     FairMultiLinkedData* 	GetPointerToLinks() const { return fLink;}
 
-    virtual std::vector<FairLink> GetSortedMCTracks();
+    std::vector<FairLink> GetSortedMCTracks();
 
-    virtual void SetLinks(FairMultiLinkedData links);           ///< Sets the links as vector of FairLink
-    virtual void SetLink(FairLink link);      					///< Sets the Links with a single FairLink
-    virtual void SetInsertHistory(Bool_t val);
-    virtual void SetEntryNr(FairLink val);
-    virtual void SetPointerToLinks(FairMultiLinkedData* links) {fLink = links;}
+    void SetLinks(FairMultiLinkedData links);           ///< Sets the links as vector of FairLink
+    void SetLink(FairLink link);      					///< Sets the Links with a single FairLink
+    void SetInsertHistory(Bool_t val);
+    void SetEntryNr(FairLink val);
+    void SetPointerToLinks(FairMultiLinkedData* links) {fLink = links;}
 
-    virtual void AddLinks(FairMultiLinkedData links, Float_t mult = 1.0);		///< Adds a List of FairLinks (FairMultiLinkedData_Interface) to fLinks
-    virtual void AddLink(FairLink link);      									///< Adds a FairLink link at the end of fLinks. If multi is kTRUE a link is allowed more than once otherwise
-    virtual void AddInterfaceData(FairMultiLinkedData_Interface* data);
+    void AddLinks(FairMultiLinkedData links, Float_t mult = 1.0);		///< Adds a List of FairLinks (FairMultiLinkedData_Interface) to fLinks
+    void AddLink(FairLink link);      									///< Adds a FairLink link at the end of fLinks. If multi is kTRUE a link is allowed more than once otherwise
+    void AddInterfaceData(FairMultiLinkedData_Interface* data);
 
 
 
-    virtual void ResetLinks();
+    void ResetLinks();
 
 
     std::ostream& PrintLinkInfo(std::ostream& out = std::cout) const {


### PR DESCRIPTION
Closes issue #544.
The virtual keyword was removed from all FairMultiLinkedData_Interface methods.