### PR TITLE
provide backwards-compatibility for old IsLogNeeded API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,7 @@ endif()
 
 # FairRoot only supports ROOT6, so check which version is available
 find_package(ROOT 6.10.00 REQUIRED)
-find_package(FairLogger 1.0.6 REQUIRED)
+find_package(FairLogger 1.1.0 REQUIRED)
 find_package(Pythia6)
 find_package(Pythia8)
 

--- a/examples/MQ/serialization/data_generator/RooDataGenerator.h
+++ b/examples/MQ/serialization/data_generator/RooDataGenerator.h
@@ -160,7 +160,7 @@ class MultiVariatePDF
 
     void Init(double t_start)
     {
-        RooMsgService::instance().setGlobalKillBelow(ERROR);
+        RooMsgService::instance().setGlobalKillBelow(MsgLevel::ERROR);
         TDatime* time = new TDatime();
         int seed = time->GetTime();
         delete time;

--- a/fairtools/FairLogger.cxx
+++ b/fairtools/FairLogger.cxx
@@ -183,6 +183,11 @@ bool FairLogger::IsLogNeeded(fair::Severity severity)
     return fair::Logger::Logging(severity);
 }
 
+bool FairLogger::IsLogNeeded(FairLogLevel level)
+{
+    return fair::Logger::Logging(ConvertLogLevelToString(level));
+}
+
 void FairLogger::LogFatalMessage()
 {
     // Since Fatal indicates a fatal error it is maybe usefull to have

--- a/fairtools/FairLogger.h
+++ b/fairtools/FairLogger.h
@@ -27,6 +27,33 @@ class FairLogger;
 
 #define MESSAGE_ORIGIN __FILE__, CONVERTTOSTRING(__LINE__), __FUNCTION__
 
+// backwards-compatibility with older FairLogger calls, TODO: delete me as soon as possible
+enum FairLogLevel
+{
+    FATAL,
+    ERROR,
+    WARNING,
+    INFO,
+    DEBUG,
+    DEBUG1,
+    DEBUG2,
+    DEBUG3,
+    DEBUG4
+};
+
+// backwards-compatibility with older FairLogger calls, TODO: delete me as soon as possible
+static const char* const LogLevelString[] = {
+    "FATAL",
+    "ERROR",
+    "WARNING",
+    "INFO",
+    "DEBUG",
+    "DEBUG1",
+    "DEBUG2",
+    "DEBUG3",
+    "DEBUG4"
+};
+
 class FairLogger
 {
   public:
@@ -85,6 +112,7 @@ class FairLogger
     }
 
     bool IsLogNeeded(fair::Severity severity);
+    bool IsLogNeeded(FairLogLevel level);
 
     void Fatal  (const char* file, const char* line, const char* func, const char* format, ...)  __attribute__((deprecated("Use 'LOG(severity) << content;' macro interface instead.")));
     void Error  (const char* file, const char* line, const char* func, const char* format, ...)  __attribute__((deprecated("Use 'LOG(severity) << content;' macro interface instead.")));
@@ -113,6 +141,8 @@ class FairLogger
     ~FairLogger() {}
 
     void Log(fair::Severity level, const char* file, const char* line, const char*, const char* format, va_list arglist);
+
+    const char* ConvertLogLevelToString(FairLogLevel level) const { return LogLevelString[level]; }
 
     static void LogFatalMessage();
 


### PR DESCRIPTION
This change requires FairLogger 1.1.0