### PR TITLE
Fix cmake error when ROOT has no opengl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,11 +308,14 @@ If(Geant3_FOUND)
  add_subdirectory(trackbase)
 EndIf ()
 
-execute_process(COMMAND ${ROOT_CONFIG_EXECUTABLE} --has-opengl OUTPUT_VARIABLE ROOT_HAS_OPENGL)
-if(${ROOT_HAS_OPENGL} MATCHES "yes")
+execute_process(COMMAND ${ROOT_CONFIG_EXECUTABLE} --has-opengl OUTPUT_VARIABLE
+    ROOT_HAS_OPENGL_VAR)
+if(${ROOT_HAS_OPENGL_VAR} MATCHES "yes")
   add_subdirectory(eventdisplay)
+  Set(ROOT_HAS_OPENGL TRUE)
 else()
   message(STATUS "eventdisplay will not be built, because ROOT has no opengl support.")
+  Set(ROOT_HAS_OPENGL FALSE)
 endif()
 
 add_subdirectory(MbsAPI)

--- a/examples/simulation/Tutorial4/src/CMakeLists.txt
+++ b/examples/simulation/Tutorial4/src/CMakeLists.txt
@@ -27,7 +27,7 @@ set(sources
   tools/Mille.cc
 )
 
-if(ROOT_HAS_OPENGL)
+if(${ROOT_HAS_OPENGL})
   list(APPEND sources
     display/FairTutorialDet4PointDraw.cxx
   )
@@ -63,7 +63,7 @@ target_link_libraries(${target} PUBLIC
   FairRoot::GeoBase
   FairRoot::ParBase
   FairRoot::Gen
-  FairRoot::EventDisplay
+  $<$<BOOL:${ROOT_HAS_OPENGL}>:FairRoot::EventDisplay>
 
   Core
   Physics


### PR DESCRIPTION
When compiling FairRoot without OpenGL support, cmake throws an error that Tutorial4 depends on eventdisplay library, but the corresponding target was not found. The problem is in the ROOT_HAS_OPENGL flag. In the main CMakeLists.txt it is of type String, but in Tutorial4/CMakelists.txt it is treated as boolean. This PR fixes this issue.
---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
