### PR TITLE
Improve adding container to the container factory

### DIFF
--- a/parbase/FairContFact.cxx
+++ b/parbase/FairContFact.cxx
@@ -218,3 +218,19 @@ void FairContFact::print()
         c->print();
     }
 }
+
+Bool_t FairContFact::AddContainer(FairContainer* cont)
+{
+    // Check if a container already exist in the List of containers
+    // If it alread exist print an error message and return kFALSE
+    // such that the user can handle the issue
+    if (nullptr != containers->FindObject(cont)) {
+        LOG(error) << "The container " << cont->GetName() << " already exist in the "
+                   << "container factory " << GetName() << ".\n"
+                   << "Duplicate container is not added.";
+        return kFALSE;
+    }
+
+    containers->Add(cont);
+    return kTRUE;
+}

--- a/parbase/FairContFact.h
+++ b/parbase/FairContFact.h
@@ -55,6 +55,8 @@ class FairContFact : public TNamed
     FairParSet* getContainer(const char*);
     virtual FairParSet* createContainer(FairContainer*) { return 0; }
     virtual void activateParIo(FairParIo*) {}
+    /// @param[in] container Transfers ownership if return value is true
+    Bool_t AddContainer(FairContainer*);
 
   protected:
     TList* containers;   // all parameter containers managed by this factory


### PR DESCRIPTION
Add a function to add a container to the factory that also checks if the
container already exist. If the container already exist it is not added
again and kFALSE is returned. Otherwise it is added and kTRUE is returned.
The "normal" way to add containers is to use the TList data member directly
which will not report any errors when adding the container. Only when the
destructor of the runtime database is called one will see an error message

Error in <TList::Delete>: A list is accessing an object (0x55d2e2220550)
already deleted (list name = TList)

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [ ] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
