### PR TITLE
Do not run pixel_static test in parallel

### DIFF
--- a/examples/MQ/pixelDetector/run/CMakeLists.txt
+++ b/examples/MQ/pixelDetector/run/CMakeLists.txt
@@ -21,6 +21,7 @@ Add_Test(pixel_static
 	${CMAKE_CURRENT_BINARY_DIR}/startFairMQPixel.sh --work-dir ${CMAKE_BINARY_DIR} -p 3 --command static --force-kill true)
 Set_Tests_Properties(pixel_static PROPERTIES DEPENDS pixel_dbin_TGeant3)
 Set_Tests_Properties(pixel_static PROPERTIES TIMEOUT ${MaxTestTime})
+Set_Tests_Properties(pixel_static PROPERTIES RUN_SERIAL ON)
 Set_Tests_Properties(pixel_static PROPERTIES PASS_REGULAR_EXPRESSION "Shell script finished successfully")
 
 set(INCLUDE_DIRECTORIES


### PR DESCRIPTION
This can be reversed once we made sure, the test can run in parallel
with others.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
