### PR TITLE
Fix rst type on README.rst

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ FairRoot  is distributed under the terms of the GNU Lesser General Public Licenc
 ## Release information
 Please see : https://github.com/FairRootGroup/FairRoot/releases
 
-##Getting started
+## Getting started
 Please see : http://fairroot.gsi.de/getting_started  for  details.
 
 


### PR DESCRIPTION

---

Checklist:

* [x] Rebased against `dev` branch
* [x] ~My name is in the resp. CONTRIBUTORS/AUTHORS file~  I do not want to add my name for adding a space to the readme
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
