### PR TITLE
RegisterAny has no folder support, reverting back to Register

### DIFF
--- a/base/steer/FairTrajFilter.cxx
+++ b/base/steer/FairTrajFilter.cxx
@@ -94,7 +94,7 @@ FairTrajFilter::~FairTrajFilter()
 void FairTrajFilter::Init(TString brName, TString folderName)
 {
 
-  FairRootManager::Instance()->RegisterAny(brName, fTrackCollection, kTRUE);
+  FairRootManager::Instance()->Register(brName.Data(), folderName.Data(), fTrackCollection, kTRUE);
 }
 
 void FairTrajFilter::Reset()


### PR DESCRIPTION
Fixes #799.

@ihrivnac This commit is reverting part of your commit 243b43e45cf7ea6709fb38ee056b1567bc7d043b. Is the `Register` -> `RegisterAny` change related to the MT functionality of `FairTrajFilter`? Would you be fine with this change?