### PR TITLE
Add missing include paths

### DIFF
--- a/examples/MQ/9-PixelDetector/src/CMakeLists.txt
+++ b/examples/MQ/9-PixelDetector/src/CMakeLists.txt
@@ -16,6 +16,7 @@ set(INCLUDE_DIRECTORIES
   ${CMAKE_SOURCE_DIR}/examples/MQ/9-PixelDetector/src
   ${CMAKE_SOURCE_DIR}/examples/MQ/9-PixelDetector/src/devices
   ${CMAKE_SOURCE_DIR}/examples/common/mcstack
+  ${FairLogger_INCDIR}
 )
 
 

--- a/examples/advanced/Tutorial3/CMakeLists.txt
+++ b/examples/advanced/Tutorial3/CMakeLists.txt
@@ -30,6 +30,7 @@ Set(INCLUDE_DIRECTORIES
   ${CMAKE_SOURCE_DIR}/examples/advanced/Tutorial3/MQ/run
   ${CMAKE_SOURCE_DIR}/examples/advanced/Tutorial3/MQ/data
   ${CMAKE_CURRENT_BINARY_DIR}
+  ${FairLogger_INCDIR}
 )
 
 Set(SYSTEM_INCLUDE_DIRECTORIES

--- a/examples/common/passive/CMakeLists.txt
+++ b/examples/common/passive/CMakeLists.txt
@@ -12,6 +12,7 @@
 Set(INCLUDE_DIRECTORIES
   ${BASE_INCLUDE_DIRECTORIES}
   ${CMAKE_SOURCE_DIR}/examples/common/passive
+  ${FairLogger_INCDIR}
 )
 
 Include_Directories( ${INCLUDE_DIRECTORIES})

--- a/examples/simulation/Tutorial1/src/CMakeLists.txt
+++ b/examples/simulation/Tutorial1/src/CMakeLists.txt
@@ -13,6 +13,7 @@ Set(INCLUDE_DIRECTORIES
   ${BASE_INCLUDE_DIRECTORIES}
   ${CMAKE_SOURCE_DIR}/examples/simulation/Tutorial1/src
   ${CMAKE_SOURCE_DIR}/examples/common/mcstack
+  ${FairLogger_INCDIR}
 )
 
 Include_Directories(${INCLUDE_DIRECTORIES})

--- a/examples/simulation/Tutorial2/src/CMakeLists.txt
+++ b/examples/simulation/Tutorial2/src/CMakeLists.txt
@@ -13,6 +13,7 @@ Set(INCLUDE_DIRECTORIES
   ${BASE_INCLUDE_DIRECTORIES}
   ${CMAKE_SOURCE_DIR}/examples/simulation/Tutorial2/src
   ${CMAKE_SOURCE_DIR}/examples/common/mcstack
+  ${FairLogger_INCDIR}
 )
 
 Include_Directories(${INCLUDE_DIRECTORIES})

--- a/examples/simulation/Tutorial4/src/CMakeLists.txt
+++ b/examples/simulation/Tutorial4/src/CMakeLists.txt
@@ -19,6 +19,7 @@ Set(INCLUDE_DIRECTORIES
   ${CMAKE_SOURCE_DIR}/examples/simulation/Tutorial4/src/reco
   ${CMAKE_SOURCE_DIR}/examples/simulation/Tutorial4/src/tools
   ${CMAKE_SOURCE_DIR}/examples/common/mcstack
+  ${FairLogger_INCDIR}
 )
 
 Include_Directories(${INCLUDE_DIRECTORIES})

--- a/examples/simulation/rutherford/src/CMakeLists.txt
+++ b/examples/simulation/rutherford/src/CMakeLists.txt
@@ -13,6 +13,7 @@ Set(INCLUDE_DIRECTORIES
   ${BASE_INCLUDE_DIRECTORIES}
   ${CMAKE_SOURCE_DIR}/examples/simulation/rutherford/src
   ${CMAKE_SOURCE_DIR}/examples/common/mcstack
+  ${FairLogger_INCDIR}
 )
 
 Include_Directories(${INCLUDE_DIRECTORIES})


### PR DESCRIPTION
This is not relevant for FairSoft, but for aliBuild, where we do not
have a shared installation prefix.