### PR TITLE
Remove const from channel ref to allow non-const receive

### DIFF
--- a/base/MQ/devices/FairMQUnpacker.h
+++ b/base/MQ/devices/FairMQUnpacker.h
@@ -109,7 +109,7 @@ class FairMQUnpacker : public FairMQDevice
 
     void Run()
     {
-        const FairMQChannel& inputChannel = fChannels.at(fInputChannelName).at(0);
+        FairMQChannel& inputChannel = fChannels.at(fInputChannelName).at(0);
 
         while (CheckCurrentState(RUNNING))
         {


### PR DESCRIPTION
This is needed for FairMQ 1.3.7

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
