### PR TITLE
Deprecate fairlogger endl

### DIFF
--- a/fairtools/FairLogger.h
+++ b/fairtools/FairLogger.h
@@ -124,8 +124,8 @@ class FairLogger
     void Debug3 (const char* file, const char* line, const char* func, const char* format, ...)  __attribute__((deprecated("Use 'LOG(debug3) << content;' macro interface instead.")));
     void Debug4 (const char* file, const char* line, const char* func, const char* format, ...)  __attribute__((deprecated("Use 'LOG(debug4) << content;' macro interface instead.")));
 
-    static char const endl;
-    static char const flush;
+    static char const endl __attribute__((deprecated("Line break is now added automatically by the LOG macro, this variable only adds empty space.")));
+    static char const flush __attribute__((deprecated("Data is now flushed automatically by the LOG macro, this variable only adds empty space.")));
 
     void SetScreenStreamToCerr(bool /* useCerr */)
     {

--- a/parbase/FairParAsciiFileIo.cxx
+++ b/parbase/FairParAsciiFileIo.cxx
@@ -82,7 +82,7 @@ Bool_t FairParAsciiFileIo::open(const Text_t* fname, const Text_t* status)
 Bool_t FairParAsciiFileIo::open(const TList* fnamelist, const Text_t* status)
 {
   if ( 0 == fnamelist->GetEntries() ) {
-    LOG(error) << "The defined list of parameter files is empty. There are no parameters initialized from the ASCII files."; 
+    LOG(error) << "The defined list of parameter files is empty. There are no parameters initialized from the ASCII files.";
     return kFALSE;
   }
   TString outFileName = gSystem->WorkingDirectory();
@@ -100,7 +100,7 @@ Bool_t FairParAsciiFileIo::open(const TList* fnamelist, const Text_t* status)
     TString strParPath = string->GetString();
     gSystem->ExpandPathName(strParPath);
     if (gSystem->AccessPathName(strParPath))
-        LOG(FATAL) << "Parameter file " << strParPath << " does not exist." << FairLogger::endl;
+        LOG(fatal) << "Parameter file " << strParPath << " does not exist.";
     //    cout <<  string->GetString() <<endl;
     catCommand += string->GetString();
     catCommand += " ";


### PR DESCRIPTION
Since the new logger interface is available for over a year now, this would help to get rid of useless code.
Any use of `FairLogger::endl` will produce something like:
```
parbase/FairParAsciiFileIo.cxx:103:92: warning: ‘FairLogger::endl’ is deprecated: Line break is now added automatically by the LOG macro, this variable only adds empty space. [-Wdeprecated-declarations]
         LOG(FATAL) << "Parameter file " << strParPath << " does not exist." << FairLogger::endl;
                                                                                            ^~~~
In file included from /home/orybalch/dev/FairRoot/parbase/FairParAsciiFileIo.cxx:24:
/home/orybalch/dev/FairRoot/fairtools/FairLogger.h:127:23: note: declared here
     static char const endl __attribute__((deprecated("Line break is now added automatically by the LOG macro, this variable only adds empty space.")));
```

A deprecation for the uppercase severity names will be added on the FairRootGroup::FairLogger side (FairRootGroup/FairLogger#15).

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
