### PR TITLE
Add missing includes for ROOT 6.22

### DIFF
--- a/base/event/FairPrintFairLinks.h
+++ b/base/event/FairPrintFairLinks.h
@@ -14,6 +14,7 @@
 
 // framework includes
 #include "FairTask.h"
+#include "TObjString.h"
 
 #include <map>
 

--- a/fairtools/MCStepLogger/MCStepLoggerImpl.cxx
+++ b/fairtools/MCStepLogger/MCStepLoggerImpl.cxx
@@ -40,6 +40,7 @@
 #include <iostream>
 #include <map>
 #include <set>
+#include <sstream>
 #include <utility>   // for pair
 #ifdef NDEBUG
 #undef NDEBUG


### PR DESCRIPTION
ROOT 6.22 removes some unneeded includes in its headers. This results in FairRoot missing some includes, which are added explicitly in this commit/PR.

Adding these headers fixes the build with ROOT 6.22 and should not result in any changes for ROOT <6.22 due to the include guards.

Please let me know if you have any comments or would like me to make any changes.

---

Checklist:

* [x] Rebased against `dev` branch
* [ ] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [ ] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
