### PR TITLE
Reintroduce removed interface as deprecated

### DIFF
--- a/base/steer/FairRootManager.cxx
+++ b/base/steer/FairRootManager.cxx
@@ -1093,4 +1093,15 @@ void FairRootManager::UpdateSinkFileName()
 }
 //_____________________________________________________________________________
 
+//_____________________________________________________________________________
+TFile* FairRootManager::GetOutFile()
+{
+  LOG(WARNING) << "FairRootManager::GetOutFile() deprecated. Use separate file to store additional data.";
+  auto sink = GetSink();
+  assert(sink->GetSinkType() == kFILESINK);
+  auto rootFileSink = static_cast<FairRootFileSink*>(sink);
+  return rootFileSink->GetRootFile();
+}
+//_____________________________________________________________________________
+
 ClassImp(FairRootManager)

--- a/base/steer/FairRootManager.h
+++ b/base/steer/FairRootManager.h
@@ -251,6 +251,10 @@ class FairRootManager : public TObject
     Int_t  GetInstanceId() const { return fId; }
     void   UpdateSinkFileName();
 
+    // vvvvvvvvvv depracted functions, replaced by FairSink vvvvvvvvvv
+    /** Return a pointer to the output File of type TFile */
+    TFile* GetOutFile();
+    // ^^^^^^^^^^ depracted functions, replaced by FairSink ^^^^^^^^^^
   private:
 
     // helper struct since std::pair has problems with type_info


### PR DESCRIPTION
Hope, this helps @TobiasStockmanns' transition to the new `FairSink` interfaces (#773).