### PR TITLE
Fix serialization ex

### DIFF
--- a/examples/MQ/serialization/data_generator/runGenerateData.cxx
+++ b/examples/MQ/serialization/data_generator/runGenerateData.cxx
@@ -15,6 +15,7 @@
 
 #include <iostream>
 #include <csignal>
+#include <memory>
 #include <vector>
 
 #include "boost/program_options.hpp"
@@ -115,13 +116,14 @@ int main(int argc, char** argv)
         // loop over t (= bunch index), generate data from pdf, fill digi and save to file
         for (unsigned int t = 0; t < tmax; t++)
         {
-            unsigned int nDigi = static_cast<unsigned int>(gaussN.generate(n, 1)->get(0)->getRealValue("N"));
+            unique_ptr<RooDataSet> gaussSample(gaussN.generate(n, 1));
+            unsigned int nDigi = static_cast<unsigned int>(gaussSample->get(0)->getRealValue("N"));
             LOG(info) << "Bunch number " << t + 1 << "/" << tmax
                       << " (" << 100. * static_cast<double>(t + 1) / static_cast<double>(tmax) << " %). Number of generated digis: "
                       << nDigi << ", payload = " << nDigi * (3 * sizeof(Int_t) + 2 * sizeof(Double_t)) << " bytes";
 
-            RooDataSet* simdataset = model.GetGeneratedData(nDigi, t);
-            SaveDataToFile<TDigi, RootFileManager>(rootman, simdataset);
+            unique_ptr<RooDataSet> simdataset(model.GetGeneratedData(nDigi, t));
+            SaveDataToFile<TDigi, RootFileManager>(rootman, simdataset.get());
         }
 
         LOG(info) << "Data generation successful";


### PR DESCRIPTION
During the investigation why some tests are failing as shown in #819 I found two memory leaks which have led to a (occasional for GCC older than 8) segfault in the global ROOT end of program cleanup. I have not understood how the segfault and the memory leaks were related exactly, though.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
