### PR TITLE
Add linking with VMC library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,8 @@ find_package2(PUBLIC Protobuf)
 find_package2(PUBLIC msgpack)
 find_package2(PUBLIC Flatbuffers)
 
+find_package2(PUBLIC VMC)
+
 find_package2(PUBLIC Geant3)
 find_package2(PUBLIC Geant4)
 
@@ -494,6 +496,9 @@ if(PROJECT_PACKAGE_DEPENDENCIES)
       endif()
     elseif(${dep} STREQUAL yaml-cpp)
       get_filename_component(prefix ${YAML_CPP_INCLUDE_DIR}/.. ABSOLUTE)
+  elseif(${dep} STREQUAL VMC)
+      get_target_property(vmc_include VMCLibrary INTERFACE_INCLUDE_DIRECTORIES)
+      get_filename_component(prefix ${vmc_include}/../.. ABSOLUTE)
     elseif(${dep} STREQUAL Geant4VMC)
       string(REPLACE ":" ";" geant4vmc_include ${Geant4VMC_INCLUDE_DIRS})
       list(GET geant4vmc_include 0 geant4vmc_include)

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -133,8 +133,9 @@ target_link_libraries(${target} PUBLIC
   Proof
   RIO
   Tree
-  VMC
   $<$<BOOL:${ROOT_GDML_FOUND}>:Gdml>
+
+  VMCLibrary
 )
 
 target_compile_definitions(${target} PRIVATE

--- a/base/sim/fastsim/CMakeLists.txt
+++ b/base/sim/fastsim/CMakeLists.txt
@@ -43,9 +43,10 @@ target_link_libraries(${target} PUBLIC
 
   Geom # TGeoManager
   Core # Rtypes
-  VMC # TVirtualMC
   EG # TParticle
   Physics # TVector
+
+  VMCLibrary
 )
 
 fairroot_target_root_dictionary(${target}

--- a/examples/MQ/pixelDetector/src/CMakeLists.txt
+++ b/examples/MQ/pixelDetector/src/CMakeLists.txt
@@ -92,7 +92,8 @@ target_link_libraries(${target} PUBLIC
   Physics
   Geom
   Hist
-  VMC
+
+  VMCLibrary
 )
 
 fairroot_target_root_dictionary(${target}

--- a/examples/MQ/pixelSimSplit/src/CMakeLists.txt
+++ b/examples/MQ/pixelSimSplit/src/CMakeLists.txt
@@ -54,7 +54,8 @@ target_link_libraries(${target} PUBLIC
   FairMQ::FairMQ
 
   Core
-  VMC
+
+  VMCLibrary
 )
 
 fairroot_target_root_dictionary(${target}

--- a/examples/common/gconfig/CMakeLists.txt
+++ b/examples/common/gconfig/CMakeLists.txt
@@ -37,7 +37,7 @@ target_link_libraries(${target} PUBLIC
   FairRoot::MCConfigurator # FairYamlVMCConfig
   FairRoot::MCStack # FairStack
 
-  VMC # TVirtualMC
+  VMCLibrary # TVirtualMC
 )
 
 fairroot_target_root_dictionary(${target}

--- a/examples/common/mcstack/CMakeLists.txt
+++ b/examples/common/mcstack/CMakeLists.txt
@@ -43,7 +43,8 @@ target_link_libraries(${target} PUBLIC
   Physics # TLorentzVector, TVector3
   MathCore # TMath
   EG # TDatabasePDG, TParticle
-  VMC # TMCProcess
+
+  VMCLibrary # TMCProcess
 )
 
 fairroot_target_root_dictionary(${target}

--- a/examples/simulation/Tutorial1/src/CMakeLists.txt
+++ b/examples/simulation/Tutorial1/src/CMakeLists.txt
@@ -51,7 +51,8 @@ target_link_libraries(${target} PUBLIC
   Core
   Physics
   Geom
-  VMC
+
+  VMCLibrary
 )
 
 fairroot_target_root_dictionary(${target}

--- a/examples/simulation/Tutorial2/src/CMakeLists.txt
+++ b/examples/simulation/Tutorial2/src/CMakeLists.txt
@@ -46,7 +46,8 @@ target_link_libraries(${target} PUBLIC
 
   Core
   Physics
-  VMC
+
+  VMCLibrary
 )
 
 fairroot_target_root_dictionary(${target}

--- a/examples/simulation/Tutorial4/src/CMakeLists.txt
+++ b/examples/simulation/Tutorial4/src/CMakeLists.txt
@@ -68,10 +68,11 @@ target_link_libraries(${target} PUBLIC
   Core
   Physics
   Geom
-  VMC
   MathCore
   Hist
   $<$<BOOL:${ROOT_HAS_OPENGL}>:Eve>
+
+  VMCLibrary
 )
 
 fairroot_target_root_dictionary(${target}

--- a/examples/simulation/rutherford/src/CMakeLists.txt
+++ b/examples/simulation/rutherford/src/CMakeLists.txt
@@ -43,7 +43,8 @@ target_link_libraries(${target} PUBLIC
 
   Core
   Physics
-  VMC
+
+  VMCLibrary
 )
 
 fairroot_target_root_dictionary(${target}

--- a/fairtools/MCConfigurator/CMakeLists.txt
+++ b/fairtools/MCConfigurator/CMakeLists.txt
@@ -40,7 +40,8 @@ target_link_libraries(${target} PUBLIC
   yaml-cpp
 
   Core
-  VMC
+
+  VMCLibrary
 )
 
 fairroot_target_root_dictionary(${target}

--- a/fairtools/MCStepLogger/CMakeLists.txt
+++ b/fairtools/MCStepLogger/CMakeLists.txt
@@ -31,7 +31,8 @@ target_link_libraries(${target} PUBLIC
   Tree
   Hist
   RIO
-  VMC
+  
+  VMCLibrary
 )
 
 install(TARGETS ${target} LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR})

--- a/geane/CMakeLists.txt
+++ b/geane/CMakeLists.txt
@@ -40,9 +40,10 @@ target_link_libraries(${target} PUBLIC
   Core
   EG
   Geom
-  VMC
   Physics
   MathCore
+
+  VMCLibrary
 )
 
 fairroot_target_root_dictionary(${target}


### PR DESCRIPTION
- In the next FairSoft release VMC will be a standalone package. Add it as dependency to the main CMakeLists.txt
- VMC of ROOT is deprecated. Link against VMCLibrary from VMC.
- CI will obviously fail.