### PR TITLE
Fix the bug of storing data in nonexisting sink

### DIFF
--- a/base/steer/FairRootManager.cxx
+++ b/base/steer/FairRootManager.cxx
@@ -209,6 +209,10 @@ void FairRootManager::RegisterImpl(const char* name, const char *folderName, T* 
       {
 	fSink->RegisterImpl(name,folderName,obj);
       }
+    else
+      {
+        LOG(fatal) << "The sink does not exist to store persistent branches.";
+      }
   }
   AddMemoryBranch(name, obj);
   AddBranchToList(name);

--- a/base/steer/FairRootManager.h
+++ b/base/steer/FairRootManager.h
@@ -8,6 +8,7 @@
 #ifndef FAIR_ROOT_MANAGER_H
 #define FAIR_ROOT_MANAGER_H
 
+#include "FairLogger.h"
 #include "FairSink.h"
 #include "FairSource.h"
 
@@ -419,7 +420,10 @@ void FairRootManager::RegisterAny(const char* brname, T *& obj, bool persistence
   if (persistence) {
     auto& ot = typeid(T*);
     auto& pt = typeid(T);
-    fSink->RegisterAny(brname,ot,pt,&obj);
+    if ( fSink )
+      fSink->RegisterAny(brname,ot,pt,&obj);
+    else
+      LOG(fatal) << "The sink does not exist to store persistent branches.";
   }
 }
 


### PR DESCRIPTION
Implemented check if FairRootManager. If attempt to store data
and no sink detected the application will crash.

Fixes issue #935.

[*] Rebased against `dev` branch
[*] My name is in the resp. CONTRIBUTORS/AUTHORS file
[*] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
