### PR TITLE
adding initialization of angles for TGeoTubeSeg, TGeoConeSeg and TGeoCtub shapes

### DIFF
--- a/base/sim/FairModule.cxx
+++ b/base/sim/FairModule.cxx
@@ -593,6 +593,7 @@ void FairModule::ExpandNode(TGeoNode* fN)
       LOG(debug2)<<"Sensitive Volume "<< v->GetName();
       AddSensitiveVolume(v);
     }
+    v->GetShape()->AfterStreamer();
   }
 }
 


### PR DESCRIPTION
to correct the bug: when geometric radial segmented figures, like TGeoTubeSeg, TGeoConeSeg, TGeoCtub, are specified, particle tracks can not pass through such volumes