### PR TITLE
Fix for building with Geant 10.6.x:

### DIFF
--- a/base/sim/fastsim/CMakeLists.txt
+++ b/base/sim/fastsim/CMakeLists.txt
@@ -33,12 +33,19 @@ target_link_directories(${target} PUBLIC
   ${ROOT_LIBRARY_DIR}
 )
 
+# Geant4 uses namespace since 10.5
+if(${Geant4_VERSION} VERSION_LESS "10.6")
+  set(targetG4processes G4processes)
+else()
+  set(targetG4processes Geant4::G4processes)
+endif()
+
 target_link_libraries(${target} PUBLIC
   FairRoot::FairTools
   FairRoot::Base # FairDetector,
   FairRoot::GeoBase
 
-  G4processes
+  ${targetG4processes}
   geant4vmc
 
   Geom # TGeoManager


### PR DESCRIPTION
Take into account the namespace in Geant4 libraries targets in fastsim/CMakeLists.txt

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [ ] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
