### PR TITLE
Use BoostSerializer in Tutorial3

### DIFF
--- a/base/MQ/devices/FairMQSampler.h
+++ b/base/MQ/devices/FairMQSampler.h
@@ -135,8 +135,7 @@ class FairMQSampler : public FairMQDevice
 
         fFairRunAna->Init();
         // fFairRunAna->Run(0, 0);
-        FairRootManager* ioman = FairRootManager::Instance();
-        fNumEvents = int((ioman->GetInChain())->GetEntries());
+        fNumEvents = int((FairRootManager::Instance()->GetInChain())->GetEntries());
 
         LOG(info) << "Task initialized.";
         LOG(info) << "Number of events to process: " << fNumEvents;

--- a/examples/MQ/serialization/2-multipart/Ex2Sink.h
+++ b/examples/MQ/serialization/2-multipart/Ex2Sink.h
@@ -10,8 +10,6 @@
 #include "SerializerExample2.h"
 #include "BoostSerializer.h"
 
-#include <boost/core/null_deleter.hpp>
-
 // root
 #include "TFile.h"
 #include "TTree.h"

--- a/examples/advanced/Tutorial3/MQ/fileSink/FairTestDetectorFileSinkBin.tpl
+++ b/examples/advanced/Tutorial3/MQ/fileSink/FairTestDetectorFileSinkBin.tpl
@@ -34,7 +34,7 @@ void FairTestDetectorFileSink<FairTestDetectorHit, TestDetectorPayload::Hit>::In
         FairMQMessagePtr ack(fTransportFactory->CreateMessage());
         fChannels.at(fAckChannelName).at(0).Send(ack);
 
-        fTree->Fill();
+        fTree.Fill();
 
         return true;
     });

--- a/examples/advanced/Tutorial3/MQ/fileSink/FairTestDetectorFileSinkFlatBuffers.tpl
+++ b/examples/advanced/Tutorial3/MQ/fileSink/FairTestDetectorFileSinkFlatBuffers.tpl
@@ -36,7 +36,7 @@ void FairTestDetectorFileSink<FairTestDetectorHit, TestDetectorFlat::HitPayload>
         FairMQMessagePtr ack(fTransportFactory->CreateMessage());
         fChannels.at(fAckChannelName).at(0).Send(ack);
 
-        fTree->Fill();
+        fTree.Fill();
 
         return true;
     });

--- a/examples/advanced/Tutorial3/MQ/fileSink/FairTestDetectorFileSinkMsgpack.tpl
+++ b/examples/advanced/Tutorial3/MQ/fileSink/FairTestDetectorFileSinkMsgpack.tpl
@@ -48,7 +48,7 @@ void FairTestDetectorFileSink<FairTestDetectorHit, MsgPack>::InitTask()
         FairMQMessagePtr ack(fTransportFactory->CreateMessage());
         fChannels.at(fAckChannelName).at(0).Send(ack);
 
-        fTree->Fill();
+        fTree.Fill();
 
         return true;
     });

--- a/examples/advanced/Tutorial3/MQ/fileSink/FairTestDetectorFileSinkProtobuf.tpl
+++ b/examples/advanced/Tutorial3/MQ/fileSink/FairTestDetectorFileSinkProtobuf.tpl
@@ -39,7 +39,7 @@ void FairTestDetectorFileSink<FairTestDetectorHit, TestDetectorProto::HitPayload
         FairMQMessagePtr ack(fTransportFactory->CreateMessage());
         fChannels.at(fAckChannelName).at(0).Send(ack);
 
-        fTree->Fill();
+        fTree.Fill();
 
         return true;
     });

--- a/examples/advanced/Tutorial3/MQ/fileSink/FairTestDetectorFileSinkTMessage.tpl
+++ b/examples/advanced/Tutorial3/MQ/fileSink/FairTestDetectorFileSinkTMessage.tpl
@@ -18,12 +18,12 @@ void FairTestDetectorFileSink<FairTestDetectorHit, TMessage>::InitTask()
 
         RootSerializer().Deserialize(*msg, fOutput);
 
-        fTree->SetBranchAddress("Output", &fOutput);
+        fTree.SetBranchAddress("Output", &fOutput);
 
         FairMQMessagePtr ack(fTransportFactory->CreateMessage());
         fChannels.at(fAckChannelName).at(0).Send(ack);
 
-        fTree->Fill();
+        fTree.Fill();
 
         return true;
     });

--- a/examples/advanced/Tutorial3/MQ/processorTask/FairTestDetectorMQRecoTask.h
+++ b/examples/advanced/Tutorial3/MQ/processorTask/FairTestDetectorMQRecoTask.h
@@ -12,13 +12,6 @@
 #include <sstream>
 #include <array>
 
-#include <boost/archive/text_iarchive.hpp>
-#include <boost/archive/text_oarchive.hpp>
-#include <boost/archive/binary_iarchive.hpp>
-#include <boost/archive/binary_oarchive.hpp>
-#include <boost/serialization/vector.hpp>
-#include <boost/serialization/binary_object.hpp>
-
 #include "TMath.h"
 #include "TClonesArray.h"
 
@@ -32,111 +25,46 @@
 #include "FairTestDetectorHit.h"
 #include "FairTestDetectorDigi.h"
 
-#include "BoostSerializer.h"
-
-template <typename TIn, typename TOut, typename TPayloadIn, typename TPayloadOut>
+template<typename TIn, typename TOut, typename TPayloadIn, typename TPayloadOut>
 class FairTestDetectorMQRecoTask : public FairMQProcessorTask
 {
   public:
     FairTestDetectorMQRecoTask()
-        : fRecoTask(nullptr)
-        , fDigiVector()
-        , fHitVector()
-    {
-        // coverity[pointless_expression]: suppress coverity warnings on apparant if(const).
-        if (std::is_same<TPayloadIn, boost::archive::binary_iarchive>::value || std::is_same<TPayloadIn, boost::archive::text_iarchive>::value)
-        {
-            if (fair::base::serialization::has_BoostSerialization<TIn, void(TPayloadIn&, const unsigned int)>::value == 0)
-            {
-                LOG(error) << "Method 'void serialize(TIn & ar, const unsigned int version)' was not found in input class";
-                LOG(error) << "Boost serialization for Input Payload requested, but the input type does not support it. Check the TIn parameter. Aborting.";
-                exit(EXIT_FAILURE);
-            }
-        }
-        // coverity[pointless_expression]: suppress coverity warnings on apparant if(const).
-        if (std::is_same<TPayloadOut, boost::archive::binary_oarchive>::value || std::is_same<TPayloadOut, boost::archive::text_oarchive>::value)
-        {
-            if (fair::base::serialization::has_BoostSerialization<TOut, void(TPayloadOut&, const unsigned int)>::value == 0)
-            {
-                LOG(error) << "Method 'void serialize(TOut & ar, const unsigned int version)' was not found in input class";
-                LOG(error) << "Boost serialization for Output Payload requested, but the output type does not support it. Check the TOut parameter. Aborting.";
-                exit(EXIT_FAILURE);
-            }
-        }
-    }
+        : fRecoTask()
+    {}
 
     FairTestDetectorMQRecoTask(Int_t /*verbose*/)
-        : fRecoTask(nullptr)
-        , fDigiVector()
-        , fHitVector()
-    {
-        // coverity[pointless_expression]: suppress coverity warnings on apparant if(const).
-        if (std::is_same<TPayloadIn, boost::archive::binary_iarchive>::value || std::is_same<TPayloadIn, boost::archive::text_iarchive>::value)
-        {
-            if (fair::base::serialization::has_BoostSerialization<TIn, void(TPayloadIn&, const unsigned int)>::value == 0)
-            {
-                LOG(error) << "Method 'void serialize(TIn & ar, const unsigned int version)' was not found in input class";
-                LOG(error) << "Boost serialization for Input Payload requested, but the input type does not support it. Check the TIn parameter. Aborting.";
-                exit(EXIT_FAILURE);
-            }
-        }
+        : fRecoTask()
+    {}
 
-        // coverity[pointless_expression]: suppress coverity warnings on apparant if(const).
-        if (std::is_same<TPayloadOut, boost::archive::binary_oarchive>::value || std::is_same<TPayloadOut, boost::archive::text_oarchive>::value)
-        {
-            if (fair::base::serialization::has_BoostSerialization<TOut, void(TPayloadOut&, const unsigned int)>::value == 0)
-            {
-                LOG(error) << "Method 'void serialize(TOut & ar, const unsigned int version)' was not found in input class";
-                LOG(error) << "Boost serialization for Output Payload requested, but the output type does not support it. Check the TOut parameter. Aborting.";
-                exit(EXIT_FAILURE);
-            }
-        }
-    }
     FairTestDetectorMQRecoTask(const FairTestDetectorMQRecoTask&) = delete;
     FairTestDetectorMQRecoTask operator=(const FairTestDetectorMQRecoTask&) = delete;
 
-    /** Destructor **/
     virtual ~FairTestDetectorMQRecoTask()
     {
-        if (fRecoTask->fDigiArray)
-        {
-            fRecoTask->fDigiArray->Delete();
-            delete fRecoTask->fDigiArray;
+        if (fRecoTask.fDigiArray) {
+            fRecoTask.fDigiArray->Delete();
+            delete fRecoTask.fDigiArray;
         }
-        if (fRecoTask->fHitArray)
-        {
-            fRecoTask->fHitArray->Delete();
-            delete fRecoTask->fHitArray;
-        }
-        delete fRecoTask;
-        if (fDigiVector.size() > 0)
-        {
-            fDigiVector.clear();
-        }
-        if (fHitVector.size() > 0)
-        {
-            fHitVector.clear();
+        if (fRecoTask.fHitArray) {
+            fRecoTask.fHitArray->Delete();
+            delete fRecoTask.fHitArray;
         }
     }
 
-    /** Virtual method Init **/
     virtual InitStatus Init()
     {
-        fRecoTask = new FairTestDetectorRecoTask();
-        fRecoTask->SetStreamProcessing(kTRUE);
-        fRecoTask->fDigiArray = new TClonesArray("FairTestDetectorDigi");
-        fRecoTask->fHitArray = new TClonesArray("FairTestDetectorHit");
+        fRecoTask.SetStreamProcessing(kTRUE);
+        fRecoTask.fDigiArray = new TClonesArray("FairTestDetectorDigi");
+        fRecoTask.fHitArray = new TClonesArray("FairTestDetectorHit");
 
         return kSUCCESS;
     }
 
-    /** Virtual method Exec **/
     virtual void Exec(Option_t* opt = "0");
 
   private:
-    FairTestDetectorRecoTask* fRecoTask;
-    std::vector<TIn> fDigiVector;
-    std::vector<TOut> fHitVector;
+    FairTestDetectorRecoTask fRecoTask;
 };
 
 // Template implementation of exec in FairTestDetectorMQRecoTask.tpl :

--- a/examples/advanced/Tutorial3/MQ/processorTask/FairTestDetectorMQRecoTaskBin.tpl
+++ b/examples/advanced/Tutorial3/MQ/processorTask/FairTestDetectorMQRecoTaskBin.tpl
@@ -14,20 +14,20 @@ void FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TestD
 
     TestDetectorPayload::Digi* input = static_cast<TestDetectorPayload::Digi*>(fPayload->GetData());
 
-    fRecoTask->fDigiArray->Clear();
+    fRecoTask.fDigiArray->Clear();
 
     for (int i = 0; i < numEntries; ++i)
     {
-        new ((*fRecoTask->fDigiArray)[i]) FairTestDetectorDigi(input[i].fX, input[i].fY, input[i].fZ, input[i].fTimeStamp);
-        static_cast<FairTestDetectorDigi*>(((*fRecoTask->fDigiArray)[i]))->SetTimeStampError(input[i].fTimeStampError);
+        new ((*fRecoTask.fDigiArray)[i]) FairTestDetectorDigi(input[i].fX, input[i].fY, input[i].fZ, input[i].fTimeStamp);
+        static_cast<FairTestDetectorDigi*>(((*fRecoTask.fDigiArray)[i]))->SetTimeStampError(input[i].fTimeStampError);
     }
 
-    if (!fRecoTask->fDigiArray)
+    if (!fRecoTask.fDigiArray)
     {
         LOG(error) << "FairTestDetectorMQRecoTask::Exec(): No Point array!";
     }
 
-    fRecoTask->Exec(opt);
+    fRecoTask.Exec(opt);
 
     size_t hitsSize = numEntries * sizeof(TestDetectorPayload::Hit);
 
@@ -39,7 +39,7 @@ void FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TestD
     {
         for (int i = 0; i < numEntries; ++i)
         {
-            FairTestDetectorHit* hit = static_cast<FairTestDetectorHit*>(fRecoTask->fHitArray->At(i));
+            FairTestDetectorHit* hit = static_cast<FairTestDetectorHit*>(fRecoTask.fHitArray->At(i));
 
             output[i].detID = hit->GetDetectorID();
             output[i].mcindex = hit->GetRefIndex();

--- a/examples/advanced/Tutorial3/MQ/processorTask/FairTestDetectorMQRecoTaskFlatBuffers.tpl
+++ b/examples/advanced/Tutorial3/MQ/processorTask/FairTestDetectorMQRecoTaskFlatBuffers.tpl
@@ -11,7 +11,7 @@ using namespace TestDetectorFlat;
 template <>
 void FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TestDetectorFlat::DigiPayload, TestDetectorFlat::HitPayload>::Exec(Option_t* opt)
 {
-    fRecoTask->fDigiArray->Clear();
+    fRecoTask.fDigiArray->Clear();
 
     auto digiPayload = GetDigiPayload(fPayload->GetData());
     auto digis = digiPayload->digis();
@@ -19,24 +19,24 @@ void FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TestD
 
     for (auto it = digis->begin(); it != digis->end(); ++it)
     {
-        new ((*fRecoTask->fDigiArray)[it - digis->begin()]) FairTestDetectorDigi((*it)->x(), (*it)->y(), (*it)->z(), (*it)->timestamp());
-        static_cast<FairTestDetectorDigi*>(((*fRecoTask->fDigiArray)[it - digis->begin()]))->SetTimeStampError((*it)->timestampError());
+        new ((*fRecoTask.fDigiArray)[it - digis->begin()]) FairTestDetectorDigi((*it)->x(), (*it)->y(), (*it)->z(), (*it)->timestamp());
+        static_cast<FairTestDetectorDigi*>(((*fRecoTask.fDigiArray)[it - digis->begin()]))->SetTimeStampError((*it)->timestampError());
         // LOG(info) << (*it)->x() << " " << (*it)->y() << " " << (*it)->z() << " " << (*it)->timestamp() << " " << (*it)->timestampError();
     }
 
-    if (!fRecoTask->fDigiArray)
+    if (!fRecoTask.fDigiArray)
     {
         LOG(error) << "FairTestDetectorMQRecoTask::Exec(): No Point array!";
     }
 
-    fRecoTask->Exec(opt);
+    fRecoTask.Exec(opt);
 
     flatbuffers::FlatBufferBuilder* builder = new flatbuffers::FlatBufferBuilder();
     flatbuffers::Offset<TestDetectorFlat::Hit>* hits = new flatbuffers::Offset<TestDetectorFlat::Hit>[numEntries];
 
     for (int i = 0; i < numEntries; ++i)
     {
-        FairTestDetectorHit* hit = (FairTestDetectorHit*)fRecoTask->fHitArray->At(i);
+        FairTestDetectorHit* hit = (FairTestDetectorHit*)fRecoTask.fHitArray->At(i);
         if (!hit)
         {
             continue;

--- a/examples/advanced/Tutorial3/MQ/processorTask/FairTestDetectorMQRecoTaskMsgpack.tpl
+++ b/examples/advanced/Tutorial3/MQ/processorTask/FairTestDetectorMQRecoTaskMsgpack.tpl
@@ -34,22 +34,22 @@ void FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, MsgPa
 
     int numEntries = digis.size();
 
-    fRecoTask->fDigiArray->Clear();
+    fRecoTask.fDigiArray->Clear();
 
     for (int i = 0; i < numEntries; ++i)
     {
-        new ((*fRecoTask->fDigiArray)[i]) FairTestDetectorDigi(std::get<0>(digis.at(i)), std::get<1>(digis.at(i)), std::get<2>(digis.at(i)), std::get<3>(digis.at(i)));
-        static_cast<FairTestDetectorDigi*>(((*fRecoTask->fDigiArray)[i]))->SetTimeStampError(std::get<4>(digis.at(i)));
+        new ((*fRecoTask.fDigiArray)[i]) FairTestDetectorDigi(std::get<0>(digis.at(i)), std::get<1>(digis.at(i)), std::get<2>(digis.at(i)), std::get<3>(digis.at(i)));
+        static_cast<FairTestDetectorDigi*>(((*fRecoTask.fDigiArray)[i]))->SetTimeStampError(std::get<4>(digis.at(i)));
     }
 
-    if (!fRecoTask->fDigiArray)
+    if (!fRecoTask.fDigiArray)
     {
         LOG(error) << "FairTestDetectorMQRecoTask::Exec(): No Point array!";
     }
 
     // execute task on the deserialized data (digis)
 
-    fRecoTask->Exec(opt);
+    fRecoTask.Exec(opt);
 
     // serialize the task results (hits)
 
@@ -60,7 +60,7 @@ void FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, MsgPa
 
     for (int i = 0; i < numEntries; ++i)
     {
-        FairTestDetectorHit* hit = static_cast<FairTestDetectorHit*>(fRecoTask->fHitArray->At(i));
+        FairTestDetectorHit* hit = static_cast<FairTestDetectorHit*>(fRecoTask.fHitArray->At(i));
         hits.push_back(std::make_tuple(hit->GetDetectorID(), hit->GetRefIndex(), hit->GetX(), hit->GetY(), hit->GetZ(), hit->GetDx(), hit->GetDy(), hit->GetDz()));
     }
 
@@ -90,25 +90,25 @@ void FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, MsgPa
 
 //     int numEntries = digis.size();
 
-//     fRecoTask->fDigiArray->Clear();
+//     fRecoTask.fDigiArray->Clear();
 
 //     for (int i = 0; i < numEntries; ++i)
 //     {
-//         new ((*fRecoTask->fDigiArray)[i]) FairTestDetectorDigi(std::get<0>(digis.at(i)), std::get<1>(digis.at(i)), std::get<2>(digis.at(i)), std::get<3>(digis.at(i)));
+//         new ((*fRecoTask.fDigiArray)[i]) FairTestDetectorDigi(std::get<0>(digis.at(i)), std::get<1>(digis.at(i)), std::get<2>(digis.at(i)), std::get<3>(digis.at(i)));
 //     }
 
-//     if (!fRecoTask->fDigiArray)
+//     if (!fRecoTask.fDigiArray)
 //     {
 //         LOG(error) << "FairTestDetectorMQRecoTask::Exec(): No Point array!";
 //     }
 
-//     fRecoTask->Exec(opt);
+//     fRecoTask.Exec(opt);
 
 //     MsgPackRef* container = new MsgPackRef();
 
 //     for (int i = 0; i < numEntries; ++i)
 //     {
-//         FairTestDetectorHit* hit = static_cast<FairTestDetectorHit*>(fRecoTask->fHitArray->At(i));
+//         FairTestDetectorHit* hit = static_cast<FairTestDetectorHit*>(fRecoTask.fHitArray->At(i));
 //         container->hits.push_back(std::make_tuple(hit->GetDetectorID(), hit->GetX(), hit->GetY(), hit->GetZ(), hit->GetDx(), hit->GetDy(), hit->GetDz()));
 //     }
 
@@ -120,7 +120,7 @@ void FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, MsgPa
 // template <>
 // void FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, MsgPackStream, MsgPackStream>::Exec(Option_t* opt)
 // {
-//     fRecoTask->fDigiArray->Clear();
+//     fRecoTask.fDigiArray->Clear();
 
 //     msgpack::unpacker pac;
 
@@ -136,23 +136,23 @@ void FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, MsgPa
 //         msgpack::object digiObj = msg.get();
 //         msgpack::type::tuple<int, int, int, double, double> digi;
 //         digiObj.convert(&digi);
-//         new ((*fRecoTask->fDigiArray)[numEntries]) FairTestDetectorDigi(std::get<0>(digi), std::get<1>(digi), std::get<2>(digi), std::get<3>(digi));
+//         new ((*fRecoTask.fDigiArray)[numEntries]) FairTestDetectorDigi(std::get<0>(digi), std::get<1>(digi), std::get<2>(digi), std::get<3>(digi));
 //         numEntries++;
 //     }
 
-//     if (!fRecoTask->fDigiArray)
+//     if (!fRecoTask.fDigiArray)
 //     {
 //         LOG(error) << "FairTestDetectorMQRecoTask::Exec(): No Point array!";
 //     }
 
-//     fRecoTask->Exec(opt);
+//     fRecoTask.Exec(opt);
 
 //     msgpack::sbuffer* sbuf = new msgpack::sbuffer();
 //     msgpack::packer<msgpack::sbuffer> packer(sbuf);
 
 //     for (int i = 0; i < numEntries; ++i)
 //     {
-//         FairTestDetectorHit* hit = static_cast<FairTestDetectorHit*>(fRecoTask->fHitArray->At(i));
+//         FairTestDetectorHit* hit = static_cast<FairTestDetectorHit*>(fRecoTask.fHitArray->At(i));
 //         packer.pack(std::make_tuple(hit->GetDetectorID(), hit->GetX(), hit->GetY(), hit->GetZ(), hit->GetDx(), hit->GetDy(), hit->GetDz()));
 //     }
 

--- a/examples/advanced/Tutorial3/MQ/processorTask/FairTestDetectorMQRecoTaskProtobuf.tpl
+++ b/examples/advanced/Tutorial3/MQ/processorTask/FairTestDetectorMQRecoTaskProtobuf.tpl
@@ -13,7 +13,7 @@
 template <>
 void FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TestDetectorProto::DigiPayload, TestDetectorProto::HitPayload>::Exec(Option_t* opt)
 {
-    fRecoTask->fDigiArray->Clear();
+    fRecoTask.fDigiArray->Clear();
 
     TestDetectorProto::DigiPayload dp;
     dp.ParseFromArray(fPayload->GetData(), fPayload->GetSize());
@@ -23,22 +23,22 @@ void FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TestD
     for (int i = 0; i < numEntries; ++i)
     {
         const TestDetectorProto::Digi& digi = dp.digi(i);
-        new ((*fRecoTask->fDigiArray)[i]) FairTestDetectorDigi(digi.fx(), digi.fy(), digi.fz(), digi.ftimestamp());
-        static_cast<FairTestDetectorDigi*>(((*fRecoTask->fDigiArray)[i]))->SetTimeStampError(digi.ftimestamperror());
+        new ((*fRecoTask.fDigiArray)[i]) FairTestDetectorDigi(digi.fx(), digi.fy(), digi.fz(), digi.ftimestamp());
+        static_cast<FairTestDetectorDigi*>(((*fRecoTask.fDigiArray)[i]))->SetTimeStampError(digi.ftimestamperror());
     }
 
-    if (!fRecoTask->fDigiArray)
+    if (!fRecoTask.fDigiArray)
     {
         LOG(error) << "FairTestDetectorMQRecoTask::Exec(): No Point array!";
     }
 
-    fRecoTask->Exec(opt);
+    fRecoTask.Exec(opt);
 
     TestDetectorProto::HitPayload hp;
 
     for (int i = 0; i < numEntries; ++i)
     {
-        FairTestDetectorHit* hit = static_cast<FairTestDetectorHit*>(fRecoTask->fHitArray->At(i));
+        FairTestDetectorHit* hit = static_cast<FairTestDetectorHit*>(fRecoTask.fHitArray->At(i));
         if (!hit)
         {
             continue;

--- a/examples/advanced/Tutorial3/MQ/processorTask/FairTestDetectorMQRecoTaskTMessage.tpl
+++ b/examples/advanced/Tutorial3/MQ/processorTask/FairTestDetectorMQRecoTaskTMessage.tpl
@@ -12,7 +12,7 @@
 template <>
 void FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TMessage, TMessage>::Exec(Option_t* opt)
 {
-    RootSerializer().Deserialize(*fPayload, fRecoTask->fDigiArray);
-    fRecoTask->Exec(opt);
-    RootSerializer().Serialize(*fPayload, fRecoTask->fHitArray);
+    RootSerializer().Deserialize(*fPayload, fRecoTask.fDigiArray);
+    fRecoTask.Exec(opt);
+    RootSerializer().Serialize(*fPayload, fRecoTask.fHitArray);
 }

--- a/examples/advanced/Tutorial3/MQ/run/README.md
+++ b/examples/advanced/Tutorial3/MQ/run/README.md
@@ -12,7 +12,7 @@ Each device in this example implements several serialization approaches:
 To choose specific format when running the device, provide it to the start script (binary is default):
 
 ```bash
-./startMQTut3All.sh <binary|boost|boost-text|flatbuffers|msgpack|protobuf|tmessage>
+./startMQTut3All.sh <binary|boost|flatbuffers|msgpack|protobuf|tmessage>
 ```
 
 ## Topologies
@@ -24,5 +24,3 @@ The devices can be started in different topologies:
 - `startMQTut3AllProxy` : sampler -> proxy -> 3 processors -> proxy -> sink
 - `startMQTut3PushPull` : sampler -> 2 processors -> sink (load-balanced/round robin between processors)
 - `startMQTut3ExtraProcessor` : additional processor to plug into PushPull topology
-
-The configuration is done via corresponding JSON files.

--- a/examples/advanced/Tutorial3/MQ/run/runTestDetectorFileSink.cxx
+++ b/examples/advanced/Tutorial3/MQ/run/runTestDetectorFileSink.cxx
@@ -11,48 +11,39 @@
 
 namespace bpo = boost::program_options;
 
-using TSinkBin         = FairTestDetectorFileSink<FairTestDetectorHit, TestDetectorPayload::Hit>;
-using TSinkBoostBin    = FairTestDetectorFileSink<FairTestDetectorHit, boost::archive::binary_iarchive>;
-using TSinkBoostText   = FairTestDetectorFileSink<FairTestDetectorHit, boost::archive::text_iarchive>;
-using TSinkTMessage    = FairTestDetectorFileSink<FairTestDetectorHit, TMessage>;
-#ifdef PROTOBUF
-using TSinkProtobuf    = FairTestDetectorFileSink<FairTestDetectorHit, TestDetectorProto::HitPayload>;
-#endif
-#ifdef FLATBUFFERS
-using TSinkFlatBuffers = FairTestDetectorFileSink<FairTestDetectorHit, TestDetectorFlat::HitPayload>;
-#endif
-#ifdef MSGPACK
-using TSinkMsgPack     = FairTestDetectorFileSink<FairTestDetectorHit, MsgPack>;
-#endif
-
 void addCustomOptions(bpo::options_description& options)
 {
     options.add_options()
         ("in-channel", bpo::value<std::string>()->default_value("data2"), "Name of the input channel")
         ("ack-channel", bpo::value<std::string>()->default_value("ack"), "Name of the acknowledgement channel")
-        ("data-format", bpo::value<std::string>()->default_value("binary"), "Data format (binary|boost|boost-text|flatbuffers|msgpack|protobuf|tmessage)");
+        ("data-format", bpo::value<std::string>()->default_value("binary"), "Data format (binary|boost|flatbuffers|msgpack|protobuf|tmessage)");
 }
 
 FairMQDevicePtr getDevice(const FairMQProgOptions& config)
 {
     std::string dataFormat = config.GetValue<std::string>("data-format");
 
-    if (dataFormat == "binary") { return new TSinkBin; }
-    else if (dataFormat == "boost") { return new TSinkBoostBin; }
-    else if (dataFormat == "boost-text") { return new TSinkBoostText; }
-    else if (dataFormat == "tmessage") { return new TSinkTMessage; }
+    if (dataFormat == "binary") { return new FairTestDetectorFileSink<FairTestDetectorHit, TestDetectorPayload::Hit>; }
+    else if (dataFormat == "boost") {
+        if (fair::base::serialization::has_BoostSerialization<FairTestDetectorHit, void(boost::archive::binary_iarchive&, const unsigned int)>::value == 0) {
+            LOG(error) << "Boost serialization for Input Payload requested, but the input type does not support it. Check the TIn parameter. Aborting.";
+            return nullptr;
+        }
+        return new FairTestDetectorFileSink<FairTestDetectorHit, boost::archive::binary_iarchive>;
+    }
+    else if (dataFormat == "tmessage") { return new FairTestDetectorFileSink<FairTestDetectorHit, TMessage>; }
 #ifdef FLATBUFFERS
-    else if (dataFormat == "flatbuffers") { return new TSinkFlatBuffers; }
+    else if (dataFormat == "flatbuffers") { return new FairTestDetectorFileSink<FairTestDetectorHit, TestDetectorFlat::HitPayload>; }
 #endif
 #ifdef MSGPACK
-    else if (dataFormat == "msgpack") { return new TSinkMsgPack; }
+    else if (dataFormat == "msgpack") { return new FairTestDetectorFileSink<FairTestDetectorHit, MsgPack>; }
 #endif
 #ifdef PROTOBUF
-    else if (dataFormat == "protobuf") { return new TSinkProtobuf; }
+    else if (dataFormat == "protobuf") { return new FairTestDetectorFileSink<FairTestDetectorHit, TestDetectorProto::HitPayload>; }
 #endif
     else
     {
-        LOG(error) << "No valid data format provided. (--data-format binary|boost|boost-text|flatbuffers|msgpack|protobuf|tmessage). ";
-        exit(EXIT_FAILURE);
+        LOG(error) << "No valid data format provided. (--data-format binary|boost|flatbuffers|msgpack|protobuf|tmessage). ";
+        return nullptr;
     }
 }

--- a/examples/advanced/Tutorial3/MQ/run/runTestDetectorProcessor.cxx
+++ b/examples/advanced/Tutorial3/MQ/run/runTestDetectorProcessor.cxx
@@ -1,8 +1,8 @@
 /********************************************************************************
  *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
  *                                                                              *
- *              This software is distributed under the terms of the             * 
- *              GNU Lesser General Public Licence (LGPL) version 3,             *  
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
 
@@ -12,49 +12,44 @@
 
 namespace bpo = boost::program_options;
 
-using TProcessorBin         = FairMQProcessor<FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TestDetectorPayload::Digi,       TestDetectorPayload::Hit>>;
-using TProcessorBoostBin    = FairMQProcessor<FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, boost::archive::binary_iarchive, boost::archive::binary_oarchive>>;
-using TProcessorBoostText   = FairMQProcessor<FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, boost::archive::text_iarchive,   boost::archive::text_oarchive>>;
-using TProcessorTMessage    = FairMQProcessor<FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TMessage,                        TMessage>>;
-#ifdef PROTOBUF
-using TProcessorProtobuf    = FairMQProcessor<FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TestDetectorProto::DigiPayload,  TestDetectorProto::HitPayload>>;
-#endif
-#ifdef FLATBUFFERS
-using TProcessorFlatBuffers = FairMQProcessor<FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TestDetectorFlat::DigiPayload,   TestDetectorFlat::HitPayload>>;
-#endif
-#ifdef MSGPACK
-using TProcessorMsgPack     = FairMQProcessor<FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, MsgPack,                         MsgPack>>;
-#endif
-
 void addCustomOptions(bpo::options_description& options)
 {
     options.add_options()
         ("in-channel", bpo::value<std::string>()->default_value("data1"), "Name of the input channel")
         ("out-channel", bpo::value<std::string>()->default_value("data2"), "Name of the output channel")
-        ("data-format", bpo::value<std::string>()->default_value("binary"), "Data format (binary|boost|boost-text|flatbuffers|msgpack|protobuf|tmessage)");
+        ("data-format", bpo::value<std::string>()->default_value("binary"), "Data format (binary|boost|flatbuffers|msgpack|protobuf|tmessage)");
 }
 
 FairMQDevicePtr getDevice(const FairMQProgOptions& config)
 {
     std::string dataFormat = config.GetValue<std::string>("data-format");
 
-    if (dataFormat == "binary") { return new TProcessorBin; }
-    else if (dataFormat == "boost") { return new TProcessorBoostBin; }
-    else if (dataFormat == "boost-text") { return new TProcessorBoostText; }
-    else if (dataFormat == "tmessage") { return new TProcessorTMessage; }
+    if (dataFormat == "binary") { return new FairMQProcessor<FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TestDetectorPayload::Digi, TestDetectorPayload::Hit>>; }
+    else if (dataFormat == "boost") {
+        if (fair::base::serialization::has_BoostSerialization<FairTestDetectorDigi, void(boost::archive::binary_iarchive&, const unsigned int)>::value == 0) {
+            LOG(error) << "Boost serialization for Input Payload requested, but the input type does not support it. Check the TIn parameter. Aborting.";
+            return nullptr;
+        }
+        if (fair::base::serialization::has_BoostSerialization<FairTestDetectorHit, void(boost::archive::binary_oarchive&, const unsigned int)>::value == 0) {
+            LOG(error) << "Boost serialization for Output Payload requested, but the output type does not support it. Check the TOut parameter. Aborting.";
+            return nullptr;
+        }
+        return new FairMQProcessor<FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, boost::archive::binary_iarchive, boost::archive::binary_oarchive>>;
+    }
+    else if (dataFormat == "tmessage") { return new FairMQProcessor<FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TMessage, TMessage>>; }
 #ifdef FLATBUFFERS
-    else if (dataFormat == "flatbuffers") { return new TProcessorFlatBuffers; }
+    else if (dataFormat == "flatbuffers") { return new FairMQProcessor<FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TestDetectorFlat::DigiPayload, TestDetectorFlat::HitPayload>>; }
 #endif
 #ifdef MSGPACK
-    else if (dataFormat == "msgpack") { return new TProcessorMsgPack; }
+    else if (dataFormat == "msgpack") { return new FairMQProcessor<FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, MsgPack, MsgPack>>; }
 #endif
 #ifdef PROTOBUF
-    else if (dataFormat == "protobuf") { return new TProcessorProtobuf; }
+    else if (dataFormat == "protobuf") { return new FairMQProcessor<FairTestDetectorMQRecoTask<FairTestDetectorDigi, FairTestDetectorHit, TestDetectorProto::DigiPayload, TestDetectorProto::HitPayload>>; }
 #endif
     else
     {
-        LOG(error) << "No valid data format provided. (--data-format binary|boost|boost-text|flatbuffers|msgpack|protobuf|tmessage). ";
-        exit(EXIT_FAILURE);
+        LOG(error) << "No valid data format provided. (--data-format binary|boost|flatbuffers|msgpack|protobuf|tmessage). ";
+        return nullptr;
     }
 }
 

--- a/examples/advanced/Tutorial3/MQ/run/startMQTut3All.sh.in
+++ b/examples/advanced/Tutorial3/MQ/run/startMQTut3All.sh.in
@@ -9,9 +9,6 @@ if [ "$1" = "binary" ]; then
 elif [ "$1" = "boost" ]; then
     dataFormat="boost"
     echo "Using: boost (Boost binary)"
-elif [ "$1" = "boost-text" ]; then
-    dataFormat="boost-text"
-    echo "Using: boost-text (Boost text)"
 elif [ "$1" = "flatbuffers" ]; then
     if(@FLATBUFFERS_USED@); then
         dataFormat="flatbuffers"
@@ -47,6 +44,7 @@ fi
 SAMPLER="tut3-sampler"
 SAMPLER+=" --id sampler1"
 SAMPLER+=" --data-format $dataFormat"
+SAMPLER+=" --severity info"
 SAMPLER+=" --chain-input 99"
 SAMPLER+=" --input-file @CMAKE_SOURCE_DIR@/examples/advanced/Tutorial3/macro/data/testdigi_$mcEngine.root"
 SAMPLER+=" --parameter-file @CMAKE_SOURCE_DIR@/examples/advanced/Tutorial3/macro/data/testparams_$mcEngine.root"

--- a/examples/advanced/Tutorial3/MQ/run/startMQTut3AllProxy.sh.in
+++ b/examples/advanced/Tutorial3/MQ/run/startMQTut3AllProxy.sh.in
@@ -9,9 +9,6 @@ if [ "$1" = "binary" ]; then
 elif [ "$1" = "boost" ]; then
     dataFormat="boost"
     echo "Using: boost (Boost binary)"
-elif [ "$1" = "boost-text" ]; then
-    dataFormat="boost-text"
-    echo "Using: boost-text (Boost text)"
 elif [ "$1" = "flatbuffers" ]; then
     if(@FLATBUFFERS_USED@); then
         dataFormat="flatbuffers"
@@ -47,6 +44,7 @@ fi
 SAMPLER="tut3-sampler"
 SAMPLER+=" --id sampler1"
 SAMPLER+=" --data-format $dataFormat"
+SAMPLER+=" --severity info"
 SAMPLER+=" --chain-input 99"
 SAMPLER+=" --input-file @CMAKE_SOURCE_DIR@/examples/advanced/Tutorial3/macro/data/testdigi_$mcEngine.root"
 SAMPLER+=" --parameter-file @CMAKE_SOURCE_DIR@/examples/advanced/Tutorial3/macro/data/testparams_$mcEngine.root"

--- a/examples/advanced/Tutorial3/MQ/run/startMQTut3ExtraProcessor.sh.in
+++ b/examples/advanced/Tutorial3/MQ/run/startMQTut3ExtraProcessor.sh.in
@@ -7,9 +7,6 @@ if [ "$1" = "binary" ]; then
 elif [ "$1" = "boost" ]; then
     dataFormat="boost"
     echo "Using: boost (Boost binary)"
-elif [ "$1" = "boost-text" ]; then
-    dataFormat="boost-text"
-    echo "Using: boost-text (Boost text)"
 elif [ "$1" = "flatbuffers" ]; then
     if(@FLATBUFFERS_USED@); then
         dataFormat="flatbuffers"

--- a/examples/advanced/Tutorial3/MQ/run/startMQTut3PushPull.sh.in
+++ b/examples/advanced/Tutorial3/MQ/run/startMQTut3PushPull.sh.in
@@ -9,9 +9,6 @@ if [ "$1" = "binary" ]; then
 elif [ "$1" = "boost" ]; then
     dataFormat="boost"
     echo "Using: boost (Boost binary)"
-elif [ "$1" = "boost-text" ]; then
-    dataFormat="boost-text"
-    echo "Using: boost-text (Boost text)"
 elif [ "$1" = "flatbuffers" ]; then
     if(@FLATBUFFERS_USED@); then
         dataFormat="flatbuffers"
@@ -47,6 +44,7 @@ fi
 SAMPLER="tut3-sampler"
 SAMPLER+=" --id sampler1"
 SAMPLER+=" --data-format $dataFormat"
+SAMPLER+=" --severity info"
 SAMPLER+=" --chain-input 99"
 SAMPLER+=" --input-file @CMAKE_SOURCE_DIR@/examples/advanced/Tutorial3/macro/data/testdigi_$mcEngine.root"
 SAMPLER+=" --parameter-file @CMAKE_SOURCE_DIR@/examples/advanced/Tutorial3/macro/data/testparams_$mcEngine.root"

--- a/examples/advanced/Tutorial3/MQ/run/startMQTut3Three.sh.in
+++ b/examples/advanced/Tutorial3/MQ/run/startMQTut3Three.sh.in
@@ -9,9 +9,6 @@ if [ "$1" = "binary" ]; then
 elif [ "$1" = "boost" ]; then
     dataFormat="boost"
     echo "Using: boost (Boost binary)"
-elif [ "$1" = "boost-text" ]; then
-    dataFormat="boost-text"
-    echo "Using: boost-text (Boost text)"
 elif [ "$1" = "flatbuffers" ]; then
     if(@FLATBUFFERS_USED@); then
         dataFormat="flatbuffers"
@@ -47,6 +44,7 @@ fi
 SAMPLER="tut3-sampler"
 SAMPLER+=" --id sampler1"
 SAMPLER+=" --data-format $dataFormat"
+SAMPLER+=" --severity info"
 SAMPLER+=" --chain-input 99"
 SAMPLER+=" --input-file @CMAKE_SOURCE_DIR@/examples/advanced/Tutorial3/macro/data/testdigi_$mcEngine.root"
 SAMPLER+=" --parameter-file @CMAKE_SOURCE_DIR@/examples/advanced/Tutorial3/macro/data/testparams_$mcEngine.root"
@@ -57,6 +55,7 @@ xterm -geometry 80x23+0+0 -hold -e @CMAKE_BINARY_DIR@/bin/examples/advanced/Tuto
 PROCESSOR="tut3-processor"
 PROCESSOR+=" --id processor1"
 PROCESSOR+=" --data-format $dataFormat"
+PROCESSOR+=" --severity info"
 PROCESSOR+=" --channel-config name=data1,type=pull,method=connect,address=tcp://localhost:5565"
 PROCESSOR+="                  name=data2,type=push,method=connect,address=tcp://localhost:5570"
 xterm -geometry 80x23+500+0 -hold -e @CMAKE_BINARY_DIR@/bin/examples/advanced/Tutorial3/$PROCESSOR &
@@ -64,6 +63,7 @@ xterm -geometry 80x23+500+0 -hold -e @CMAKE_BINARY_DIR@/bin/examples/advanced/Tu
 FILESINK="tut3-sink"
 FILESINK+=" --id sink1"
 FILESINK+=" --data-format $dataFormat"
+FILESINK+=" --severity info"
 FILESINK+=" --channel-config name=data2,type=pull,method=bind,address=tcp://localhost:5570"
 FILESINK+="                  name=ack,type=push,method=connect,address=tcp://localhost:5999"
 xterm -geometry 80x23+1000+0 -hold -e @CMAKE_BINARY_DIR@/bin/examples/advanced/Tutorial3/$FILESINK &

--- a/examples/advanced/Tutorial3/MQ/samplerTask/FairTestDetectorDigiLoader.h
+++ b/examples/advanced/Tutorial3/MQ/samplerTask/FairTestDetectorDigiLoader.h
@@ -15,13 +15,7 @@
 #define FAIRTESTDETECTORDIGILOADER_H
 
 #include <iostream>
-#include <type_traits>
 #include <array>
-
-#include <boost/archive/text_oarchive.hpp>
-#include <boost/archive/binary_oarchive.hpp>
-#include <boost/serialization/vector.hpp>
-#include <boost/serialization/binary_object.hpp>
 
 #include "FairTestDetectorPayload.h"
 #include "FairTestDetectorDigi.h"
@@ -29,40 +23,15 @@
 #include "FairMQSamplerTask.h"
 #include "FairMQLogger.h"
 
-#include "BoostSerializer.h"
-
-template <typename TOut, typename TPayloadOut>
+template<typename TOut, typename TPayloadOut>
 class FairTestDetectorDigiLoader : public FairMQSamplerTask
 {
   public:
     FairTestDetectorDigiLoader()
         : FairMQSamplerTask("Load class TOut")
-        , fDigiVector()
-    {
-        // coverity[pointless_expression]: suppress coverity warnings on apparant if(const).
-        if (std::is_same<TPayloadOut, boost::archive::binary_oarchive>::value || std::is_same<TPayloadOut, boost::archive::text_oarchive>::value)
-        {
-            if (fair::base::serialization::has_BoostSerialization<TOut, void(TPayloadOut&, const unsigned int)>::value == 0)
-            {
-                LOG(error) << "Method 'void serialize(TOut & ar, const unsigned int version)' was not found in input class";
-                LOG(error) << "Boost serialization for Output Payload requested, but the output type does not support it. Check the TOut parameter. Aborting.";
-                exit(EXIT_FAILURE);
-            }
-        }
-    }
-
-    virtual ~FairTestDetectorDigiLoader()
-    {
-        if (fDigiVector.size() > 0)
-        {
-            fDigiVector.clear();
-        }
-    }
+    {}
 
     virtual void Exec(Option_t* opt);
-
-  private:
-    std::vector<TOut> fDigiVector;
 };
 
 // Template implementation is in FairTestDetectorDigiLoader.tpl :

--- a/examples/advanced/Tutorial3/MQ/samplerTask/FairTestDetectorDigiLoaderBoost.tpl
+++ b/examples/advanced/Tutorial3/MQ/samplerTask/FairTestDetectorDigiLoaderBoost.tpl
@@ -7,29 +7,13 @@
 
 // Default implementation of FairTestDetectorDigiLoader::Exec() with Boost transport data format
 
+#include "BoostSerializer.h"
+
 // example TOut: FairTestDetectorDigi
-// example TPayloadOut: boost::archive::binary_oarchive, boost::archive::text_oarchive
+// example TPayloadOut: boost::archive::binary_oarchive
 template <typename TOut, typename TPayloadOut>
 void FairTestDetectorDigiLoader<TOut, TPayloadOut>::Exec(Option_t* /*opt*/)
 {
-    std::ostringstream oss;
-    TPayloadOut outputArchive(oss);
-    for (int i = 0; i < fInput->GetEntriesFast(); ++i)
-    {
-        TOut* digi = static_cast<TOut*>(fInput->At(i));
-        if (!digi)
-        {
-            continue;
-        }
-        fDigiVector.push_back(*digi);
-    }
-
-    outputArchive << fDigiVector;
-    std::string* strMsg = new std::string(oss.str());
-    fPayload = FairMQMessagePtr(fTransportFactory->CreateMessage(const_cast<char*>(strMsg->c_str()), // data
-                                                                                   strMsg->length(), // size
-                                                                                   [](void* /*data*/, void* obj){ delete static_cast<std::string*>(obj); },
-                                                                                   strMsg)); // object that manages the data
-
-    fDigiVector.clear();
+    fPayload = FairMQMessagePtr(fTransportFactory->CreateMessage());
+    BoostSerializer<TOut>().Serialize(*fPayload, fInput);
 }


### PR DESCRIPTION
- Use the common base/policies/Serialization/BoostSerializer in Tutorial3 MQ part, which was previously implemented inline.
- Remove support for boost text archive from BoostSerializer (it is very slow) - leaves only binary archive as a single possibility - simplifies interface.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
