### PR TITLE
Make writting an event to the output optional in FairRunSim.

### DIFF
--- a/base/sim/FairMCApplication.cxx
+++ b/base/sim/FairMCApplication.cxx
@@ -114,6 +114,7 @@ FairMCApplication::FairMCApplication(const char* name, const char* title,
    listDetectors(),
    fMC(NULL),
    fRun(NULL),
+   fSaveCurrentEvent(kTRUE),
    fRunInfo(),
    fGeometryIsInitialized(kFALSE)
 {
@@ -203,6 +204,7 @@ FairMCApplication::FairMCApplication(const FairMCApplication& rhs)
    listDetectors(),
    fMC(NULL),
    fRun(NULL),
+   fSaveCurrentEvent(kTRUE),
    fRunInfo(),
    fGeometryIsInitialized(kFALSE)
 {
@@ -293,6 +295,7 @@ FairMCApplication::FairMCApplication()
    listActiveDetectors(),
    listDetectors(),
    fMC(NULL),
+   fSaveCurrentEvent(kTRUE),
    fRunInfo(),
    fGeometryIsInitialized(kFALSE)
 {
@@ -828,8 +831,12 @@ void FairMCApplication::FinishEvent()
   }
     
     
-  if (fRootManager) fRootManager->Fill();
-  
+  if (fRootManager && fSaveCurrentEvent) {
+    fRootManager->Fill();
+  } else {
+    fSaveCurrentEvent = kTRUE;
+  }
+
   for( std::list<FairDetector *>::iterator  listIter = listActiveDetectors.begin();
         listIter != listActiveDetectors.end();
         listIter++)

--- a/base/sim/FairMCApplication.h
+++ b/base/sim/FairMCApplication.h
@@ -185,6 +185,13 @@ class FairMCApplication : public TVirtualMCApplication
 
     void AddMeshList ( TObjArray* meshList );
 
+    /**
+    * Set if the current event should be written to the output file.
+    * The default value which is set back after each event is to store
+    * the event.
+    */
+    void                  SetSaveCurrentEvent(Bool_t set) {fSaveCurrentEvent=set;}
+
   private:
     // methods
     Int_t GetIonPdg(Int_t z, Int_t a) const;
@@ -270,6 +277,9 @@ class FairMCApplication : public TVirtualMCApplication
     TVirtualMC*  fMC;
     /** Pointer to FairRunSim //! */
     FairRunSim*  fRun;
+
+    /** Flag if the current event should be saved */
+    Bool_t fSaveCurrentEvent;
     
     ClassDef(FairMCApplication,4)  //Interface to MonteCarlo application
 


### PR DESCRIPTION
Allow to switch off the writing of an event to the output file in case
of a simulation run. A task running after the simulation in FairRunSim
events loop can set the flag to false which skips writting the whole
event to the output file.
Backport commit 5ccd89b17cfbd9e806eda5913874d3797884454f from dev branch.