### PR TITLE
Example of histogram server, implemented in a device

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -26,6 +26,7 @@ EndIf()
 
 If(FairMQ_FOUND)
   add_subdirectory(MQ/Lmd)
+  add_subdirectory(MQ/histogramServer)
 EndIf()
 
 If(Go_FOUND AND ZeroMQ_FOUND)

--- a/examples/MQ/histogramServer/CMakeLists.txt
+++ b/examples/MQ/histogramServer/CMakeLists.txt
@@ -1,0 +1,78 @@
+ ################################################################################
+ #    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    #
+ #                                                                              #
+ #              This software is distributed under the terms of the             #
+ #              GNU Lesser General Public Licence (LGPL) version 3,             #
+ #                  copied verbatim in the file "LICENSE"                       #
+ ################################################################################
+
+Set(INCLUDE_DIRECTORIES
+  ${BASE_INCLUDE_DIRECTORIES}
+  ${FairMQ_INCDIR}
+  ${FairMQ_INCDIR}/fairmq
+  ${CMAKE_SOURCE_DIR}/examples/MQ/histogramServer
+  ${CMAKE_SOURCE_DIR}/base/MQ/policies/Serialization
+  ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+Include_Directories(${INCLUDE_DIRECTORIES})
+Include_Directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
+
+Set(LINK_DIRECTORIES
+  ${Boost_LIBRARY_DIRS}
+  ${ROOT_LIBRARY_DIR}
+)
+
+Link_Directories(${LINK_DIRECTORIES})
+
+set(SRCS
+)
+
+Set(NO_DICT_SRCS
+  "FairMQExHistoDevice.cxx"
+  "FairMQExHistoServer.cxx"
+  "FairMQExHistoCanvasDrawer.cxx"
+  "FairMQExHistoCanvasDrawerExample.cxx"
+)
+
+set(DEPENDENCIES
+  ${DEPENDENCIES}
+  FairMQ::FairMQ
+  Base
+)
+
+set(LINKDEF "FairMQExHistoLinkDef.h")
+
+set(LIBRARY_NAME FairMQExHistogramServer)
+
+GENERATE_LIBRARY()
+
+set(Exe_Names
+  ex-histo-device
+  ex-histo-server
+)
+
+set(Exe_Source
+  runExHistoDevice.cxx
+  runExHistoCanvasDrawer.cxx
+)
+
+list(LENGTH Exe_Names _length)
+math(EXPR _length ${_length}-1)
+
+set(BIN_DESTINATION share/fairbase/examples/MQ/histogramServer/bin)
+set(EXECUTABLE_OUTPUT_PATH "${EXECUTABLE_OUTPUT_PATH}/examples/MQ/histogramServer")
+
+ForEach(_file RANGE 0 ${_length})
+  list(GET Exe_Names ${_file} _name)
+  list(GET Exe_Source ${_file} _src)
+  set(EXE_NAME ${_name})
+  set(SRCS ${_src})
+  set(DEPENDENCIES FairMQExHistogramServer)
+  GENERATE_EXECUTABLE()
+EndForEach(_file RANGE 0 ${_length})
+
+set(EX_BIN_DIR ${EXECUTABLE_OUTPUT_PATH})
+set(MAIN_BINARY_DIR ${CMAKE_BINARY_DIR})
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/fairmq-start-ex-histo.sh.in ${EXECUTABLE_OUTPUT_PATH}/fairmq-start-ex-histo.sh)
+

--- a/examples/MQ/histogramServer/FairMQExHistoCanvasDrawer.cxx
+++ b/examples/MQ/histogramServer/FairMQExHistoCanvasDrawer.cxx
@@ -1,0 +1,8 @@
+/********************************************************************************
+ *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+#include "FairMQExHistoCanvasDrawer.h"

--- a/examples/MQ/histogramServer/FairMQExHistoCanvasDrawer.h
+++ b/examples/MQ/histogramServer/FairMQExHistoCanvasDrawer.h
@@ -1,0 +1,29 @@
+/********************************************************************************
+ *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+#ifndef FAIRMQEXHISTOCANVASDRAWER
+#define FAIRMQEXHISTOCANVASDRAWER
+
+class THttpServer;
+class TObjArray;
+
+class FairMQExHistoCanvasDrawer
+{
+  public:
+    FairMQExHistoCanvasDrawer() {}
+    virtual ~FairMQExHistoCanvasDrawer() {}
+
+    virtual void CreateCanvases(THttpServer&) = 0;
+
+    virtual void DrawHistograms(TObjArray&) = 0;
+
+  private:
+    FairMQExHistoCanvasDrawer(const FairMQExHistoCanvasDrawer&);
+    FairMQExHistoCanvasDrawer& operator=(const FairMQExHistoCanvasDrawer&);
+};
+
+#endif

--- a/examples/MQ/histogramServer/FairMQExHistoCanvasDrawerExample.cxx
+++ b/examples/MQ/histogramServer/FairMQExHistoCanvasDrawerExample.cxx
@@ -1,0 +1,76 @@
+/********************************************************************************
+ *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+#include "FairMQExHistoCanvasDrawerExample.h"
+
+#include "TCanvas.h"
+#include "THttpServer.h"
+#include "TObjArray.h"
+#include "TH1.h"
+
+#include <cassert>
+
+FairMQExHistoCanvasDrawerExample::FairMQExHistoCanvasDrawerExample()
+    : fCanvas(nullptr)
+{
+}
+
+FairMQExHistoCanvasDrawerExample::~FairMQExHistoCanvasDrawerExample() {}
+
+void FairMQExHistoCanvasDrawerExample::CreateCanvases(THttpServer& server)
+{
+    assert(! fCanvas);
+    fCanvas = std::unique_ptr<TCanvas, std::function<void(TCanvas*)>>
+    (
+        new TCanvas("c1", "", 10, 10, 1000, 1000),
+        [&](TCanvas* p){server.Unregister(p);delete p;}
+     );
+    fCanvas->Divide(2, 2);
+    server.Register("Canvases", fCanvas.get());
+}
+
+void FairMQExHistoCanvasDrawerExample::DrawHistograms(TObjArray& arrayHisto)
+{
+    for (int i = 0; i < arrayHisto.GetEntriesFast(); i++)
+    {
+        TObject* obj = arrayHisto.At(i);
+        TH1* histogram = static_cast<TH1*>(obj);
+
+        if (TString(histogram->GetName()).EqualTo("histo1"))
+        {
+            fCanvas->cd(1);
+            histogram->Draw();
+            fCanvas->cd(0);
+            fCanvas->Modified();
+            fCanvas->Update();
+        }
+        else if (TString(histogram->GetName()).EqualTo("histo2"))
+        {
+            fCanvas->cd(2);
+            histogram->Draw();
+            fCanvas->cd(0);
+            fCanvas->Modified();
+            fCanvas->Update();
+        }
+        else if (TString(histogram->GetName()).EqualTo("histo3"))
+        {
+            fCanvas->cd(3);
+            histogram->Draw("COL");
+            fCanvas->cd(0);
+            fCanvas->Modified();
+            fCanvas->Update();
+        }
+        else if (TString(histogram->GetName()).EqualTo("histo4"))
+        {
+            fCanvas->cd(4);
+            histogram->Draw("COL");
+            fCanvas->cd(0);
+            fCanvas->Modified();
+            fCanvas->Update();
+        }
+    }
+}

--- a/examples/MQ/histogramServer/FairMQExHistoCanvasDrawerExample.h
+++ b/examples/MQ/histogramServer/FairMQExHistoCanvasDrawerExample.h
@@ -1,0 +1,35 @@
+/********************************************************************************
+ *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+#ifndef FAIRMQEXHISTOCANVASDRAWEREXAMPLE
+#define FAIRMQEXHISTOCANVASDRAWEREXAMPLE
+
+#include "FairMQExHistoCanvasDrawer.h"
+
+class TCanvas;
+
+#include <memory>
+#include <functional>
+
+class FairMQExHistoCanvasDrawerExample : public FairMQExHistoCanvasDrawer
+{
+  public:
+    FairMQExHistoCanvasDrawerExample();
+    virtual ~FairMQExHistoCanvasDrawerExample();
+
+    void CreateCanvases(THttpServer&);
+
+    void DrawHistograms(TObjArray&);
+
+  private:
+    FairMQExHistoCanvasDrawerExample(const FairMQExHistoCanvasDrawerExample&);
+    FairMQExHistoCanvasDrawerExample& operator=(const FairMQExHistoCanvasDrawerExample&);
+
+    std::unique_ptr<TCanvas, std::function<void(TCanvas*)>> fCanvas;
+};
+
+#endif

--- a/examples/MQ/histogramServer/FairMQExHistoDevice.cxx
+++ b/examples/MQ/histogramServer/FairMQExHistoDevice.cxx
@@ -1,0 +1,76 @@
+/********************************************************************************
+ *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+#include <chrono>
+#include <thread>
+
+#include "FairMQExHistoDevice.h"
+#include "RootSerializer.h"
+
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TRandom3.h"
+#include "TObjArray.h"
+#include "TMessage.h"
+#include "TMath.h"
+
+FairMQExHistoDevice::FairMQExHistoDevice()
+    : FairMQDevice()
+    , fRandom(0)
+    , fArrayHisto()
+{
+}
+
+FairMQExHistoDevice::~FairMQExHistoDevice() {}
+
+void FairMQExHistoDevice::InitTask()
+{
+    fh_histo1 = TH1F("histo1", "", 200, -0.5, 1.5);
+    fh_histo2 = TH1F("histo2", "", 1000, -5., 5.);
+    fh_histo3 = TH2F("histo3", "", 40, -2., 2., 40, -2., 2.);
+    fh_histo4 = TH2F("histo4", "", 40, -2., 2., 40, -2., 2.);
+
+    fArrayHisto.Add(&fh_histo1);
+    fArrayHisto.Add(&fh_histo2);
+    fArrayHisto.Add(&fh_histo3);
+    fArrayHisto.Add(&fh_histo4);
+}
+
+void FairMQExHistoDevice::PreRun() {}
+
+void FairMQExHistoDevice::PostRun() {}
+
+bool FairMQExHistoDevice::ConditionalRun()
+{
+    fh_histo1.Fill(fRandom.Uniform(0., 1.));
+    fh_histo2.Fill(fRandom.Gaus(0., 1.));
+    double x = fRandom.Uniform(0., 1.);
+    double y = fRandom.Uniform(x, 1.);
+    fh_histo3.Fill(x, y);
+    double r = fRandom.Uniform(0., 1.);
+    double phi = TMath::DegToRad() * fRandom.Uniform(0., 360.);
+    x = r * TMath::Cos(phi);
+    y = r * TMath::Sin(phi);
+    fh_histo4.Fill(x, y);
+
+    FairMQMessagePtr message(NewMessage());
+    Serialize<RootSerializer>(*message, &fArrayHisto);
+
+    for (auto& channel : fChannels)
+    {
+        Send(message, channel.first.data());
+    }
+
+    fh_histo1.Reset();
+    fh_histo2.Reset();
+    fh_histo3.Reset();
+    fh_histo4.Reset();
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    return true;
+}

--- a/examples/MQ/histogramServer/FairMQExHistoDevice.h
+++ b/examples/MQ/histogramServer/FairMQExHistoDevice.h
@@ -1,0 +1,43 @@
+/********************************************************************************
+ *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+#ifndef FAIRMQEXHISTODEVICE
+#define FAIRMQEXHISTODEVICE
+
+#include "FairMQDevice.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TRandom3.h"
+#include "TObjArray.h"
+
+class FairMQExHistoDevice : public FairMQDevice
+{
+  public:
+    FairMQExHistoDevice();
+    virtual ~FairMQExHistoDevice();
+
+  protected:
+    virtual void InitTask();
+    virtual void PreRun();
+    virtual void PostRun();
+    virtual bool ConditionalRun();
+
+  private:
+    FairMQExHistoDevice(const FairMQExHistoDevice&);
+    FairMQExHistoDevice& operator=(const FairMQExHistoDevice&);
+
+    TRandom3 fRandom;
+
+    TH1F fh_histo1;
+    TH1F fh_histo2;
+    TH2F fh_histo3;
+    TH2F fh_histo4;
+
+    TObjArray fArrayHisto;
+};
+
+#endif

--- a/examples/MQ/histogramServer/FairMQExHistoLinkDef.h
+++ b/examples/MQ/histogramServer/FairMQExHistoLinkDef.h
@@ -1,0 +1,14 @@
+/********************************************************************************
+ *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+#ifdef __CINT__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#endif

--- a/examples/MQ/histogramServer/FairMQExHistoServer.cxx
+++ b/examples/MQ/histogramServer/FairMQExHistoServer.cxx
@@ -1,0 +1,123 @@
+/********************************************************************************
+ *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+#include <mutex>
+
+#include "FairMQExHistoServer.h"
+#include "FairMQExHistoCanvasDrawer.h"
+#include "FairLogger.h"
+#include "RootSerializer.h"
+
+#include "TObjArray.h"
+#include "TH1.h"
+#include "TMessage.h"
+#include "THttpServer.h"
+
+std::mutex mtx;
+
+FairMQExHistoServer::FairMQExHistoServer()
+    : FairMQDevice()
+    , fInputChannelName("histogram-in")
+    , fArrayHisto()
+    , fNMessages(0)
+    , fServer("http:8080")
+    , fCanvasDrawer(nullptr)
+    , fStopThread(false)
+{
+}
+
+FairMQExHistoServer::~FairMQExHistoServer() {}
+
+void FairMQExHistoServer::InitTask()
+{
+    OnData(fInputChannelName, &FairMQExHistoServer::ReceiveData);
+
+    if (fCanvasDrawer)
+    {
+        fCanvasDrawer->CreateCanvases(fServer);
+    }
+}
+
+bool FairMQExHistoServer::ReceiveData(FairMQMessagePtr& msg, int index)
+{
+    TObject* tempObject = nullptr;
+    Deserialize<RootSerializer>(*msg, tempObject);
+
+    if (TString(tempObject->ClassName()).EqualTo("TObjArray"))
+    {
+        std::lock_guard<std::mutex> lk(mtx);
+        TObjArray* arrayHisto = static_cast<TObjArray*>(tempObject);
+        TH1* histogram_new;
+        TH1* histogram_existing;
+        for (Int_t i = 0; i < arrayHisto->GetEntriesFast(); i++)
+        {
+            TObject* obj = arrayHisto->At(i);
+            TH1* histogram = static_cast<TH1*>(obj);
+            int index1 = FindHistogram(histogram->GetName());
+            if (-1 == index1)
+            {
+                histogram_new = static_cast<TH1*>(histogram->Clone());
+                fArrayHisto.Add(histogram_new);
+                fServer.Register("Histograms", histogram_new);
+            }
+            else
+            {
+                histogram_existing = static_cast<TH1*>(fArrayHisto.At(index1));
+                histogram_existing->Add(histogram);
+            }
+        }
+
+        arrayHisto->Clear();
+    }
+
+    fNMessages += 1;
+
+    delete tempObject;
+
+    return true;
+}
+
+void FairMQExHistoServer::PreRun()
+{
+    fStopThread = false;
+    fThread = std::thread(&FairMQExHistoServer::UpdateHttpServer, this);
+}
+
+void FairMQExHistoServer::UpdateHttpServer()
+{
+    while (!fStopThread)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        std::lock_guard<std::mutex> lk(mtx);
+
+        if (fCanvasDrawer)
+        {
+            fCanvasDrawer->DrawHistograms(fArrayHisto);
+        }
+
+        fServer.ProcessRequests();
+    }
+}
+
+void FairMQExHistoServer::PostRun()
+{
+    fStopThread = true;
+    fThread.join();
+}
+
+int FairMQExHistoServer::FindHistogram(const std::string& name)
+{
+    for (int i = 0; i < fArrayHisto.GetEntriesFast(); i++)
+    {
+        TObject* obj = fArrayHisto.At(i);
+        if (TString(obj->GetName()).EqualTo(name))
+        {
+            return i;
+        }
+    }
+    return -1;
+}

--- a/examples/MQ/histogramServer/FairMQExHistoServer.h
+++ b/examples/MQ/histogramServer/FairMQExHistoServer.h
@@ -1,0 +1,65 @@
+/********************************************************************************
+ *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+#ifndef FAIRMQEXHISTOSERVER
+#define FAIRMQEXHISTOSERVER
+
+#include "FairMQDevice.h"
+
+#include "THttpServer.h"
+#include "TObjArray.h"
+
+#include <thread>
+#include <string>
+#include <memory>
+
+class FairMQExHistoCanvasDrawer;
+
+class FairMQExHistoServer : public FairMQDevice
+{
+  public:
+    FairMQExHistoServer();
+
+    virtual ~FairMQExHistoServer();
+
+    void UpdateHttpServer();
+
+    void SetCanvasDrawer(std::unique_ptr<FairMQExHistoCanvasDrawer> canvasDrawer)
+    {
+        fCanvasDrawer = std::move(canvasDrawer);
+    }
+
+  protected:
+    virtual void InitTask();
+
+    bool ReceiveData(FairMQMessagePtr& msg, int index);
+
+    virtual void PreRun();
+
+    virtual void PostRun();
+
+  private:
+    std::string fInputChannelName;
+
+    TObjArray fArrayHisto;
+
+    int fNMessages;
+
+    THttpServer fServer;
+
+    std::unique_ptr<FairMQExHistoCanvasDrawer> fCanvasDrawer;
+
+    std::thread fThread;
+    bool fStopThread;
+
+    int FindHistogram(const std::string& name);
+
+    FairMQExHistoServer(const FairMQExHistoServer&);
+    FairMQExHistoServer& operator=(const FairMQExHistoServer&);
+};
+
+#endif

--- a/examples/MQ/histogramServer/fairmq-start-ex-histo.sh.in
+++ b/examples/MQ/histogramServer/fairmq-start-ex-histo.sh.in
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+DEVICE="ex-histo-device"
+DEVICE+=" --id device1"
+DEVICE+=" --channel-config name=histogram-in,type=pub,method=connect,address=tcp://localhost:5555,rateLogging=0"
+xterm -geometry 80x23+0+0 -hold -e "source @MAIN_BINARY_DIR@/config.sh &&\
+@EX_BIN_DIR@/Debug/$DEVICE" &
+
+DEVICE="ex-histo-device"
+DEVICE+=" --id device2"
+DEVICE+=" --channel-config name=histogram-in,type=pub,method=connect,address=tcp://localhost:5555,rateLogging=0"
+xterm -geometry 80x23+0+0 -hold -e "source @MAIN_BINARY_DIR@/config.sh &&\
+@EX_BIN_DIR@/Debug/$DEVICE" &
+
+DEVICE="ex-histo-device"
+DEVICE+=" --id device3"
+DEVICE+=" --channel-config name=histogram-in,type=pub,method=connect,address=tcp://localhost:5555,rateLogging=0"
+xterm -geometry 80x23+0+0 -hold -e "source @MAIN_BINARY_DIR@/config.sh &&\
+@EX_BIN_DIR@/Debug/$DEVICE" &
+
+DEVICE="ex-histo-device"
+DEVICE+=" --id device4"
+DEVICE+=" --channel-config name=histogram-in,type=pub,method=connect,address=tcp://localhost:5555,rateLogging=0"
+xterm -geometry 80x23+0+0 -hold -e "source @MAIN_BINARY_DIR@/config.sh &&\
+@EX_BIN_DIR@/Debug/$DEVICE" &
+
+SERVER="ex-histo-server"
+SERVER+=" --id server1"
+SERVER+=" --channel-config name=histogram-in,type=sub,method=bind,address=tcp://localhost:5555,rateLogging=0"
+xterm -geometry 80x23+500+0 -hold -e "source @MAIN_BINARY_DIR@/config.sh &&\
+@EX_BIN_DIR@/Debug/$SERVER" &

--- a/examples/MQ/histogramServer/runExHistoCanvasDrawer.cxx
+++ b/examples/MQ/histogramServer/runExHistoCanvasDrawer.cxx
@@ -1,0 +1,15 @@
+/********************************************************************************
+ *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+#include "runExHistoServer.h"
+
+#include "FairMQExHistoCanvasDrawerExample.h"
+
+std::unique_ptr<FairMQExHistoCanvasDrawer> getCanvasDrawer()
+{
+    return std::unique_ptr<FairMQExHistoCanvasDrawer>{ new FairMQExHistoCanvasDrawerExample() };
+}

--- a/examples/MQ/histogramServer/runExHistoDevice.cxx
+++ b/examples/MQ/histogramServer/runExHistoDevice.cxx
@@ -1,0 +1,23 @@
+/********************************************************************************
+ *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+#include "runFairMQDevice.h"
+
+#include "FairMQExHistoDevice.h"
+
+namespace bpo = boost::program_options;
+
+void addCustomOptions(bpo::options_description& /*options*/)
+{
+}
+
+FairMQDevicePtr getDevice(const FairMQProgOptions& /*config*/)
+{
+    FairMQExHistoDevice* histoDevice = new FairMQExHistoDevice();
+
+    return histoDevice;
+}

--- a/examples/MQ/histogramServer/runExHistoServer.h
+++ b/examples/MQ/histogramServer/runExHistoServer.h
@@ -1,0 +1,30 @@
+/********************************************************************************
+ *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+#include <memory>
+
+#include "runFairMQDevice.h"
+
+#include "FairMQExHistoServer.h"
+
+namespace bpo = boost::program_options;
+
+void addCustomOptions(bpo::options_description& /*options*/)
+{
+}
+
+std::unique_ptr<FairMQExHistoCanvasDrawer> getCanvasDrawer();
+
+FairMQDevicePtr getDevice(const FairMQProgOptions& /*config*/)
+{
+    FairMQExHistoServer* histoServer = new FairMQExHistoServer();
+
+    histoServer->SetCanvasDrawer(getCanvasDrawer());
+
+    return histoServer;
+}
+


### PR DESCRIPTION
A device sending multiple histograms to the generic server. Server publishes the histograms using THttpServer. Implementation with the generic CanvasDrawer.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
