### PR TITLE
Use --tags when detecting version via git

### DIFF
--- a/cmake/modules/GenerateVersionInfo.cmake
+++ b/cmake/modules/GenerateVersionInfo.cmake
@@ -11,7 +11,7 @@
  Find_Package(Git)
 
  If(GIT_FOUND AND EXISTS "${SOURCE_DIR}/.git")
-   Execute_Process(COMMAND ${GIT_EXECUTABLE} describe
+   Execute_Process(COMMAND ${GIT_EXECUTABLE} describe --tags
                    OUTPUT_VARIABLE FAIRROOT_GIT_VERSION
                    OUTPUT_STRIP_TRAILING_WHITESPACE
                    WORKING_DIRECTORY ${SOURCE_DIR}


### PR DESCRIPTION
This aligns things to the same behavior used elsewhere and allows non-annotated tags like the one we use for the O2 nightlies to work.