### PR TITLE
Add LOG(fatal) when ProcessNodes is called outside of ConstructGeometry

### DIFF
--- a/base/sim/FairMCApplication.cxx
+++ b/base/sim/FairMCApplication.cxx
@@ -115,6 +115,7 @@ FairMCApplication::FairMCApplication(const char* name, const char* title,
    fMC(NULL),
    fRun(NULL),
    fSaveCurrentEvent(kTRUE),
+   fState(kUnknown),
    fRunInfo(),
    fGeometryIsInitialized(kFALSE)
 {
@@ -205,6 +206,7 @@ FairMCApplication::FairMCApplication(const FairMCApplication& rhs)
    fMC(NULL),
    fRun(NULL),
    fSaveCurrentEvent(kTRUE),
+   fState(kUnknown),
    fRunInfo(),
    fGeometryIsInitialized(kFALSE)
 {
@@ -297,6 +299,7 @@ FairMCApplication::FairMCApplication()
    fMC(NULL),
    fRun(NULL),
    fSaveCurrentEvent(kTRUE),
+   fState(kUnknown),
    fRunInfo(),
    fGeometryIsInitialized(kFALSE)
 {
@@ -400,6 +403,8 @@ FairMCApplication& FairMCApplication::operator=(const FairMCApplication& rhs)
     //gROOT->GetListOfBrowsables()->Add(fFairTaskList);
     
     fDetMap=new TRefArray(1000);
+
+    fState = rhs.fState;
   }
   
   return *this;
@@ -929,6 +934,8 @@ void FairMCApplication::ConstructGeometry()
     LOG(fatal) << "gGeoManager not initialized at FairMCApplication::ConstructGeometry\n";
   }
 
+  fState = kConstructGeometry;
+
   fModIter->Reset();
   FairModule* Mod=NULL;
   Int_t NoOfVolumes=0;
@@ -992,11 +999,15 @@ void FairMCApplication::ConstructGeometry()
   }
 
   gGeoManager->RefreshPhysicalNodes(kFALSE);
+
+  fState = kUnknown;
 }
 
 //_____________________________________________________________________________
 void FairMCApplication::InitGeometry()
 {
+  fState = kInitGeometry;
+
   LOG(info) << "FairMCApplication::InitGeometry: "
     << fRootManager->GetInstanceId();
   
@@ -1135,6 +1146,7 @@ void FairMCApplication::InitGeometry()
 
   fGeometryIsInitialized=kTRUE;
 
+  fState = kUnknown;
 }
 
 //_____________________________________________________________________________

--- a/base/sim/FairMCApplication.h
+++ b/base/sim/FairMCApplication.h
@@ -44,6 +44,9 @@ class TObjArray;
 class TRefArray;
 class TTask;
 class TVirtualMC;
+
+enum FairMCApplicationState {kUnknown, kConstructGeometry, kInitGeometry};
+
 /**
  * The Main Application ( Interface to MonteCarlo application )
  * @author M. Al-Turany, D. Bertini
@@ -194,6 +197,11 @@ class FairMCApplication : public TVirtualMCApplication
     */
     void                  SetSaveCurrentEvent(Bool_t set) {fSaveCurrentEvent=set;}
 
+    /**
+     * Get the current application state.
+     */
+    FairMCApplicationState GetState() const { return fState; }
+
   private:
     // methods
     Int_t GetIonPdg(Int_t z, Int_t a) const;
@@ -283,7 +291,10 @@ class FairMCApplication : public TVirtualMCApplication
 
     /** Flag if the current event should be saved */
     Bool_t fSaveCurrentEvent;
-    
+
+    /** Current state */
+    FairMCApplicationState fState; //!
+
     ClassDef(FairMCApplication,4)  //Interface to MonteCarlo application
 
   private:

--- a/base/sim/FairModule.cxx
+++ b/base/sim/FairModule.cxx
@@ -22,6 +22,7 @@
 #include "FairRuntimeDb.h"              // for FairRuntimeDb
 #include "FairVolume.h"                 // for FairVolume
 #include "FairVolumeList.h"             // for FairVolumeList
+#include "FairMCApplication.h"
 
 #include "TBuffer.h"                    // for TBuffer, operator<<, etc
 #include "TCollection.h"                // for TIter
@@ -258,6 +259,14 @@ void FairModule::SetGeometryFileName(TString fname, TString)
 //__________________________________________________________________________
 void FairModule::ProcessNodes(TList* aList)
 {
+  if(kConstructGeometry != FairMCApplication::Instance()->GetState())
+  {
+      LOG(fatal) << "Detected call to FairModule::ProcessNodes() \
+      while not in FairMCApplication::ConstructGeometry()\n\
+      Call templated function FairModule::ConstructASCIIGeometry()\
+      from ConstructGeometry() of your detector class. Aborting...";
+  }
+
   if(!svList) { svList=new TRefArray(); }
   if(!vList) { vList=new FairVolumeList(); }
 


### PR DESCRIPTION
- Abort if a detector class has called FairModule::ProcessNodes, while outside of FairMCApplication::ConstructGeometry()
- Will probably break parts of experiment code. Fix: when creating geometry from ASCII file, call templated function FairModule::ConstructASCIIGeometry() from ConstructGeometry() of the detector class.
- FairRoot tests will fail. Fix is in #869 