### PR TITLE
Ease interface change

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,9 +37,9 @@ pipeline{
       steps{
         script {
           parallel(buildMatrix([
-            [os: 'Debian8',    arch: 'x86_64', compiler: 'gcc4.9',         fairsoft: 'apr18'],
-            [os: 'MacOS10.11', arch: 'x86_64', compiler: 'AppleLLVM8.0.0', fairsoft: 'apr18'],
-            [os: 'MacOS10.13', arch: 'x86_64', compiler: 'AppleLLVM9.0.0', fairsoft: 'apr18'],
+            [os: 'Debian8',    arch: 'x86_64', compiler: 'gcc4.9',         fairsoft: 'may18'],
+            [os: 'MacOS10.11', arch: 'x86_64', compiler: 'AppleLLVM8.0.0', fairsoft: 'may18'],
+            [os: 'MacOS10.13', arch: 'x86_64', compiler: 'AppleLLVM9.0.0', fairsoft: 'may18'],
           ]) { spec, label ->
             sh '''\
               echo "export BUILDDIR=$PWD/build" >> Dart.cfg

--- a/base/sink/FairRootFileSink.h
+++ b/base/sink/FairRootFileSink.h
@@ -46,7 +46,7 @@ public:
     virtual void        FillEventHeader(FairEventHeader* feh);
 
     virtual TFile*      OpenRootFile(TString fileName="");
-    const TFile*        GetRootFile (){return fRootFile;}
+    TFile*              GetRootFile (){return fRootFile;}
     virtual TString     GetFileName (){return (fRootFile?fRootFile->GetName():"");}
 
     virtual void        SetOutTree(TTree* fTree) { fOutTree=fTree;}

--- a/base/steer/FairRun.cxx
+++ b/base/steer/FairRun.cxx
@@ -156,4 +156,15 @@ void FairRun::SetOutputFileName(const TString& name) {
 }
 //_____________________________________________________________________________
 
+//_____________________________________________________________________________
+TFile* FairRun::GetOutputFile()
+{
+  LOG(WARNING) << "FairRun::GetOutputFile() deprecated. Use FairRootFileSink.";
+  auto sink = GetSink();
+  assert(sink->GetSinkType() == kFILESINK);
+  auto rootFileSink = static_cast<FairRootFileSink*>(sink);
+  return rootFileSink->GetRootFile();
+}
+//_____________________________________________________________________________
+
 ClassImp(FairRun)

--- a/base/steer/FairRun.cxx
+++ b/base/steer/FairRun.cxx
@@ -159,7 +159,7 @@ void FairRun::SetOutputFileName(const TString& name) {
 //_____________________________________________________________________________
 TFile* FairRun::GetOutputFile()
 {
-  LOG(WARNING) << "FairRun::GetOutputFile() deprecated. Use FairRootFileSink.";
+  LOG(WARNING) << "FairRun::GetOutputFile() deprecated. Use separate file to store additional data.";
   auto sink = GetSink();
   assert(sink->GetSinkType() == kFILESINK);
   auto rootFileSink = static_cast<FairRootFileSink*>(sink);

--- a/base/steer/FairRun.h
+++ b/base/steer/FairRun.h
@@ -166,6 +166,7 @@ class FairRun : public TNamed
      * Set the  output file name without creating the file
      */
     void SetOutputFileName(const TString& name);
+    TFile* GetOutputFile();
     // ^^^^^^^^^^ depracted functions, replaced by FairSink ^^^^^^^^^^
 
   private:


### PR DESCRIPTION
@karabowi According to #771 the removed `FairRun::GetOutputFile()` member function is used in PandaRoot. Should we put it back as deprecated like the setters?