### PR TITLE
Fix the bug in FairStack::CloneStack()

### DIFF
--- a/examples/common/mcstack/FairStack.h
+++ b/examples/common/mcstack/FairStack.h
@@ -199,7 +199,14 @@ class FairStack : public FairGenericStack
     }
 
     /** Clone this object (used in MT mode only) */
-    virtual FairGenericStack* CloneStack() const { return new FairStack(); }
+    virtual FairGenericStack* CloneStack() const {
+        FairStack* clonedStack = new FairStack();
+        clonedStack->StoreSecondaries(fStoreSecondaries);
+        clonedStack->SetMinPoints(fMinPoints);
+        clonedStack->SetEnergyCut(fEnergyCut);
+        clonedStack->StoreMothers(fStoreMothers);
+        return clonedStack;
+    }
 
   private:
     /** STL stack (FILO) used to handle the TParticles for tracking **/


### PR DESCRIPTION
When running multi-threaded Geant4 the stack settings 
are now cloned properly.

---

Checklist:

[*] Rebased against `dev` branch
[*] My name is in the resp. CONTRIBUTORS/AUTHORS file
[*] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
