### PR TITLE
Few changes to allow running of Geant4 transport in multithreaded mode.

### DIFF
--- a/base/sim/FairDetector.cxx
+++ b/base/sim/FairDetector.cxx
@@ -82,7 +82,7 @@ void FairDetector::DefineSensitiveVolumes()
   TGeoVolume* volume;
   while ( ( volume = static_cast<TGeoVolume*>(next()) ) ) {
     if ( IsSensitive(volume->GetName()) ) {
-      LOG(info)<<"Sensitive Volume "<< volume->GetName();
+      LOG(debug)<<"Sensitive Volume "<< volume->GetName();
       AddSensitiveVolume(volume);
     }
   }

--- a/base/sim/FairDetector.cxx
+++ b/base/sim/FairDetector.cxx
@@ -72,11 +72,35 @@ FairDetector::FairDetector()
 {
 }
 
+// -------------------------------------------------------------------------
+
+void FairDetector::DefineSensitiveVolumes()
+{
+  LOG(info) << "FairDetector::DefineSensitiveVolumes";
+  TObjArray* volumes = gGeoManager->GetListOfVolumes();
+  TIter next(volumes);
+  TGeoVolume* volume;
+  while ( ( volume = static_cast<TGeoVolume*>(next()) ) ) {
+    if ( CheckIfSensitive(volume->GetName()) ) {
+      LOG(info)<<"Sensitive Volume "<< volume->GetName();
+      AddSensitiveVolume(volume);
+    }
+  }
+}
+
+// -------------------------------------------------------------------------
+
 void   FairDetector::Initialize()
 {
 // Registers hits collection in Root manager;
 // sets sensitive volumes.
 // ---
+
+  // Define sensitive volumes if in MT
+  if ( gMC->IsMT() ) {
+    std::cout << "Define sensitive volume " << std::endl;
+    DefineSensitiveVolumes();
+  }
 
   Int_t NoOfEntries=svList->GetEntries();
   Int_t fMCid;

--- a/base/sim/FairDetector.cxx
+++ b/base/sim/FairDetector.cxx
@@ -81,7 +81,7 @@ void FairDetector::DefineSensitiveVolumes()
   TIter next(volumes);
   TGeoVolume* volume;
   while ( ( volume = static_cast<TGeoVolume*>(next()) ) ) {
-    if ( CheckIfSensitive(volume->GetName()) ) {
+    if ( IsSensitive(volume->GetName()) ) {
       LOG(info)<<"Sensitive Volume "<< volume->GetName();
       AddSensitiveVolume(volume);
     }

--- a/base/sim/FairDetector.h
+++ b/base/sim/FairDetector.h
@@ -79,13 +79,13 @@ class FairDetector : public FairModule
       return fDetId;
     }
 
-    virtual void DefineSensitiveVolumes();
-
   protected:
     /** Copy constructor */
     FairDetector(const FairDetector&);
     /** Assignment operator */
     FairDetector& operator= (const FairDetector&);
+
+    void DefineSensitiveVolumes();
 
     Int_t fDetId; // Detector Id has to be set from ctr.
     FairLogger* fLogger;  //! /// FairLogger

--- a/base/sim/FairDetector.h
+++ b/base/sim/FairDetector.h
@@ -79,6 +79,8 @@ class FairDetector : public FairModule
       return fDetId;
     }
 
+    virtual void DefineSensitiveVolumes();
+
   protected:
     /** Copy constructor */
     FairDetector(const FairDetector&);

--- a/base/sim/FairGenericStack.cxx
+++ b/base/sim/FairGenericStack.cxx
@@ -93,7 +93,6 @@ FairGenericStack* FairGenericStack::CloneStack() const
   return 0;
 }
 
-
 void FairGenericStack::FastSimMoveParticleTo(Double_t xx, Double_t yy, Double_t zz, Double_t tt,
                                       Double_t px, Double_t py, Double_t pz, Double_t en)
 {

--- a/base/sim/FairMCApplication.cxx
+++ b/base/sim/FairMCApplication.cxx
@@ -606,7 +606,7 @@ TVirtualMCApplication* FairMCApplication::CloneForWorker() const
   // and pass some data from master FairRunSim object
   FairRunSim* workerRun = new FairRunSim(kFALSE);
   workerRun->SetName(fRun->GetName()); // Transport engine
-  workerRun->SetUserOutputFileName(fRun->GetUserOutputFileName());
+  workerRun->SetSink(fRun->GetSink()->CloneSink());
 
   // Trajectories filter is created explicitly as we do not call
   // FairRunSim::Init on workers
@@ -637,9 +637,8 @@ void FairMCApplication::InitOnWorker()
 
   // Generate per-thread file name
   // and create a new sink on worker
-  TString workerFileName = fRun->GetUserOutputFileName();
-  fRootManager->UpdateFileName(workerFileName);
-  fRun->SetSink(new FairRootFileSink(workerFileName));
+  // moved to CloneForWorker and specific sink->CloneSink();
+
   fRootManager->InitSink();
 
   // Cache thread-local gMC

--- a/base/sim/FairMCApplication.cxx
+++ b/base/sim/FairMCApplication.cxx
@@ -812,7 +812,10 @@ void FairMCApplication::FinishEvent()
 {
 // User actions after finishing of an event
 // ---
-  LOG(debug) << "FairMCMCApplication::FinishEvent: " << fRootManager->GetInstanceId();
+  LOG(debug) << "[" << fRootManager->GetInstanceId() << " FairMCMCApplication::FinishEvent: " << fMCEventHeader->GetEventID() << " (MC " << gMC->CurrentEvent() << ")";
+  if ( gMC->IsMT() && fRun->GetSink()->GetSinkType() == kONLINESINK ) { // fix the rare case when running G4 multithreaded on MQ
+    fMCEventHeader->SetEventID(gMC->CurrentEvent()+1);
+  }
 
   // --> Fill the stack output array
   fStack->FillTrackArray();

--- a/base/sim/FairMCApplication.cxx
+++ b/base/sim/FairMCApplication.cxx
@@ -65,6 +65,9 @@ class TParticle;
 #include <stdlib.h>                     // for getenv, exit
 #include <utility>                      // for pair
 
+#include <mutex>          // std::mutex
+std::mutex mtx;           // mutex for critical section
+
 using std::pair;
 
 FairMCApplication* FairMCApplication::fgMasterInstance = 0;
@@ -596,6 +599,7 @@ void FairMCApplication::PreTrack()
 //_____________________________________________________________________________
 TVirtualMCApplication* FairMCApplication::CloneForWorker() const
 {
+  mtx.lock();
   LOG(info) << "FairMCApplication::CloneForWorker ";
 
   // Create new FairRunSim object on worker
@@ -613,6 +617,8 @@ TVirtualMCApplication* FairMCApplication::CloneForWorker() const
   // Create new FairMCApplication object on worker
   FairMCApplication* workerApplication = new FairMCApplication(*this);
   workerApplication->SetGenerator(fEvGen->ClonePrimaryGenerator());
+
+  mtx.unlock();
 
   return workerApplication;
 }

--- a/base/sim/FairModule.cxx
+++ b/base/sim/FairModule.cxx
@@ -557,14 +557,15 @@ void FairModule::ConstructASCIIGeometry()
 
 Bool_t FairModule::CheckIfSensitive(std::string)
 {
-    LOG(warn)<<"Implement IsSensitive in the detector class which inherits from FairModule";
+    LOG(warn)<<"The method CheckIfSensitive is deprecated. Use IsSensitive.";
     return kFALSE;
 }
 
 //__________________________________________________________________________
 Bool_t FairModule::IsSensitive(const std::string& name)
 {
-    LOG(warn)<<"The method CheckIfSensitive is deprecated. Use IsSensitive.";
+    LOG(warn)<<"Implement IsSensitive in the detector class which inherits from FairModule";
+    LOG(warn)<<"For now calling the obsolete function CheckIfSensitive";
     return CheckIfSensitive(name);
 }
 

--- a/base/sim/FairModule.cxx
+++ b/base/sim/FairModule.cxx
@@ -479,7 +479,7 @@ void FairModule::ExpandNodeForGDML(TGeoNode* curNode)
     AssignMediumAtImport(curVol);
 
     // Check if the volume is sensitive
-    if ( (this->InheritsFrom("FairDetector")) && CheckIfSensitive(curVol->GetName())) {
+    if ( (this->InheritsFrom("FairDetector")) && IsSensitive(curVol->GetName())) {
         LOG(debug2)<<"Sensitive Volume "<< curVol->GetName();
         AddSensitiveVolume(curVol);
     }
@@ -557,8 +557,15 @@ void FairModule::ConstructASCIIGeometry()
 
 Bool_t FairModule::CheckIfSensitive(std::string)
 {
-  LOG(warn)<<"The method CheckIfSensitive has to be implemented in the detector class which inherits from FairModule";
-  return kFALSE;
+    LOG(warn)<<"Implement IsSensitive in the detector class which inherits from FairModule";
+    return kFALSE;
+}
+
+//__________________________________________________________________________
+Bool_t FairModule::IsSensitive(const std::string& name)
+{
+    LOG(warn)<<"The method CheckIfSensitive is deprecated. Use IsSensitive.";
+    return CheckIfSensitive(name);
 }
 
 void FairModule::ExpandNode(TGeoNode* fN)
@@ -583,7 +590,7 @@ void FairModule::ExpandNode(TGeoNode* fN)
       LOG(debug2)<<"Register Volume " << v->GetName();
       v->RegisterYourself();
     }
-    if ( (this->InheritsFrom("FairDetector")) && CheckIfSensitive(v->GetName())) {
+    if ( (this->InheritsFrom("FairDetector")) && IsSensitive(v->GetName())) {
       LOG(debug2)<<"Sensitive Volume "<< v->GetName();
       AddSensitiveVolume(v);
     }

--- a/base/sim/FairModule.h
+++ b/base/sim/FairModule.h
@@ -93,6 +93,8 @@ class FairModule:  public TNamed
 
     /**Set the sensitivity flag for volumes, called from ConstructASCIIRootGeometry(), and has to be implimented for detectors
      * which use ConstructASCIIRootGeometry() to build the geometry */
+    virtual Bool_t      IsSensitive(const std::string& name);
+    /**The function below is depracated, please change to the new method above */
     virtual Bool_t      CheckIfSensitive(std::string name);
     /**called from ConstructRootGeometry()*/
     virtual void        ExpandNode(TGeoNode* Node);

--- a/base/sink/FairRootFileSink.cxx
+++ b/base/sink/FairRootFileSink.cxx
@@ -108,7 +108,7 @@ Bool_t FairRootFileSink::InitSink()
 
     //FairRun* fRun = FairRun::Instance();
     /**Check if a simulation run!*/
-    fOutFolder= gROOT->GetRootFolder()->AddFolder(FairRootManager::GetFolderName(), "Main Folder");
+    fOutFolder= gROOT->GetRootFolder()->AddFolder(Form("%s_%d",FairRootManager::GetFolderName(),FairRootManager::Instance()->GetInstanceId()), "Main Folder");
     gROOT->GetListOfBrowsables()->Add(fOutFolder);
 
     LOG(info) << "FairRootFileSink initialized.";
@@ -256,11 +256,11 @@ void FairRootFileSink::RegisterAny(const char* brname, const std::type_info &oi,
 
 void FairRootFileSink::WriteFolder() {
   fRootFile->cd();
-  if (fOutFolder!=0) {
-    fOutFolder->Write();
+  if(fOutFolder!=0) {
+    fOutFolder->Write(FairRootManager::GetFolderName());
 
     //FairRun* fRun = FairRun::Instance();
-    fOutTree =new TTree(FairRootManager::GetTreeName(), Form("/%s", FairRootManager::GetFolderName()), 99);
+    fOutTree =new TTree(FairRootManager::GetTreeName(), Form("/%s_%d",FairRootManager::GetFolderName(),FairRootManager::Instance()->GetInstanceId()), 99);
     TruncateBranchNames();
     CreatePersistentBranchesAny();
   }
@@ -346,5 +346,19 @@ Int_t FairRootFileSink::Write(const char*, Int_t, Int_t)
   }
   return 0;
 }
+//_____________________________________________________________________________
+
+//_____________________________________________________________________________
+FairSink*  FairRootFileSink::CloneSink() {
+    FairRootManager* tempMan = FairRootManager::Instance();
+
+    TString workerFileName = fRootFile->GetName();
+    tempMan->UpdateFileName(workerFileName);
+    FairRootFileSink* newSink = new FairRootFileSink(workerFileName);
+
+    LOG(info) << "FairRootFileSink::CloneSink(). manager " << tempMan->GetInstanceId();
+    return newSink;
+}
+//_____________________________________________________________________________
 
 ClassImp(FairRootFileSink)

--- a/base/sink/FairRootFileSink.h
+++ b/base/sink/FairRootFileSink.h
@@ -70,7 +70,7 @@ class FairRootFileSink : public FairSink
 
     virtual FairSink*   CloneSink();
 
-private:
+ private:
     /** Title of input sink, could be input, background or signal*/
     TString fOutputTitle;
     /** ROOT file */

--- a/base/sink/FairRootFileSink.h
+++ b/base/sink/FairRootFileSink.h
@@ -68,7 +68,9 @@ class FairRootFileSink : public FairSink
     virtual void      WriteObject(TObject* f, const char*, Int_t option = 0);
     virtual void      WriteGeometry();
 
-  private:
+    virtual FairSink*   CloneSink();
+
+private:
     /** Title of input sink, could be input, background or signal*/
     TString fOutputTitle;
     /** ROOT file */

--- a/base/sink/FairSink.h
+++ b/base/sink/FairSink.h
@@ -61,6 +61,8 @@ class FairSink
     virtual void WriteObject(TObject* f, const char*, Int_t option = 0) = 0;
     virtual void WriteGeometry() = 0;
 
+    virtual FairSink*   CloneSink() = 0;
+
   protected:
     struct TypeAddressPair {
       TypeAddressPair(const std::type_info& oi, const std::type_info& pi, void* a) : origtypeinfo(oi), persistenttypeinfo(pi), ptraddr(a) {}

--- a/examples/MQ/pixelDetector/macros/run_sim.C
+++ b/examples/MQ/pixelDetector/macros/run_sim.C
@@ -6,7 +6,7 @@
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
 
-void run_sim(Int_t nEvents = 10, TString mcEngine = "TGeant3", Int_t fileId = 0)
+void run_sim(Int_t nEvents = 10, TString mcEngine = "TGeant3", Int_t fileId = 0, Bool_t isMT = kFALSE)
 {
   TString dir = getenv("VMCWORKDIR");
   TString tutdir = dir + "/MQ/pixelDetector";
@@ -50,6 +50,7 @@ void run_sim(Int_t nEvents = 10, TString mcEngine = "TGeant3", Int_t fileId = 0)
   // -----   Create simulation run   ----------------------------------------
   FairRunSim* run = new FairRunSim();
   run->SetName(mcEngine);              // Transport engine
+  run->SetIsMT(isMT);                  // Multi-threading mode (Geant4 only)
   run->SetSink(new FairRootFileSink(outFile));
   FairRuntimeDb* rtdb = run->GetRuntimeDb();
   // ------------------------------------------------------------------------

--- a/examples/MQ/pixelDetector/run/scripts/startFairMQPixel.sh.in
+++ b/examples/MQ/pixelDetector/run/scripts/startFairMQPixel.sh.in
@@ -2,6 +2,12 @@
 
 source @CMAKE_BINARY_DIR@/config.sh -p
 
+echo "*********************************************************************"
+pwd
+echo "*********************************************************************"
+ps -fea
+echo "*********************************************************************"
+
 MAXINDEX="--max-index -1"
 TRANSPORT="--transport zeromq"
 VERBOSE="--severity INFO"
@@ -99,6 +105,9 @@ else
 fi
 ###########################
 
+echo "*********************************************************************"
+echo "cout<<cbmsim->GetEntries()<<endl;" | root -l -b $INPUTFILE | tail -1
+echo "*********************************************************************"
 
 
 ########################### Start the chain of the devices
@@ -107,16 +116,16 @@ fi
 ########################## start Parameter server
 SERVER="@fairroot_bin_dir@/"
 SERVER+="parmq-server $TRANSPORT"
-SERVER+=" --id pixDet-parmq-server --channel-config name=param,type=rep,method=bind,rateLogging=0,address=tcp://*:5105"
+SERVER+=" --id pixDet-parmq-server --channel-config name=param,type=rep,method=bind,rateLogging=0,address=tcp://*:5405"
 SERVER+=" --channel-name param --first-input-name $ROOTPARAM --second-input-name $ASCIIPARAM --second-input-type ASCII $CONTROL"
 
 ########################## start SAMPLER
 SAMPLER="@pixel_bin_dir@/"
 SAMPLER+="pixel-sampler $TRANSPORT"
 SAMPLER+=" --id pixDet-sampler1 --severity info"
-SAMPLER+=" --channel-config name=data-out,type=push,method=bind,rateLogging=1,address=tcp://*:5106"
+SAMPLER+=" --channel-config name=data-out,type=push,method=bind,rateLogging=1,address=tcp://*:5406"
 if [ "$COMMAND" == "static" ]; then
-    SAMPLER+=" --ack-channel ack --channel-config name=ack,type=pull,method=bind,rateLogging=0,address=tcp://*:5108"
+    SAMPLER+=" --ack-channel ack --channel-config name=ack,type=pull,method=bind,rateLogging=0,address=tcp://*:5408"
 fi
 SAMPLER+=" --file-name $INPUTFILE --branch-name $INPUTBRANCH --branch-name EventHeader. $MAXINDEX $CONTROL"
 
@@ -124,9 +133,9 @@ SAMPLER+=" --file-name $INPUTFILE --branch-name $INPUTBRANCH --branch-name Event
 PROCESSOR="@pixel_bin_dir@/"
 PROCESSOR+="pixel-processor $TRANSPORT"
 PROCESSOR+=" $VERBOSE"
-PROCESSOR+=" --channel-config name=param,type=req,method=connect,rateLogging=0,address=tcp://localhost:5105"
-PROCESSOR+=" --channel-config name=data-in,type=pull,method=connect,rateLogging=1,address=tcp://localhost:5106"
-PROCESSOR+=" --channel-config name=data-out,type=push,method=connect,rateLogging=1,address=tcp://localhost:5107"
+PROCESSOR+=" --channel-config name=param,type=req,method=connect,rateLogging=0,address=tcp://localhost:5405"
+PROCESSOR+=" --channel-config name=data-in,type=pull,method=connect,rateLogging=1,address=tcp://localhost:5406"
+PROCESSOR+=" --channel-config name=data-out,type=push,method=connect,rateLogging=1,address=tcp://localhost:5407"
 PROCESSOR+=" $FAIRTASKNAME $CONTROL"
 
 for (( i=0 ; i<$NOFPROCESSORS ; i++ ))
@@ -137,9 +146,9 @@ done
 ########################## start FILESINK
 FILESINK="@pixel_bin_dir@/"
 FILESINK+="pixel-sink $TRANSPORT"
-FILESINK+=" --id pixDet-sink1 --channel-config name=data-in,type=pull,method=bind,rateLogging=1,address=tcp://*:5107"
+FILESINK+=" --id pixDet-sink1 --channel-config name=data-in,type=pull,method=bind,rateLogging=1,address=tcp://*:5407"
 if [ "$COMMAND" == "static" ]; then
-    FILESINK+=" --ack-channel ack --channel-config name=ack,type=push,method=connect,rateLogging=0,address=tcp://localhost:5108"
+    FILESINK+=" --ack-channel ack --channel-config name=ack,type=push,method=connect,rateLogging=0,address=tcp://localhost:5408"
 fi
 FILESINK+=" --file-name $OUTPUTFILE $CONTROL"
 

--- a/examples/MQ/pixelDetector/src/FairOnlineSink.cxx
+++ b/examples/MQ/pixelDetector/src/FairOnlineSink.cxx
@@ -16,6 +16,8 @@
 
 #include "FairMQRunDevice.h"
 
+#include "FairRootManager.h"
+
 #include <FairMQLogger.h>
 
 FairOnlineSink::FairOnlineSink()
@@ -27,10 +29,6 @@ FairOnlineSink::FairOnlineSink()
 FairOnlineSink::FairOnlineSink(const FairOnlineSink&)
   : FairSink()
   , fMQRunDevice(nullptr)
-{
-}
-
-FairOnlineSink::~FairOnlineSink()
 {
 }
 
@@ -65,14 +63,9 @@ void FairOnlineSink::Fill()
 {
   /// Fill the Root tree.
   LOG(debug) << "[" << FairRootManager::Instance()->GetInstanceId() << "] called FairOnlineSink::Fill()!!!!";
-  
+
   if ( fMQRunDevice )
       fMQRunDevice->SendBranches();
-}
- 
-Bool_t FairOnlineSink::InitSink()
-{
-    return kTRUE;
 }
 
 //_____________________________________________________________________________

--- a/examples/MQ/pixelDetector/src/FairOnlineSink.cxx
+++ b/examples/MQ/pixelDetector/src/FairOnlineSink.cxx
@@ -41,12 +41,27 @@ void FairOnlineSink::RegisterImpl(const char* , const char* , void* )
 }
 
 //_____________________________________________________________________________
-void FairOnlineSink::RegisterAny(const char* /* brname */, const std::type_info &/* oi */, const std::type_info &/* pi */, void* /* obj */)
-{
-  return;
+void FairOnlineSink::RegisterAny(const char* brname, const std::type_info &oi, const std::type_info &pi, void* obj) {
+   fPersistentBranchesMap[brname]=std::unique_ptr<TypeAddressPair const> (new TypeAddressPair(oi, pi,obj));
 }
 
-void  FairOnlineSink::Fill()
+//_____________________________________________________________________________
+bool FairOnlineSink::IsPersistentBranchAny(const char *name) {
+    if (fPersistentBranchesMap.find(name) == fPersistentBranchesMap.end()) {
+        return false;
+    }
+    return true;
+}
+
+//_____________________________________________________________________________
+void FairOnlineSink::EmitPersistentBranchWrongTypeWarning(const char* brname, const char *type1, const char *type2) const {
+  LOG(warn) << "Trying to read from persistent branch " << brname
+               << " with wrong type " << type1
+               << " (expexted: " << type2 << " )";
+}
+
+//_____________________________________________________________________________
+void FairOnlineSink::Fill()
 {
   /// Fill the Root tree.
   LOG(debug) << "[" << FairRootManager::Instance()->GetInstanceId() << "] called FairOnlineSink::Fill()!!!!";

--- a/examples/MQ/pixelDetector/src/FairOnlineSink.cxx
+++ b/examples/MQ/pixelDetector/src/FairOnlineSink.cxx
@@ -19,15 +19,54 @@
 #include <FairMQLogger.h>
 
 FairOnlineSink::FairOnlineSink()
-  : fMQRunDevice(nullptr)
-{}
+  : FairSink()
+  , fMQRunDevice(nullptr)
+{
+}
+
+FairOnlineSink::FairOnlineSink(const FairOnlineSink&)
+  : FairSink()
+  , fMQRunDevice(nullptr)
+{
+}
+
+FairOnlineSink::~FairOnlineSink()
+{
+}
+
+//_____________________________________________________________________________
+void FairOnlineSink::RegisterImpl(const char* , const char* , void* )
+{
+  return;
+}
+
+//_____________________________________________________________________________
+void FairOnlineSink::RegisterAny(const char* /* brname */, const std::type_info &/* oi */, const std::type_info &/* pi */, void* /* obj */)
+{
+  return;
+}
 
 void  FairOnlineSink::Fill()
 {
   /// Fill the Root tree.
-  LOG(debug) << "called FairOnlineSink::Fill()!!!!";
-
-  if (fMQRunDevice) {
-    fMQRunDevice->SendBranches();
-  }
+  LOG(debug) << "[" << FairRootManager::Instance()->GetInstanceId() << "] called FairOnlineSink::Fill()!!!!";
+  
+  if ( fMQRunDevice )
+      fMQRunDevice->SendBranches();
 }
+ 
+Bool_t FairOnlineSink::InitSink()
+{
+    return kTRUE;
+}
+
+//_____________________________________________________________________________
+FairSink*  FairOnlineSink::CloneSink() {
+    FairRootManager* tempMan = FairRootManager::Instance();
+    FairOnlineSink* newSink = new FairOnlineSink(*this);
+    newSink->SetMQRunDevice(this->GetMQRunDevice());
+    LOG(info) << "[" << tempMan->GetInstanceId() << "] FairOnlineSink::CloneSink() setting MQRunDevice to " << this->GetMQRunDevice();
+
+    return newSink;
+}
+//_____________________________________________________________________________

--- a/examples/MQ/pixelDetector/src/FairOnlineSink.h
+++ b/examples/MQ/pixelDetector/src/FairOnlineSink.h
@@ -62,11 +62,40 @@ class FairOnlineSink : public FairSink
 
     virtual FairSink*   CloneSink();
 
- private:
+    bool                IsPersistentBranchAny(const char *name);
+
+    /* /// Returns a default object for a branch or looks it up when it exists already. */
+    /* /// Returns nullptr when the branch does not exist or looking up with wrong type. */
+    /* /// The returned default object will be filled with data by the framework. */
+    template<typename T>
+        T GetPersistentBranchAny(const char* name) const;
+
+
+ private: 
     FairMQRunDevice* fMQRunDevice;
+
+    // private helper function to emit a warning
+    void EmitPersistentBranchWrongTypeWarning(const char* brname, const char *typen1, const char *typen2) const;
 
     FairOnlineSink(const FairOnlineSink&);
     FairOnlineSink& operator=(const FairOnlineSink&);
 };
+
+// try to retrieve an object address from the registered branches/names
+template<typename T>
+T FairOnlineSink::GetPersistentBranchAny(const char* brname) const {
+  static_assert(std::is_pointer<T>::value, "Return type of GetPersistentBranchAny has to be a pointer");
+  using P = typename std::remove_pointer<T>::type;
+  auto iter = fPersistentBranchesMap.find(brname);
+  if(iter != fPersistentBranchesMap.end()) {
+    // verify type consistency
+    if(typeid(P).hash_code() != iter->second->origtypeinfo.hash_code()) {
+      EmitPersistentBranchWrongTypeWarning(brname, typeid(P).name(), iter->second->origtypeinfo.name());
+      return nullptr;
+    }
+    return static_cast<T>(iter->second->ptraddr);
+  }
+  return nullptr;
+}
 
 #endif /* FAIRONLINESIK_H_ */

--- a/examples/MQ/pixelDetector/src/FairOnlineSink.h
+++ b/examples/MQ/pixelDetector/src/FairOnlineSink.h
@@ -48,8 +48,8 @@ class FairOnlineSink : public FairSink
 
     virtual Int_t     Write(const char* /* name=0 */, Int_t /* option=0 */, Int_t /* bufsize=0 */) {return -1;}
 
-    virtual void      RegisterImpl(const char* , const char* , void* ) {}
-    virtual void      RegisterAny(const char* brname, const std::type_info &oi, const std::type_info &pi, void* obj) {}
+    virtual void      RegisterImpl(const char* , const char* , void* );
+    virtual void      RegisterAny(const char* brname, const std::type_info &oi, const std::type_info &pi, void* obj);
 
     virtual void      WriteFolder() {}
     virtual bool      CreatePersistentBranchesAny() {return false;}
@@ -71,7 +71,7 @@ class FairOnlineSink : public FairSink
         T GetPersistentBranchAny(const char* name) const;
 
 
- private: 
+ private:
     FairMQRunDevice* fMQRunDevice;
 
     // private helper function to emit a warning

--- a/examples/MQ/pixelDetector/src/FairOnlineSink.h
+++ b/examples/MQ/pixelDetector/src/FairOnlineSink.h
@@ -57,7 +57,10 @@ class FairOnlineSink : public FairSink
     virtual void      WriteObject(TObject* /* f */, const char*, Int_t /* option = 0 */) {}
     virtual void      WriteGeometry() {}
 
-    virtual void      SetMQRunDevice(FairMQRunDevice* mrs) { fMQRunDevice = mrs; }
+    virtual void        SetMQRunDevice(FairMQRunDevice* mrs) { fMQRunDevice = mrs;}
+    virtual FairMQRunDevice*       GetMQRunDevice()   { return fMQRunDevice;}
+
+    virtual FairSink*   CloneSink();
 
  private:
     FairMQRunDevice* fMQRunDevice;

--- a/examples/MQ/pixelDetector/src/Pixel.cxx
+++ b/examples/MQ/pixelDetector/src/Pixel.cxx
@@ -177,11 +177,10 @@ void Pixel::ConstructGeometry()
 
 Bool_t Pixel::CheckIfSensitive(std::string name)
 {
-  TString tsname = name;
-  if (tsname.Contains("Pixel")) {
-    return kTRUE;
-  }
-  return kFALSE;
+    if ( name.find("Pixel") != std::string::npos ) {
+        return kTRUE;
+    }
+    return kFALSE;
 }
 
 void Pixel::ModifyGeometry() {  

--- a/examples/MQ/pixelDetector/src/Pixel.cxx
+++ b/examples/MQ/pixelDetector/src/Pixel.cxx
@@ -59,6 +59,20 @@ Pixel::Pixel(const char* name, Bool_t active)
 {
 }
 
+Pixel::Pixel(const Pixel& rhs)
+  : FairDetector(rhs),
+    fTrackID(-1),
+    fVolumeID(-1),
+    fPos(),
+    fMom(),
+    fTime(-1.),
+    fLength(-1.),
+    fELoss(-1),
+    fMisalignDetector(kFALSE),
+    fPixelPointCollection(new TClonesArray("PixelPoint"))
+{
+}
+
 Pixel::~Pixel()
 {
   if (fPixelPointCollection) {
@@ -136,8 +150,8 @@ void Pixel::Register()
       only during the simulation.
   */
 
-  FairRootManager::Instance()->Register("PixelPoint", "Pixel",
-                                        fPixelPointCollection, kTRUE);
+    FairRootManager::Instance()->Register("PixelPoint", "Pixel",
+                                          fPixelPointCollection, kTRUE);
 }
 
 TClonesArray* Pixel::GetCollection(Int_t iColl) const
@@ -161,8 +175,17 @@ void Pixel::ConstructGeometry()
     ConstructASCIIGeometry<PixelGeo, PixelGeoPar>(Geo, "PixelGeoPar");
 }
 
-void Pixel::ModifyGeometry() {
-  if (!fMisalignDetector) {
+Bool_t Pixel::CheckIfSensitive(std::string name)
+{
+  TString tsname = name;
+  if (tsname.Contains("Pixel")) {
+    return kTRUE;
+  }
+  return kFALSE;
+}
+
+void Pixel::ModifyGeometry() {  
+  if ( !fMisalignDetector ) {
     return;
   }
   if (0==gGeoManager) {
@@ -204,6 +227,11 @@ PixelPoint* Pixel::AddHit(Int_t trackID, Int_t detID,
   Int_t size = clref.GetEntriesFast();
   return new(clref[size]) PixelPoint(trackID, detID, pos, mom,
          time, length, eLoss);
+}
+
+FairModule* Pixel::CloneModule() const
+{
+  return new Pixel(*this);
 }
 
 extern "C" void ExternCreateDetector() {

--- a/examples/MQ/pixelDetector/src/Pixel.cxx
+++ b/examples/MQ/pixelDetector/src/Pixel.cxx
@@ -40,7 +40,6 @@ Pixel::Pixel()
     fTime(-1.),
     fLength(-1.),
     fELoss(-1),
-    fMisalignDetector(kFALSE),
     fPixelPointCollection(new TClonesArray("PixelPoint"))
 {
 }
@@ -54,7 +53,6 @@ Pixel::Pixel(const char* name, Bool_t active)
     fTime(-1.),
     fLength(-1.),
     fELoss(-1),
-    fMisalignDetector(kFALSE),
     fPixelPointCollection(new TClonesArray("PixelPoint"))
 {
 }
@@ -68,7 +66,6 @@ Pixel::Pixel(const Pixel& rhs)
     fTime(-1.),
     fLength(-1.),
     fELoss(-1),
-    fMisalignDetector(kFALSE),
     fPixelPointCollection(new TClonesArray("PixelPoint"))
 {
 }
@@ -181,40 +178,6 @@ Bool_t Pixel::IsSensitive(const std::string& name)
         return kTRUE;
     }
     return kFALSE;
-}
-
-void Pixel::ModifyGeometry() {  
-  if ( !fMisalignDetector ) {
-    return;
-  }
-  if (0==gGeoManager) {
-    std::cout<<" -E- No gGeoManager in PndGemDetector::Initialize()!"<<std::endl;
-    return;
-  }
-
-  TString tName = Form("/cave/Pixel1_1");
-  cout << tName.Data() << endl;
-  TGeoPhysicalNode* tgpn = gGeoManager->MakePhysicalNode(tName.Data());
-  if (!tgpn) {cout << "no thpn" << endl; return;}
-  cout << "got TGPN" << endl;
-  TGeoHMatrix* tghm = static_cast<TGeoHMatrix*>(tgpn->GetOriginalMatrix());
-  if (!tghm) {cout << "no tghm" << endl; return;}
-  cout << "got TGHM" << endl;
-  cout << " * * *  o r i g  * * *  o r i g  * * *  o r i g  * * *  o r i g  * * * " << endl;
-  tghm->Print();
-  tghm->RotateX(0.);
-  tghm->RotateY(0.);
-  tghm->RotateZ(0.);//gRandom->Gaus(0.,.1));
-  Double_t* trans = tghm->GetTranslation();
-  cout << "trans = " << trans[0] << " " << trans[1] << " " << trans[2] << endl;
-  cout << " * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * " << endl;
-  for (Int_t ic = 0 ; ic < 3 ; ic++)
-    trans[ic] += 3.-ic;//gRandom->Gaus(0.,.03);
-  tghm->SetTranslation(trans);
-  cout << " * * * m o v e d * * * m o v e d * * * m o v e d * * * m o v e d * * * " << endl;
-  tghm->Print();
-  cout << " * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * " << endl;
-  tgpn->Align(tghm);
 }
 
 PixelPoint* Pixel::AddHit(Int_t trackID, Int_t detID,

--- a/examples/MQ/pixelDetector/src/Pixel.cxx
+++ b/examples/MQ/pixelDetector/src/Pixel.cxx
@@ -175,7 +175,7 @@ void Pixel::ConstructGeometry()
     ConstructASCIIGeometry<PixelGeo, PixelGeoPar>(Geo, "PixelGeoPar");
 }
 
-Bool_t Pixel::CheckIfSensitive(std::string name)
+Bool_t Pixel::IsSensitive(const std::string& name)
 {
     if ( name.find("Pixel") != std::string::npos ) {
         return kTRUE;

--- a/examples/MQ/pixelDetector/src/Pixel.h
+++ b/examples/MQ/pixelDetector/src/Pixel.h
@@ -80,7 +80,7 @@ class Pixel: public FairDetector
     virtual void   PreTrack() {;}
     virtual void   BeginEvent() {;}
 
-    virtual Bool_t      CheckIfSensitive(std::string name);
+    virtual Bool_t      IsSensitive(const std::string& name);
     virtual FairModule* CloneModule() const;
 
  private:

--- a/examples/MQ/pixelDetector/src/Pixel.h
+++ b/examples/MQ/pixelDetector/src/Pixel.h
@@ -53,10 +53,6 @@ class Pixel: public FairDetector
     /**      Create the detector geometry        */
     void ConstructGeometry();
 
-    /**      Misalign the detector geometry        */
-    void ModifyGeometry();
-    void SetMisalignDetector(Bool_t tb=kTRUE) { fMisalignDetector = tb; }
-
     /**      This method is an example of how to add your own point
      *       of type PixelPoint to the clones array
     */
@@ -97,7 +93,6 @@ class Pixel: public FairDetector
 
     /** container for data points */
 
-    Bool_t         fMisalignDetector;
     TClonesArray*  fPixelPointCollection;
 
     Pixel(const Pixel&);

--- a/examples/MQ/pixelDetector/src/Pixel.h
+++ b/examples/MQ/pixelDetector/src/Pixel.h
@@ -80,7 +80,10 @@ class Pixel: public FairDetector
     virtual void   PreTrack() {;}
     virtual void   BeginEvent() {;}
 
-  private:
+    virtual Bool_t      CheckIfSensitive(std::string name);
+    virtual FairModule* CloneModule() const;
+
+ private:
     /** Track information to be stored until the track leaves the
     active volume.
     */

--- a/examples/MQ/pixelDetector/src/devices/FairMQRunDevice.cxx
+++ b/examples/MQ/pixelDetector/src/devices/FairMQRunDevice.cxx
@@ -101,9 +101,8 @@ void FairMQRunDevice::SendBranches()
             }
         }
         if ( parts.Size() > 0 ) {
-            mtx.lock();
+            std::unique_lock<std::mutex> lock(mtx);
             Send(parts,mi.first.data());
-            mtx.unlock();
         }
     }
 }

--- a/examples/MQ/pixelDetector/src/devices/FairMQRunDevice.cxx
+++ b/examples/MQ/pixelDetector/src/devices/FairMQRunDevice.cxx
@@ -73,11 +73,10 @@ void FairMQRunDevice::SendBranches()
                   LOG(debug) << "Branch \"" << ObjStr->GetString() << "\" is persistent ANY";
                   if ( ObjStr->GetString().CompareTo("MCTrack") == 0 ) {
                       TClonesArray** mcTrackArray = (static_cast<FairOnlineSink*>(FairRootManager::Instance()->GetSink()))->GetPersistentBranchAny<TClonesArray**>(ObjStr->GetString());
-                      (*mcTrackArray)->SetName("MCTrack");
-                      LOG(debug) << "[" << FairRootManager::Instance()->GetInstanceId() << "] mcTrack " << mcTrackArray << " /// *mcTrackArray " << *mcTrackArray << " /// *mcTrackArray->GetName() " << (*mcTrackArray)->GetName();
-                      TObject* objClone = 0;
                       if ( mcTrackArray ) {
-                          objClone = (*mcTrackArray)->Clone();
+                          (*mcTrackArray)->SetName("MCTrack");
+                          LOG(debug) << "[" << FairRootManager::Instance()->GetInstanceId() << "] mcTrack " << mcTrackArray << " /// *mcTrackArray " << *mcTrackArray << " /// *mcTrackArray->GetName() " << (*mcTrackArray)->GetName();
+                          TObject* objClone = (*mcTrackArray)->Clone();
                           LOG(debug) << "FairMQRunDevice::SendBranches() the track array has " << ((TClonesArray*)(objClone))->GetEntries() << " entries.";
                           FairMQMessagePtr mess(NewMessage());
                           Serialize<RootSerializer>(*mess,objClone);
@@ -91,7 +90,6 @@ void FairMQRunDevice::SendBranches()
               }
               else {
                   TObject* object   = FairRootManager::Instance()->GetObject(ObjStr->GetString());
-                  TObject* objClone = 0;
                   if ( object ) {
                       objClone = object->Clone();
                       FairMQMessagePtr mess(NewMessage());

--- a/examples/MQ/pixelDetector/src/devices/FairMQRunDevice.cxx
+++ b/examples/MQ/pixelDetector/src/devices/FairMQRunDevice.cxx
@@ -91,7 +91,7 @@ void FairMQRunDevice::SendBranches()
               else {
                   TObject* object   = FairRootManager::Instance()->GetObject(ObjStr->GetString());
                   if ( object ) {
-                      objClone = object->Clone();
+                      TObject* objClone = object->Clone();
                       FairMQMessagePtr mess(NewMessage());
                       Serialize<RootSerializer>(*mess,objClone);
                       parts.AddPart(std::move(mess));

--- a/examples/MQ/pixelDetector/src/devices/FairMQRunDevice.cxx
+++ b/examples/MQ/pixelDetector/src/devices/FairMQRunDevice.cxx
@@ -85,6 +85,7 @@ void FairMQRunDevice::SendBranches()
                       }
                   }
                   else {
+                      LOG(warning) << "FairMQRunDevice::SendBranches() hasn't got knowledge how to send any branch \"" << ObjStr->GetString().Data() << "\"";
                       continue;
                   }
               }

--- a/examples/MQ/pixelDetector/src/devices/FairMQSimDevice.cxx
+++ b/examples/MQ/pixelDetector/src/devices/FairMQSimDevice.cxx
@@ -29,9 +29,6 @@
 
 #include <cstdio> // printf
 
-#include <mutex>          // std::mutex
-std::mutex mtx;           // mutex for critical section
-
 using namespace std;
 
 FairMQSimDevice::FairMQSimDevice()

--- a/examples/MQ/pixelDetector/src/devices/FairMQSimDevice.cxx
+++ b/examples/MQ/pixelDetector/src/devices/FairMQSimDevice.cxx
@@ -29,6 +29,9 @@
 
 #include <cstdio> // printf
 
+#include <mutex>          // std::mutex
+std::mutex mtx;           // mutex for critical section
+
 using namespace std;
 
 FairMQSimDevice::FairMQSimDevice()
@@ -65,6 +68,8 @@ void FairMQSimDevice::InitTask()
   }
 
   fRunSim->SetName(fTransportName.data());
+  //  fRunSim->SetSimulationConfig(new FairVMCConfig());
+  fRunSim->SetIsMT(kFALSE);
 
   if (fUserConfig.Length() > 0)
     fRunSim->SetUserConfig(fUserConfig);

--- a/examples/MQ/pixelDetector/src/devices/FairMQSimDevice.h
+++ b/examples/MQ/pixelDetector/src/devices/FairMQSimDevice.h
@@ -29,7 +29,7 @@ class FairField;
 class FairParIo;
 class FairPrimaryGenerator;
 class TObjArray;
-class FairSink;
+class FairOnlineSink;
 
 class FairMQSimDevice : public FairMQRunDevice
 {
@@ -81,7 +81,7 @@ class FairMQSimDevice : public FairMQRunDevice
     FairParIo*            fSecondParameter;   // second input (used if not found in first input)
     TString               fUserConfig;        //!                  /** Macro for geant configuration*/
     TString               fUserCuts;          //!                  /** Macro for geant cuts*/
-    FairSink*             fSink;
+    FairOnlineSink*       fSink;
     // ------ ---------- -------- ------
 
     void UpdateParameterServer();

--- a/examples/MQ/pixelDetector/src/devices/FairMQSimDevice.h
+++ b/examples/MQ/pixelDetector/src/devices/FairMQSimDevice.h
@@ -29,7 +29,7 @@ class FairField;
 class FairParIo;
 class FairPrimaryGenerator;
 class TObjArray;
-class FairOnlineSink;
+class FairSink;
 
 class FairMQSimDevice : public FairMQRunDevice
 {
@@ -81,7 +81,7 @@ class FairMQSimDevice : public FairMQRunDevice
     FairParIo*            fSecondParameter;   // second input (used if not found in first input)
     TString               fUserConfig;        //!                  /** Macro for geant configuration*/
     TString               fUserCuts;          //!                  /** Macro for geant cuts*/
-    FairOnlineSink*       fSink;
+    FairSink*             fSink;
     // ------ ---------- -------- ------
 
     void UpdateParameterServer();

--- a/examples/advanced/Tutorial3/macro/run_digi_reco_proof.C
+++ b/examples/advanced/Tutorial3/macro/run_digi_reco_proof.C
@@ -31,7 +31,7 @@ void run_digi_reco_proof(Int_t nofFiles, TString mcEngine="TGeant3" )
   TStopwatch timer;
 
   // -----   Reconstruction run   -------------------------------------------
-  FairRunAnaProof *fRun= new FairRunAnaProof("");
+  FairRunAnaProof *fRun= new FairRunAnaProof("workers=4");
   TString inFile=Form("file://%s/data/testrun_%s_f%d.root",workDir.Data(),mcEngine.Data(),0);
   if ( nofFiles == 1 )
       inFile=Form("file://%s/data/testrun_%s.root",workDir.Data(),mcEngine.Data());

--- a/examples/common/gconfig/g4Config.yaml
+++ b/examples/common/gconfig/g4Config.yaml
@@ -2,7 +2,7 @@ Geant4_UserGeometry:     "geomRoot"
 Geant4_PhysicsList:      "QGSP_BERT_EMV"
 Geant4_SpecialProcess:   "stepLimiter+specialCuts+specialControls"
 Geant4_SpecialStacking:  false
-#Geant4_Multithreaded:   false
+Geant4_Multithreaded:    false
 
 Geant4_MaxNStep:         10000    #default is 30000
 Geant4_Commands:

--- a/examples/common/mcstack/FairStack.cxx
+++ b/examples/common/mcstack/FairStack.cxx
@@ -302,7 +302,7 @@ void FairStack::Reset()
 
 void FairStack::Register()
 {
-  if ( gMC && ( ! gMC->IsMT() ) ) {
+  if ( gMC ) {
     FairRootManager::Instance()->Register("MCTrack", "Stack", fTracks,kTRUE);
   } else {
     FairRootManager::Instance()->RegisterAny("MCTrack",fTracks,kTRUE);

--- a/examples/common/passive/FairMagnet.cxx
+++ b/examples/common/passive/FairMagnet.cxx
@@ -47,7 +47,7 @@ void FairMagnet::ConstructGeometry()
   }
 }
 
-Bool_t FairMagnet::CheckIfSensitive(std::string /*name*/)
+Bool_t FairMagnet::IsSensitive(const std::string& /*name*/)
 {
   // just to get rid of the warrning during run, not need this is a passive element!
   return kFALSE;

--- a/examples/common/passive/FairMagnet.h
+++ b/examples/common/passive/FairMagnet.h
@@ -22,7 +22,7 @@ class FairMagnet : public FairModule
     virtual ~FairMagnet();
     void ConstructGeometry();
     void ConstructASCIIGeometry();
-    Bool_t CheckIfSensitive(std::string name);
+    Bool_t IsSensitive(const std::string& name);
 
     virtual FairModule* CloneModule() const;
 

--- a/examples/simulation/Tutorial1/src/FairFastSimExample.cxx
+++ b/examples/simulation/Tutorial1/src/FairFastSimExample.cxx
@@ -128,14 +128,7 @@ void FairFastSimExample::Register()
         this collection will not be written to the file, it will exist
         only during the simulation.
     */
-    if (!gMC->IsMT())
-    {
-        FairRootManager::Instance()->Register("FastSimPoint", "FastSimDetDet", fPointsArray, kTRUE);
-    }
-    else
-    {
-        FairRootManager::Instance()->RegisterAny("FastSimPoint", fPointsArray, kTRUE);
-    }
+    FairRootManager::Instance()->Register("FastSimPoint", "FastSimDetDet", fPointsArray, kTRUE);
 }
 
 TClonesArray* FairFastSimExample::GetCollection(Int_t iColl) const

--- a/examples/simulation/Tutorial1/src/FairFastSimExample.cxx
+++ b/examples/simulation/Tutorial1/src/FairFastSimExample.cxx
@@ -78,18 +78,23 @@ void FairFastSimExample::FastSimProcessParticle()
     TVirtualMC::GetMC()->TrackMomentum(fMom);
 
     FairStack* stack = static_cast<FairStack*>(TVirtualMC::GetMC()->GetStack());
+    fTrackID = TVirtualMC::GetMC()->GetStack()->GetCurrentTrackNumber();
 
-    stack->FastSimPushSecondary(fTrackID,11,-12.5,-12.5,20.+5.+0.1,fPos.T(),
-                                0.1,0.1,1.0,1.0,0.,0.,0.,kPHadronic,1,0);
-    stack->FastSimPushSecondary(fTrackID,11,-12.5,-12.5,20.+5.+0.1,fPos.T(),
-                                -0.1,-0.1,1.0,1.0,0.,0.,0.,kPHadronic,1,0);
+    if ( TVirtualMC::GetMC()->TrackPid() == 211 ) { // let only pion create secondaries
+        stack->FastSimPushSecondary(fTrackID,11,-12.5,-12.5,20.+5.+0.1,fPos.T(),
+                                    0.1,0.1,1.0,1.0,0.,0.,0.,kPHadronic,1,0);
+        stack->FastSimPushSecondary(fTrackID,11,-12.5,-12.5,20.+5.+0.1,fPos.T(),
+                                    -0.1,-0.1,1.0,1.0,0.,0.,0.,kPHadronic,1,0);
+    }
     stack->FastSimMoveParticleTo(
-        12.5, 12.5, 20. + 5. + 0.1, TVirtualMC::GetMC()->TrackTime(), fMom.X(), fMom.Y(), fMom.Z(), fMom.E());
+        12.5, 12.5, 20. + 5. + 0.1, TVirtualMC::GetMC()->TrackTime(), fMom.X(), fMom.Y(), fMom.Z(), 0.99*fMom.E());
 
-    stack->FastSimPushSecondary(fTrackID,11,-12.5,-12.5,20.+5.+0.1,fPos.T(),
-                                -0.1,0.1,1.0,1.0,0.,0.,0.,kPHadronic,1,0);
-    stack->FastSimPushSecondary(fTrackID,11,-12.5,-12.5,20.+5.+0.1,fPos.T(),
-                                0.1,-0.1,1.0,1.0,0.,0.,0.,kPHadronic,1,0);
+    if ( TVirtualMC::GetMC()->TrackPid() == 211 ) { // let only pion create secondaries
+        stack->FastSimPushSecondary(fTrackID,11,-12.5,-12.5,20.+5.+0.1,fPos.T(),
+                                    -0.1,0.1,1.0,1.0,0.,0.,0.,kPHadronic,1,0);
+        stack->FastSimPushSecondary(fTrackID,11,-12.5,-12.5,20.+5.+0.1,fPos.T(),
+                                    0.1,-0.1,1.0,1.0,0.,0.,0.,kPHadronic,1,0);
+    }
 
 //    stack->FastSimMoveParticleTo(
 //        25., 25., 20. + 0.1, TVirtualMC::GetMC()->TrackTime(), fMom.X(), fMom.Y(), fMom.Z(), fMom.E());
@@ -97,7 +102,6 @@ void FairFastSimExample::FastSimProcessParticle()
 //    stack->FastSimMoveParticleTo(
 //        24., 24., 50. + 0.1, TVirtualMC::GetMC()->TrackTime(), fMom.X(), fMom.Y(), fMom.Z(), fMom.E());
 
-    fTrackID = TVirtualMC::GetMC()->GetStack()->GetCurrentTrackNumber();
     fVolumeID = 0;
     fTime = TVirtualMC::GetMC()->TrackTime() * 1.0e09;
     fLength = TVirtualMC::GetMC()->TrackLength();

--- a/examples/simulation/Tutorial1/src/FairFastSimExample.cxx
+++ b/examples/simulation/Tutorial1/src/FairFastSimExample.cxx
@@ -181,6 +181,15 @@ FairTutorialDet1Point* FairFastSimExample::AddHit(Int_t trackID,
     return new (clref[size]) FairTutorialDet1Point(trackID, detID, pos, mom, time, length, eLoss);
 }
 
+Bool_t FairFastSimExample::CheckIfSensitive(std::string name)
+{
+  TString tsname = name;
+  if ( tsname.CompareTo("fast_sim_vol") == 0 ) {
+    return kTRUE;
+  }
+  return kFALSE;
+}
+
 FairModule* FairFastSimExample::CloneModule() const { return new FairFastSimExample(*this); }
 
 ClassImp(FairFastSimExample)

--- a/examples/simulation/Tutorial1/src/FairFastSimExample.cxx
+++ b/examples/simulation/Tutorial1/src/FairFastSimExample.cxx
@@ -183,11 +183,7 @@ FairTutorialDet1Point* FairFastSimExample::AddHit(Int_t trackID,
 
 Bool_t FairFastSimExample::CheckIfSensitive(std::string name)
 {
-  TString tsname = name;
-  if ( tsname.CompareTo("fast_sim_vol") == 0 ) {
-    return kTRUE;
-  }
-  return kFALSE;
+    return name == "fast_sim_vol";
 }
 
 FairModule* FairFastSimExample::CloneModule() const { return new FairFastSimExample(*this); }

--- a/examples/simulation/Tutorial1/src/FairFastSimExample.cxx
+++ b/examples/simulation/Tutorial1/src/FairFastSimExample.cxx
@@ -181,7 +181,7 @@ FairTutorialDet1Point* FairFastSimExample::AddHit(Int_t trackID,
     return new (clref[size]) FairTutorialDet1Point(trackID, detID, pos, mom, time, length, eLoss);
 }
 
-Bool_t FairFastSimExample::CheckIfSensitive(std::string name)
+Bool_t FairFastSimExample::IsSensitive(const std::string& name)
 {
     return name == "fast_sim_vol";
 }

--- a/examples/simulation/Tutorial1/src/FairFastSimExample.h
+++ b/examples/simulation/Tutorial1/src/FairFastSimExample.h
@@ -55,7 +55,7 @@ class FairFastSimExample : public FairFastSimDetector
     */
     virtual void EndOfEvent();
 
-    virtual Bool_t      CheckIfSensitive(std::string name);
+    virtual Bool_t      IsSensitive(const std::string& name);
 
     virtual FairModule* CloneModule() const;
 

--- a/examples/simulation/Tutorial1/src/FairFastSimExample.h
+++ b/examples/simulation/Tutorial1/src/FairFastSimExample.h
@@ -55,6 +55,8 @@ class FairFastSimExample : public FairFastSimDetector
     */
     virtual void EndOfEvent();
 
+    virtual Bool_t      CheckIfSensitive(std::string name);
+
     virtual FairModule* CloneModule() const;
 
   protected:

--- a/examples/simulation/Tutorial1/src/FairFastSimExample2.cxx
+++ b/examples/simulation/Tutorial1/src/FairFastSimExample2.cxx
@@ -80,7 +80,7 @@ void FairFastSimExample2::FastSimProcessParticle()
     FairStack* stack = static_cast<FairStack*>(TVirtualMC::GetMC()->GetStack());
 
     stack->FastSimMoveParticleTo(
-        24., 24., 50. + 5. + 0.1, TVirtualMC::GetMC()->TrackTime(), fMom.X(), fMom.Y(), fMom.Z(), fMom.E());
+        24., 24., 50. + 5. + 0.1, TVirtualMC::GetMC()->TrackTime(), fMom.X(), fMom.Y(), fMom.Z(), 0.99*fMom.E());
 
     fTrackID = TVirtualMC::GetMC()->GetStack()->GetCurrentTrackNumber();
     fVolumeID = 0;

--- a/examples/simulation/Tutorial1/src/FairFastSimExample2.cxx
+++ b/examples/simulation/Tutorial1/src/FairFastSimExample2.cxx
@@ -162,7 +162,7 @@ FairTutorialDet1Point* FairFastSimExample2::AddHit(Int_t trackID,
     return new (clref[size]) FairTutorialDet1Point(trackID, detID, pos, mom, time, length, eLoss);
 }
 
-Bool_t FairFastSimExample2::CheckIfSensitive(std::string name)
+Bool_t FairFastSimExample2::IsSensitive(const std::string& name)
 {
     return name == "fast_sim_vol_n2";
 }

--- a/examples/simulation/Tutorial1/src/FairFastSimExample2.cxx
+++ b/examples/simulation/Tutorial1/src/FairFastSimExample2.cxx
@@ -109,14 +109,7 @@ void FairFastSimExample2::Register()
         this collection will not be written to the file, it will exist
         only during the simulation.
     */
-    if (!gMC->IsMT())
-    {
-        FairRootManager::Instance()->Register("FastSimPoint2", "FastSimDetDet", fPointsArray, kTRUE);
-    }
-    else
-    {
-        FairRootManager::Instance()->RegisterAny("FastSimPoint2", fPointsArray, kTRUE);
-    }
+    FairRootManager::Instance()->Register("FastSimPoint2", "FastSimDetDet", fPointsArray, kTRUE);
 }
 
 TClonesArray* FairFastSimExample2::GetCollection(Int_t iColl) const

--- a/examples/simulation/Tutorial1/src/FairFastSimExample2.cxx
+++ b/examples/simulation/Tutorial1/src/FairFastSimExample2.cxx
@@ -162,6 +162,15 @@ FairTutorialDet1Point* FairFastSimExample2::AddHit(Int_t trackID,
     return new (clref[size]) FairTutorialDet1Point(trackID, detID, pos, mom, time, length, eLoss);
 }
 
+Bool_t FairFastSimExample2::CheckIfSensitive(std::string name)
+{
+  TString tsname = name;
+  if ( tsname.CompareTo("fast_sim_vol_n2") == 0 ) {
+    return kTRUE;
+  }
+  return kFALSE;
+}
+
 FairModule* FairFastSimExample2::CloneModule() const { return new FairFastSimExample2(*this); }
 
 ClassImp(FairFastSimExample2)

--- a/examples/simulation/Tutorial1/src/FairFastSimExample2.cxx
+++ b/examples/simulation/Tutorial1/src/FairFastSimExample2.cxx
@@ -164,11 +164,7 @@ FairTutorialDet1Point* FairFastSimExample2::AddHit(Int_t trackID,
 
 Bool_t FairFastSimExample2::CheckIfSensitive(std::string name)
 {
-  TString tsname = name;
-  if ( tsname.CompareTo("fast_sim_vol_n2") == 0 ) {
-    return kTRUE;
-  }
-  return kFALSE;
+    return name == "fast_sim_vol_n2";
 }
 
 FairModule* FairFastSimExample2::CloneModule() const { return new FairFastSimExample2(*this); }

--- a/examples/simulation/Tutorial1/src/FairFastSimExample2.h
+++ b/examples/simulation/Tutorial1/src/FairFastSimExample2.h
@@ -56,7 +56,7 @@ class FairFastSimExample2 : public FairFastSimDetector
     */
     virtual void EndOfEvent();
 
-    virtual Bool_t      CheckIfSensitive(std::string name);
+    virtual Bool_t      IsSensitive(const std::string& name);
 
     virtual FairModule* CloneModule() const;
 

--- a/examples/simulation/Tutorial1/src/FairFastSimExample2.h
+++ b/examples/simulation/Tutorial1/src/FairFastSimExample2.h
@@ -54,8 +54,9 @@ class FairFastSimExample2 : public FairFastSimDetector
     /** The following methods can be implemented if you need to make
      *  any optional action in your detector during the transport.
     */
-
     virtual void EndOfEvent();
+
+    virtual Bool_t      CheckIfSensitive(std::string name);
 
     virtual FairModule* CloneModule() const;
 

--- a/examples/simulation/Tutorial1/src/FairTutorialDet1.cxx
+++ b/examples/simulation/Tutorial1/src/FairTutorialDet1.cxx
@@ -129,13 +129,8 @@ void FairTutorialDet1::Register()
       only during the simulation.
   */
 
-  if (! gMC->IsMT() ) {
     FairRootManager::Instance()->Register("TutorialDetPoint", "TutorialDet",
                                           fFairTutorialDet1PointCollection, kTRUE);
-  } else {
-    FairRootManager::Instance()->RegisterAny("TutorialDetPoint",
-                                             fFairTutorialDet1PointCollection, kTRUE);
-  }
 }
 
 TClonesArray* FairTutorialDet1::GetCollection(Int_t iColl) const

--- a/examples/simulation/Tutorial1/src/FairTutorialDet1.cxx
+++ b/examples/simulation/Tutorial1/src/FairTutorialDet1.cxx
@@ -144,7 +144,7 @@ void FairTutorialDet1::Reset()
   fFairTutorialDet1PointCollection->Clear();
 }
 
-Bool_t FairTutorialDet1::CheckIfSensitive(std::string name)
+Bool_t FairTutorialDet1::IsSensitive(const std::string& name)
 {
     if ( name.find("tutdet") != std::string::npos ) {
         return kTRUE;

--- a/examples/simulation/Tutorial1/src/FairTutorialDet1.cxx
+++ b/examples/simulation/Tutorial1/src/FairTutorialDet1.cxx
@@ -149,6 +149,15 @@ void FairTutorialDet1::Reset()
   fFairTutorialDet1PointCollection->Clear();
 }
 
+Bool_t FairTutorialDet1::CheckIfSensitive(std::string name)
+{
+  TString tsname = name;
+  if (tsname.Contains("tutdet")) {
+    return kTRUE;
+  }
+  return kFALSE;
+}
+
 void FairTutorialDet1::ConstructGeometry()
 {
   /** If you are using the standard ASCII input for the geometry

--- a/examples/simulation/Tutorial1/src/FairTutorialDet1.cxx
+++ b/examples/simulation/Tutorial1/src/FairTutorialDet1.cxx
@@ -146,11 +146,10 @@ void FairTutorialDet1::Reset()
 
 Bool_t FairTutorialDet1::CheckIfSensitive(std::string name)
 {
-  TString tsname = name;
-  if (tsname.Contains("tutdet")) {
-    return kTRUE;
-  }
-  return kFALSE;
+    if ( name.find("tutdet") != std::string::npos ) {
+        return kTRUE;
+    }
+    return kFALSE;
 }
 
 void FairTutorialDet1::ConstructGeometry()

--- a/examples/simulation/Tutorial1/src/FairTutorialDet1.h
+++ b/examples/simulation/Tutorial1/src/FairTutorialDet1.h
@@ -84,6 +84,8 @@ class FairTutorialDet1: public FairDetector
 
     virtual FairModule* CloneModule() const;
 
+    virtual Bool_t      CheckIfSensitive(std::string name);
+
   private:
     static FairTutorialDet1Geo* fgGeo;   //!
 

--- a/examples/simulation/Tutorial1/src/FairTutorialDet1.h
+++ b/examples/simulation/Tutorial1/src/FairTutorialDet1.h
@@ -84,7 +84,7 @@ class FairTutorialDet1: public FairDetector
 
     virtual FairModule* CloneModule() const;
 
-    virtual Bool_t      CheckIfSensitive(std::string name);
+    virtual Bool_t      IsSensitive(const std::string& name);
 
   private:
     static FairTutorialDet1Geo* fgGeo;   //!

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2.cxx
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2.cxx
@@ -133,13 +133,8 @@ void FairTutorialDet2::Register()
   */
   auto mgr = FairRootManager::Instance();
 
-  if (! gMC->IsMT()) {
-    mgr->Register("TutorialDetPoint", "TutorialDet",
-                  fFairTutorialDet2PointCollection, kTRUE);
-  } else {
-    mgr->RegisterAny("TutorialDetPoint",
-                     fFairTutorialDet2PointCollection, kTRUE);
-  }
+  mgr->Register("TutorialDetPoint", "TutorialDet",
+                fFairTutorialDet2PointCollection, kTRUE);
 
   // example how to register any type T
   mgr->RegisterAny("TutorialCustomData", fCustomData, kTRUE);

--- a/examples/simulation/Tutorial4/src/mc/FairTutorialDet4.cxx
+++ b/examples/simulation/Tutorial4/src/mc/FairTutorialDet4.cxx
@@ -247,7 +247,7 @@ void FairTutorialDet4::ConstructGeometry()
   }
 }
 
-Bool_t FairTutorialDet4::CheckIfSensitive(std::string name)
+Bool_t FairTutorialDet4::IsSensitive(const std::string& name)
 {
     if ( name.find("tut4") != std::string::npos ) {
         return kTRUE;

--- a/examples/simulation/Tutorial4/src/mc/FairTutorialDet4.cxx
+++ b/examples/simulation/Tutorial4/src/mc/FairTutorialDet4.cxx
@@ -249,11 +249,10 @@ void FairTutorialDet4::ConstructGeometry()
 
 Bool_t FairTutorialDet4::CheckIfSensitive(std::string name)
 {
-  TString tsname = name;
-  if (tsname.Contains("tut4")) {
-    return kTRUE;
-  }
-  return kFALSE;
+    if ( name.find("tut4") != std::string::npos ) {
+        return kTRUE;
+    }
+    return kFALSE;
 }
 
 void FairTutorialDet4::ConstructASCIIGeometry()

--- a/examples/simulation/Tutorial4/src/mc/FairTutorialDet4.cxx
+++ b/examples/simulation/Tutorial4/src/mc/FairTutorialDet4.cxx
@@ -218,11 +218,8 @@ void FairTutorialDet4::Register()
       only during the simulation.
   */
 
-  if (!gMC->IsMT()) {
-    FairRootManager::Instance()->Register("TutorialDetPoint", "TutorialDet", fFairTutorialDet4PointCollection, kTRUE);
-  } else {
-    FairRootManager::Instance()->RegisterAny("TutorialDetPoint", fFairTutorialDet4PointCollection, kTRUE);
-  }
+    FairRootManager::Instance()->Register("TutorialDetPoint", "TutorialDet",
+                                          fFairTutorialDet4PointCollection, kTRUE);
 }
 
 TClonesArray* FairTutorialDet4::GetCollection(Int_t iColl) const

--- a/examples/simulation/Tutorial4/src/mc/FairTutorialDet4.h
+++ b/examples/simulation/Tutorial4/src/mc/FairTutorialDet4.h
@@ -98,7 +98,7 @@ class FairTutorialDet4 : public FairDetector
 
     virtual void RegisterAlignmentMatrices();
 
-    virtual Bool_t CheckIfSensitive(std::string name);
+    virtual Bool_t IsSensitive(const std::string& name);
 
   private:
     static FairTutorialDet4Geo* fgGeo;   //!

--- a/examples/simulation/rutherford/src/FairRutherford.cxx
+++ b/examples/simulation/rutherford/src/FairRutherford.cxx
@@ -125,13 +125,8 @@ void FairRutherford::Register()
       only during the simulation.
   */
 
-  if ( ! gMC->IsMT() ) {
     FairRootManager::Instance()->Register("FairRutherfordPoint", "FairRutherford",
                                           fFairRutherfordPointCollection, kTRUE);
-  } else {
-    FairRootManager::Instance()->RegisterAny("FairRutherfordPoint",
-                                             fFairRutherfordPointCollection, kTRUE);
-  }
 }
 
 TClonesArray* FairRutherford::GetCollection(Int_t iColl) const

--- a/fairtools/MCConfigurator/FairYamlVMCConfig.cxx
+++ b/fairtools/MCConfigurator/FairYamlVMCConfig.cxx
@@ -123,6 +123,11 @@ void FairYamlVMCConfig::SetupGeant4()
     }
     bool mtMode = FairRunSim::Instance()->IsMT();
 
+    if (fYamlConfig["Geant4_Multithreaded"]) {
+        mtMode = fYamlConfig["Geant4_Multithreaded"].as<bool>();
+        //        LOG(info) << "Setting Geant4 multithreaded to " << (mtMode?"true":"false");
+    }
+
     FairFastSimRunConfiguration* runConfiguration
         = new FairFastSimRunConfiguration(fYamlConfig["Geant4_UserGeometry"]  .as<std::string>(),
                                           fYamlConfig["Geant4_PhysicsList"]   .as<std::string>(),

--- a/templates/NewDetector_root_containers/NewDetector.cxx
+++ b/templates/NewDetector_root_containers/NewDetector.cxx
@@ -263,11 +263,10 @@ void NewDetector::DefineSensitiveVolumes()
 
 Bool_t NewDetector::CheckIfSensitive(std::string name)
 {
-  if(TString(name).Contains("Det"))
-  {
-    return kTRUE;
-  }
-  return kFALSE;
+    if ( name.find("Det") != std::string::npos ) {
+        return kTRUE;
+    }
+    return kFALSE;
 }
 
 ClassImp(NewDetector)

--- a/templates/NewDetector_root_containers/NewDetector.cxx
+++ b/templates/NewDetector_root_containers/NewDetector.cxx
@@ -254,14 +254,14 @@ void NewDetector::DefineSensitiveVolumes()
   TIter next(volumes);
   TGeoVolume* volume;
   while ( ( volume = static_cast<TGeoVolume*>(next()) ) ) {
-    if ( CheckIfSensitive(volume->GetName()) ) {
+    if ( IsSensitive(volume->GetName()) ) {
       LOG(debug2)<<"Sensitive Volume "<< volume->GetName();
       AddSensitiveVolume(volume);
     }
   }
 }
 
-Bool_t NewDetector::CheckIfSensitive(std::string name)
+Bool_t NewDetector::IsSensitive(const std::string& name)
 {
     if ( name.find("Det") != std::string::npos ) {
         return kTRUE;

--- a/templates/NewDetector_root_containers/NewDetector.h
+++ b/templates/NewDetector_root_containers/NewDetector.h
@@ -79,7 +79,7 @@ class NewDetector: public FairDetector
 
     virtual FairModule* CloneModule() const;
 
-    virtual Bool_t CheckIfSensitive(std::string name);
+    virtual Bool_t IsSensitive(const std::string& name);
 
   private:
 

--- a/templates/NewDetector_stl_containers/NewDetector.cxx
+++ b/templates/NewDetector_stl_containers/NewDetector.cxx
@@ -249,7 +249,7 @@ void NewDetector::DefineSensitiveVolumes()
     TGeoVolume* volume;
     while ((volume = static_cast<TGeoVolume*>(next())))
     {
-        if (CheckIfSensitive(volume->GetName()))
+        if (IsSensitive(volume->GetName()))
         {
             LOG(debug2) << "Sensitive Volume " << volume->GetName();
             AddSensitiveVolume(volume);
@@ -257,7 +257,7 @@ void NewDetector::DefineSensitiveVolumes()
     }
 }
 
-Bool_t NewDetector::CheckIfSensitive(std::string name)
+Bool_t NewDetector::IsSensitive(const std::string& name)
 {
     if ( name.find("Det") != std::string::npos ) {
         return kTRUE;

--- a/templates/NewDetector_stl_containers/NewDetector.cxx
+++ b/templates/NewDetector_stl_containers/NewDetector.cxx
@@ -259,8 +259,7 @@ void NewDetector::DefineSensitiveVolumes()
 
 Bool_t NewDetector::CheckIfSensitive(std::string name)
 {
-    if (TString(name).Contains("Det"))
-    {
+    if ( name.find("Det") != std::string::npos ) {
         return kTRUE;
     }
     return kFALSE;

--- a/templates/NewDetector_stl_containers/NewDetector.h
+++ b/templates/NewDetector_stl_containers/NewDetector.h
@@ -72,7 +72,7 @@ class NewDetector : public FairDetector
 
     virtual FairModule* CloneModule() const;
 
-    virtual Bool_t CheckIfSensitive(std::string name);
+    virtual Bool_t IsSensitive(const std::string& name);
     
     virtual TClonesArray* GetCollection(Int_t iColl) const { return NULL; }
 

--- a/templates/project_root_containers/NewDetector/NewDetector.cxx
+++ b/templates/project_root_containers/NewDetector/NewDetector.cxx
@@ -263,11 +263,10 @@ void NewDetector::DefineSensitiveVolumes()
 
 Bool_t NewDetector::CheckIfSensitive(std::string name)
 {
-  if(TString(name).Contains("Det"))
-  {
-    return kTRUE;
-  }
-  return kFALSE;
+    if ( name.find("Det") != std::string::npos ) {
+        return kTRUE;
+    }
+    return kFALSE;
 }
 
 ClassImp(NewDetector)

--- a/templates/project_root_containers/NewDetector/NewDetector.cxx
+++ b/templates/project_root_containers/NewDetector/NewDetector.cxx
@@ -254,14 +254,14 @@ void NewDetector::DefineSensitiveVolumes()
   TIter next(volumes);
   TGeoVolume* volume;
   while ( ( volume = static_cast<TGeoVolume*>(next()) ) ) {
-    if ( CheckIfSensitive(volume->GetName()) ) {
+    if ( IsSensitive(volume->GetName()) ) {
       LOG(debug2)<<"Sensitive Volume "<< volume->GetName();
       AddSensitiveVolume(volume);
     }
   }
 }
 
-Bool_t NewDetector::CheckIfSensitive(std::string name)
+Bool_t NewDetector::IsSensitive(const std::string& name)
 {
     if ( name.find("Det") != std::string::npos ) {
         return kTRUE;

--- a/templates/project_root_containers/NewDetector/NewDetector.h
+++ b/templates/project_root_containers/NewDetector/NewDetector.h
@@ -79,7 +79,7 @@ class NewDetector: public FairDetector
 
     virtual FairModule* CloneModule() const;
 
-    virtual Bool_t CheckIfSensitive(std::string name);
+    virtual Bool_t IsSensitive(const std::string& name);
 
   private:
 

--- a/templates/project_stl_containers/NewDetector/NewDetector.cxx
+++ b/templates/project_stl_containers/NewDetector/NewDetector.cxx
@@ -249,7 +249,7 @@ void NewDetector::DefineSensitiveVolumes()
     TGeoVolume* volume;
     while ((volume = static_cast<TGeoVolume*>(next())))
     {
-        if (CheckIfSensitive(volume->GetName()))
+        if (IsSensitive(volume->GetName()))
         {
             LOG(debug2) << "Sensitive Volume " << volume->GetName();
             AddSensitiveVolume(volume);
@@ -257,7 +257,7 @@ void NewDetector::DefineSensitiveVolumes()
     }
 }
 
-Bool_t NewDetector::CheckIfSensitive(std::string name)
+Bool_t NewDetector::IsSensitive(const std::string& name)
 {
     if ( name.find("Det") != std::string::npos ) {
         return kTRUE;

--- a/templates/project_stl_containers/NewDetector/NewDetector.cxx
+++ b/templates/project_stl_containers/NewDetector/NewDetector.cxx
@@ -259,8 +259,7 @@ void NewDetector::DefineSensitiveVolumes()
 
 Bool_t NewDetector::CheckIfSensitive(std::string name)
 {
-    if (TString(name).Contains("Det"))
-    {
+    if ( name.find("Det") != std::string::npos ) {
         return kTRUE;
     }
     return kFALSE;

--- a/templates/project_stl_containers/NewDetector/NewDetector.h
+++ b/templates/project_stl_containers/NewDetector/NewDetector.h
@@ -72,7 +72,7 @@ class NewDetector : public FairDetector
 
     virtual FairModule* CloneModule() const;
 
-    virtual Bool_t CheckIfSensitive(std::string name);
+    virtual Bool_t IsSensitive(const std::string& name);
     
     virtual TClonesArray* GetCollection(Int_t iColl) const { return NULL; }
 


### PR DESCRIPTION
FairMCApplication - added mutex lock in CloneForWorker() function, otherwise unstable
FairDetector      - DefineSensitiveVolumes() function runs only in multithreaded mode
Pixel             - CheckIfSensitive() function is needed by FairDetector to make detector active
                    CloneModule() function need by G4MT to copy detector

---

Checklist:

 [ * ] Rebased against `dev` branch
 [ * ] My name is in the resp. CONTRIBUTORS/AUTHORS file
 [ * ] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
