### PR TITLE
Move SetSpecialPhysicsCuts API from FairDetector to FairModule

### DIFF
--- a/base/sim/FairDetector.h
+++ b/base/sim/FairDetector.h
@@ -94,9 +94,6 @@ class FairDetector : public FairModule
     virtual void   FinishEvent() {
       ;
     }
-    virtual void   SetSpecialPhysicsCuts() {
-      ;
-    }
     void SaveGeoParams();
     Int_t  GetDetId() {
       return fDetId;

--- a/base/sim/FairMCApplication.cxx
+++ b/base/sim/FairMCApplication.cxx
@@ -1039,18 +1039,15 @@ void FairMCApplication::InitGeometry()
   while((obj=fModIter->Next())) {
     detector=dynamic_cast<FairDetector*>(obj);
     module=dynamic_cast<FairModule*>(obj);
-    // check first if we have a FairDetector
+    if(module) {
+      module->SetSpecialPhysicsCuts();
+    }
     if(detector) {
       // check whether detector is active 
       if(detector->IsActive()) {
         detector->Initialize();
-        detector->SetSpecialPhysicsCuts();
         detector->Register();
       }
-    }
-    // if not a FairDetector, maybe it's just a FairModule where SetSpecialPhysicsCuts should still be applied
-    else if(module) {
-      module->SetSpecialPhysicsCuts();
     }
   }
   fModIter->Reset();

--- a/base/sim/FairModule.h
+++ b/base/sim/FairModule.h
@@ -76,6 +76,9 @@ class FairModule:  public TNamed
     virtual void        ModifyGeometry() {;}
     /**construct geometry from GDML files*/
     virtual void        ConstructGDMLGeometry(TGeoMatrix*);
+    /** custom settings of processes and cuts for media to be forwarded to the 
+     ** detector simulation */
+    virtual void        SetSpecialPhysicsCuts() {;}
     /** Clone this object (used in MT mode only)*/
     virtual FairModule* CloneModule() const;
     /** Init worker run (used in MT mode only) */


### PR DESCRIPTION
This promotes the SetSpecialPhysicsCuts interface to FairModule,
so that cuts can be adjusted for passive modules.

Correspoding changes were done in FairMCApplication.