### PR TITLE
Provide access to time-of-flight of a particle.

### DIFF
--- a/geane/FairGeanePro.cxx
+++ b/geane/FairGeanePro.cxx
@@ -56,6 +56,7 @@ FairGeanePro::FairGeanePro()
     fvpf(TVector3(0., 0., 0.)),
     fvwi(TVector3(0., 0., 0.)),
     ftrklength(0.),
+    ftrktime(0.),
     flag(0),
     fApp(FairGeaneApplication::Instance()),
     fPrintErrors(kTRUE)
@@ -361,6 +362,8 @@ Bool_t FairGeanePro::Propagate(Int_t PDG)
 
   ftrklength=gMC3->TrackLength();
 
+  ftrktime=gMC3->TrackTime();
+
   Double_t trasp[25];
   for(int i = 0; i < 25; i++) {
     //       trasp[i] = afErtrio->ertrsp[i]; // single precision tr. mat.
@@ -495,6 +498,7 @@ Bool_t FairGeanePro::PropagateToPCA(Int_t pca)
   fvpf = TVector3(0.,0.,0.);
   fvwi = TVector3(0.,0.,0.);
   ftrklength = 0;
+  ftrktime = 0;
   return kTRUE;
 }
 
@@ -512,6 +516,7 @@ Bool_t FairGeanePro::PropagateToPCA(Int_t pca, Int_t dir)
   fvpf = TVector3(0.,0.,0.);
   fvwi = TVector3(0.,0.,0.);
   ftrklength = 0;
+  ftrktime = 0;
   return kTRUE;
 }
 
@@ -530,6 +535,7 @@ Bool_t FairGeanePro::ActualFindPCA(Int_t pca, FairTrackParP* par, Int_t dir)
   fvpf = TVector3(0.,0.,0.);
   fvwi = TVector3(0.,0.,0.);
   ftrklength = 0;
+  ftrktime = 0;
   for(Int_t i=0; i<15; i++) { ein[i]=0.00; }
   return kTRUE;
 }
@@ -546,6 +552,7 @@ Bool_t FairGeanePro::BackTrackToVertex()
   fvpf = TVector3(0.,0.,0.);
   fvwi = TVector3(0.,0.,0.);
   ftrklength = 0;
+  ftrktime = 0;
   return kTRUE;
 }
 
@@ -561,6 +568,7 @@ Bool_t FairGeanePro::PropagateToVirtualPlaneAtPCA(Int_t pca)
   fvpf = TVector3(0.,0.,0.);
   fvwi = TVector3(0.,0.,0.);
   ftrklength = 0;
+  ftrktime = 0;
   return kTRUE;
 }
 
@@ -576,6 +584,7 @@ Bool_t FairGeanePro::BackTrackToVirtualPlaneAtPCA(Int_t pca)
   fvpf = TVector3(0.,0.,0.);
   fvwi = TVector3(0.,0.,0.);
   ftrklength = 0;
+  ftrktime = 0;
   return kTRUE;
 }
 

--- a/geane/FairGeanePro.h
+++ b/geane/FairGeanePro.h
@@ -65,6 +65,7 @@ class FairGeanePro : public TNamed
     TVector3 GetPCAOnWire() { return fvwi; }
     TVector3 GetPCAOnTrack() { return fvpf; }
     Float_t GetLengthAtPCA() { return ftrklength; }
+    Float_t GetTimeAtPCA() { return ftrktime; }
     Bool_t PropagateToVirtualPlaneAtPCA(Int_t pca);
     Bool_t BackTrackToVertex();
     Bool_t BackTrackToVirtualPlaneAtPCA(Int_t pca);
@@ -113,6 +114,7 @@ class FairGeanePro : public TNamed
     Double_t fRad, fDi;
     TVector3 fvpf, fvwi;
     Float_t ftrklength;
+    Float_t ftrktime;
     Int_t flag;
     FairGeaneApplication* fApp;
     Double_t trpmat[5][5];


### PR DESCRIPTION
- added FairGeanePro::GetTimeAtPCA() method.

solves #751 

@TobiasStockmanns can you check please if it works for you?