### PR TITLE
Fix typos and formatting issues in readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ FairRoot  is distributed under the terms of the GNU Lesser General Public Licenc
 ## Release information
 Please see : https://github.com/FairRootGroup/FairRoot/releases
 
-##Getting started
+## Getting started
 Please see : http://fairroot.gsi.de/getting_started  for  details.
 
 
@@ -83,7 +83,7 @@ echo 'treename=name_you_chose' > config/rootmanager.dat
 
 3. Install the template:
 
-   you need to copy the  [project template] (https://github.com/FairRootGroup/FairRoot/tree/dev/templates/project_template) to you own directory  
+   you need to copy the  [project template](https://github.com/FairRootGroup/FairRoot/tree/dev/templates/project_template) to you own directory  
 
     ```bash
     # Set the shell variable FAIRROOTPATH to the FairRoot installation directory
@@ -164,7 +164,7 @@ also in AlFa_DIR
 - requires new versions of VMC packages built with CMake
 and installed either in AlFa_DIR or available on path
 
- ```bash
+```bash
   cmake \
   -DCMAKE_INSTALL_PREFIX="Installation_directory_for_fairroot" \
   -DFAIRROOT_MODULAR_BUILD=ON \

--- a/examples/common/README.md
+++ b/examples/common/README.md
@@ -1,22 +1,23 @@
 # common
 
-This directory contains common stuff needed by different examples for sinulation and reconstruction.
+This directory contains common stuff needed by different examples for simulation and reconstruction.
 
 ## gconfig
 
-set of macros needed to steer the simulation e.g: cuts, physics lists, external deceys, etc.
+Set of macros needed to steer the simulation e.g: cuts, physics lists, external decays, etc.
 
-## mcstack
-example implimentation of a particle stack for simulation
+## mcstack 
+
+Example implementation of a particle stack for simulation
 
 ## passive
 
-set of passive components (cave, pipe, magnet) that are used by more than tutorial for simulation
+Set of passive components (cave, pipe, magnet) that are used by more than tutorial for simulation
 
 ## geometry
 
-set gemetry description files in ASCII and ROOT formate used by different tutorials
+Set geometry description files in ASCII and ROOT formats used by different tutorials
 
 ## input
 
-example of event generator input files that are used in simulation
+Example of event generator input files that are used in simulation

--- a/examples/simulation/README.md
+++ b/examples/simulation/README.md
@@ -6,7 +6,7 @@ Implement a simple detector using the old ASCII interface to describe the geomet
 
 ## Tutorial2
 
-Reading and writing paramters
+Reading and writing parameters
 
 ## Tutorial4
 
@@ -15,5 +15,5 @@ ROOT geometry as input for detector description
 
 ## rutherford
 
-simple simulation of the Rutherford experiment, with event display.
+Simple simulation of the Rutherford experiment, with event display.
 


### PR DESCRIPTION
This commit fixes some simple typos and markdown formatting issues in the README and the example READMEs.

Sorry for the noise.

---

Checklist:

* [ ] Rebased against `dev` branch
* [ ] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [ ] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
