### PR TITLE
Hotfix v18.0 to support CMake 3.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ SET(VMCWORKDIR ${CMAKE_SOURCE_DIR}/examples)
 # any of the features of the new standard
 Set(CheckSrcDir "${CMAKE_SOURCE_DIR}/cmake/checks")
 include(CheckCXX11Features)
+include(CheckSymbolExists)
 
 # FairRoot only uses C++11 or later, so we need an compiler which supports C++11
 # Check if the used compiler support C++11. If not stop with an error message

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ endforeach()
 # Set project version
 SET(FAIRROOT_MAJOR_VERSION 18)
 SET(FAIRROOT_MINOR_VERSION 0)
-SET(FAIRROOT_PATCH_VERSION 6)
+SET(FAIRROOT_PATCH_VERSION 8)
 
 # Set name of our project to "FAIRROOT".
 # Has to be done after check of cmake version


### PR DESCRIPTION
Tested on Fedora 30 with CMake `3.15.1` only.

Resolve #905 