### PR TITLE
remove unused FairMQProgOptions includes

### DIFF
--- a/base/MQ/devices/BaseMQFileSink.h
+++ b/base/MQ/devices/BaseMQFileSink.h
@@ -18,7 +18,6 @@
 
 #include "FairMQDevice.h"
 #include "FairMQLogger.h"
-#include <options/FairMQProgOptions.h>
 
 template <typename InputPolicy, typename OutputPolicy>
 class BaseMQFileSink : public FairMQDevice, public InputPolicy, public OutputPolicy

--- a/base/MQ/devices/FairMQLmdSampler.h
+++ b/base/MQ/devices/FairMQLmdSampler.h
@@ -32,7 +32,6 @@ extern "C"
 #include "FairMQLogger.h"
 #include "FairMQDevice.h"
 #include "FairMQMessage.h"
-#include <options/FairMQProgOptions.h> // device->fConfig
 
 class FairMQLmdSampler : public FairMQDevice
 {

--- a/base/MQ/devices/FairMQSampler.h
+++ b/base/MQ/devices/FairMQSampler.h
@@ -37,7 +37,6 @@
 #include "FairMQDevice.h"
 #include "FairMQSamplerTask.h"
 #include "FairMQLogger.h"
-#include <options/FairMQProgOptions.h>
 
 /**
  * Reads simulated digis from a root file and samples the digi as a time-series UDP stream.

--- a/base/MQ/devices/FairMQUnpacker.h
+++ b/base/MQ/devices/FairMQUnpacker.h
@@ -16,7 +16,6 @@
 #define FAIRMQUNPACKER_H
 
 #include "FairMQDevice.h"
-#include <options/FairMQProgOptions.h>
 #include "RootSerializer.h"
 
 #include <stdexcept>

--- a/examples/MQ/parameters/FairMQExParamsClient.cxx
+++ b/examples/MQ/parameters/FairMQExParamsClient.cxx
@@ -18,7 +18,6 @@
 #include "FairMQLogger.h"
 #include "FairMQExParamsClient.h"
 #include "FairMQExParamsParOne.h"
-#include <options/FairMQProgOptions.h>
 
 #include "RootSerializer.h"
 #include "Rtypes.h"

--- a/examples/MQ/pixelAlternative/src/devices/FairMQPixAltFileSinkBin.cxx
+++ b/examples/MQ/pixelAlternative/src/devices/FairMQPixAltFileSinkBin.cxx
@@ -17,7 +17,6 @@
 
 #include "FairMQPixAltFileSinkBin.h"
 #include "FairMQLogger.h"
-#include <options/FairMQProgOptions.h>
 
 #include "PixelPayload.h"
 #include "PixelHit.h"

--- a/examples/MQ/pixelAlternative/src/devices/FairMQPixAltSamplerBin.cxx
+++ b/examples/MQ/pixelAlternative/src/devices/FairMQPixAltSamplerBin.cxx
@@ -17,7 +17,6 @@
 
 #include "FairMQPixAltSamplerBin.h"
 #include "FairMQLogger.h"
-#include <options/FairMQProgOptions.h>
 
 #include "FairMQMessage.h"
 

--- a/examples/MQ/pixelDetector/src/devices/FairMQPixelFileSink.cxx
+++ b/examples/MQ/pixelDetector/src/devices/FairMQPixelFileSink.cxx
@@ -20,7 +20,6 @@
 #include "FairMCEventHeader.h"
 #include "FairMQPixelFileSink.h"
 #include "FairMQLogger.h"
-#include <options/FairMQProgOptions.h>
 
 using namespace std;
 

--- a/examples/MQ/pixelDetector/src/devices/FairMQPixelFileSinkBin.cxx
+++ b/examples/MQ/pixelDetector/src/devices/FairMQPixelFileSinkBin.cxx
@@ -17,7 +17,6 @@
 
 #include "FairMQPixelFileSinkBin.h"
 #include "FairMQLogger.h"
-#include <options/FairMQProgOptions.h>
 
 #include "TVector3.h"
 

--- a/examples/MQ/pixelDetector/src/devices/FairMQPixelSampler.cxx
+++ b/examples/MQ/pixelDetector/src/devices/FairMQPixelSampler.cxx
@@ -19,7 +19,6 @@
 
 #include "FairMQLogger.h"
 #include "FairMQMessage.h"
-#include <options/FairMQProgOptions.h>
 
 #include "FairSource.h"
 #include "FairFileSource.h"

--- a/examples/MQ/pixelDetector/src/devices/FairMQPixelSamplerBin.cxx
+++ b/examples/MQ/pixelDetector/src/devices/FairMQPixelSamplerBin.cxx
@@ -14,7 +14,6 @@
 
 #include "FairMQPixelSamplerBin.h"
 #include "FairMQLogger.h"
-#include <options/FairMQProgOptions.h>
 
 #include "FairMQMessage.h"
 

--- a/examples/MQ/pixelDetector/src/devices/FairMQSimDevice.cxx
+++ b/examples/MQ/pixelDetector/src/devices/FairMQSimDevice.cxx
@@ -16,7 +16,6 @@
   
 #include "FairMQLogger.h"
 #include "FairMQMessage.h"
-#include "FairMQProgOptions.h"
 
 #include "FairOnlineSink.h"
 

--- a/parmq/ParameterMQServer.cxx
+++ b/parmq/ParameterMQServer.cxx
@@ -25,7 +25,6 @@
 
 #include "ParameterMQServer.h"
 #include "FairMQLogger.h"
-#include <options/FairMQProgOptions.h>
 
 using namespace std;
 


### PR DESCRIPTION
In these files the FairMQProgOptions class is not used directly, but only as a member of FairMQDevice (if at all), which includes the header itself.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
