### PR TITLE
Format addendum

### DIFF
--- a/base/event/FairEventHeader.h
+++ b/base/event/FairEventHeader.h
@@ -71,7 +71,7 @@ class FairEventHeader : public TNamed
     /**MC entry number from input chain*/
     Int_t fMCEntryNo;
 
-    ClassDef(FairEventHeader, 3)
+    ClassDef(FairEventHeader, 3);
 };
 
 #endif

--- a/base/event/FairFileHeader.h
+++ b/base/event/FairFileHeader.h
@@ -68,7 +68,7 @@ class FairFileHeader : public TNamed
     FairFileHeader(const FairFileHeader&);
     FairFileHeader& operator=(const FairFileHeader&);
 
-    ClassDef(FairFileHeader, 2)
+    ClassDef(FairFileHeader, 2);
 };
 
 #endif

--- a/base/event/FairFileInfo.h
+++ b/base/event/FairFileInfo.h
@@ -50,7 +50,7 @@ class FairFileInfo : public TNamed
     FairFileInfo(const FairFileInfo&);
     FairFileInfo& operator=(const FairFileInfo&);
 
-    ClassDef(FairFileInfo, 1)
+    ClassDef(FairFileInfo, 1);
 };
 
 #endif   // FAIRFILEINFO_H

--- a/base/event/FairMCPoint.h
+++ b/base/event/FairMCPoint.h
@@ -116,7 +116,7 @@ class FairMCPoint : public FairMultiLinkedData_Interface
     Int_t fDetectorID;          ///< Detector unique identifier
     Double32_t fX, fY, fZ;      ///< Position of hit [cm]
 
-    ClassDef(FairMCPoint, 5)
+    ClassDef(FairMCPoint, 5);
 };
 
 inline void FairMCPoint::SetMomentum(const TVector3& mom)

--- a/base/event/FairRadLenPoint.h
+++ b/base/event/FairRadLenPoint.h
@@ -84,7 +84,7 @@ class FairRadLenPoint : public FairMCPoint
     Double_t fXOut, fYOut, fZOut;
     Double_t fPxOut, fPyOut, fPzOut;
 
-    ClassDef(FairRadLenPoint, 1)
+    ClassDef(FairRadLenPoint, 1);
 };
 
 #endif

--- a/base/event/FairRadMapPoint.h
+++ b/base/event/FairRadMapPoint.h
@@ -95,7 +95,7 @@ class FairRadMapPoint : public FairMCPoint
     Double_t fXOut, fYOut, fZOut;
     Double_t fPxOut, fPyOut, fPzOut;
 
-    ClassDef(FairRadMapPoint, 3)
+    ClassDef(FairRadMapPoint, 3);
 };
 
 #endif

--- a/base/event/FairRecoEventHeader.h
+++ b/base/event/FairRecoEventHeader.h
@@ -102,7 +102,7 @@ class FairRecoEventHeader : public TNamed
     /** Event Time Error **/
     Double_t fEventTimeError;
 
-    ClassDef(FairRecoEventHeader, 1)
+    ClassDef(FairRecoEventHeader, 1);
 };
 
 #endif

--- a/base/event/FairRunInfo.h
+++ b/base/event/FairRunInfo.h
@@ -45,7 +45,7 @@ class FairRunInfo : public TObject
     FairRunInfo(const FairRunInfo&);
     FairRunInfo& operator=(const FairRunInfo&);
 
-    ClassDef(FairRunInfo, 2)
+    ClassDef(FairRunInfo, 2);
 };
 
 #endif

--- a/base/field/FairFieldFactory.h
+++ b/base/field/FairFieldFactory.h
@@ -44,7 +44,8 @@ class FairFieldFactory
 
     ClassDef(FairFieldFactory, 1);
 
-        private : FairFieldFactory(const FairFieldFactory& M);
+  private:
+    FairFieldFactory(const FairFieldFactory& M);
     FairFieldFactory& operator=(const FairFieldFactory&) { return *this; }
 };
 

--- a/base/field/FairFieldFactory.h
+++ b/base/field/FairFieldFactory.h
@@ -42,7 +42,7 @@ class FairFieldFactory
     FairFieldFactory* fCreator;
     static FairFieldFactory* fgRinstance;
 
-    ClassDef(FairFieldFactory, 1)
+    ClassDef(FairFieldFactory, 1);
 
         private : FairFieldFactory(const FairFieldFactory& M);
     FairFieldFactory& operator=(const FairFieldFactory&) { return *this; }

--- a/base/sim/FairBaseContFact.h
+++ b/base/sim/FairBaseContFact.h
@@ -29,7 +29,7 @@ class FairBaseContFact : public FairContFact
      * For an actual context, which is not an empty string and not the default context
      * of this container, the name is concatinated with the context. */
     FairParSet* createContainer(FairContainer*);
-    ClassDef(FairBaseContFact, 0)
+    ClassDef(FairBaseContFact, 0);
 };
 
 #endif /* !FAIRBASECONTFACT_H */

--- a/base/sim/FairBaseParSet.h
+++ b/base/sim/FairBaseParSet.h
@@ -110,7 +110,7 @@ class FairBaseParSet : public FairParGenericSet
     /// Random Seed from gRandom
     UInt_t fRandomSeed;
 
-    ClassDef(FairBaseParSet, 6)
+    ClassDef(FairBaseParSet, 6);
 
         private : FairBaseParSet(const FairBaseParSet& L);
     FairBaseParSet& operator=(const FairBaseParSet&) { return *this; }

--- a/base/sim/FairBaseParSet.h
+++ b/base/sim/FairBaseParSet.h
@@ -112,7 +112,8 @@ class FairBaseParSet : public FairParGenericSet
 
     ClassDef(FairBaseParSet, 6);
 
-        private : FairBaseParSet(const FairBaseParSet& L);
+  private:
+    FairBaseParSet(const FairBaseParSet& L);
     FairBaseParSet& operator=(const FairBaseParSet&) { return *this; }
 };
 

--- a/base/sim/FairDetector.h
+++ b/base/sim/FairDetector.h
@@ -110,6 +110,6 @@ class FairDetector : public FairModule
     Int_t fDetId;          // Detector Id has to be set from ctr.
     FairLogger* fLogger;   //! /// FairLogger
 
-    ClassDef(FairDetector, 1)
+    ClassDef(FairDetector, 1);
 };
 #endif   // FAIRDETECTOR_H

--- a/base/sim/FairDoubleHit.h
+++ b/base/sim/FairDoubleHit.h
@@ -63,6 +63,6 @@ class FairDoubleHit : public FairMultiLinkedData
     virtual Double_t dy_out() = 0;
     virtual Double_t dz_out() = 0;
 
-    ClassDef(FairDoubleHit, 1)   // FAIRDoubleHit
+    ClassDef(FairDoubleHit, 1);
 };
 #endif   // FAIRDOUBLEHIT_H

--- a/base/sim/FairGeaneApplication.h
+++ b/base/sim/FairGeaneApplication.h
@@ -77,7 +77,9 @@ class FairGeaneApplication : public TVirtualMCApplication
 
     // Interface to MonteCarlo application
     ClassDef(FairGeaneApplication, 1);
-        private : FairGeaneApplication(const FairGeaneApplication&);
+
+  private:
+    FairGeaneApplication(const FairGeaneApplication&);
     FairGeaneApplication& operator=(const FairGeaneApplication&);
 };
 

--- a/base/sim/FairGeaneApplication.h
+++ b/base/sim/FairGeaneApplication.h
@@ -75,7 +75,8 @@ class FairGeaneApplication : public TVirtualMCApplication
     Bool_t fDebug;            //!
     TLorentzVector fTrkPos;   //!
 
-    ClassDef(FairGeaneApplication, 1)   // Interface to MonteCarlo application
+    // Interface to MonteCarlo application
+    ClassDef(FairGeaneApplication, 1);
         private : FairGeaneApplication(const FairGeaneApplication&);
     FairGeaneApplication& operator=(const FairGeaneApplication&);
 };

--- a/base/sim/FairGenericStack.h
+++ b/base/sim/FairGenericStack.h
@@ -185,7 +185,7 @@ class FairGenericStack : public TVirtualMCStack
     Int_t fFSFirstSecondary;                         //!
     Int_t fFSNofSecondaries;                         //!
 
-    ClassDef(FairGenericStack, 1)
+    ClassDef(FairGenericStack, 1);
 };
 
 template<typename T>

--- a/base/sim/FairGeoParSet.h
+++ b/base/sim/FairGeoParSet.h
@@ -77,7 +77,8 @@ class FairGeoParSet : public FairParGenericSet
     TGeoManager* fGeom;
     ClassDef(FairGeoParSet, 1);
 
-        private : FairGeoParSet(const FairGeoParSet& L);
+  private:
+    FairGeoParSet(const FairGeoParSet& L);
     FairGeoParSet& operator=(const FairGeoParSet&) { return *this; }
 };
 

--- a/base/sim/FairGeoParSet.h
+++ b/base/sim/FairGeoParSet.h
@@ -75,7 +75,7 @@ class FairGeoParSet : public FairParGenericSet
     TObjArray* fGeoNodes;   //!
     /// Full Geometry
     TGeoManager* fGeom;
-    ClassDef(FairGeoParSet, 1)
+    ClassDef(FairGeoParSet, 1);
 
         private : FairGeoParSet(const FairGeoParSet& L);
     FairGeoParSet& operator=(const FairGeoParSet&) { return *this; }

--- a/base/sim/FairMCApplication.h
+++ b/base/sim/FairMCApplication.h
@@ -302,7 +302,7 @@ class FairMCApplication : public TVirtualMCApplication
     /** Current state */
     FairMCApplicationState fState;   //!
 
-    ClassDef(FairMCApplication, 4)   // Interface to MonteCarlo application
+    ClassDef(FairMCApplication, 4);
 
         private
         :

--- a/base/sim/FairMCApplication.h
+++ b/base/sim/FairMCApplication.h
@@ -304,10 +304,9 @@ class FairMCApplication : public TVirtualMCApplication
 
     ClassDef(FairMCApplication, 4);
 
-        private
-        :
-        /** Protected copy constructor */
-        FairMCApplication(const FairMCApplication&);
+  private:
+    /** Protected copy constructor */
+    FairMCApplication(const FairMCApplication&);
     /** Protected assignment operator */
     FairMCApplication& operator=(const FairMCApplication&);
 

--- a/base/sim/FairModule.h
+++ b/base/sim/FairModule.h
@@ -159,7 +159,7 @@ class FairModule : public TNamed
     Bool_t fGeoSaved;   //! flag for initialisation
     TVirtualMC* fMC;    //! cahed pointer to MC (available only after initialization)
 
-    ClassDef(FairModule, 4)
+    ClassDef(FairModule, 4);
 };
 
 template<class T, class U>

--- a/base/sim/FairParticle.h
+++ b/base/sim/FairParticle.h
@@ -113,7 +113,7 @@ class FairParticle : public TObject
     Int_t fbaryon;
     Bool_t fstable;
 
-    ClassDef(FairParticle, 3)   // Extended TParticle
+    ClassDef(FairParticle, 3);
 };
 
 #endif   // FAIR_PARTICLE_H

--- a/base/sim/FairVolume.h
+++ b/base/sim/FairVolume.h
@@ -77,7 +77,7 @@ class FairVolume : public TNamed
     FairModule* fModule;     /**The Module in which the volume is */
     FairGeoNode* fNode;      /**Node corresponding to this volume*/
 
-    ClassDef(FairVolume, 2)   // Volume Definition
+    ClassDef(FairVolume, 2);
 };
 
 #endif

--- a/base/sim/FairVolumeList.h
+++ b/base/sim/FairVolumeList.h
@@ -44,7 +44,7 @@ class FairVolumeList : public TObject
     Int_t getEntries() { return fData->GetEntries(); }
     FairVolume* At(Int_t pos) { return (dynamic_cast<FairVolume*>(fData->At(pos))); }
 
-    ClassDef(FairVolumeList, 1)   // Volume List
+    ClassDef(FairVolumeList, 1);
 };
 
 #endif   // FAIR_VOLUMELIST_H

--- a/base/sim/fastsim/FairFastSimDetector.h
+++ b/base/sim/fastsim/FairFastSimDetector.h
@@ -48,7 +48,7 @@ class FairFastSimDetector : public FairDetector
 
     FairFastSimDetector& operator=(const FairFastSimDetector&);
 
-    ClassDef(FairFastSimDetector, 1)
+    ClassDef(FairFastSimDetector, 1);
 };
 
 #endif   //! FAIRFASTSIMDETECTOR_H

--- a/base/sink/FairRootFileSink.h
+++ b/base/sink/FairRootFileSink.h
@@ -93,7 +93,7 @@ class FairRootFileSink : public FairSink
     /**File Header*/
     FairFileHeader* fFileHeader;   //!
 
-    ClassDef(FairRootFileSink, 1)
+    ClassDef(FairRootFileSink, 1);
 };
 
 #endif /* defined(__FAIRROOT__FairRootFileSink__) */

--- a/base/sink/FairSink.h
+++ b/base/sink/FairSink.h
@@ -89,7 +89,7 @@ class FairSink
     std::map<std::string, std::unique_ptr<TypeAddressPair const>> fPersistentBranchesMap;   //!
 
   public:
-    ClassDef(FairSink, 1)
+    ClassDef(FairSink, 1);
 };
 
 #endif

--- a/base/source/FairFileSource.h
+++ b/base/source/FairFileSource.h
@@ -198,7 +198,7 @@ class FairFileSource : public FairSource
                                 */
     Bool_t fCheckFileLayout;   //!
 
-    ClassDef(FairFileSource, 3)
+    ClassDef(FairFileSource, 3);
 };
 
 #endif /* defined(__FAIRROOT__FairFileSource__) */

--- a/base/source/FairLmdSource.h
+++ b/base/source/FairLmdSource.h
@@ -60,7 +60,7 @@ class FairLmdSource : public FairMbsSource
 
     FairLmdSource& operator=(const FairLmdSource&);
 
-    ClassDef(FairLmdSource, 0)
+    ClassDef(FairLmdSource, 0);
 };
 
 #endif

--- a/base/source/FairMbsSource.h
+++ b/base/source/FairMbsSource.h
@@ -40,7 +40,7 @@ class FairMbsSource : public FairOnlineSource
                   Short_t subCrate,
                   Short_t control);
 
-    ClassDef(FairMbsSource, 0)
+    ClassDef(FairMbsSource, 0);
 };
 
 #endif

--- a/base/source/FairMbsStreamSource.h
+++ b/base/source/FairMbsStreamSource.h
@@ -50,7 +50,7 @@ class FairMbsStreamSource : public FairMbsSource
     FairMbsStreamSource& operator=(const FairMbsStreamSource&);
 
   public:
-    ClassDef(FairMbsStreamSource, 0)
+    ClassDef(FairMbsStreamSource, 0);
 };
 
 #endif

--- a/base/source/FairMixedSource.h
+++ b/base/source/FairMixedSource.h
@@ -228,7 +228,7 @@ class FairMixedSource : public FairSource
     FairMixedSource& operator=(const FairMixedSource&);
 
   public:
-    ClassDef(FairMixedSource, 0)
+    ClassDef(FairMixedSource, 0);
 };
 
 #endif /* defined(__FAIRROOT__FairMixedSource__) */

--- a/base/source/FairOnlineSource.h
+++ b/base/source/FairOnlineSource.h
@@ -52,7 +52,7 @@ class FairOnlineSource : public FairSource
   private:
     FairOnlineSource& operator=(const FairOnlineSource&);
 
-    ClassDef(FairOnlineSource, 0)
+    ClassDef(FairOnlineSource, 0);
 };
 
 #endif

--- a/base/source/FairRemoteSource.h
+++ b/base/source/FairRemoteSource.h
@@ -43,7 +43,7 @@ class FairRemoteSource : public FairMbsSource
     FairRemoteSource& operator=(const FairRemoteSource&);
 
   public:
-    ClassDef(FairRemoteSource, 0)
+    ClassDef(FairRemoteSource, 0);
 };
 
 #endif

--- a/base/source/FairSource.h
+++ b/base/source/FairSource.h
@@ -64,7 +64,7 @@ class FairSource : public TObject
     Int_t fRunId;
 
   public:
-    ClassDef(FairSource, 2)
+    ClassDef(FairSource, 2);
 };
 
 #endif

--- a/base/source/FairUnpack.h
+++ b/base/source/FairUnpack.h
@@ -46,7 +46,7 @@ class FairUnpack : public TObject
     virtual void Register() = 0;
 
   public:
-    ClassDef(FairUnpack, 0)
+    ClassDef(FairUnpack, 0);
 };
 
 #endif

--- a/base/source/MRevBuffer.h
+++ b/base/source/MRevBuffer.h
@@ -60,7 +60,7 @@ class REvent : public TObject
     Short_t subEvtControl[100];
     Int_t* pSubEvt[100];
 
-    ClassDef(REvent, 0)   // prototype for event
+    ClassDef(REvent, 0);
 };
 
 class MRevBuffer : public TObject
@@ -132,7 +132,7 @@ class MRevBuffer : public TObject
 
     void RevClose(TSocket* pSocket);   // input Socket ptr
 
-    ClassDef(MRevBuffer, 0)   // prototype for remote event buffer
+    ClassDef(MRevBuffer, 0);
 };
 
 #endif   // !MRevBuffer_H

--- a/base/steer/FairLinkManager.h
+++ b/base/steer/FairLinkManager.h
@@ -42,7 +42,7 @@ class FairLinkManager : public TObject
 
     FairLogger* fLogger;   //!
 
-    ClassDef(FairLinkManager, 1)   // Root IO manager
+    ClassDef(FairLinkManager, 1);
 };
 
 #endif   // FAIR_ROOT_MANAGER_H

--- a/base/steer/FairRingSorter.h
+++ b/base/steer/FairRingSorter.h
@@ -70,7 +70,7 @@ class FairRingSorter : public TObject
     double fCellWidth;
     int fVerbose;
 
-    ClassDef(FairRingSorter, 1)
+    ClassDef(FairRingSorter, 1);
 };
 
 #endif /* FairRingSorter_H_ */

--- a/base/steer/FairRootManager.h
+++ b/base/steer/FairRootManager.h
@@ -418,7 +418,7 @@ class FairRootManager : public TObject
     // data members
     Int_t fId;   // This manager ID
 
-    ClassDef(FairRootManager, 12)   // Root IO manager
+    ClassDef(FairRootManager, 12);
 };
 
 // FIXME: move to source since we can make it non-template dependent

--- a/base/steer/FairRun.h
+++ b/base/steer/FairRun.h
@@ -216,6 +216,6 @@ class FairRun : public TNamed
 
     void AlignGeometry() const;
 
-    ClassDef(FairRun, 5)
+    ClassDef(FairRun, 5);
 };
 #endif   // FAIRRUN_H

--- a/base/steer/FairRunAna.h
+++ b/base/steer/FairRunAna.h
@@ -188,7 +188,7 @@ class FairRunAna : public FairRun
     /** Flag for Event Header Persistency */
     Bool_t fStoreEventHeader;   //!
 
-    ClassDef(FairRunAna, 6)
+    ClassDef(FairRunAna, 6);
 };
 
 #endif   // FAIRRUNANA_H

--- a/base/steer/FairRunAnaProof.h
+++ b/base/steer/FairRunAnaProof.h
@@ -91,7 +91,7 @@ class FairRunAnaProof : public FairRunAna
 
     FairFileSource* fProofFileSource;
 
-    ClassDef(FairRunAnaProof, 1)
+    ClassDef(FairRunAnaProof, 1);
 };
 
 #endif   // FAIRRUNANAPROOF_H

--- a/base/steer/FairRunOnline.h
+++ b/base/steer/FairRunOnline.h
@@ -108,7 +108,7 @@ class FairRunOnline : public FairRun
 
     virtual void Fill();
 
-    ClassDef(FairRunOnline, 0)
+    ClassDef(FairRunOnline, 0);
 };
 
 #endif   // FAIRRUNONLINE_H

--- a/base/steer/FairRunSim.h
+++ b/base/steer/FairRunSim.h
@@ -223,7 +223,7 @@ class FairRunSim : public FairRun
     bool fUseSimSetupFunction = false;
     FairGenericVMCConfig* fSimulationConfig;   //!                 /** Simulation configuration */
 
-    ClassDef(FairRunSim, 2)
+    ClassDef(FairRunSim, 2);
 };
 
 #endif   // FAIRRUNSIM_H

--- a/base/steer/FairWriteoutBufferAbsBasis.h
+++ b/base/steer/FairWriteoutBufferAbsBasis.h
@@ -25,7 +25,7 @@ class FairWriteoutBufferAbsBasis : public TObject
     virtual void WriteOutData(double time) = 0;
     virtual void WriteOutAllData() = 0;
 
-    ClassDef(FairWriteoutBufferAbsBasis, 1)
+    ClassDef(FairWriteoutBufferAbsBasis, 1);
 };
 
 #endif /* FAIRWRITEOUTBUFFERABSBASIS_H_ */

--- a/datamatch/FairMCDataCrawler.h
+++ b/datamatch/FairMCDataCrawler.h
@@ -66,4 +66,4 @@ class FairMCDataCrawler : public TObject
     ClassDef(FairMCDataCrawler, 1);
 };
 
-#endif /* PNDMCDATACRAWLER_H_ */
+#endif /* FAIRMCDATACRAWLER_H_ */

--- a/datamatch/FairMCList.h
+++ b/datamatch/FairMCList.h
@@ -59,4 +59,4 @@ class FairMCList : public TObject
     ClassDef(FairMCList, 1);
 };
 
-#endif /* PNDMCLIST_H_ */
+#endif /* FAIRMCLIST_H_ */

--- a/datamatch/FairMCMatch.h
+++ b/datamatch/FairMCMatch.h
@@ -134,4 +134,4 @@ class FairMCMatch : public TNamed
     ClassDef(FairMCMatch, 1);
 };
 
-#endif /* PNDMCMATCH_H_ */
+#endif /* FAIRMCMATCH_H_ */

--- a/datamatch/FairMCMatchLoaderTask.h
+++ b/datamatch/FairMCMatchLoaderTask.h
@@ -10,7 +10,7 @@
 // -----                  Created 20/03/07  by R.Kliemt               -----
 // -------------------------------------------------------------------------
 
-/** PNDMCMATCHCREATORTASK.h
+/** FairMCMatchLoaderTask.h
  *@author T.Stockmanns <t.stockmanns@fz-juelich.de>
  **
  ** Displays all available informations for a given event

--- a/datamatch/FairMCObject.h
+++ b/datamatch/FairMCObject.h
@@ -127,4 +127,4 @@ class FairMCObject : public TObject
     ClassDef(FairMCObject, 0);
 };
 
-#endif /* PNDMCOBJECT_H_ */
+#endif /* FAIRMCOBJECT_H_ */

--- a/datamatch/FairMCStage.h
+++ b/datamatch/FairMCStage.h
@@ -93,4 +93,4 @@ class FairMCStage : public FairMCObject
     ClassDef(FairMCStage, 1);
 };
 
-#endif /* PNDMCSTAGE_H_ */
+#endif /* FAIRMCSTAGE_H_ */

--- a/eventdisplay/FairEventManagerEditor.h
+++ b/eventdisplay/FairEventManagerEditor.h
@@ -53,7 +53,8 @@ class FairEventManagerEditor : public TGedFrame
     virtual void MinEnergy();
     virtual void Init();
 
-    ClassDef(FairEventManagerEditor, 0);   // Specialization of TGedEditor for proper update propagation to TEveManager.
+    // Specialization of TGedEditor for proper update propagation to TEveManager.
+    ClassDef(FairEventManagerEditor, 0);
 };
 
 #endif

--- a/eventdisplay/FairMCTracksEditor.h
+++ b/eventdisplay/FairMCTracksEditor.h
@@ -36,7 +36,8 @@ class FairMCTracksEditor : public TGedFrame
 
     virtual void SetModel(TObject* obj);
 
-    ClassDef(FairMCTracksEditor, 0);   // Specialization of TGedEditor for proper update propagation to TEveManager.
+    // Specialization of TGedEditor for proper update propagation to TEveManager.
+    ClassDef(FairMCTracksEditor, 0);
 };
 
 #endif

--- a/eventdisplay/FairXMLNode.h
+++ b/eventdisplay/FairXMLNode.h
@@ -52,7 +52,7 @@ class FairXMLAttrib : public TNamed
      */
     void SetValue(TString val) { SetTitle(val); };
     virtual ~FairXMLAttrib(){};
-    ClassDef(FairXMLAttrib, 1)
+    ClassDef(FairXMLAttrib, 1);
 };
 /**
  * class for representing XML node
@@ -148,7 +148,7 @@ class FairXMLNode : public TNamed
      */
     FairXMLNode *GetChild(Int_t index) const;
     virtual ~FairXMLNode();
-    ClassDef(FairXMLNode, 1)
+    ClassDef(FairXMLNode, 1);
 };
 
 /**
@@ -191,7 +191,7 @@ class FairXMLFile : public TObject
      * destroy object (and save xml file if needed and Close was not called)
      */
     virtual ~FairXMLFile();
-    ClassDef(FairXMLFile, 1)
+    ClassDef(FairXMLFile, 1);
 };
 
 #endif /* FAIRXLMNODE_H_ */

--- a/examples/MQ/Lmd/FairMBSUnpacker.h
+++ b/examples/MQ/Lmd/FairMBSUnpacker.h
@@ -60,7 +60,7 @@ class FairMBSUnpacker : public FairUnpack
 
   public:
     // Class definition
-    ClassDef(FairMBSUnpacker, 1)
+    ClassDef(FairMBSUnpacker, 1);
 };
 
 #endif

--- a/examples/MQ/parameters/FairMQExParamsContFact.h
+++ b/examples/MQ/parameters/FairMQExParamsContFact.h
@@ -23,7 +23,7 @@ class FairMQExParamsContFact : public FairContFact
     ~FairMQExParamsContFact() {}
 
     FairParSet* createContainer(FairContainer*);
-    ClassDef(FairMQExParamsContFact, 0)
+    ClassDef(FairMQExParamsContFact, 0);
 };
 
 #endif /* FAIRMQEXPARAMSCONTFACT_H */

--- a/examples/MQ/pixelDetector/src/Pixel.h
+++ b/examples/MQ/pixelDetector/src/Pixel.h
@@ -96,7 +96,7 @@ class Pixel : public FairDetector
     Pixel(const Pixel&);
     Pixel& operator=(const Pixel&);
 
-    ClassDef(Pixel, 1)
+    ClassDef(Pixel, 1);
 };
 
 #endif   // PIXEL_H

--- a/examples/MQ/pixelDetector/src/PixelContFact.h
+++ b/examples/MQ/pixelDetector/src/PixelContFact.h
@@ -24,7 +24,7 @@ class PixelContFact : public FairContFact
     PixelContFact();
     ~PixelContFact() {}
     FairParSet* createContainer(FairContainer*);
-    ClassDef(PixelContFact, 0); // Factory for all Pixel parameter containers
+    ClassDef(PixelContFact, 0);   // Factory for all Pixel parameter containers
 };
 
 #endif

--- a/examples/MQ/pixelDetector/src/PixelContFact.h
+++ b/examples/MQ/pixelDetector/src/PixelContFact.h
@@ -24,7 +24,7 @@ class PixelContFact : public FairContFact
     PixelContFact();
     ~PixelContFact() {}
     FairParSet* createContainer(FairContainer*);
-    ClassDef(PixelContFact, 0)   // Factory for all Pixel parameter containers
+    ClassDef(PixelContFact, 0); // Factory for all Pixel parameter containers
 };
 
 #endif

--- a/examples/MQ/pixelDetector/src/PixelDigiBinSource.h
+++ b/examples/MQ/pixelDetector/src/PixelDigiBinSource.h
@@ -76,7 +76,7 @@ class PixelDigiBinSource : public FairSource
     PixelDigiBinSource(const PixelDigiBinSource&);
     PixelDigiBinSource& operator=(const PixelDigiBinSource&);
 
-    ClassDef(PixelDigiBinSource, 1)
+    ClassDef(PixelDigiBinSource, 1);
 };
 
 #endif /* defined(PIXELDIGISOURCE_H_) */

--- a/examples/MQ/pixelDetector/src/PixelDigiSource.h
+++ b/examples/MQ/pixelDetector/src/PixelDigiSource.h
@@ -76,7 +76,7 @@ class PixelDigiSource : public FairSource
     PixelDigiSource(const PixelDigiSource&);
     PixelDigiSource& operator=(const PixelDigiSource&);
 
-    ClassDef(PixelDigiSource, 1)
+    ClassDef(PixelDigiSource, 1);
 };
 
 #endif /* defined(PIXELDIGISOURCE_H_) */

--- a/examples/MQ/pixelDetector/src/PixelGeo.h
+++ b/examples/MQ/pixelDetector/src/PixelGeo.h
@@ -26,7 +26,7 @@ class PixelGeo : public FairGeoSet
     const char* getEleName(Int_t);
     inline Int_t getModNumInMod(const TString&);
 
-    ClassDef(PixelGeo, 1)
+    ClassDef(PixelGeo, 1);
 };
 
 inline Int_t PixelGeo::getModNumInMod(const TString& name)

--- a/examples/MQ/pixelDetector/src/PixelGeoPar.h
+++ b/examples/MQ/pixelDetector/src/PixelGeoPar.h
@@ -38,7 +38,7 @@ class PixelGeoPar : public FairParGenericSet
     PixelGeoPar(const PixelGeoPar&);
     PixelGeoPar& operator=(const PixelGeoPar&);
 
-    ClassDef(PixelGeoPar, 1)
+    ClassDef(PixelGeoPar, 1);
 };
 
 #endif

--- a/examples/MQ/pixelDetector/src/PixelPoint.h
+++ b/examples/MQ/pixelDetector/src/PixelPoint.h
@@ -41,7 +41,7 @@ class PixelPoint : public FairMCPoint
     PixelPoint(const PixelPoint& point);
     PixelPoint operator=(const PixelPoint& point);
 
-    ClassDef(PixelPoint, 1)
+    ClassDef(PixelPoint, 1);
 };
 
 #endif

--- a/examples/advanced/MbsTutorial/FairMBSRawItem.h
+++ b/examples/advanced/MbsTutorial/FairMBSRawItem.h
@@ -64,7 +64,7 @@ class FairMBSRawItem : public TObject
     UShort_t fQdcData; /**< QDC data. */
 
   public:
-    ClassDef(FairMBSRawItem, 1)
+    ClassDef(FairMBSRawItem, 1);
 };
 
 #endif

--- a/examples/advanced/MbsTutorial/FairMBSTask.h
+++ b/examples/advanced/MbsTutorial/FairMBSTask.h
@@ -52,7 +52,7 @@ class FairMBSTask : public FairTask
     FairMBSTask& operator=(const FairMBSTask&);
 
   public:
-    ClassDef(FairMBSTask, 1)
+    ClassDef(FairMBSTask, 1);
 };
 
 #endif

--- a/examples/advanced/MbsTutorial/FairMBSUnpack.h
+++ b/examples/advanced/MbsTutorial/FairMBSUnpack.h
@@ -57,7 +57,7 @@ class FairMBSUnpack : public FairUnpack
 
   public:
     // Class definition
-    ClassDef(FairMBSUnpack, 1)
+    ClassDef(FairMBSUnpack, 1);
 };
 
 #endif

--- a/examples/advanced/Tutorial3/data/FairTestDetectorPoint.h
+++ b/examples/advanced/Tutorial3/data/FairTestDetectorPoint.h
@@ -73,7 +73,7 @@ class FairTestDetectorPoint : public FairMCPoint
     FairTestDetectorPoint(const FairTestDetectorPoint&);
     FairTestDetectorPoint operator=(const FairTestDetectorPoint&);
 
-    ClassDef(FairTestDetectorPoint, 2)
+    ClassDef(FairTestDetectorPoint, 2);
 };
 
 #endif /* FAIRTESTDETECTORPOINT_H_ */

--- a/examples/advanced/Tutorial3/simulation/FairConstField.h
+++ b/examples/advanced/Tutorial3/simulation/FairConstField.h
@@ -45,7 +45,7 @@ class FairConstField : public FairField
                    Double_t bY,
                    Double_t bZ);
 
-    /** Constructor from PndFieldPar **/
+    /** Constructor from FairConstPar **/
     FairConstField(FairConstPar* fieldPar);
 
     /** Destructor **/

--- a/examples/advanced/Tutorial3/simulation/FairTestDetector.h
+++ b/examples/advanced/Tutorial3/simulation/FairTestDetector.h
@@ -107,7 +107,7 @@ class FairTestDetector : public FairDetector
     FairTestDetector(const FairTestDetector&);
     FairTestDetector& operator=(const FairTestDetector&);
 
-    ClassDef(FairTestDetector, 1)
+    ClassDef(FairTestDetector, 1);
 };
 
 #endif /* FAIRTESTDETECTOR_H_ */

--- a/examples/advanced/Tutorial3/simulation/FairTestDetectorContFact.h
+++ b/examples/advanced/Tutorial3/simulation/FairTestDetectorContFact.h
@@ -23,7 +23,7 @@ class FairTestDetectorContFact : public FairContFact
     FairTestDetectorContFact();
     ~FairTestDetectorContFact() {}
     FairParSet* createContainer(FairContainer*);
-  
+
     // Factory for all FairTestDetector parameter containers
     ClassDef(FairTestDetectorContFact, 0);
 };

--- a/examples/advanced/Tutorial3/simulation/FairTestDetectorContFact.h
+++ b/examples/advanced/Tutorial3/simulation/FairTestDetectorContFact.h
@@ -23,7 +23,9 @@ class FairTestDetectorContFact : public FairContFact
     FairTestDetectorContFact();
     ~FairTestDetectorContFact() {}
     FairParSet* createContainer(FairContainer*);
-    ClassDef(FairTestDetectorContFact, 0)   // Factory for all FairTestDetector parameter containers
+  
+    // Factory for all FairTestDetector parameter containers
+    ClassDef(FairTestDetectorContFact, 0);
 };
 
 #endif /* FAIRTESTDETECTORCONTFACT_H_ */

--- a/examples/advanced/Tutorial3/simulation/FairTestDetectorGeo.h
+++ b/examples/advanced/Tutorial3/simulation/FairTestDetectorGeo.h
@@ -24,7 +24,7 @@ class FairTestDetectorGeo : public FairGeoSet
     const char* getModuleName(Int_t);
     const char* getEleName(Int_t);
     inline Int_t getModNumInMod(const TString&);
-    ClassDef(FairTestDetectorGeo, 1)
+    ClassDef(FairTestDetectorGeo, 1);
 };
 
 inline Int_t FairTestDetectorGeo::getModNumInMod(const TString& name)

--- a/examples/advanced/Tutorial3/simulation/FairTestDetectorGeoPar.h
+++ b/examples/advanced/Tutorial3/simulation/FairTestDetectorGeoPar.h
@@ -38,7 +38,7 @@ class FairTestDetectorGeoPar : public FairParGenericSet
     FairTestDetectorGeoPar(const FairTestDetectorGeoPar&);
     FairTestDetectorGeoPar& operator=(const FairTestDetectorGeoPar&);
 
-    ClassDef(FairTestDetectorGeoPar, 1)
+    ClassDef(FairTestDetectorGeoPar, 1);
 };
 
 #endif /* FAIRTESTDETECTORGEOPAR_H_ */

--- a/examples/advanced/propagator/src/FairTutPropContFact.h
+++ b/examples/advanced/propagator/src/FairTutPropContFact.h
@@ -22,7 +22,9 @@ class FairTutPropContFact : public FairContFact
     FairTutPropContFact();
     ~FairTutPropContFact() {}
     FairParSet* createContainer(FairContainer*);
-    ClassDef(FairTutPropContFact, 0)   // Factory for all FairTutProp parameter containers
+
+    // Factory for all FairTutProp parameter containers
+    ClassDef(FairTutPropContFact, 0);
 };
 
 #endif /* FAIRTUTPROPCONTFACT_H_ */

--- a/examples/advanced/propagator/src/FairTutPropDet.h
+++ b/examples/advanced/propagator/src/FairTutPropDet.h
@@ -92,7 +92,7 @@ class FairTutPropDet : public FairDetector
     FairTutPropDet(const FairTutPropDet&);
     FairTutPropDet& operator=(const FairTutPropDet&);
 
-    ClassDef(FairTutPropDet, 1)
+    ClassDef(FairTutPropDet, 1);
 };
 
 #endif   // FAIRTUTPROPDET_H

--- a/examples/advanced/propagator/src/FairTutPropGeo.h
+++ b/examples/advanced/propagator/src/FairTutPropGeo.h
@@ -24,7 +24,7 @@ class FairTutPropGeo : public FairGeoSet
     const char* getModuleName(Int_t);
     const char* getEleName(Int_t);
     inline Int_t getModNumInMod(const TString&);
-    ClassDef(FairTutPropGeo, 1)
+    ClassDef(FairTutPropGeo, 1);
 };
 
 inline Int_t FairTutPropGeo::getModNumInMod(const TString& name)

--- a/examples/advanced/propagator/src/FairTutPropGeoPar.h
+++ b/examples/advanced/propagator/src/FairTutPropGeoPar.h
@@ -36,7 +36,7 @@ class FairTutPropGeoPar : public FairParGenericSet
     FairTutPropGeoPar(const FairTutPropGeoPar&);
     FairTutPropGeoPar& operator=(const FairTutPropGeoPar&);
 
-    ClassDef(FairTutPropGeoPar, 1)
+    ClassDef(FairTutPropGeoPar, 1);
 };
 
 #endif   // FAIRTUTPROPGEOPAR_H

--- a/examples/advanced/propagator/src/FairTutPropPoint.h
+++ b/examples/advanced/propagator/src/FairTutPropPoint.h
@@ -47,7 +47,7 @@ class FairTutPropPoint : public FairMCPoint
     FairTutPropPoint(const FairTutPropPoint& point);
     FairTutPropPoint operator=(const FairTutPropPoint& point);
 
-    ClassDef(FairTutPropPoint, 1)
+    ClassDef(FairTutPropPoint, 1);
 };
 
 #endif   // FAIRTUTPROPPOINT_H

--- a/examples/common/mcstack/FairStack.h
+++ b/examples/common/mcstack/FairStack.h
@@ -275,7 +275,7 @@ class FairStack : public FairGenericStack
     FairStack(const FairStack&);
     FairStack& operator=(const FairStack&);
 
-    ClassDef(FairStack, 1)
+    ClassDef(FairStack, 1);
 };
 
 #endif

--- a/examples/common/passive/FairCave.h
+++ b/examples/common/passive/FairCave.h
@@ -25,7 +25,8 @@ class FairCave : public FairModule
   private:
     FairCave(const FairCave& rhs);
     Double_t world[3];
-    ClassDef(FairCave, 1)   // PNDCaveSD
+
+    ClassDef(FairCave, 1);
 };
 
 #endif   // Cave_H

--- a/examples/common/passive/FairGeoCave.h
+++ b/examples/common/passive/FairGeoCave.h
@@ -29,7 +29,8 @@ class FairGeoCave : public FairGeoSet
     void addRefNodes();
     void write(std::fstream&);
     void print();
-    ClassDef(FairGeoCave, 0)   // Class for the geometry of CAVE
+
+    ClassDef(FairGeoCave, 0); // Class for the geometry of CAVE
 };
 
 #endif /* !PNDGEOCAVE_H */

--- a/examples/common/passive/FairGeoCave.h
+++ b/examples/common/passive/FairGeoCave.h
@@ -5,8 +5,8 @@
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
-#ifndef PNDGEOCAVE_H
-#define PNDGEOCAVE_H
+#ifndef FAIRGEOCAVE_H
+#define FAIRGEOCAVE_H
 
 #include "FairGeoSet.h"   // for FairGeoSet
 
@@ -33,4 +33,4 @@ class FairGeoCave : public FairGeoSet
     ClassDef(FairGeoCave, 0);   // Class for the geometry of CAVE
 };
 
-#endif /* !PNDGEOCAVE_H */
+#endif /* !FAIRGEOCAVE_H */

--- a/examples/common/passive/FairGeoCave.h
+++ b/examples/common/passive/FairGeoCave.h
@@ -30,7 +30,7 @@ class FairGeoCave : public FairGeoSet
     void write(std::fstream&);
     void print();
 
-    ClassDef(FairGeoCave, 0); // Class for the geometry of CAVE
+    ClassDef(FairGeoCave, 0);   // Class for the geometry of CAVE
 };
 
 #endif /* !PNDGEOCAVE_H */

--- a/examples/common/passive/FairGeoMagnet.h
+++ b/examples/common/passive/FairGeoMagnet.h
@@ -23,7 +23,7 @@ class FairGeoMagnet : public FairGeoSet
     ~FairGeoMagnet() {}
     const char* getModuleName(Int_t) { return modName; }
     const char* getEleName(Int_t) { return eleName; }
-    ClassDef(FairGeoMagnet, 0)   // Class for the geometry of Magnet
+    ClassDef(FairGeoMagnet, 0); // Class for the geometry of Magnet
 };
 
 #endif /* !FAIRGEOMAGNET_H */

--- a/examples/common/passive/FairGeoMagnet.h
+++ b/examples/common/passive/FairGeoMagnet.h
@@ -23,7 +23,7 @@ class FairGeoMagnet : public FairGeoSet
     ~FairGeoMagnet() {}
     const char* getModuleName(Int_t) { return modName; }
     const char* getEleName(Int_t) { return eleName; }
-    ClassDef(FairGeoMagnet, 0); // Class for the geometry of Magnet
+    ClassDef(FairGeoMagnet, 0);   // Class for the geometry of Magnet
 };
 
 #endif /* !FAIRGEOMAGNET_H */

--- a/examples/common/passive/FairGeoMagnet.h
+++ b/examples/common/passive/FairGeoMagnet.h
@@ -5,8 +5,8 @@
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
-#ifndef PNDGEOMAGNET_H
-#define PNDGEOMAGNET_H
+#ifndef FAIRGEOMAGNET_H
+#define FAIRGEOMAGNET_H
 
 #include "FairGeoSet.h"   // for FairGeoSet
 

--- a/examples/common/passive/FairGeoPassivePar.h
+++ b/examples/common/passive/FairGeoPassivePar.h
@@ -35,7 +35,7 @@ class FairGeoPassivePar : public FairParGenericSet
     FairGeoPassivePar(const FairGeoPassivePar&);
     FairGeoPassivePar& operator=(const FairGeoPassivePar&);
 
-    ClassDef(FairGeoPassivePar, 1)
+    ClassDef(FairGeoPassivePar, 1);
 };
 
 #endif /* !PNDGEOPASSIVEPAR_H */

--- a/examples/common/passive/FairGeoPassivePar.h
+++ b/examples/common/passive/FairGeoPassivePar.h
@@ -5,8 +5,8 @@
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
-#ifndef PNDGEOPASSIVEPAR_H
-#define PNDGEOPASSIVEPAR_H
+#ifndef FAIRGEOPASSIVEPAR_H
+#define FAIRGEOPASSIVEPAR_H
 
 #include "FairParGenericSet.h"   // for FairParGenericSet
 
@@ -38,4 +38,4 @@ class FairGeoPassivePar : public FairParGenericSet
     ClassDef(FairGeoPassivePar, 1);
 };
 
-#endif /* !PNDGEOPASSIVEPAR_H */
+#endif /* !FAIRGEOPASSIVEPAR_H */

--- a/examples/common/passive/FairGeoPipe.h
+++ b/examples/common/passive/FairGeoPipe.h
@@ -26,7 +26,7 @@ class FairGeoPipe : public FairGeoSet
     const char* getModuleName(Int_t) { return modName; }
     const char* getEleName(Int_t) { return eleName; }
     Bool_t create(FairGeoBuilder*);
-    ClassDef(FairGeoPipe, 0)   // Class for geometry of beam pipe
+    ClassDef(FairGeoPipe, 0); // Class for geometry of beam pipe
 };
 
 #endif /* !PNDGEOPIPE_H */

--- a/examples/common/passive/FairGeoPipe.h
+++ b/examples/common/passive/FairGeoPipe.h
@@ -26,7 +26,7 @@ class FairGeoPipe : public FairGeoSet
     const char* getModuleName(Int_t) { return modName; }
     const char* getEleName(Int_t) { return eleName; }
     Bool_t create(FairGeoBuilder*);
-    ClassDef(FairGeoPipe, 0); // Class for geometry of beam pipe
+    ClassDef(FairGeoPipe, 0);   // Class for geometry of beam pipe
 };
 
 #endif /* !PNDGEOPIPE_H */

--- a/examples/common/passive/FairGeoPipe.h
+++ b/examples/common/passive/FairGeoPipe.h
@@ -5,8 +5,8 @@
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
-#ifndef PNDGEOPIPE_H
-#define PNDGEOPIPE_H
+#ifndef FAIRGEOPIPE_H
+#define FAIRGEOPIPE_H
 
 #include "FairGeoSet.h"   // for FairGeoSet
 
@@ -29,4 +29,4 @@ class FairGeoPipe : public FairGeoSet
     ClassDef(FairGeoPipe, 0);   // Class for geometry of beam pipe
 };
 
-#endif /* !PNDGEOPIPE_H */
+#endif /* !FAIRGEOPIPE_H */

--- a/examples/common/passive/FairGeoTarget.h
+++ b/examples/common/passive/FairGeoTarget.h
@@ -22,7 +22,7 @@ class FairGeoTarget : public FairGeoSet
     ~FairGeoTarget() {}
     const char* getModuleName(Int_t) { return modName; }
     const char* getEleName(Int_t) { return eleName; }
-    ClassDef(FairGeoTarget, 0); // Class for geometry of Target
+    ClassDef(FairGeoTarget, 0);   // Class for geometry of Target
 };
 
 #endif /* !PNDGEOTARGET_H */

--- a/examples/common/passive/FairGeoTarget.h
+++ b/examples/common/passive/FairGeoTarget.h
@@ -22,7 +22,7 @@ class FairGeoTarget : public FairGeoSet
     ~FairGeoTarget() {}
     const char* getModuleName(Int_t) { return modName; }
     const char* getEleName(Int_t) { return eleName; }
-    ClassDef(FairGeoTarget, 0)   // Class for geometry of Target
+    ClassDef(FairGeoTarget, 0); // Class for geometry of Target
 };
 
 #endif /* !PNDGEOTARGET_H */

--- a/examples/common/passive/FairGeoTarget.h
+++ b/examples/common/passive/FairGeoTarget.h
@@ -5,8 +5,8 @@
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
-#ifndef PNDGEOTARGET_H
-#define PNDGEOTARGET_H
+#ifndef FAIRGEOTARGET_H
+#define FAIRGEOTARGET_H
 
 #include "FairGeoSet.h"   // for FairGeoSet
 
@@ -25,4 +25,4 @@ class FairGeoTarget : public FairGeoSet
     ClassDef(FairGeoTarget, 0);   // Class for geometry of Target
 };
 
-#endif /* !PNDGEOTARGET_H */
+#endif /* !FAIRGEOTARGET_H */

--- a/examples/common/passive/FairMagnet.h
+++ b/examples/common/passive/FairMagnet.h
@@ -27,7 +27,7 @@ class FairMagnet : public FairModule
 
   private:
     FairMagnet(const FairMagnet& rhs);
-    ClassDef(FairMagnet, 1)
+    ClassDef(FairMagnet, 1);
 };
 
 #endif   // MAGNET_H

--- a/examples/common/passive/FairPassiveContFact.h
+++ b/examples/common/passive/FairPassiveContFact.h
@@ -24,7 +24,7 @@ class FairPassiveContFact : public FairContFact
     ~FairPassiveContFact() {}
     FairParSet* createContainer(FairContainer*);
 
-    ClassDef(FairPassiveContFact, 0); // Factory for all Passive parameter containers
+    ClassDef(FairPassiveContFact, 0);   // Factory for all Passive parameter containers
 };
 
 #endif /* !PNDPASSIVECONTFACT_H */

--- a/examples/common/passive/FairPassiveContFact.h
+++ b/examples/common/passive/FairPassiveContFact.h
@@ -24,7 +24,7 @@ class FairPassiveContFact : public FairContFact
     ~FairPassiveContFact() {}
     FairParSet* createContainer(FairContainer*);
 
-    ClassDef(FairPassiveContFact, 0)   // Factory for all Passive parameter containers
+    ClassDef(FairPassiveContFact, 0); // Factory for all Passive parameter containers
 };
 
 #endif /* !PNDPASSIVECONTFACT_H */

--- a/examples/common/passive/FairPassiveContFact.h
+++ b/examples/common/passive/FairPassiveContFact.h
@@ -5,8 +5,8 @@
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
-#ifndef PNDPASSIVECONTFACT_H
-#define PNDPASSIVECONTFACT_H
+#ifndef FAIRPASSIVECONTFACT_H
+#define FAIRPASSIVECONTFACT_H
 
 #include "FairContFact.h"   // for FairContFact, etc
 
@@ -27,4 +27,4 @@ class FairPassiveContFact : public FairContFact
     ClassDef(FairPassiveContFact, 0);   // Factory for all Passive parameter containers
 };
 
-#endif /* !PNDPASSIVECONTFACT_H */
+#endif /* !FAIRPASSIVECONTFACT_H */

--- a/examples/common/passive/FairPipe.h
+++ b/examples/common/passive/FairPipe.h
@@ -25,7 +25,7 @@ class FairPipe : public FairModule
 
   private:
     FairPipe(const FairPipe& rhs);
-    ClassDef(FairPipe, 1); // PNDPIPE
+    ClassDef(FairPipe, 1);   // PNDPIPE
 };
 
 #endif   // PIPE_H

--- a/examples/common/passive/FairPipe.h
+++ b/examples/common/passive/FairPipe.h
@@ -25,7 +25,7 @@ class FairPipe : public FairModule
 
   private:
     FairPipe(const FairPipe& rhs);
-    ClassDef(FairPipe, 1)   // PNDPIPE
+    ClassDef(FairPipe, 1); // PNDPIPE
 };
 
 #endif   // PIPE_H

--- a/examples/common/passive/FairPipe.h
+++ b/examples/common/passive/FairPipe.h
@@ -25,7 +25,8 @@ class FairPipe : public FairModule
 
   private:
     FairPipe(const FairPipe& rhs);
-    ClassDef(FairPipe, 1);   // PNDPIPE
+
+    ClassDef(FairPipe, 1);
 };
 
 #endif   // PIPE_H

--- a/examples/common/passive/FairTarget.h
+++ b/examples/common/passive/FairTarget.h
@@ -24,7 +24,7 @@ class FairTarget : public FairModule
 
   private:
     FairTarget(const FairTarget& rhs);
-    ClassDef(FairTarget, 1)
+    ClassDef(FairTarget, 1);
 };
 
 #endif   // Target_H

--- a/examples/simulation/Tutorial1/src/FairFastSimExample.h
+++ b/examples/simulation/Tutorial1/src/FairFastSimExample.h
@@ -81,7 +81,7 @@ class FairFastSimExample : public FairFastSimDetector
     FairFastSimExample(const FairFastSimExample&);
     FairFastSimExample& operator=(const FairFastSimExample&);
 
-    ClassDef(FairFastSimExample, 2)
+    ClassDef(FairFastSimExample, 2);
 };
 
 #endif   // FAIRTUTORIALDET_H

--- a/examples/simulation/Tutorial1/src/FairFastSimExample2.h
+++ b/examples/simulation/Tutorial1/src/FairFastSimExample2.h
@@ -81,7 +81,7 @@ class FairFastSimExample2 : public FairFastSimDetector
     FairFastSimExample2(const FairFastSimExample2&);
     FairFastSimExample2& operator=(const FairFastSimExample2&);
 
-    ClassDef(FairFastSimExample2, 2)
+    ClassDef(FairFastSimExample2, 2);
 };
 
 #endif   // FAIRTUTORIALDET_H

--- a/examples/simulation/Tutorial1/src/FairSimConfig.h
+++ b/examples/simulation/Tutorial1/src/FairSimConfig.h
@@ -46,7 +46,7 @@ class FairSimConfig
     std::string fParameterFile;
     int fRandomSeed;
 
-    ClassDef(FairSimConfig, 1)
+    ClassDef(FairSimConfig, 1);
 };
 
 #endif

--- a/examples/simulation/Tutorial1/src/FairTutorialDet1.h
+++ b/examples/simulation/Tutorial1/src/FairTutorialDet1.h
@@ -102,7 +102,7 @@ class FairTutorialDet1 : public FairDetector
     FairTutorialDet1(const FairTutorialDet1&);
     FairTutorialDet1& operator=(const FairTutorialDet1&);
 
-    ClassDef(FairTutorialDet1, 1)
+    ClassDef(FairTutorialDet1, 1);
 };
 
 #endif   // FAIRTUTORIALDET_H

--- a/examples/simulation/Tutorial1/src/FairTutorialDet1ContFact.h
+++ b/examples/simulation/Tutorial1/src/FairTutorialDet1ContFact.h
@@ -23,7 +23,7 @@ class FairTutorialDet1ContFact : public FairContFact
     FairTutorialDet1ContFact();
     ~FairTutorialDet1ContFact() {}
     FairParSet* createContainer(FairContainer*);
-    ClassDef(FairTutorialDet1ContFact, 0)   // Factory for all MyDet parameter containers
+    ClassDef(FairTutorialDet1ContFact, 0); // Factory for all MyDet parameter containers
 };
 
 #endif /* !FAIRTUTORIALDETCONTFACT_H */

--- a/examples/simulation/Tutorial1/src/FairTutorialDet1ContFact.h
+++ b/examples/simulation/Tutorial1/src/FairTutorialDet1ContFact.h
@@ -23,7 +23,7 @@ class FairTutorialDet1ContFact : public FairContFact
     FairTutorialDet1ContFact();
     ~FairTutorialDet1ContFact() {}
     FairParSet* createContainer(FairContainer*);
-    ClassDef(FairTutorialDet1ContFact, 0); // Factory for all MyDet parameter containers
+    ClassDef(FairTutorialDet1ContFact, 0);   // Factory for all MyDet parameter containers
 };
 
 #endif /* !FAIRTUTORIALDETCONTFACT_H */

--- a/examples/simulation/Tutorial1/src/FairTutorialDet1Geo.h
+++ b/examples/simulation/Tutorial1/src/FairTutorialDet1Geo.h
@@ -25,7 +25,7 @@ class FairTutorialDet1Geo : public FairGeoSet
     const char* getModuleName(Int_t);
     const char* getEleName(Int_t);
     inline Int_t getModNumInMod(const TString&);
-    ClassDef(FairTutorialDet1Geo, 1)
+    ClassDef(FairTutorialDet1Geo, 1);
 };
 
 inline Int_t FairTutorialDet1Geo::getModNumInMod(const TString& name)

--- a/examples/simulation/Tutorial1/src/FairTutorialDet1GeoPar.h
+++ b/examples/simulation/Tutorial1/src/FairTutorialDet1GeoPar.h
@@ -38,7 +38,7 @@ class FairTutorialDet1GeoPar : public FairParGenericSet
     FairTutorialDet1GeoPar(const FairTutorialDet1GeoPar&);
     FairTutorialDet1GeoPar& operator=(const FairTutorialDet1GeoPar&);
 
-    ClassDef(FairTutorialDet1GeoPar, 1)
+    ClassDef(FairTutorialDet1GeoPar, 1);
 };
 
 #endif /* FAIRTUTORIALDETGEOPAR_H */

--- a/examples/simulation/Tutorial1/src/FairTutorialDet1Point.h
+++ b/examples/simulation/Tutorial1/src/FairTutorialDet1Point.h
@@ -45,7 +45,7 @@ class FairTutorialDet1Point : public FairMCPoint
     /** Output to screen **/
     virtual void Print(const Option_t* opt) const;
 
-    ClassDef(FairTutorialDet1Point, 1)
+    ClassDef(FairTutorialDet1Point, 1);
 };
 
 #endif

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2.h
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2.h
@@ -106,7 +106,7 @@ class FairTutorialDet2 : public FairDetector
     FairTutorialDet2(const FairTutorialDet2&);
     FairTutorialDet2& operator=(const FairTutorialDet2&);
 
-    ClassDef(FairTutorialDet2, 1)
+    ClassDef(FairTutorialDet2, 1);
 };
 
 #endif   // FAIRTUTORIALDET_H

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2ContFact.h
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2ContFact.h
@@ -23,7 +23,7 @@ class FairTutorialDet2ContFact : public FairContFact
     FairTutorialDet2ContFact();
     ~FairTutorialDet2ContFact() {}
     FairParSet* createContainer(FairContainer*);
-    ClassDef(FairTutorialDet2ContFact, 0); // Factory for all MyDet parameter containers
+    ClassDef(FairTutorialDet2ContFact, 0);   // Factory for all MyDet parameter containers
 };
 
 #endif /* !FAIRTUTORIALDETCONTFACT_H */

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2ContFact.h
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2ContFact.h
@@ -23,7 +23,7 @@ class FairTutorialDet2ContFact : public FairContFact
     FairTutorialDet2ContFact();
     ~FairTutorialDet2ContFact() {}
     FairParSet* createContainer(FairContainer*);
-    ClassDef(FairTutorialDet2ContFact, 0)   // Factory for all MyDet parameter containers
+    ClassDef(FairTutorialDet2ContFact, 0); // Factory for all MyDet parameter containers
 };
 
 #endif /* !FAIRTUTORIALDETCONTFACT_H */

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2CustomTask.h
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2CustomTask.h
@@ -43,6 +43,6 @@ class FairTutorialDet2CustomTask : public FairTask
     // note that we are forced to put const on data that we are consuming
     std::vector<CustomClass> const* fCustomData = nullptr;    //!
     std::vector<CustomClass> const* fCustomData2 = nullptr;   //!
-    ClassDef(FairTutorialDet2CustomTask, 1)
+    ClassDef(FairTutorialDet2CustomTask, 1);
 };
 #endif   // FAIRTUTORIALDETCUSTOMTASK_H

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2Digitizer.h
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2Digitizer.h
@@ -69,7 +69,7 @@ class FairTutorialDet2Digitizer : public FairTask
     FairTutorialDet2Digitizer(const FairTutorialDet2Digitizer&);
     FairTutorialDet2Digitizer& operator=(const FairTutorialDet2Digitizer&);
 
-    ClassDef(FairTutorialDet2Digitizer, 1)
+    ClassDef(FairTutorialDet2Digitizer, 1);
 };
 
 #endif   // FAIRTUTORIALDETDIGITIZER_H

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2Geo.h
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2Geo.h
@@ -24,7 +24,7 @@ class FairTutorialDet2Geo : public FairGeoSet
     const char* getModuleName(Int_t);
     const char* getEleName(Int_t);
     inline Int_t getModNumInMod(const TString&);
-    ClassDef(FairTutorialDet2Geo, 1)
+    ClassDef(FairTutorialDet2Geo, 1);
 };
 
 inline Int_t FairTutorialDet2Geo::getModNumInMod(const TString& name)

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2GeoPar.h
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2GeoPar.h
@@ -38,7 +38,7 @@ class FairTutorialDet2GeoPar : public FairParGenericSet
     FairTutorialDet2GeoPar(const FairTutorialDet2GeoPar&);
     FairTutorialDet2GeoPar& operator=(const FairTutorialDet2GeoPar&);
 
-    ClassDef(FairTutorialDet2GeoPar, 1)
+    ClassDef(FairTutorialDet2GeoPar, 1);
 };
 
 #endif /* FAIRTUTORIALDETGEOPAR_H */

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2Point.h
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2Point.h
@@ -45,7 +45,7 @@ class FairTutorialDet2Point : public FairMCPoint
     /** Output to screen **/
     virtual void Print(const Option_t* opt) const;
 
-    ClassDef(FairTutorialDet2Point, 1)
+    ClassDef(FairTutorialDet2Point, 1);
 };
 
 // a custom class holding some data

--- a/examples/simulation/Tutorial4/src/data/FairTutorialDet4Point.h
+++ b/examples/simulation/Tutorial4/src/data/FairTutorialDet4Point.h
@@ -45,7 +45,7 @@ class FairTutorialDet4Point : public FairMCPoint
     /** Output to screen **/
     virtual void Print(const Option_t* opt) const;
 
-    ClassDef(FairTutorialDet4Point, 1)
+    ClassDef(FairTutorialDet4Point, 1);
 };
 
 #endif

--- a/examples/simulation/Tutorial4/src/mc/FairTutorialDet4.h
+++ b/examples/simulation/Tutorial4/src/mc/FairTutorialDet4.h
@@ -138,7 +138,7 @@ class FairTutorialDet4 : public FairDetector
     FairTutorialDet4(const FairTutorialDet4&);
     FairTutorialDet4& operator=(const FairTutorialDet4&);
 
-    ClassDef(FairTutorialDet4, 3)
+    ClassDef(FairTutorialDet4, 3);
 };
 
 #endif   // FAIRTUTORIALDET_H

--- a/examples/simulation/Tutorial4/src/mc/FairTutorialDet4Geo.h
+++ b/examples/simulation/Tutorial4/src/mc/FairTutorialDet4Geo.h
@@ -25,7 +25,7 @@ class FairTutorialDet4Geo : public FairGeoSet
     const char* getModuleName(Int_t);
     const char* getEleName(Int_t);
     inline Int_t getModNumInMod(const TString&);
-    ClassDef(FairTutorialDet4Geo, 1)
+    ClassDef(FairTutorialDet4Geo, 1);
 };
 
 inline Int_t FairTutorialDet4Geo::getModNumInMod(const TString& name)

--- a/examples/simulation/Tutorial4/src/param/FairTutorialDet4ContFact.h
+++ b/examples/simulation/Tutorial4/src/param/FairTutorialDet4ContFact.h
@@ -23,7 +23,7 @@ class FairTutorialDet4ContFact : public FairContFact
     FairTutorialDet4ContFact();
     ~FairTutorialDet4ContFact() {}
     FairParSet* createContainer(FairContainer*);
-    ClassDef(FairTutorialDet4ContFact, 0); // Factory for all MyDet parameter containers
+    ClassDef(FairTutorialDet4ContFact, 0);   // Factory for all MyDet parameter containers
 };
 
 #endif /* !FAIRTUTORIALDETCONTFACT_H */

--- a/examples/simulation/Tutorial4/src/param/FairTutorialDet4ContFact.h
+++ b/examples/simulation/Tutorial4/src/param/FairTutorialDet4ContFact.h
@@ -23,7 +23,7 @@ class FairTutorialDet4ContFact : public FairContFact
     FairTutorialDet4ContFact();
     ~FairTutorialDet4ContFact() {}
     FairParSet* createContainer(FairContainer*);
-    ClassDef(FairTutorialDet4ContFact, 0)   // Factory for all MyDet parameter containers
+    ClassDef(FairTutorialDet4ContFact, 0); // Factory for all MyDet parameter containers
 };
 
 #endif /* !FAIRTUTORIALDETCONTFACT_H */

--- a/examples/simulation/Tutorial4/src/param/FairTutorialDet4GeoPar.h
+++ b/examples/simulation/Tutorial4/src/param/FairTutorialDet4GeoPar.h
@@ -43,7 +43,7 @@ class FairTutorialDet4GeoPar : public FairParGenericSet
     FairTutorialDet4GeoPar(const FairTutorialDet4GeoPar&);
     FairTutorialDet4GeoPar& operator=(const FairTutorialDet4GeoPar&);
 
-    ClassDef(FairTutorialDet4GeoPar, 2)
+    ClassDef(FairTutorialDet4GeoPar, 2);
 };
 
 #endif /* FAIRTUTORIALDETGEOPAR_H */

--- a/examples/simulation/Tutorial4/src/param/FairTutorialDet4MisalignPar.h
+++ b/examples/simulation/Tutorial4/src/param/FairTutorialDet4MisalignPar.h
@@ -47,7 +47,7 @@ class FairTutorialDet4MisalignPar : public FairParGenericSet
     FairTutorialDet4MisalignPar(const FairTutorialDet4MisalignPar&);
     FairTutorialDet4MisalignPar& operator=(const FairTutorialDet4MisalignPar&);
 
-    ClassDef(FairTutorialDet4MisalignPar, 1)
+    ClassDef(FairTutorialDet4MisalignPar, 1);
 };
 
 #endif

--- a/examples/simulation/Tutorial4/src/tools/FairTutorialDet4GeoHandler.h
+++ b/examples/simulation/Tutorial4/src/tools/FairTutorialDet4GeoHandler.h
@@ -76,7 +76,7 @@ class FairTutorialDet4GeoHandler : public TObject
     FairTutorialDet4GeoHandler(const FairTutorialDet4GeoHandler&);
     FairTutorialDet4GeoHandler operator=(const FairTutorialDet4GeoHandler&);
 
-    ClassDef(FairTutorialDet4GeoHandler, 1)
+    ClassDef(FairTutorialDet4GeoHandler, 1);
 };
 
 #endif   // FAIRTUTORIALDETGEOHANDLER_H

--- a/examples/simulation/rutherford/src/FairRutherford.h
+++ b/examples/simulation/rutherford/src/FairRutherford.h
@@ -99,7 +99,7 @@ class FairRutherford : public FairDetector
     FairRutherford(const FairRutherford&);
     FairRutherford& operator=(const FairRutherford&);
 
-    ClassDef(FairRutherford, 1)
+    ClassDef(FairRutherford, 1);
 };
 
 #endif   // CBMRUTHERFORD_H

--- a/examples/simulation/rutherford/src/FairRutherfordContFact.h
+++ b/examples/simulation/rutherford/src/FairRutherfordContFact.h
@@ -23,7 +23,7 @@ class FairRutherfordContFact : public FairContFact
     FairRutherfordContFact();
     ~FairRutherfordContFact() {}
     FairParSet* createContainer(FairContainer*);
-    ClassDef(FairRutherfordContFact, 0); // Factory for all FairRutherford parameter containers
+    ClassDef(FairRutherfordContFact, 0);   // Factory for all FairRutherford parameter containers
 };
 
 #endif

--- a/examples/simulation/rutherford/src/FairRutherfordContFact.h
+++ b/examples/simulation/rutherford/src/FairRutherfordContFact.h
@@ -23,7 +23,7 @@ class FairRutherfordContFact : public FairContFact
     FairRutherfordContFact();
     ~FairRutherfordContFact() {}
     FairParSet* createContainer(FairContainer*);
-    ClassDef(FairRutherfordContFact, 0)   // Factory for all FairRutherford parameter containers
+    ClassDef(FairRutherfordContFact, 0); // Factory for all FairRutherford parameter containers
 };
 
 #endif

--- a/examples/simulation/rutherford/src/FairRutherfordGeo.h
+++ b/examples/simulation/rutherford/src/FairRutherfordGeo.h
@@ -25,7 +25,7 @@ class FairRutherfordGeo : public FairGeoSet
     const char* getModuleName(Int_t);
     const char* getEleName(Int_t);
     inline Int_t getModNumInMod(const TString&);
-    ClassDef(FairRutherfordGeo, 1)
+    ClassDef(FairRutherfordGeo, 1);
 };
 
 inline Int_t FairRutherfordGeo::getModNumInMod(const TString& name)

--- a/examples/simulation/rutherford/src/FairRutherfordGeoPar.h
+++ b/examples/simulation/rutherford/src/FairRutherfordGeoPar.h
@@ -38,7 +38,7 @@ class FairRutherfordGeoPar : public FairParGenericSet
     FairRutherfordGeoPar(const FairRutherfordGeoPar&);
     FairRutherfordGeoPar& operator=(const FairRutherfordGeoPar&);
 
-    ClassDef(FairRutherfordGeoPar, 1)
+    ClassDef(FairRutherfordGeoPar, 1);
 };
 
 #endif

--- a/examples/simulation/rutherford/src/FairRutherfordPoint.h
+++ b/examples/simulation/rutherford/src/FairRutherfordPoint.h
@@ -53,7 +53,7 @@ class FairRutherfordPoint : public FairMCPoint
     FairRutherfordPoint(const FairRutherfordPoint& point);
     FairRutherfordPoint operator=(const FairRutherfordPoint& point);
 
-    ClassDef(FairRutherfordPoint, 1)
+    ClassDef(FairRutherfordPoint, 1);
 };
 
 #endif

--- a/fairtools/FairLogger.h
+++ b/fairtools/FairLogger.h
@@ -150,7 +150,7 @@ class FairLogger
     std::vector<char> fDynamicBuffer;
     char* fBufferPointer;
 
-    ClassDef(FairLogger, 4)
+    ClassDef(FairLogger, 4);
 };
 
 #define gLogger (FairLogger::GetLogger())

--- a/fairtools/FairMonitor.h
+++ b/fairtools/FairMonitor.h
@@ -113,7 +113,7 @@ class FairMonitor : public TNamed
     void GetTaskMap(TTask* tempTask);
     void AnalyzeObjectMap(TTask* tempTask);
 
-    ClassDef(FairMonitor, 0)
+    ClassDef(FairMonitor, 0);
 };
 
 extern FairMonitor* gMonitor;

--- a/fairtools/FairSystemInfo.h
+++ b/fairtools/FairSystemInfo.h
@@ -28,7 +28,7 @@ class FairSystemInfo
     Float_t GetMaxMemory();
     size_t GetCurrentMemory();
 
-    ClassDef(FairSystemInfo, 1)
+    ClassDef(FairSystemInfo, 1);
 };
 
 #endif   // BASE_FAIRSYSTEMINFO_H_

--- a/geane/FairGeane.h
+++ b/geane/FairGeane.h
@@ -40,10 +40,11 @@ class FairGeane : public FairTask
 
     ClassDef(FairGeane, 1);
 
-        protected : FairGeaneApplication* fApp;   //!
-    const char* fName;                            //!
-    TString fUserConfig;                          //!
-    TString fUserCuts;                            //!
+  protected:
+    FairGeaneApplication* fApp;   //!
+    const char* fName;            //!
+    TString fUserConfig;          //!
+    TString fUserCuts;            //!
 
   private:
     FairGeane(const FairGeane&);

--- a/geane/FairGeane.h
+++ b/geane/FairGeane.h
@@ -38,7 +38,7 @@ class FairGeane : public FairTask
 
     void SetField(FairField* field);
 
-    ClassDef(FairGeane, 1)
+    ClassDef(FairGeane, 1);
 
         protected : FairGeaneApplication* fApp;   //!
     const char* fName;                            //!

--- a/generators/FairBaseMCGenerator.h
+++ b/generators/FairBaseMCGenerator.h
@@ -74,7 +74,7 @@ class FairBaseMCGenerator : public FairGenerator
     Double_t fPDGMass;
     Double_t fVx, fVy, fVz;
     Double_t fVex, fVey, fVez;
-    ClassDef(FairBaseMCGenerator, 1)
+    ClassDef(FairBaseMCGenerator, 1);
 };
 
 #endif /* FAIR_BASEMCGENERATOR_H_ */

--- a/generators/FairIonGenerator.h
+++ b/generators/FairIonGenerator.h
@@ -97,7 +97,7 @@ class FairIonGenerator : public FairBaseMCGenerator
     FairIonGenerator(const FairIonGenerator&);
     FairIonGenerator& operator=(const FairIonGenerator&);
 
-    ClassDef(FairIonGenerator, 2)
+    ClassDef(FairIonGenerator, 2);
 };
 
 #endif

--- a/generators/FairYPtGenerator.h
+++ b/generators/FairYPtGenerator.h
@@ -32,7 +32,7 @@ class FairYPtGenerator : public FairBaseMCGenerator
 
   private:
     TH2D fYPt;   // Y-Pt distribution
-    ClassDef(FairYPtGenerator, 1)
+    ClassDef(FairYPtGenerator, 1);
 };
 
 #endif /* CBM_NOV_ANALYSIS_CBMFEMTO_HELPERS_FAIRYPTGENERATOR_H_ */

--- a/geobase/FairGeoAsciiIo.h
+++ b/geobase/FairGeoAsciiIo.h
@@ -52,7 +52,7 @@ class FairGeoAsciiIo : public FairGeoIo
   private:
     FairGeoAsciiIo(const FairGeoAsciiIo&);
     FairGeoAsciiIo& operator=(const FairGeoAsciiIo&);
-    ClassDef(FairGeoAsciiIo, 0)   // Class for geometry I/O from ASCII file
+    ClassDef(FairGeoAsciiIo, 0); // Class for geometry I/O from ASCII file
 };
 
 #endif /* !FAIRGEOASCIIIO_H */

--- a/geobase/FairGeoAsciiIo.h
+++ b/geobase/FairGeoAsciiIo.h
@@ -52,7 +52,7 @@ class FairGeoAsciiIo : public FairGeoIo
   private:
     FairGeoAsciiIo(const FairGeoAsciiIo&);
     FairGeoAsciiIo& operator=(const FairGeoAsciiIo&);
-    ClassDef(FairGeoAsciiIo, 0); // Class for geometry I/O from ASCII file
+    ClassDef(FairGeoAsciiIo, 0);   // Class for geometry I/O from ASCII file
 };
 
 #endif /* !FAIRGEOASCIIIO_H */

--- a/geobase/FairGeoAssembly.h
+++ b/geobase/FairGeoAssembly.h
@@ -28,7 +28,7 @@ class FairGeoAssembly : public FairGeoBasicShape
     Bool_t writePoints(std::fstream*, FairGeoVolume*);
     void printPoints(FairGeoVolume* volu);
 
-    ClassDef(FairGeoAssembly, 0)   // class for geometry shape ASSEMBLY
+    ClassDef(FairGeoAssembly, 0); // class for geometry shape ASSEMBLY
 };
 
 #endif /* !FAIRGEOASSEMBLY_H */

--- a/geobase/FairGeoAssembly.h
+++ b/geobase/FairGeoAssembly.h
@@ -28,7 +28,7 @@ class FairGeoAssembly : public FairGeoBasicShape
     Bool_t writePoints(std::fstream*, FairGeoVolume*);
     void printPoints(FairGeoVolume* volu);
 
-    ClassDef(FairGeoAssembly, 0); // class for geometry shape ASSEMBLY
+    ClassDef(FairGeoAssembly, 0);   // class for geometry shape ASSEMBLY
 };
 
 #endif /* !FAIRGEOASSEMBLY_H */

--- a/geobase/FairGeoBasicShape.h
+++ b/geobase/FairGeoBasicShape.h
@@ -45,7 +45,7 @@ class FairGeoBasicShape : public TNamed
 
   protected:
     void posInMother(const FairGeoTransform&, const FairGeoTransform&);
-    ClassDef(FairGeoBasicShape, 0)   // base class for all shapes
+    ClassDef(FairGeoBasicShape, 0); // base class for all shapes
         private : FairGeoBasicShape(const FairGeoBasicShape&);
     FairGeoBasicShape& operator=(const FairGeoBasicShape&);
 };

--- a/geobase/FairGeoBasicShape.h
+++ b/geobase/FairGeoBasicShape.h
@@ -45,8 +45,9 @@ class FairGeoBasicShape : public TNamed
 
   protected:
     void posInMother(const FairGeoTransform&, const FairGeoTransform&);
-    ClassDef(FairGeoBasicShape, 0); // base class for all shapes
-        private : FairGeoBasicShape(const FairGeoBasicShape&);
+    ClassDef(FairGeoBasicShape, 0);   // base class for all shapes
+  private:
+    FairGeoBasicShape(const FairGeoBasicShape&);
     FairGeoBasicShape& operator=(const FairGeoBasicShape&);
 };
 

--- a/geobase/FairGeoBrik.h
+++ b/geobase/FairGeoBrik.h
@@ -23,7 +23,7 @@ class FairGeoBrik : public FairGeoBasicShape
     ~FairGeoBrik();
     TArrayD* calcVoluParam(FairGeoVolume*);
     void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&);
-    ClassDef(FairGeoBrik, 0); // class for geometry shape BOX or BRIK
+    ClassDef(FairGeoBrik, 0);   // class for geometry shape BOX or BRIK
 };
 
 #endif /* !FAIRGEOBRIK_H */

--- a/geobase/FairGeoBrik.h
+++ b/geobase/FairGeoBrik.h
@@ -23,7 +23,7 @@ class FairGeoBrik : public FairGeoBasicShape
     ~FairGeoBrik();
     TArrayD* calcVoluParam(FairGeoVolume*);
     void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&);
-    ClassDef(FairGeoBrik, 0)   // class for geometry shape BOX or BRIK
+    ClassDef(FairGeoBrik, 0); // class for geometry shape BOX or BRIK
 };
 
 #endif /* !FAIRGEOBRIK_H */

--- a/geobase/FairGeoBuilder.h
+++ b/geobase/FairGeoBuilder.h
@@ -34,7 +34,7 @@ class FairGeoBuilder : public TNamed
     virtual void finalize() {}
     inline const Int_t& GetNMedia() const { return nMed; }
     inline void SetNMedia(const Int_t& nmed) { nMed = nmed; }
-    ClassDef(FairGeoBuilder, 0)
+    ClassDef(FairGeoBuilder, 0);
 };
 
 #endif /* !FAIRGEOBUILDER_H */

--- a/geobase/FairGeoCompositeVolume.h
+++ b/geobase/FairGeoCompositeVolume.h
@@ -33,7 +33,8 @@ class FairGeoCompositeVolume : public FairGeoVolume
     void print();
     ClassDef(FairGeoCompositeVolume, 1);
 
-        private : FairGeoCompositeVolume(const FairGeoCompositeVolume&);
+  private:
+    FairGeoCompositeVolume(const FairGeoCompositeVolume&);
     FairGeoCompositeVolume& operator=(const FairGeoCompositeVolume&);
 };
 

--- a/geobase/FairGeoCompositeVolume.h
+++ b/geobase/FairGeoCompositeVolume.h
@@ -31,7 +31,7 @@ class FairGeoCompositeVolume : public FairGeoVolume
     void setComponent(FairGeoVolume*, const Int_t);
     void clear();
     void print();
-    ClassDef(FairGeoCompositeVolume, 1)
+    ClassDef(FairGeoCompositeVolume, 1);
 
         private : FairGeoCompositeVolume(const FairGeoCompositeVolume&);
     FairGeoCompositeVolume& operator=(const FairGeoCompositeVolume&);

--- a/geobase/FairGeoCone.h
+++ b/geobase/FairGeoCone.h
@@ -30,7 +30,7 @@ class FairGeoCone : public FairGeoBasicShape
     Int_t readPoints(std::fstream*, FairGeoVolume*);
     Bool_t writePoints(std::fstream*, FairGeoVolume*);
     void printPoints(FairGeoVolume* volu);
-    ClassDef(FairGeoCone, 0)   //
+    ClassDef(FairGeoCone, 0);
 };
 
 #endif /* !FAIRGEOCONE_H */

--- a/geobase/FairGeoCons.h
+++ b/geobase/FairGeoCons.h
@@ -30,7 +30,8 @@ class FairGeoCons : public FairGeoBasicShape
     Int_t readPoints(std::fstream*, FairGeoVolume*);
     Bool_t writePoints(std::fstream*, FairGeoVolume*);
     void printPoints(FairGeoVolume* volu);
-    ClassDef(FairGeoCons, 0)   //
+
+    ClassDef(FairGeoCons, 0);
 };
 
 #endif /* !FAIRGEOCONS_H */

--- a/geobase/FairGeoEltu.h
+++ b/geobase/FairGeoEltu.h
@@ -31,7 +31,7 @@ class FairGeoEltu : public FairGeoBasicShape
     Int_t readPoints(std::fstream*, FairGeoVolume*);
     Bool_t writePoints(std::fstream*, FairGeoVolume*);
     void printPoints(FairGeoVolume* volu);
-    ClassDef(FairGeoEltu, 0)   //
+    ClassDef(FairGeoEltu, 0);
 };
 
 #endif /* !FAIRGEOELTU_H */

--- a/geobase/FairGeoInterface.h
+++ b/geobase/FairGeoInterface.h
@@ -84,7 +84,7 @@ class FairGeoInterface : public TObject
     void addSetupFile(const char* f) { setupFile = f; }
     Bool_t readSetupFile();
     void print();
-    void SetNoOfSets(Int_t n) { nSets = n; }   //
+    void SetNoOfSets(Int_t n) { nSets = n; }
 
   private:
     FairGeoInterface(const FairGeoInterface&);
@@ -93,7 +93,7 @@ class FairGeoInterface : public TObject
     FairGeoIo* connectInput(const char*);
     Bool_t connectOutput(const char*);
 
-    ClassDef(FairGeoInterface, 0)   //
+    ClassDef(FairGeoInterface, 0);
 };
 
 #endif /* !FAIRGEOINTERFACE_H */

--- a/geobase/FairGeoIo.h
+++ b/geobase/FairGeoIo.h
@@ -36,7 +36,7 @@ class FairGeoIo : public TObject
     virtual Bool_t setHistoryDate(const char*) = 0;
 
   private:
-    ClassDef(FairGeoIo, 0)   //
+    ClassDef(FairGeoIo, 0);
 };
 
 #endif /* !FAIRGEOIO_H */

--- a/geobase/FairGeoLoader.h
+++ b/geobase/FairGeoLoader.h
@@ -43,7 +43,7 @@ class FairGeoLoader : public TNamed
     FairGeoInterface* fInterface;       //!  /** Hades Geometry Interface*/
     FairGeoBuilder* fGeoBuilder;        //!   /**Geometry builder*/
 
-    ClassDef(FairGeoLoader, 1)
+    ClassDef(FairGeoLoader, 1);
 };
 
 #endif

--- a/geobase/FairGeoMatrix.h
+++ b/geobase/FairGeoMatrix.h
@@ -28,7 +28,7 @@ class FairGeoMatrix : public TObject
     Double_t det(void);
     FairGeoVector operator*(FairGeoVector& v);
     FairGeoMatrix& operator/=(Double_t d);
-    ClassDef(FairGeoMatrix, 0)
+    ClassDef(FairGeoMatrix, 0);
 };
 
 #endif

--- a/geobase/FairGeoMedia.h
+++ b/geobase/FairGeoMedia.h
@@ -48,7 +48,7 @@ class FairGeoMedia : public TNamed
     FairGeoMedia(const FairGeoMedia&);
     FairGeoMedia& operator=(const FairGeoMedia&);
 
-    ClassDef(FairGeoMedia, 0)   //
+    ClassDef(FairGeoMedia, 0);
 };
 
 #endif /* !FAIRGEOMEDIA_H */

--- a/geobase/FairGeoMedium.h
+++ b/geobase/FairGeoMedium.h
@@ -86,7 +86,7 @@ class FairGeoMedium : public TNamed
     // TODO: correct copy constructor for FairGeoMedium
     //    FairGeoMedium& operator=(const FairGeoMedium&);
 
-    ClassDef(FairGeoMedium, 1)   //
+    ClassDef(FairGeoMedium, 1);   //
 };
 
 inline Bool_t FairGeoMedium::isSensitive()

--- a/geobase/FairGeoNode.h
+++ b/geobase/FairGeoNode.h
@@ -112,7 +112,7 @@ class FairGeoNode : public FairGeoVolume
         }
     }
 
-    ClassDef(FairGeoNode, 1)   //
+    ClassDef(FairGeoNode, 1);   //
 };
 
 // -------------------- inlines --------------------------

--- a/geobase/FairGeoOldAsciiIo.h
+++ b/geobase/FairGeoOldAsciiIo.h
@@ -55,7 +55,7 @@ class FairGeoOldAsciiIo : public FairGeoIo
     FairGeoOldAsciiIo(const FairGeoOldAsciiIo&);
     FairGeoOldAsciiIo& operator=(const FairGeoOldAsciiIo&);
 
-    ClassDef(FairGeoOldAsciiIo, 0)   //
+    ClassDef(FairGeoOldAsciiIo, 0);   //
 };
 
 #endif /* !FAIRGEOOLDASCIIIO_H */

--- a/geobase/FairGeoPcon.h
+++ b/geobase/FairGeoPcon.h
@@ -31,7 +31,7 @@ class FairGeoPcon : public FairGeoBasicShape
     Int_t readPoints(std::fstream*, FairGeoVolume*);
     Bool_t writePoints(std::fstream*, FairGeoVolume*);
     void printPoints(FairGeoVolume* volu);
-    ClassDef(FairGeoPcon, 0)   //
+    ClassDef(FairGeoPcon, 0);   //
 };
 
 #endif /* !FAIRGEOPCON_H */

--- a/geobase/FairGeoPgon.h
+++ b/geobase/FairGeoPgon.h
@@ -31,7 +31,7 @@ class FairGeoPgon : public FairGeoBasicShape
     Int_t readPoints(std::fstream*, FairGeoVolume*);
     Bool_t writePoints(std::fstream*, FairGeoVolume*);
     void printPoints(FairGeoVolume* volu);
-    ClassDef(FairGeoPgon, 0)   //
+    ClassDef(FairGeoPgon, 0);   //
 };
 
 #endif /* !FAIRGEOPGON_H */

--- a/geobase/FairGeoRootBuilder.h
+++ b/geobase/FairGeoRootBuilder.h
@@ -38,7 +38,7 @@ class FairGeoRootBuilder : public FairGeoBuilder
     Int_t createMedium(FairGeoMedium*);
     void finalize();
     void checkOverlaps(Double_t ovlp = 0.0001);
-    ClassDef(FairGeoRootBuilder, 0)   //
+    ClassDef(FairGeoRootBuilder, 0);   //
 };
 
 #endif /* !FAIRGEOROOTBUILDER_H */

--- a/geobase/FairGeoRotation.h
+++ b/geobase/FairGeoRotation.h
@@ -54,7 +54,7 @@ class FairGeoRotation : public TObject
     inline void print() const;
     TRotMatrix* createTRotMatrix(const Text_t* name = "", const Text_t* title = "");
 
-    ClassDef(FairGeoRotation, 1)   //
+    ClassDef(FairGeoRotation, 1);   //
 };
 
 // -------------------- inlines ---------------------------

--- a/geobase/FairGeoSet.h
+++ b/geobase/FairGeoSet.h
@@ -99,7 +99,7 @@ class FairGeoSet : public TNamed
     virtual void print();
     virtual Bool_t create(FairGeoBuilder*);
     void compare(FairGeoSet&);
-    ClassDef(FairGeoSet, 0)   //
+    ClassDef(FairGeoSet, 0);   //
 
         private : FairGeoSet(const FairGeoSet&);
     FairGeoSet& operator=(const FairGeoSet&);

--- a/geobase/FairGeoSet.h
+++ b/geobase/FairGeoSet.h
@@ -101,7 +101,8 @@ class FairGeoSet : public TNamed
     void compare(FairGeoSet&);
     ClassDef(FairGeoSet, 0);   //
 
-        private : FairGeoSet(const FairGeoSet&);
+  private:
+    FairGeoSet(const FairGeoSet&);
     FairGeoSet& operator=(const FairGeoSet&);
 };
 

--- a/geobase/FairGeoShapes.h
+++ b/geobase/FairGeoShapes.h
@@ -37,7 +37,7 @@ class FairGeoShapes : public TObject
     Int_t readPoints(std::fstream*, FairGeoVolume*);
     Bool_t writePoints(std::fstream*, FairGeoVolume*);
     void printPoints(FairGeoVolume* volu);
-    ClassDef(FairGeoShapes, 0)   //
+    ClassDef(FairGeoShapes, 0);   //
 };
 
 #endif /* !FAIRGEOSHAPES_H */

--- a/geobase/FairGeoSphe.h
+++ b/geobase/FairGeoSphe.h
@@ -31,7 +31,7 @@ class FairGeoSphe : public FairGeoBasicShape
     Int_t readPoints(std::fstream*, FairGeoVolume*);
     Bool_t writePoints(std::fstream*, FairGeoVolume*);
     void printPoints(FairGeoVolume* volu);
-    ClassDef(FairGeoSphe, 0)   //
+    ClassDef(FairGeoSphe, 0);   //
 };
 
 #endif /* !FAIRGEOSPHE_H */

--- a/geobase/FairGeoTorus.h
+++ b/geobase/FairGeoTorus.h
@@ -28,7 +28,7 @@ class FairGeoTorus : public FairGeoBasicShape
     Bool_t writePoints(std::fstream*, FairGeoVolume*);
     void printPoints(FairGeoVolume* volu);
 
-    ClassDef(FairGeoTorus, 0)   // class for geometry shape TORUS
+    ClassDef(FairGeoTorus, 0);   // class for geometry shape TORUS
 };
 
 #endif /* !FAIRGEOTORUS_H */

--- a/geobase/FairGeoTransform.h
+++ b/geobase/FairGeoTransform.h
@@ -54,7 +54,7 @@ class FairGeoTransform : public TObject
     const FairGeoRotation& getRotation() const { return rot; }
 
     inline void setTransform(const FairGeoTransform& t);
-    ClassDef(FairGeoTransform, 1)   //
+    ClassDef(FairGeoTransform, 1);   //
 };
 
 inline FairGeoTransform::FairGeoTransform(const FairGeoTransform& t)

--- a/geobase/FairGeoTrap.h
+++ b/geobase/FairGeoTrap.h
@@ -27,7 +27,7 @@ class FairGeoTrap : public FairGeoBasicShape
     ~FairGeoTrap();
     TArrayD* calcVoluParam(FairGeoVolume*);
     void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&);
-    ClassDef(FairGeoTrap, 0)   // class for geometry shape TRAP
+    ClassDef(FairGeoTrap, 0);   // class for geometry shape TRAP
 };
 
 #endif /* !FAIRGEOTRAP_H */

--- a/geobase/FairGeoTrd1.h
+++ b/geobase/FairGeoTrd1.h
@@ -28,7 +28,7 @@ class FairGeoTrd1 : public FairGeoBasicShape
     TArrayD* calcVoluParam(FairGeoVolume*);
     void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&);
 
-    ClassDef(FairGeoTrd1, 0)   // class for geometry shape TRD1
+    ClassDef(FairGeoTrd1, 0);   // class for geometry shape TRD1
 };
 
 #endif /* !FAIRGEOTRD1_H */

--- a/geobase/FairGeoTube.h
+++ b/geobase/FairGeoTube.h
@@ -27,7 +27,7 @@ class FairGeoTube : public FairGeoBasicShape
     Int_t readPoints(std::fstream*, FairGeoVolume*);
     Bool_t writePoints(std::fstream*, FairGeoVolume*);
     void printPoints(FairGeoVolume* volu);
-    ClassDef(FairGeoTube, 0)   // class for geometry shape TUBE
+    ClassDef(FairGeoTube, 0);   // class for geometry shape TUBE
 };
 
 #endif /* !FAIRGEOTUBE_H */

--- a/geobase/FairGeoTubs.h
+++ b/geobase/FairGeoTubs.h
@@ -27,7 +27,7 @@ class FairGeoTubs : public FairGeoBasicShape
     Int_t readPoints(std::fstream*, FairGeoVolume*);
     Bool_t writePoints(std::fstream*, FairGeoVolume*);
     void printPoints(FairGeoVolume* volu);
-    ClassDef(FairGeoTubs, 0)   // class for geometry shape TUBS
+    ClassDef(FairGeoTubs, 0);   // class for geometry shape TUBS
 };
 
 #endif /* !FAIRGEOTUBS_H */

--- a/geobase/FairGeoVector.h
+++ b/geobase/FairGeoVector.h
@@ -99,7 +99,7 @@ class FairGeoVector : public TObject
     inline void round(Int_t n);
     inline friend std::ostream& operator<<(std::ostream& put, const FairGeoVector& v);
     inline friend std::istream& operator>>(std::istream& get, FairGeoVector& v);
-    ClassDef(FairGeoVector, 1)   // vector with 3 components
+    ClassDef(FairGeoVector, 1);   // vector with 3 components
 };
 
 // -------------------- inlines ---------------------------

--- a/geobase/FairGeoVolume.h
+++ b/geobase/FairGeoVolume.h
@@ -64,7 +64,7 @@ class FairGeoVolume : public TNamed
     Int_t getMCid() { return fgMCid; }
     void setMCid(Int_t MCid) { fgMCid = MCid; }
 
-    ClassDef(FairGeoVolume, 1)   //
+    ClassDef(FairGeoVolume, 1);   //
 };
 
 // -------------------- inlines --------------------------

--- a/parbase/FairContFact.h
+++ b/parbase/FairContFact.h
@@ -42,7 +42,7 @@ class FairContainer : public TNamed
     void print();
     TString getConcatName();
     const char* getContext();
-    ClassDef(FairContainer, 0)   // class for list elements in class FairContFact
+    ClassDef(FairContainer, 0);   // class for list elements in class FairContFact
 };
 
 class FairContFact : public TNamed
@@ -64,7 +64,7 @@ class FairContFact : public TNamed
     }
     /** Fair Logger */
     FairLogger* fLogger;        //!
-    ClassDef(FairContFact, 0)   // base class of all factories for parameter containers
+    ClassDef(FairContFact, 0);   // base class of all factories for parameter containers
 
         private : FairContFact(const FairContFact&);
     FairContFact& operator=(const FairContFact&);

--- a/parbase/FairContFact.h
+++ b/parbase/FairContFact.h
@@ -63,10 +63,11 @@ class FairContFact : public TNamed
         return (static_cast<FairContainer*>(containers->FindObject(name)))->getActualContext();
     }
     /** Fair Logger */
-    FairLogger* fLogger;        //!
+    FairLogger* fLogger;         //!
     ClassDef(FairContFact, 0);   // base class of all factories for parameter containers
 
-        private : FairContFact(const FairContFact&);
+  private:
+    FairContFact(const FairContFact&);
     FairContFact& operator=(const FairContFact&);
 };
 

--- a/parbase/FairDetParAsciiFileIo.h
+++ b/parbase/FairDetParAsciiFileIo.h
@@ -48,7 +48,7 @@ class FairDetParAsciiFileIo : public FairDetParIo
     FairDetParAsciiFileIo& operator=(const FairDetParAsciiFileIo&);
     FairDetParAsciiFileIo(const FairDetParAsciiFileIo&);
 
-    ClassDef(FairDetParAsciiFileIo, 0)   // Class for detector parameter I/O from ascii file
+    ClassDef(FairDetParAsciiFileIo, 0);   // Class for detector parameter I/O from ascii file
 };
 
 #endif /* !FAIRDETPARASCIIFILEIO_H */

--- a/parbase/FairDetParIo.h
+++ b/parbase/FairDetParIo.h
@@ -34,7 +34,7 @@ class FairDetParIo : public TNamed
     // writes parameter container to output
     virtual Int_t write(FairParSet*) { return kFALSE; }
 
-    ClassDef(FairDetParIo, 0)   // Base class for detector parameter IO
+    ClassDef(FairDetParIo, 0);   // Base class for detector parameter IO
 };
 
 #endif /* !HDETPARIO_H */

--- a/parbase/FairDetParRootFileIo.h
+++ b/parbase/FairDetParRootFileIo.h
@@ -37,7 +37,7 @@ class FairDetParRootFileIo : public FairDetParIo
     FairDetParRootFileIo(const FairDetParRootFileIo&);
     FairDetParRootFileIo& operator=(const FairDetParRootFileIo&);
 
-    ClassDef(FairDetParRootFileIo, 0)   // detector base class for parameter I/O from ROOT file
+    ClassDef(FairDetParRootFileIo, 0);   // detector base class for parameter I/O from ROOT file
 };
 
 #endif /* !FAIRDETPARROOTFILEIO_H */

--- a/parbase/FairParAsciiFileIo.h
+++ b/parbase/FairParAsciiFileIo.h
@@ -59,7 +59,7 @@ class FairParAsciiFileIo : public FairParIo
     FairParAsciiFileIo(const FairParAsciiFileIo&);
     FairParAsciiFileIo& operator=(const FairParAsciiFileIo&);
 
-    ClassDef(FairParAsciiFileIo, 0)   // Parameter I/O from ASCII files
+    ClassDef(FairParAsciiFileIo, 0);   // Parameter I/O from ASCII files
 };
 
 #endif /* !FAIRPARASCIIFILEIO_H */

--- a/parbase/FairParGenericSet.h
+++ b/parbase/FairParGenericSet.h
@@ -37,7 +37,7 @@ class FairParGenericSet : public FairParSet
     FairParGenericSet()
         : FairParSet()
     {}
-    ClassDef(FairParGenericSet, 1)   // Base class for generic-style parameter containers
+    ClassDef(FairParGenericSet, 1);   // Base class for generic-style parameter containers
 };
 
 #endif /* !FAIRPARGENERICSET_H */

--- a/parbase/FairParIo.h
+++ b/parbase/FairParIo.h
@@ -61,7 +61,7 @@ class FairParIo : public TObject
     FairParIo(const FairParIo&);
     FairParIo& operator=(const FairParIo&);
 
-    ClassDef(FairParIo, 0)   // Base class for all parameter I/Os
+    ClassDef(FairParIo, 0);   // Base class for all parameter I/Os
 };
 
 #endif /* !FAIRPARIO_H */

--- a/parbase/FairParRootFileIo.h
+++ b/parbase/FairParRootFileIo.h
@@ -45,7 +45,7 @@ class FairParRootFile : public TNamed
     FairParRootFile(const FairParRootFile&);
     FairParRootFile& operator=(const FairParRootFile&);
 
-    ClassDef(FairParRootFile, 0)   // ROOT file for Parameter I/O
+    ClassDef(FairParRootFile, 0);   // ROOT file for Parameter I/O
 };
 
 class FairParRootFileIo : public FairParIo
@@ -91,7 +91,7 @@ class FairParRootFileIo : public FairParIo
     FairParRootFileIo(const FairParRootFileIo&);
     FairParRootFileIo& operator=(const FairParRootFileIo&);
 
-    ClassDef(FairParRootFileIo, 0)   // Parameter I/O from ROOT files
+    ClassDef(FairParRootFileIo, 0);   // Parameter I/O from ROOT files
 };
 
 #endif /* !FAIRPARROOTFILEIO_H */

--- a/parbase/FairParSet.h
+++ b/parbase/FairParSet.h
@@ -92,7 +92,7 @@ class FairParSet : public TObject
     FairParSet& operator=(const FairParSet&);
     FairParSet(const FairParSet&);
 
-    ClassDef(FairParSet, 2)   // Base class for all parameter containers
+    ClassDef(FairParSet, 2);   // Base class for all parameter containers
 };
 
 #endif /* !FAIRPARSET_H */

--- a/parbase/FairParamList.h
+++ b/parbase/FairParamList.h
@@ -74,7 +74,8 @@ class FairParamObj : public TNamed
   private:
     FairParamObj& operator=(const FairParamObj&);
 
-    ClassDef(FairParamObj, 0)   // Class for binary parameter object (name + binary array)
+    // Class for binary parameter object (name + binary array)
+    ClassDef(FairParamObj, 0);
 };
 
 class FairParamList : public TObject
@@ -139,7 +140,8 @@ class FairParamList : public TObject
     FairParamList(const FairParamList&);
     FairParamList& operator=(const FairParamList&);
 
-    ClassDef(FairParamList, 4)   // Class for lists of parameters (of type FairParamObj)
+    // Class for lists of parameters (of type FairParamObj)
+    ClassDef(FairParamList, 4);
 };
 
 #endif /* !FAIRPARAMLIST_H */

--- a/parbase/FairRtdbRun.h
+++ b/parbase/FairRtdbRun.h
@@ -52,7 +52,7 @@ class FairParVersion : public TNamed
     }
     void setRootVersion(Int_t v) { rootVersion = v; }
     Int_t getRootVersion() { return rootVersion; }
-    ClassDef(FairParVersion, 1)   // Class for parameter versions
+    ClassDef(FairParVersion, 1);   // Class for parameter versions
 };
 
 class FairRtdbRun : public TNamed
@@ -82,7 +82,7 @@ class FairRtdbRun : public TNamed
   private:
     FairRtdbRun& operator=(const FairRtdbRun&);
 
-    ClassDef(FairRtdbRun, 1)   // Class for parameter version management of a run
+    ClassDef(FairRtdbRun, 1);   // Class for parameter version management of a run
 };
 
 // -------------------- inlines ---------------------------

--- a/parbase/FairRuntimeDb.h
+++ b/parbase/FairRuntimeDb.h
@@ -112,7 +112,7 @@ class FairRuntimeDb : public TObject
     FairRuntimeDb& operator=(const FairRuntimeDb&) { return *this; }
     Bool_t initContainers(void);
 
-    ClassDef(FairRuntimeDb, 0)   // Class for runtime database
+    ClassDef(FairRuntimeDb, 0);   // Class for runtime database
 };
 
 #endif /* !FAIRRUNTIMEDB_H */

--- a/templates/NewDetector_root_containers/NewDetector.h
+++ b/templates/NewDetector_root_containers/NewDetector.h
@@ -97,7 +97,7 @@ class NewDetector : public FairDetector
 
     void DefineSensitiveVolumes();
 
-    ClassDef(NewDetector, 2)
+    ClassDef(NewDetector, 2);
 };
 
 #endif   // NEWDETECTOR_H

--- a/templates/NewDetector_root_containers/NewDetectorContFact.h
+++ b/templates/NewDetector_root_containers/NewDetectorContFact.h
@@ -21,7 +21,7 @@ class NewDetectorContFact : public FairContFact
     NewDetectorContFact();
     ~NewDetectorContFact() {}
     FairParSet* createContainer(FairContainer*);
-    ClassDef(NewDetectorContFact, 0)   // Factory for all NewDetector parameter containers
+    ClassDef(NewDetectorContFact, 0);   // Factory for all NewDetector parameter containers
 };
 
 #endif

--- a/templates/NewDetector_root_containers/NewDetectorGeo.h
+++ b/templates/NewDetector_root_containers/NewDetectorGeo.h
@@ -22,7 +22,7 @@ class NewDetectorGeo : public FairGeoSet
     const char* getModuleName(Int_t);
     const char* getEleName(Int_t);
     inline Int_t getModNumInMod(const TString&);
-    ClassDef(NewDetectorGeo, 1)
+    ClassDef(NewDetectorGeo, 1);
 };
 
 inline Int_t NewDetectorGeo::getModNumInMod(const TString& name)

--- a/templates/NewDetector_root_containers/NewDetectorGeoPar.h
+++ b/templates/NewDetector_root_containers/NewDetectorGeoPar.h
@@ -36,7 +36,7 @@ class NewDetectorGeoPar : public FairParGenericSet
     NewDetectorGeoPar(const NewDetectorGeoPar&);
     NewDetectorGeoPar& operator=(const NewDetectorGeoPar&);
 
-    ClassDef(NewDetectorGeoPar, 1)
+    ClassDef(NewDetectorGeoPar, 1);
 };
 
 #endif

--- a/templates/NewDetector_root_containers/NewDetectorPoint.h
+++ b/templates/NewDetector_root_containers/NewDetectorPoint.h
@@ -48,7 +48,7 @@ class NewDetectorPoint : public FairMCPoint
     NewDetectorPoint(const NewDetectorPoint& point);
     NewDetectorPoint operator=(const NewDetectorPoint& point);
 
-    ClassDef(NewDetectorPoint, 1)
+    ClassDef(NewDetectorPoint, 1);
 };
 
 #endif

--- a/templates/NewDetector_stl_containers/NewDetector.h
+++ b/templates/NewDetector_stl_containers/NewDetector.h
@@ -95,7 +95,7 @@ class NewDetector : public FairDetector
 
     void DefineSensitiveVolumes();
 
-    ClassDef(NewDetector, 2)
+    ClassDef(NewDetector, 2);
 };
 
 #endif   // NEWDETECTOR_H

--- a/templates/NewDetector_stl_containers/NewDetectorContFact.h
+++ b/templates/NewDetector_stl_containers/NewDetectorContFact.h
@@ -21,7 +21,7 @@ class NewDetectorContFact : public FairContFact
     NewDetectorContFact();
     ~NewDetectorContFact() {}
     FairParSet* createContainer(FairContainer*);
-    ClassDef(NewDetectorContFact, 0)   // Factory for all NewDetector parameter containers
+    ClassDef(NewDetectorContFact, 0);   // Factory for all NewDetector parameter containers
 };
 
 #endif

--- a/templates/NewDetector_stl_containers/NewDetectorGeo.h
+++ b/templates/NewDetector_stl_containers/NewDetectorGeo.h
@@ -22,7 +22,7 @@ class NewDetectorGeo : public FairGeoSet
     const char* getModuleName(Int_t);
     const char* getEleName(Int_t);
     inline Int_t getModNumInMod(const TString&);
-    ClassDef(NewDetectorGeo, 1)
+    ClassDef(NewDetectorGeo, 1);
 };
 
 inline Int_t NewDetectorGeo::getModNumInMod(const TString& name)

--- a/templates/NewDetector_stl_containers/NewDetectorGeoPar.h
+++ b/templates/NewDetector_stl_containers/NewDetectorGeoPar.h
@@ -36,7 +36,7 @@ class NewDetectorGeoPar : public FairParGenericSet
     NewDetectorGeoPar(const NewDetectorGeoPar&);
     NewDetectorGeoPar& operator=(const NewDetectorGeoPar&);
 
-    ClassDef(NewDetectorGeoPar, 1)
+    ClassDef(NewDetectorGeoPar, 1);
 };
 
 #endif

--- a/templates/NewDetector_stl_containers/NewDetectorPoint.h
+++ b/templates/NewDetector_stl_containers/NewDetectorPoint.h
@@ -85,7 +85,7 @@ class NewDetectorPoint
     NewDetectorPoint(const NewDetectorPoint& point);
     NewDetectorPoint operator=(const NewDetectorPoint& point);
 
-    ClassDef(NewDetectorPoint, 1)
+    ClassDef(NewDetectorPoint, 1);
 };
 
 inline void NewDetectorPoint::SetMomentum(const TVector3& mom)

--- a/templates/NewParameterContainer/NewParameterContainer.h
+++ b/templates/NewParameterContainer/NewParameterContainer.h
@@ -27,7 +27,7 @@ class NewParameterContainer : public FairParGenericSet
     NewParameterContainer(const NewParameterContainer&);
     NewParameterContainer& operator=(const NewParameterContainer&);
 
-    ClassDef(NewParameterContainer, 1)
+    ClassDef(NewParameterContainer, 1);
 };
 
 #endif

--- a/templates/project_root_containers/MyProjData/MyProjStack.h
+++ b/templates/project_root_containers/MyProjData/MyProjStack.h
@@ -242,7 +242,7 @@ class MyProjStack : public FairGenericStack
     MyProjStack(const MyProjStack&);
     MyProjStack& operator=(const MyProjStack&);
 
-    ClassDef(MyProjStack, 1)
+    ClassDef(MyProjStack, 1);
 };
 
 #endif

--- a/templates/project_root_containers/MyProjGenerators/Pythia6Generator.h
+++ b/templates/project_root_containers/MyProjGenerators/Pythia6Generator.h
@@ -70,8 +70,8 @@
  Derived from FairGenerator.
 **/
 
-#ifndef PND_PYTHIAGENERATOR_H
-#define PND_PYTHIAGENERATOR_H
+#ifndef My_PYTHIA6GENERATOR_H
+#define My_PYTHIA6GENERATOR_H
 
 #include "FairGenerator.h"   // for FairGenerator
 

--- a/templates/project_root_containers/MyProjGenerators/Pythia8Generator.h
+++ b/templates/project_root_containers/MyProjGenerators/Pythia8Generator.h
@@ -9,8 +9,8 @@
 // -----                  M. Al-Turany   June 2014                     -----
 // -------------------------------------------------------------------------
 
-#ifndef PNDP8GENERATOR_H
-#define PNDP8GENERATOR_H 1
+#ifndef My_PYTHIA8GENERATOR_H
+#define My_PYTHIA8GENERATOR_H 1
 
 #include "FairGenerator.h"    // for FairGenerator
 #include "Pythia8/Basics.h"   // for RndmEngine
@@ -94,4 +94,4 @@ class Pythia8Generator : public FairGenerator
     ClassDef(Pythia8Generator, 1);
 };
 
-#endif /* !PNDP8GENERATOR_H */
+#endif /* !My_PYTHIA8GENERATOR_H */

--- a/templates/project_root_containers/NewDetector/NewDetector.h
+++ b/templates/project_root_containers/NewDetector/NewDetector.h
@@ -97,7 +97,7 @@ class NewDetector : public FairDetector
 
     void DefineSensitiveVolumes();
 
-    ClassDef(NewDetector, 2)
+    ClassDef(NewDetector, 2);
 };
 
 #endif   // NEWDETECTOR_H

--- a/templates/project_root_containers/NewDetector/NewDetectorContFact.h
+++ b/templates/project_root_containers/NewDetector/NewDetectorContFact.h
@@ -21,7 +21,7 @@ class NewDetectorContFact : public FairContFact
     NewDetectorContFact();
     ~NewDetectorContFact() {}
     FairParSet* createContainer(FairContainer*);
-    ClassDef(NewDetectorContFact, 0)   // Factory for all NewDetector parameter containers
+    ClassDef(NewDetectorContFact, 0);   // Factory for all NewDetector parameter containers
 };
 
 #endif

--- a/templates/project_root_containers/NewDetector/NewDetectorGeo.h
+++ b/templates/project_root_containers/NewDetector/NewDetectorGeo.h
@@ -22,7 +22,7 @@ class NewDetectorGeo : public FairGeoSet
     const char* getModuleName(Int_t);
     const char* getEleName(Int_t);
     inline Int_t getModNumInMod(const TString&);
-    ClassDef(NewDetectorGeo, 1)
+    ClassDef(NewDetectorGeo, 1);
 };
 
 inline Int_t NewDetectorGeo::getModNumInMod(const TString& name)

--- a/templates/project_root_containers/NewDetector/NewDetectorGeoPar.h
+++ b/templates/project_root_containers/NewDetector/NewDetectorGeoPar.h
@@ -36,7 +36,7 @@ class NewDetectorGeoPar : public FairParGenericSet
     NewDetectorGeoPar(const NewDetectorGeoPar&);
     NewDetectorGeoPar& operator=(const NewDetectorGeoPar&);
 
-    ClassDef(NewDetectorGeoPar, 1)
+    ClassDef(NewDetectorGeoPar, 1);
 };
 
 #endif

--- a/templates/project_root_containers/NewDetector/NewDetectorPoint.h
+++ b/templates/project_root_containers/NewDetector/NewDetectorPoint.h
@@ -48,7 +48,7 @@ class NewDetectorPoint : public FairMCPoint
     NewDetectorPoint(const NewDetectorPoint& point);
     NewDetectorPoint operator=(const NewDetectorPoint& point);
 
-    ClassDef(NewDetectorPoint, 1)
+    ClassDef(NewDetectorPoint, 1);
 };
 
 #endif

--- a/templates/project_root_containers/passive/MyCave.h
+++ b/templates/project_root_containers/passive/MyCave.h
@@ -34,7 +34,7 @@ class MyCave : public FairModule
     MyCave(const MyCave&);
     MyCave& operator=(const MyCave&);
 
-    ClassDef(MyCave, 1)   // PNDCaveSD
+    ClassDef(MyCave, 1);   // PNDCaveSD
 };
 
 #endif   // Cave_H

--- a/templates/project_root_containers/passive/MyCave.h
+++ b/templates/project_root_containers/passive/MyCave.h
@@ -34,7 +34,7 @@ class MyCave : public FairModule
     MyCave(const MyCave&);
     MyCave& operator=(const MyCave&);
 
-    ClassDef(MyCave, 1);   // PNDCaveSD
+    ClassDef(MyCave, 1);
 };
 
 #endif   // Cave_H

--- a/templates/project_root_containers/passive/MyGeoCave.h
+++ b/templates/project_root_containers/passive/MyGeoCave.h
@@ -40,4 +40,4 @@ class MyGeoCave : public FairGeoSet
     ClassDef(MyGeoCave, 0);   // Class for the geometry of CAVE
 };
 
-#endif /* !PNDGEOCAVE_H */
+#endif /* !MyGEOCAVE_H */

--- a/templates/project_root_containers/passive/MyGeoCave.h
+++ b/templates/project_root_containers/passive/MyGeoCave.h
@@ -37,7 +37,7 @@ class MyGeoCave : public FairGeoSet
     void addRefNodes();
     void write(std::fstream&);
     void print();
-    ClassDef(MyGeoCave, 0)   // Class for the geometry of CAVE
+    ClassDef(MyGeoCave, 0);   // Class for the geometry of CAVE
 };
 
 #endif /* !PNDGEOCAVE_H */

--- a/templates/project_root_containers/passive/MyMagnet.h
+++ b/templates/project_root_containers/passive/MyMagnet.h
@@ -33,7 +33,7 @@ class MyMagnet : public FairModule
     MyMagnet(const MyMagnet&);
     MyMagnet& operator=(const MyMagnet&);
 
-    ClassDef(MyMagnet, 1)
+    ClassDef(MyMagnet, 1);
 };
 
 #endif   // MAGNET_H

--- a/templates/project_root_containers/passive/MyPassiveContFact.h
+++ b/templates/project_root_containers/passive/MyPassiveContFact.h
@@ -11,8 +11,8 @@
 // -----                Created 26/03/14  by M. Al-Turany              -----
 // -------------------------------------------------------------------------
 
-#ifndef PNDPASSIVECONTFACT_H
-#define PNDPASSIVECONTFACT_H
+#ifndef My_PASSIVECONTFACT_H
+#define My_PASSIVECONTFACT_H
 
 #include "FairContFact.h"   // for FairContFact, etc
 
@@ -32,4 +32,4 @@ class MyPassiveContFact : public FairContFact
     ClassDef(MyPassiveContFact, 0);   // Factory for all Passive parameter containers
 };
 
-#endif /* !PNDPASSIVECONTFACT_H */
+#endif /* !My_PASSIVECONTFACT_H */

--- a/templates/project_root_containers/passive/MyPassiveContFact.h
+++ b/templates/project_root_containers/passive/MyPassiveContFact.h
@@ -29,7 +29,7 @@ class MyPassiveContFact : public FairContFact
     MyPassiveContFact();
     ~MyPassiveContFact() {}
     FairParSet* createContainer(FairContainer*);
-    ClassDef(MyPassiveContFact, 0)   // Factory for all Passive parameter containers
+    ClassDef(MyPassiveContFact, 0);   // Factory for all Passive parameter containers
 };
 
 #endif /* !PNDPASSIVECONTFACT_H */

--- a/templates/project_root_containers/passive/MyPipe.h
+++ b/templates/project_root_containers/passive/MyPipe.h
@@ -31,7 +31,7 @@ class MyPipe : public FairModule
     MyPipe(const MyPipe&);
     MyPipe& operator=(const MyPipe&);
 
-    ClassDef(MyPipe, 1)   // MyPIPE
+    ClassDef(MyPipe, 1);   // MyPIPE
 };
 
 #endif   // PIPE_H

--- a/templates/project_stl_containers/MyProjData/MyProjStack.h
+++ b/templates/project_stl_containers/MyProjData/MyProjStack.h
@@ -242,7 +242,7 @@ class MyProjStack : public FairGenericStack
     MyProjStack(const MyProjStack&);
     MyProjStack& operator=(const MyProjStack&);
 
-    ClassDef(MyProjStack, 1)
+    ClassDef(MyProjStack, 1);
 };
 
 #endif

--- a/templates/project_stl_containers/MyProjGenerators/Pythia6Generator.h
+++ b/templates/project_stl_containers/MyProjGenerators/Pythia6Generator.h
@@ -70,8 +70,8 @@
  Derived from FairGenerator.
 **/
 
-#ifndef PND_PYTHIAGENERATOR_H
-#define PND_PYTHIAGENERATOR_H
+#ifndef My_PYTHIA6GENERATOR_H
+#define My_PYTHIA6GENERATOR_H
 
 #include "FairGenerator.h"   // for FairGenerator
 

--- a/templates/project_stl_containers/MyProjGenerators/Pythia8Generator.h
+++ b/templates/project_stl_containers/MyProjGenerators/Pythia8Generator.h
@@ -9,8 +9,8 @@
 // -----                  M. Al-Turany   June 2014                     -----
 // -------------------------------------------------------------------------
 
-#ifndef PNDP8GENERATOR_H
-#define PNDP8GENERATOR_H 1
+#ifndef My_PYTHIA8GENERATOR_H
+#define My_PYTHIA8GENERATOR_H 1
 
 #include "FairGenerator.h"    // for FairGenerator
 #include "Pythia8/Basics.h"   // for RndmEngine
@@ -94,4 +94,4 @@ class Pythia8Generator : public FairGenerator
     ClassDef(Pythia8Generator, 1);
 };
 
-#endif /* !PNDP8GENERATOR_H */
+#endif /* !My_PYTHIA8GENERATOR_H */

--- a/templates/project_stl_containers/NewDetector/NewDetector.h
+++ b/templates/project_stl_containers/NewDetector/NewDetector.h
@@ -95,7 +95,7 @@ class NewDetector : public FairDetector
 
     void DefineSensitiveVolumes();
 
-    ClassDef(NewDetector, 2)
+    ClassDef(NewDetector, 2);
 };
 
 #endif   // NEWDETECTOR_H

--- a/templates/project_stl_containers/NewDetector/NewDetectorContFact.h
+++ b/templates/project_stl_containers/NewDetector/NewDetectorContFact.h
@@ -21,7 +21,7 @@ class NewDetectorContFact : public FairContFact
     NewDetectorContFact();
     ~NewDetectorContFact() {}
     FairParSet* createContainer(FairContainer*);
-    ClassDef(NewDetectorContFact, 0)   // Factory for all NewDetector parameter containers
+    ClassDef(NewDetectorContFact, 0);   // Factory for all NewDetector parameter containers
 };
 
 #endif

--- a/templates/project_stl_containers/NewDetector/NewDetectorGeo.h
+++ b/templates/project_stl_containers/NewDetector/NewDetectorGeo.h
@@ -22,7 +22,7 @@ class NewDetectorGeo : public FairGeoSet
     const char* getModuleName(Int_t);
     const char* getEleName(Int_t);
     inline Int_t getModNumInMod(const TString&);
-    ClassDef(NewDetectorGeo, 1)
+    ClassDef(NewDetectorGeo, 1);
 };
 
 inline Int_t NewDetectorGeo::getModNumInMod(const TString& name)

--- a/templates/project_stl_containers/NewDetector/NewDetectorGeoPar.h
+++ b/templates/project_stl_containers/NewDetector/NewDetectorGeoPar.h
@@ -36,7 +36,7 @@ class NewDetectorGeoPar : public FairParGenericSet
     NewDetectorGeoPar(const NewDetectorGeoPar&);
     NewDetectorGeoPar& operator=(const NewDetectorGeoPar&);
 
-    ClassDef(NewDetectorGeoPar, 1)
+    ClassDef(NewDetectorGeoPar, 1);
 };
 
 #endif

--- a/templates/project_stl_containers/NewDetector/NewDetectorPoint.h
+++ b/templates/project_stl_containers/NewDetector/NewDetectorPoint.h
@@ -85,7 +85,7 @@ class NewDetectorPoint
     NewDetectorPoint(const NewDetectorPoint& point);
     NewDetectorPoint operator=(const NewDetectorPoint& point);
 
-    ClassDef(NewDetectorPoint, 1)
+    ClassDef(NewDetectorPoint, 1);
 };
 
 inline void NewDetectorPoint::SetMomentum(const TVector3& mom)

--- a/templates/project_stl_containers/passive/MyCave.h
+++ b/templates/project_stl_containers/passive/MyCave.h
@@ -34,7 +34,7 @@ class MyCave : public FairModule
     MyCave(const MyCave&);
     MyCave& operator=(const MyCave&);
 
-    ClassDef(MyCave, 1)   // PNDCaveSD
+    ClassDef(MyCave, 1);   // PNDCaveSD
 };
 
 #endif   // Cave_H

--- a/templates/project_stl_containers/passive/MyCave.h
+++ b/templates/project_stl_containers/passive/MyCave.h
@@ -34,7 +34,7 @@ class MyCave : public FairModule
     MyCave(const MyCave&);
     MyCave& operator=(const MyCave&);
 
-    ClassDef(MyCave, 1);   // PNDCaveSD
+    ClassDef(MyCave, 1);
 };
 
 #endif   // Cave_H

--- a/templates/project_stl_containers/passive/MyGeoCave.h
+++ b/templates/project_stl_containers/passive/MyGeoCave.h
@@ -37,7 +37,7 @@ class MyGeoCave : public FairGeoSet
     void addRefNodes();
     void write(std::fstream&);
     void print();
-    ClassDef(MyGeoCave, 0)   // Class for the geometry of CAVE
+    ClassDef(MyGeoCave, 0);   // Class for the geometry of CAVE
 };
 
 #endif /* !PNDGEOCAVE_H */

--- a/templates/project_stl_containers/passive/MyGeoCave.h
+++ b/templates/project_stl_containers/passive/MyGeoCave.h
@@ -40,4 +40,4 @@ class MyGeoCave : public FairGeoSet
     ClassDef(MyGeoCave, 0);   // Class for the geometry of CAVE
 };
 
-#endif /* !PNDGEOCAVE_H */
+#endif /* !MYGEOCAVE_H */

--- a/templates/project_stl_containers/passive/MyMagnet.h
+++ b/templates/project_stl_containers/passive/MyMagnet.h
@@ -33,7 +33,7 @@ class MyMagnet : public FairModule
     MyMagnet(const MyMagnet&);
     MyMagnet& operator=(const MyMagnet&);
 
-    ClassDef(MyMagnet, 1)
+    ClassDef(MyMagnet, 1);
 };
 
 #endif   // MAGNET_H

--- a/templates/project_stl_containers/passive/MyPassiveContFact.h
+++ b/templates/project_stl_containers/passive/MyPassiveContFact.h
@@ -11,8 +11,8 @@
 // -----                Created 26/03/14  by M. Al-Turany              -----
 // -------------------------------------------------------------------------
 
-#ifndef PNDPASSIVECONTFACT_H
-#define PNDPASSIVECONTFACT_H
+#ifndef My_PASSIVECONTFACT_H
+#define My_PASSIVECONTFACT_H
 
 #include "FairContFact.h"   // for FairContFact, etc
 
@@ -32,4 +32,4 @@ class MyPassiveContFact : public FairContFact
     ClassDef(MyPassiveContFact, 0);   // Factory for all Passive parameter containers
 };
 
-#endif /* !PNDPASSIVECONTFACT_H */
+#endif /* !My_PASSIVECONTFACT_H */

--- a/templates/project_stl_containers/passive/MyPassiveContFact.h
+++ b/templates/project_stl_containers/passive/MyPassiveContFact.h
@@ -29,7 +29,7 @@ class MyPassiveContFact : public FairContFact
     MyPassiveContFact();
     ~MyPassiveContFact() {}
     FairParSet* createContainer(FairContainer*);
-    ClassDef(MyPassiveContFact, 0)   // Factory for all Passive parameter containers
+    ClassDef(MyPassiveContFact, 0);   // Factory for all Passive parameter containers
 };
 
 #endif /* !PNDPASSIVECONTFACT_H */

--- a/templates/project_stl_containers/passive/MyPipe.h
+++ b/templates/project_stl_containers/passive/MyPipe.h
@@ -31,7 +31,7 @@ class MyPipe : public FairModule
     MyPipe(const MyPipe&);
     MyPipe& operator=(const MyPipe&);
 
-    ClassDef(MyPipe, 1)   // MyPIPE
+    ClassDef(MyPipe, 1);   // MyPIPE
 };
 
 #endif   // PIPE_H

--- a/trackbase/FairPropagator.h
+++ b/trackbase/FairPropagator.h
@@ -124,7 +124,7 @@ class FairPropagator : public TNamed
         return PCAOutputStruct();
     }
 
-    ClassDef(FairPropagator, 1)
+    ClassDef(FairPropagator, 1);
 };
 
 #endif


### PR DESCRIPTION
`ClassDef` also should have a semicolon at the end, otherwise formatter will get lost in the following code.

Didn't see this in the first run because only few classes have code after `ClassDef`.
