### PR TITLE
Correct a bug because of adding particles to Geant4 (fMC is null)

### DIFF
--- a/base/sim/FairMCApplication.cxx
+++ b/base/sim/FairMCApplication.cxx
@@ -1198,31 +1198,30 @@ void  FairMCApplication::AddIons()
 //_____________________________________________________________________________
 void  FairMCApplication::AddParticles()
 {
-
-  TObjArray* NewIons=fRun->GetUserDefIons();
-  TIterator* Iter=NewIons->MakeIterator();
-  Iter->Reset();
-  TObject* obj=0;
-  TObjArray* NewPart=fRun->GetUserDefParticles();
-  TIterator* parIter=NewPart->MakeIterator();
+  TObjArray* NewPart = fRun->GetUserDefParticles();
+  TIterator* parIter = NewPart->MakeIterator();
   parIter->Reset();
-  obj=0;
+
+  // check MC engine is not null (fMC is 0x00 at this line in case of Geant4)
+  TVirtualMC* curMC = TVirtualMC::GetMC();
+  if (!curMC) LOG(fatal)<<"No MC engine was defined before AddParticles()";
+
+  TObject* obj=0;
   FairParticle* particle=0;
-  while((obj=parIter->Next())) {
-    particle=dynamic_cast <FairParticle*> (obj);
-    if(particle) {                // (Int_t pdg, const char* name, TMCParticleType type,
-      //Double_t mass, Double_t charge, Double_t lifetime);
+  while ((obj = parIter->Next())) {
+    particle = dynamic_cast <FairParticle*> (obj);
+    if (particle) {  // (Int_t pdg, const char* name, TMCParticleType type, Double_t mass, Double_t charge, Double_t lifetime);
       LOG(info) << "Add Particle: " << particle->GetName()  << " with PDG " <<   particle->GetPDG() << "\n"<<
-           particle->GetName() << "            // const TString& name \n" <<
-           particle->GetMCType()<<"             // TMCParticleType mcType \n" <<
+           particle->GetName() << "           // const TString& name \n" <<
+           particle->GetMCType()<<"           // TMCParticleType mcType \n" <<
            particle->GetMass()<<"             // Double_t mass   \n" <<
            particle->GetCharge()<<"           // Double_t charge \n" <<
            particle->GetDecayTime()<<"        // Double_t lifetime  \n" <<
-           particle->GetPType()<<  "           // const TString& pType, \n" <<
+           particle->GetPType()<<  "          // const TString& pType, \n" <<
            particle->GetWidth()<<   "         // Double_t width   \n" <<
            particle->GetSpin()<<    "         // Int_t iSpin  \n" <<
            particle->GetiParity()<< "         // Int_t iParity \n" <<
-           particle->GetConjugation()<<"       // Int_t iConjugation  \n" <<
+           particle->GetConjugation()<<"      // Int_t iConjugation  \n" <<
            particle->GetIsospin()<<   "       // Int_t iIsospin   \n" <<
            particle->GetIsospinZ()<<  "       // Int_t iIsospinZ    \n" <<
            particle->GetgParity()<<   "       // Int_t gParity    \n" <<
@@ -1230,33 +1229,33 @@ void  FairMCApplication::AddParticles()
            particle->GetBaryon()<<  "         // Int_t baryon   \n" <<
            particle->IsStable() <<  "         // Bool_t stable   \n";
 
-      fMC->DefineParticle(particle->GetPDG(),              // Int_t pdg
-                          particle->GetName(),             // const TString& name
-                          particle->GetMCType(),             // TMCParticleType mcType
-                          particle->GetMass(),             // Double_t mass
-                          particle->GetCharge(),           // Double_t charge
-                          particle->GetDecayTime(),        // Double_t lifetime
-                          particle->GetPType(),             // const TString& pType,
-                          particle->GetWidth(),            // Double_t width
-                          particle->GetSpin(),             // Int_t iSpin
-                          particle->GetiParity(),          // Int_t iParity
-                          particle->GetConjugation(),       // Int_t iConjugation
-                          particle->GetIsospin(),          // Int_t iIsospin
-                          particle->GetIsospinZ(),         // Int_t iIsospinZ
-                          particle->GetgParity(),          // Int_t gParity
-                          particle->GetLepton(),           // Int_t lepton
-                          particle->GetBaryon(),           // Int_t baryon
-                          particle->IsStable()             // Bool_t stable
-                         );
-      //Add Ion to gGeoManager visualization
-      if(gGeoManager) {
-        gGeoManager->SetPdgName(particle->GetPDG(),particle->GetName() );
-      }
+      curMC->DefineParticle(particle->GetPDG(),              // Int_t pdg
+                            particle->GetName(),             // const TString& name
+                            particle->GetMCType(),           // TMCParticleType mcType
+                            particle->GetMass(),             // Double_t mass
+                            particle->GetCharge(),           // Double_t charge
+                            particle->GetDecayTime(),        // Double_t lifetime
+                            particle->GetPType(),            // const TString& pType,
+                            particle->GetWidth(),            // Double_t width
+                            particle->GetSpin(),             // Int_t iSpin
+                            particle->GetiParity(),          // Int_t iParity
+                            particle->GetConjugation(),      // Int_t iConjugation
+                            particle->GetIsospin(),          // Int_t iIsospin
+                            particle->GetIsospinZ(),         // Int_t iIsospinZ
+                            particle->GetgParity(),          // Int_t gParity
+                            particle->GetLepton(),           // Int_t lepton
+                            particle->GetBaryon(),           // Int_t baryon
+                            particle->IsStable()             // Bool_t stable
+                         );   
+
+      //Add Particle to gGeoManager visualization
+      if(gGeoManager)
+        gGeoManager->SetPdgName(particle->GetPDG(), particle->GetName());
     }
   }
-  delete   parIter;
+
+  delete parIter;
   AddDecayModes();
-  delete Iter;
 }
 
 //_____________________________________________________________________________


### PR DESCRIPTION
The exception occurs when a user adds new particles to Geant4 to transport

Geant 4 calls AddParticles() function (FairMCApplication class) in own constructor but fMC pointer is initialized later in FairRunSim (fApp->InitMC).
fMC pointer (which is 0x00 in the case) was replaced by TVirtualMC::GetMC in FairMCApplication::AddParticles(), and some cosmetic modifications were made to simplify reading the function.