### PR TITLE
Fixed undefined behaviour (Fixes #887)

### DIFF
--- a/base/sim/FairMCApplication.cxx
+++ b/base/sim/FairMCApplication.cxx
@@ -1011,6 +1011,7 @@ Bool_t FairMCApplication::MisalignGeometry()
 {
   // call this only here
   fRun->AlignGeometry();
+  return true;
 }
 
 //_____________________________________________________________________________


### PR DESCRIPTION
Fixes undefined behavior, caused by a missing return value in `FairMCApplication::MisalignGeometry()`
