### PR TITLE
Do not build FastSim module if Geant4 not found

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -9,7 +9,10 @@
 # the array .
 # The extension is already found.  Any number of sources could be listed here.
 
-add_subdirectory (sim/fastsim)
+# only build fastsim module if Geant4 was found
+if (Geant4_FOUND)
+  add_subdirectory (sim/fastsim)
+endif()
 
 If(NOT DEFINED BUILD_MBS)
   Set(BUILD_MBS TRUE)


### PR DESCRIPTION
This is useful for clients using FairRoot without
the simulation components.

Relates to https://github.com/alisw/alidist/pull/1776