### PR TITLE
Fix deps

### DIFF
--- a/MbsAPI/CMakeLists.txt
+++ b/MbsAPI/CMakeLists.txt
@@ -1,8 +1,8 @@
  ################################################################################
  #    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    #
  #                                                                              #
- #              This software is distributed under the terms of the             # 
- #              GNU Lesser General Public Licence (LGPL) version 3,             #  
+ #              This software is distributed under the terms of the             #
+ #              GNU Lesser General Public Licence (LGPL) version 3,             #
  #                  copied verbatim in the file "LICENSE"                       #
  ################################################################################
 # Create a library called "libBase" which includes the source files given in
@@ -25,18 +25,8 @@ Set(INCLUDE_DIRECTORIES
   ${CMAKE_SOURCE_DIR}/MbsAPI
 )
 
-Set(SYSTEM_INCLUDE_DIRECTORIES
-  ${ROOT_INCLUDE_DIR}
-)
-
 Include_Directories(${INCLUDE_DIRECTORIES})
 Include_Directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
-
-Set(LINK_DIRECTORIES
-  ${ROOT_LIBRARY_DIR}
-)
-
-Link_Directories(${LINK_DIRECTORIES})
 
 # List of source files
 Set(MBSAPI_SRCS
@@ -70,7 +60,6 @@ Set(MBSAPI_HEADERS
 
 ############### build the library #####################
 add_library(MbsAPI SHARED ${MBSAPI_SRCS})
-target_link_libraries(MbsAPI ${ROOT_LIBRARIES})
 set_target_properties(MbsAPI PROPERTIES ${FAIRROOT_LIBRARY_PROPERTIES})
 
 ############### install the library ###################

--- a/examples/MQ/Lmd/CMakeLists.txt
+++ b/examples/MQ/Lmd/CMakeLists.txt
@@ -47,7 +47,7 @@ Set(SRCS
 )
 
 Set(DEPENDENCIES
-  Base MbsAPI MbsTutorial FairMQ::FairMQ
+  Base MbsAPI MbsTutorial FairMQ::FairMQ Net
 )
 
 Set(LINKDEF LmdLinkDef.h)

--- a/examples/MQ/pixelDetector/src/CMakeLists.txt
+++ b/examples/MQ/pixelDetector/src/CMakeLists.txt
@@ -1,8 +1,8 @@
  ################################################################################
  #    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    #
  #                                                                              #
- #              This software is distributed under the terms of the             # 
- #              GNU Lesser General Public Licence (LGPL) version 3,             #  
+ #              This software is distributed under the terms of the             #
+ #              GNU Lesser General Public Licence (LGPL) version 3,             #
  #                  copied verbatim in the file "LICENSE"                       #
  ################################################################################
 # Create a library called "libPixel" which includes the source files given in
@@ -31,7 +31,7 @@ Include_Directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
 set(LINK_DIRECTORIES
 ${ROOT_LIBRARY_DIR}
 ${Boost_LIBRARY_DIRS}
-) 
+)
 
 link_directories( ${LINK_DIRECTORIES})
 
@@ -83,7 +83,7 @@ PixelHit.cxx
 PixelTrack.cxx
 )
 
-Set(HEADERS 
+Set(HEADERS
 Pixel.h
 PixelContFact.h
 PixelDigitize.h
@@ -110,17 +110,18 @@ PixelPayload.h
 Set(LINKDEF PixelLinkDef.h)
 Set(LIBRARY_NAME Pixel)
 Set(DEPENDENCIES
-    Base 
+    Base
     GeoBase
     ParBase
     MCStack
     FairMQ::FairMQ
-    BaseMQ 
+    BaseMQ
     Gen
     Passive
-    ${Boost_THREAD_LIBRARY} 
-    ${Boost_SYSTEM_LIBRARY} 
-    ${Boost_SERIALIZATION_LIBRARY} 
+    Net
+    ${Boost_THREAD_LIBRARY}
+    ${Boost_SYSTEM_LIBRARY}
+    ${Boost_SERIALIZATION_LIBRARY}
    ${Boost_PROGRAM_OPTIONS_LIBRARY}
 )
 

--- a/examples/MQ/serialization/CMakeLists.txt
+++ b/examples/MQ/serialization/CMakeLists.txt
@@ -70,6 +70,7 @@ set(DEPENDENCIES
     BaseMQ
     ${Boost_SERIALIZATION_LIBRARY}
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
+    Net
     Minuit
     XMLIO
     MathMore

--- a/examples/advanced/Tutorial3/CMakeLists.txt
+++ b/examples/advanced/Tutorial3/CMakeLists.txt
@@ -173,7 +173,7 @@ Set(LINKDEF FairTestDetectorLinkDef.h)
 Set(LIBRARY_NAME FairTestDetector)
 
 Set(DEPENDENCIES
-  Base MCStack FairMQ::FairMQ BaseMQ
+  Base MCStack FairMQ::FairMQ BaseMQ Net
   ${Boost_THREAD_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}
   ${Boost_SERIALIZATION_LIBRARY}


### PR DESCRIPTION
Follow-up on question in alisw/alidist#1768.

@ktf Does this help? I believe the `liblz4` dep you see comes in transitively from ROOT's `libCore` (It has a dep to `liblzma` on my ROOT installation, but IIRC this depends on the ROOT config and/or version)
