### PR TITLE
cmake: Replace UTF-8 message strings

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -29,6 +29,7 @@ Rademakers, Fons
 Rohr, David
 Shahoyan, Ruben
 Stockmanns, Tobias
+Tacke, Christian
 Ustyuzhanin, Andrey
 von Haller, Barthélémy
 Wenzel, Sandro

--- a/cmake/modules/FindFairRoot.cmake
+++ b/cmake/modules/FindFairRoot.cmake
@@ -25,7 +25,7 @@ else()
   set(FAIRROOTPATH $ENV{FAIRROOTPATH})
 endif()
 
-MESSAGE(STATUS "Setting FairRoot environment…")
+MESSAGE(STATUS "Setting FairRoot environment:")
 
 FIND_PATH(FAIRROOT_INCLUDE_DIR NAMES FairRun.h PATHS
   ${FAIRROOTPATH}/include
@@ -53,10 +53,10 @@ endif()
 
 if(FAIRROOT_INCLUDE_DIR AND FAIRROOT_LIBRARY_DIR)
    set(FAIRROOT_FOUND TRUE)
-   MESSAGE(STATUS "FairRoot ... - found ${FAIRROOTPATH}")
-   MESSAGE(STATUS "FairRoot Library directory  :     ${FAIRROOT_LIBRARY_DIR}")
-   MESSAGE(STATUS "FairRoot Include path…      :     ${FAIRROOT_INCLUDE_DIR}")
-   MESSAGE(STATUS "FairRoot Cmake Modules      :     ${FAIRROOT_CMAKEMOD_DIR}")
+   MESSAGE(STATUS "  FairRoot prefix            : ${FAIRROOTPATH}")
+   MESSAGE(STATUS "  FairRoot Library directory : ${FAIRROOT_LIBRARY_DIR}")
+   MESSAGE(STATUS "  FairRoot Include path      : ${FAIRROOT_INCLUDE_DIR}")
+   MESSAGE(STATUS "  FairRoot Cmake Modules     : ${FAIRROOT_CMAKEMOD_DIR}")
 
 else(FAIRROOT_INCLUDE_DIR AND FAIRROOT_LIBRARY_DIR)
    set(FAIRROOT_FOUND FALSE)


### PR DESCRIPTION
Under some circumstances (spack + other things) outputting UTF-8 strings can confuse/break other systems. As this output is not critical in any form, replace the strings with ASCII-only versions.

Yes, those other systems should be fixed. But this workaround is much easier and quicker.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)