### PR TITLE
Fix test running for pixel examples

### DIFF
--- a/examples/MQ/pixelDetector/run/CMakeLists.txt
+++ b/examples/MQ/pixelDetector/run/CMakeLists.txt
@@ -105,9 +105,9 @@ install(TARGETS pixel-sampler pixel-processor pixel-sink pixel-sampler-bin pixel
   RUNTIME DESTINATION ${PROJECT_INSTALL_DATADIR}/examples/MQ/pixelDetector/bin
 )
 
-set(maxTestTime 60)
+set(maxTestTime 100)
 
-add_test(ex_MQ_pixel_simulation ${CMAKE_CURRENT_BINARY_DIR}/startFairMQPixelSimulation.sh --work-dir ${CMAKE_CURRENT_BINARY_DIR}/../ -n 1000 -g TGeant3 -c static -s 6 --force-kill true -m 20 -v veryhigh -l false)
+add_test(ex_MQ_pixel_simulation ${CMAKE_CURRENT_BINARY_DIR}/startFairMQPixelSimulation.sh --work-dir ${CMAKE_CURRENT_BINARY_DIR}/../ -n 1000 -g TGeant3 -c static -s 3 --force-kill true -m 100 -v veryhigh -l false)
 set_tests_properties(ex_MQ_pixel_simulation PROPERTIES
   DEPENDS ex_MQ_pixel_static
   TIMEOUT ${maxTestTime}

--- a/examples/MQ/pixelDetector/run/scripts/startFairMQPixelSimulation.sh.in
+++ b/examples/MQ/pixelDetector/run/scripts/startFairMQPixelSimulation.sh.in
@@ -175,6 +175,7 @@ done
 for (( i=0 ; i<$NOFSIMULS ; i++ ))
 do
     ASAMPLER[i]="$SAMPLER --id pixSim-sampler$i --random-seed ${RANDOMNUMBER[i]}"
+#    echo "$i >> ${ASAMPLER[i]}"
 done
 ########################## start FILESINK
 FILESINK="@pixel_bin_dir@/"
@@ -257,22 +258,33 @@ if [ "$COMMAND" == "static" ]; then
     done
     printf "|\n"
 
-    SAMPLERRUNNING=0
+    for (( i=0 ; i<$NOFSIMULS ; i++ ))
+    do
+	SAMPLERRUNNING[i]=10
+    done
+
+    ALLSAMPLERSRUNNING=0
     for ((isec = 0 ; isec < MAXRUNNINGTIME ; isec++ ));
     do
-	if (( SAMPLERRUNNING != -1 )); then
-	    SAMPLERRUNNING=0
+	if (( ALLSAMPLERSRUNNING != -1 )); then
+	    ALLSAMPLERSRUNNING=0
 	    for (( isimul=0 ; isimul<$NOFSIMULS ; isimul++ ))
 	    do
 		CHECK_SAMPLER="$(kill -0 ${SAMPLER_PID[isimul]} &> /dev/null && echo $RUN_STRING)";
 		if [ "$CHECK_SAMPLER" == "$RUN_STRING" ];
 		then
-		    SAMPLERRUNNING=1;
+		    SAMPLERRUNNING[isimul]=10
+		else
+		    if (( SAMPLERRUNNING[isimul] > 0 )); then
+			SAMPLERRUNNING[isimul]=$((SAMPLERRUNNING[isimul]-1))
+		    fi
 		fi
+		ALLSAMPLERSRUNNING=$((ALLSAMPLERSRUNNING+SAMPLERRUNNING[isimul]))
+#		echo "$CHECK_SAMPLER -> ${SAMPLERRUNNING[isimul]} -> $ALLSAMPLERSRUNNING"
 	    done
-	    if (( SAMPLERRUNNING == 0 )); then
+	    if (( ALLSAMPLERSRUNNING == 0 )); then
 		MAXRUNNINGTIME=$((isec+2)); #TODO let it run for two more seconds after all samplers finish working... workaround for now
-		SAMPLERRUNNING=-1
+		ALLSAMPLERSRUNNING=-1
 	    fi
 	fi
 
@@ -285,6 +297,7 @@ if [ "$COMMAND" == "static" ]; then
 	done
 	FILESINK_INFO="$(ps -o %cpu -o rss $FILESINK_PID | tail -1)"
 	printf " %5s %6s |\r" $FILESINK_INFO
+#	echo $ALLSAMPLERSRUNNING
 	sleep 1;
     done;
     echo;

--- a/examples/MQ/pixelSimSplit/run/scripts/test-splitMQ.sh.in
+++ b/examples/MQ/pixelSimSplit/run/scripts/test-splitMQ.sh.in
@@ -7,6 +7,22 @@ if [ -f @splitmc_file_location@/MQ.simulation_TGeant3.data.root ]; then
     rm -rf @splitmc_file_location@/MQ.simulation_TGeant3.data.root
 fi
 
+FORCEKILL=true
+CHECK_BEFORE="$(ps -fea | grep "\-\-id pixSplit" | grep -v grep)"
+if [ -n "$CHECK_BEFORE" ];
+then
+    echo "some example/MQ/pixelSimSplit programs are still running:"
+    echo $CHECK_BEFORE
+    echo "quit them before proceeding."
+    if [ "$FORCEKILL" == "true" ];
+    then
+        echo "trying to kill..."
+        ps -fea | grep "\-\-id pixSplit" | grep -v grep | awk '{print $2}' | xargs kill -9
+    else
+        exit
+    fi
+fi
+
 INPUT_EVENTS="100"
 
 GENERATOR="@splitmc_bin_location@/pixel-sim-gen --id pixSplit-gen --channel-config name=primariesChannel,type=push,method=bind,rateLogging=1,address=tcp://*:5901 --running-mode pp --severity DEBUG --nof-events $INPUT_EVENTS --chunk-size 10 --ack-channel ack --channel-config name=ack,type=pull,method=bind,rateLogging=1,address=tcp://*:5905 --control static --color false"
@@ -38,10 +54,30 @@ $PARMQSERVER &> par_log.dat &
 PARMQSERVER_PID=$!
 
 echo "Wait for generator to finish"
-wait $GENERATOR_PID
+RUN_STRING="Running"
+MAXRUNNINGTIME=60
+
+for ((isec = 0 ; isec < MAXRUNNINGTIME ; isec++ ));
+do
+    sleep 1
+#    echo "$isec"
+    CHECK_SAMPLER="$(kill -0 $GENERATOR_PID &> /dev/null && echo $RUN_STRING)";
+    if [ "$CHECK_SAMPLER" != "$RUN_STRING" ];
+    then
+	echo "Generator finished after $isec seconds."
+	break;
+    fi
+done
 
 echo "Sleep 1 second"
 sleep 1
+
+CHECK_SAMPLER="$(kill -0 $GENERATOR_PID &> /dev/null && echo $RUN_STRING)";
+if [ "$CHECK_SAMPLER" == "$RUN_STRING" ];
+then
+    echo "Killing running generator"
+    kill $GENERATOR_PID
+fi
 
 echo "Kill other devices"
 kill $TRANSPORTER_PID


### PR DESCRIPTION
Increase the max running time, reduce number of parallel jobs,
automatic control over individual runninng processes for pixel_simulation.
Check for and kill old running processes, improve process cleaning
after the test end for pixelSimSplit.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
