### PR TITLE
FairRootFileSink: Stability fix to retrieve dictionary

### DIFF
--- a/base/sink/FairRootFileSink.cxx
+++ b/base/sink/FairRootFileSink.cxx
@@ -335,7 +335,7 @@ bool FairRootFileSink::CreatePersistentBranchesAny()
 
       // for the branch creation we need a TClass describing the object
       // get it from ROOT via the type name
-      auto cl = TClass::GetClass(tname.c_str());
+      auto cl = TClass::GetClass(tinfo);
       if(!cl) {
         LOG(FATAL) << "No TClass found for " << tname << "\n";
         return false;


### PR DESCRIPTION
It appears more robust to retrieve a dictionary using a typeid
rather than a demangled string describing the type.
This is solving an issue (https://github.com/AliceO2Group/AliceO2/issues/1186) where dictionaries where not found for types having a very long name.
