### PR TITLE
Initialize FairSink before initializing FairSource

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ endforeach()
 # Set project version
 SET(FAIRROOT_MAJOR_VERSION 18)
 SET(FAIRROOT_MINOR_VERSION 0)
-SET(FAIRROOT_PATCH_VERSION 4)
+SET(FAIRROOT_PATCH_VERSION 5)
 
 # Set name of our project to "FAIRROOT".
 # Has to be done after check of cmake version

--- a/base/steer/FairRunOnline.cxx
+++ b/base/steer/FairRunOnline.cxx
@@ -136,8 +136,12 @@ void FairRunOnline::Init()
     fIsInitialized = kTRUE;
   }
 
-  fRootManager->InitSource();
+  // we have to initialize the sink before initializing the source
+  // This is needed in case the source registers some objects to
+  // the output
+  // In this case the output must exist
   fRootManager->InitSink();
+  fRootManager->InitSource();
 
   //  FairGeoLoader* loader = new FairGeoLoader("TGeo", "Geo Loader");
   //  FairGeoInterface* GeoInterFace = loader->getGeoInterface();


### PR DESCRIPTION
The order of the initialization is important since FairSource may register
objects to the output. To do this the output has already to exist which is
the case if FairSink was already initialized.
Bump the version info.
---

Checklist:

* [ x] Rebased against `v18.0_patches` branch
* [ x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [ x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
