### PR TITLE
Suppress the warning on usage of depracated function

### DIFF
--- a/base/sim/FairModule.cxx
+++ b/base/sim/FairModule.cxx
@@ -560,7 +560,10 @@ Bool_t FairModule::IsSensitive(const std::string& name)
 {
     //    LOG(warn) << "Implement IsSensitive in the detector class which inherits from FairModule";
     //    LOG(warn) << "For now calling the obsolete function CheckIfSensitive";
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     return CheckIfSensitive(name);
+#pragma GCC diagnostic pop
 }
 
 void FairModule::ExpandNode(TGeoNode* fN)


### PR DESCRIPTION
Till the replacement of the CheckIfSensitive function with IsSensitive
in the daughter projects, we have to call the CheckIfSensitive depracated
function.

Addresses issue #973.

--

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
