### PR TITLE
Fix FairMultiLinkedData insert history bug

### DIFF
--- a/base/event/FairMultiLinkedData_Interface.cxx
+++ b/base/event/FairMultiLinkedData_Interface.cxx
@@ -181,6 +181,7 @@ void FairMultiLinkedData_Interface::AddInterfaceData(FairMultiLinkedData_Interfa
 
 void FairMultiLinkedData_Interface::SetInsertHistory(Bool_t val)
 {
+    CreateFairMultiLinkedData();
     if (GetPointerToLinks() != 0) {
         GetPointerToLinks()->SetInsertHistory(val);
     }

--- a/base/steer/FairRootManager.cxx
+++ b/base/steer/FairRootManager.cxx
@@ -606,7 +606,7 @@ TObject* FairRootManager::GetCloneOfLinkData(const FairLink link)
   } else {
     TClonesArray* dataArray = static_cast<TClonesArray*>(GetObject(GetBranchName(type)));
 
-//    std::cout << "dataArray size: " << dataArray->GetEntriesFast() << std::endl;
+    std::cout << "FairRootManager::GetCloneOfLinkData() dataArray size: " << dataArray->GetEntriesFast() << std::endl;
     if (index < dataArray->GetEntriesFast()) {
 //      std::cout << "DataArray at index " << index << " has Link: " << ((FairMultiLinkedData*)dataArray->At(index))->GetNLinks() << std::cout;
       result = dataArray->At(index)->Clone();

--- a/base/steer/FairTSBufferFunctional.cxx
+++ b/base/steer/FairTSBufferFunctional.cxx
@@ -127,9 +127,10 @@ TClonesArray* FairTSBufferFunctional::GetData(Double_t stopParameter)
 TClonesArray* FairTSBufferFunctional::GetData(Double_t startParameter, Double_t stopParameter)
 {
   if (fStartFunction != 0) {
-    fBufferArray->Clear();
+    fBufferArray->Delete();
+    fOutputArray->Delete();
     Int_t startIndex = FindStartIndex(startParameter);
-    std::cout << "StartIndex: " << startIndex << "/" << GetBranchIndex() << std::endl;
+//    std::cout << "StartParameter : " << startParameter << " StartIndex: " << startIndex << "/" << GetBranchIndex() << " size BufferArray " << fBufferArray->GetEntries() <<std::endl;
     if (startIndex > -1) {
       ReadInEntry(fBranchIndex);
       fBufferArray->AbsorbObjects(fInputArray, startIndex, fInputArray->GetEntries() -1);


### PR DESCRIPTION
Fix bug in copy and assignment opertor of FairMultiLinkedData_Interface class described in issue #927.
---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [ ] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
