### PR TITLE
Allow to compile v18.0 using FairSoft RC_feb19

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,7 +277,7 @@ Message("-- Looking for Boost ...")
 Unset(Boost_INCLUDE_DIR CACHE)
 Unset(Boost_LIBRARY_DIRS CACHE)
 find_package(Boost 1.67 COMPONENTS thread system timer program_options random filesystem chrono exception regex
-    serialization log log_setup atomic date_time signals)
+    serialization log log_setup atomic date_time signals container)
 If (Boost_FOUND)
   Set(Boost_Avail 1)
   Set(LD_LIBRARY_PATH ${LD_LIBRARY_PATH} ${Boost_LIBRARY_DIR})

--- a/base/MQ/devices/FairMQUnpacker.h
+++ b/base/MQ/devices/FairMQUnpacker.h
@@ -107,7 +107,7 @@ class FairMQUnpacker : public FairMQDevice
 
     void Run()
     {
-        const FairMQChannel& inputChannel = fChannels.at(fInputChannelName).at(0);
+        FairMQChannel& inputChannel = fChannels.at(fInputChannelName).at(0);
 
         while (CheckCurrentState(RUNNING))
         {

--- a/examples/simulation/Tutorial4/src/mc/FairTutorialDet4.cxx
+++ b/examples/simulation/Tutorial4/src/mc/FairTutorialDet4.cxx
@@ -360,8 +360,14 @@ void FairTutorialDet4::ModifyGeometryByFullPath()
 
     TGeoRotation* rrot = new TGeoRotation("rot",dphi,dtheta,dpsi);
     TGeoCombiTrans localdelta = *(new TGeoCombiTrans(dx,dy,dz, rrot));
-//      localdelta.Print();
-    TGeoHMatrix nlocal = *l3 * localdelta;
+
+    // Need to do this as since ROOT 6.14 TGeoMatrix has no multiplication operator anymore
+    // it is implimnted now in TGeoHMatrix
+    TGeoHMatrix l3m = TGeoHMatrix(*l3);
+    TGeoHMatrix ldm = TGeoHMatrix(localdelta);
+    // TGeoHMatrix nlocal = *l3 * localdelta;
+    TGeoHMatrix nlocal = l3m * ldm;
+
     TGeoHMatrix* nl3 = new TGeoHMatrix(nlocal); // new matrix, representing real position (from new local mis RS to the global one)
 
     TGeoPhysicalNode* pn3 = gGeoManager->MakePhysicalNode(volPath);
@@ -414,7 +420,14 @@ void FairTutorialDet4::ModifyGeometryBySymlink()
     TGeoRotation* rrot = new TGeoRotation("rot",dphi,dtheta,dpsi);
     TGeoCombiTrans localdelta = *(new TGeoCombiTrans(dx,dy,dz, rrot));
     localdelta.Print();
-    TGeoHMatrix nlocal = *l3 * localdelta;
+
+   // Need to do this as since ROOT 6.14 TGeoMatrix has no multiplication operator anymore
+    // it is implimnted now in TGeoHMatrix
+    TGeoHMatrix l3m = TGeoHMatrix(*l3);
+    TGeoHMatrix ldm = TGeoHMatrix(localdelta);
+    // TGeoHMatrix nlocal = *l3 * localdelta;
+    TGeoHMatrix nlocal = l3m * ldm;
+
     TGeoHMatrix* nl3 = new TGeoHMatrix(nlocal); // new matrix, representing real position (from new local mis RS to the global one)
 
     node->Align(nl3);


### PR DESCRIPTION
This pull request fixes some issues of the v18.0 patches branch when using the upcoming FairSoft version (RC_feb19). With the proposed changes the code of branch v18.0_patches compiles with the release candidate as well as with the latest FairSoft release.
---

Checklist:

* [x ] Rebased against `v18.0_patches` branch
* [ x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x ] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
