### PR TITLE
Quick fix.

### DIFF
--- a/base/sink/FairRootFileSink.cxx
+++ b/base/sink/FairRootFileSink.cxx
@@ -26,6 +26,7 @@
 #include "TFolder.h"
 #include "FairRun.h"
 #include "FairRootManager.h"            // to GetTreeName()
+#include "FairMonitor.h"                // to store histograms at the end
 #include "TGeoManager.h"                // for TGeoManager, gGeoManager
 #include "TRandom.h"                    // for TRandom, gRandom
 #include "TROOT.h"
@@ -379,6 +380,7 @@ Int_t FairRootFileSink::Write(const char*, Int_t, Int_t)
     // fOutTree->Print();
 
     fRootFile = fOutTree->GetCurrentFile();
+    FairMonitor::GetMonitor()->StoreHistograms(fRootFile);
     LOG(DEBUG) << "FairRootFileSink::Write to file: "  << fRootFile->GetName();
     fRootFile->cd();
     fOutTree->Write();

--- a/base/steer/FairRootManager.cxx
+++ b/base/steer/FairRootManager.cxx
@@ -406,7 +406,7 @@ void FairRootManager::Fill()
 //_____________________________________________________________________________
 void FairRootManager::LastFill()
 {
-  FairMonitor::GetMonitor()->StoreHistograms();
+    //  FairMonitor::GetMonitor()->StoreHistograms(); MOVED TO FairRootFileSink
   if (fFillLastData) {
       if ( fSink ) fSink->Fill();
   }

--- a/fairtools/FairMonitor.cxx
+++ b/fairtools/FairMonitor.cxx
@@ -45,6 +45,7 @@ FairMonitor* FairMonitor::instance = NULL;
 FairMonitor::FairMonitor()
   : TNamed("FairMonitor","Monitor for FairRoot")
   , fRunMonitor(kFALSE)
+  , fDrawCanvas(kFALSE)
   , fRunTime(0.)
   , fRunMem(0.)
   , fTimerMap()
@@ -623,7 +624,12 @@ void FairMonitor::StoreHistograms(TFile* sinkFile)
   if ( !fRunMonitor ) {
     return;
   }
+  Bool_t wasBatch = gROOT->IsBatch();
+  if ( !fDrawCanvas && !wasBatch ) // default: switching to batch mode if draw canvas disabled
+    gROOT->SetBatch(kTRUE);
   this->Draw();
+  if ( !fDrawCanvas && !wasBatch ) // default: switching to batch mode if draw canvas disabled
+    gROOT->SetBatch(kFALSE);
 
   TFile* histoFile = sinkFile;
   if ( fOutputFileName.Length() > 1 && fOutputFileName != sinkFile->GetName() ) {
@@ -638,7 +644,6 @@ void FairMonitor::StoreHistograms(TFile* sinkFile)
     thist->Write();
   }
   fCanvas->Write();
-  fCanvas->Close();
 
   if ( histoFile != sinkFile ) {
     histoFile->Close();

--- a/fairtools/FairMonitor.cxx
+++ b/fairtools/FairMonitor.cxx
@@ -618,22 +618,20 @@ void FairMonitor::DrawHist(TString specString) {
 //_____________________________________________________________________________
 
 //_____________________________________________________________________________
-void FairMonitor::StoreHistograms()
+void FairMonitor::StoreHistograms(TFile* sinkFile)
 {
   if ( !fRunMonitor ) {
     return;
   }
   this->Draw();
 
-  TFile* prevFile = gFile;
-
-  TFile* outFile = NULL;
-  if ( fOutputFileName.Length() > 1 && fOutputFileName != gFile->GetName() ) {
-    outFile = TFile::Open(fOutputFileName,"recreate");
+  TFile* histoFile = sinkFile;
+  if ( fOutputFileName.Length() > 1 && fOutputFileName != sinkFile->GetName() ) {
+      histoFile = TFile::Open(fOutputFileName,"recreate");
   }
 
-  gFile->mkdir("MonitorResults");
-  gFile->cd("MonitorResults");
+  histoFile->mkdir("MonitorResults");
+  histoFile->cd("MonitorResults");
   TIter next(fHistList);
   while ( TH1* thist = (static_cast<TH1*>(next())) ) {
     thist->SetBins(thist->GetEntries(),0,thist->GetEntries());
@@ -642,12 +640,10 @@ void FairMonitor::StoreHistograms()
   fCanvas->Write();
   fCanvas->Close();
 
-  if ( outFile ) {
-    outFile->Close();
-    delete outFile;
+  if ( histoFile != sinkFile ) {
+    histoFile->Close();
+    delete histoFile;
   }
-
-  gDirectory = prevFile;
 }
 //_____________________________________________________________________________
 

--- a/fairtools/FairMonitor.h
+++ b/fairtools/FairMonitor.h
@@ -33,6 +33,7 @@ class FairMonitor : public TNamed
   static FairMonitor* GetMonitor();
 
   void EnableMonitor(Bool_t tempBool = kTRUE, TString fileName = "") { fRunMonitor = tempBool; fOutputFileName = fileName; }
+  void EnableDrawing(Bool_t tempBool = kTRUE) { fDrawCanvas = tempBool; }
   Bool_t IsRunning() { return fRunMonitor; }
 
   void StartMonitoring(const TTask* tTask, const char* identStr) {
@@ -76,6 +77,7 @@ class FairMonitor : public TNamed
     FairMonitor& operator=(const FairMonitor&);
 
     Bool_t fRunMonitor;
+    Bool_t fDrawCanvas;
 
     Double_t fRunTime; 
     Double_t fRunMem;

--- a/fairtools/FairMonitor.h
+++ b/fairtools/FairMonitor.h
@@ -66,7 +66,7 @@ class FairMonitor : public TNamed
 
   TList* GetHistList() { return fHistList; }
 
-  void StoreHistograms();
+  void StoreHistograms(TFile* sinkFile);
 
   private:
     static FairMonitor* instance;


### PR DESCRIPTION
Changed the logic of FairMonitor::StoreHistograms.
This is no more called by FairRootManager, but by the FairRootFileSink
at the end of the run.

Fixes the crash of the FairMonitor with recent FairSofts.

Describe your proposal.

Mention any issue this PR is resolves or is related to.

---

Checklist:

* [ ] Rebased against `dev` branch
* [ ] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [ ] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
