### PR TITLE
Fix the null fSource ptr in FRM::InitObjectAs

### DIFF
--- a/base/steer/FairRootManager.h
+++ b/base/steer/FairRootManager.h
@@ -484,6 +484,10 @@ TPtr FairRootManager::InitObjectAs(const char* brname)
     if (obj != nullptr)
         return *obj;
 
+    if (!fSource) {
+        return nullptr;
+    }
+
     // it does not seem to be the case, let us create the pointer which will be initialized
     // with the data (pointer to T)
     T** addr = new T*;


### PR DESCRIPTION
Addresses the issue #983.

---

Checklist:

[ X ] Rebased against `dev` branch
[ X ] My name is in the resp. CONTRIBUTORS/AUTHORS file
[ X ] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
