### PR TITLE
Remove signals from required boost modules (not needed anymore)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,7 +215,7 @@ Unset(Boost_LIBRARY_DIRS CACHE)
 
 find_package2(PUBLIC Boost
   VERSION 1.67
-  COMPONENTS thread system timer program_options random filesystem chrono exception regex serialization log log_setup atomic date_time signals
+  COMPONENTS thread system timer program_options random filesystem chrono exception regex serialization log log_setup atomic date_time
   ADD_REQUIREMENTS_OF FairMQ
 )
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -26,6 +26,7 @@ Pierre-Alain, Loizeau
 Pflueger, Stefan
 Richter, Matthias
 Rademakers, Fons
+Rohr, David
 Shahoyan, Ruben
 Stockmanns, Tobias
 Ustyuzhanin, Andrey


### PR DESCRIPTION
Remove "signals" from the required boost modules, otherwise it fails to compile with boost 1.70

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
