### PR TITLE
Update in CMake: Added Root libraries as targets:

### DIFF
--- a/cmake/modules/FindROOT.cmake
+++ b/cmake/modules/FindROOT.cmake
@@ -159,6 +159,17 @@ If(ROOT_FOUND)
 
     Include(ROOTMacros)
 
+  # Aliases for imported VMC packages ROOT dependencies
+  foreach(_root_dep VMC Core RIO Tree Rint Physics MathCore Thread Geom EG)
+    find_library(${_root_dep}_LIB ${_root_dep} PATHS ${ROOT_LIBRARY_DIR})
+    if(${_root_dep}_LIB)
+      add_library(${_root_dep} SHARED IMPORTED GLOBAL)
+      set_target_properties(${_root_dep} PROPERTIES IMPORTED_LOCATION ${${_root_dep}_LIB})
+      add_library(ROOT::${_root_dep} ALIAS ${_root_dep})
+      message(STATUS "ROOT::${_root_dep} target added by hand.")
+    endif()
+  endforeach(_root_dep)
+
 Else(ROOT_FOUND)
 
   If(ROOT_FIND_REQUIRED)


### PR DESCRIPTION
This is needed to find the imported ROOT dependencies when linking against the VMC packages (geant4_vmc, vgm)

This modification is needed to get FairRoot compiled with the latest versions of VMC packages, which require to be built with ROOT CMake configuration file. As FairRoot defines ROOT definition in its own Find module, the library targets were missing.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [ ] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
