### PR TITLE
Fixed issue when SIMPATH was unset, added hint.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,11 +92,11 @@ Check_Compiler()
 # If alibuild is used the compiler flags are passed on the command line
 # and are also added to CMAKE_CXX_FLAGS.
 # So check if CMAKE_CXX_FLAGS has the compiler flags -std=c++11 or -std=c++14
-String(FIND ${CMAKE_CXX_FLAGS} "-std=c++11" POS_C++11)
+String(FIND "${CMAKE_CXX_FLAGS}" "-std=c++11" POS_C++11)
 If(${POS_C++11} EQUAL -1)
-  String(FIND ${CMAKE_CXX_FLAGS} "-std=c++14" POS_C++11)
+  String(FIND "${CMAKE_CXX_FLAGS}" "-std=c++14" POS_C++11)
   If(${POS_C++11} EQUAL -1)
-    String(FIND ${CMAKE_CXX_FLAGS} "-std=c++17" POS_C++11)
+    String(FIND "${CMAKE_CXX_FLAGS}" "-std=c++17" POS_C++11)
     If(${POS_C++11} EQUAL -1)
       Message(FATAL_ERROR "FairSoft wasn't compiled with c++11, c++14 or c++17 support. Please recompile FairSoft with a compiler which supports at least c++11.")
     EndIf()

--- a/cmake/modules/CheckCompiler.cmake
+++ b/cmake/modules/CheckCompiler.cmake
@@ -87,7 +87,7 @@ If(FAIRSOFT_CONFIG)
   String(STRIP ${FAIRSOFT_CXX_FLAGS} FAIRSOFT_CXX_FLAGS)
   Set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FAIRSOFT_CXX_FLAGS}")
 Else()
-  Message(STATUS "fairsoft-config not found")
+  Message(STATUS "fairsoft-config not found. Is SIMPATH or FAIRSOFT_ROOT set correctly?")
 EndIf()
 
 


### PR DESCRIPTION
When SIMPATH was unset, running cmake resulted in: 


  -- fairsoft-config not found
  --- Found a Linux system
  --- Found GNU compiler collection
  --- Build Type: RelWithDebInfo
  --- Compiler Flags:   -O2 -g -Wshadow

  CMake Error at CMakeLists.txt:95 (String):
    String sub-command FIND requires 3 or 4 parameters.


  CMake Error at CMakeLists.txt:96 (If):
    if given arguments:

      "EQUAL" "-1"

    Unknown arguments specified

This was not found to be a very helpful. Thus, I added "'s around the find arguments so they work even when empty, plus added a hint on the fairsoft-config not found info message. 
---

Checklist:

* [X] Rebased against `dev` branch
* [ ] My name is in the resp. CONTRIBUTORS/AUTHORS file -> no, trivial patch, public domain. 
* [ ] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules) -> partly, as have other commits :-)
