### PR TITLE
Serialization example tests: setup environment

### DIFF
--- a/examples/MQ/serialization/1-simple/testSerializationEx1.sh.in
+++ b/examples/MQ/serialization/1-simple/testSerializationEx1.sh.in
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source @CMAKE_BINARY_DIR@/config.sh -p
+
 trap 'kill -TERM $GENERATE_PID; kill -TERM $SAMPLER_PID; kill -TERM $PROCESSOR1_PID; kill -TERM $FILESINK_PID; wait $GENERATE_PID; wait $SAMPLER_PID; wait $PROCESSOR1_PID; wait $FILESINK_PID;' TERM
 
 INPUTFILE="@CMAKE_CURRENT_BINARY_DIR@/data_io/testinput1.root"

--- a/examples/MQ/serialization/2-multipart/testSerializationEx2.sh.in
+++ b/examples/MQ/serialization/2-multipart/testSerializationEx2.sh.in
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source @CMAKE_BINARY_DIR@/config.sh -p
+
 trap 'kill -TERM $GENERATE_PID; kill -TERM $SAMPLER_PID; kill -TERM $PROCESSOR1_PID; kill -TERM $FILESINK_PID; wait $GENERATE_PID; wait $SAMPLER_PID; wait $PROCESSOR1_PID; wait $FILESINK_PID;' TERM
 
 INPUTFILE="@CMAKE_CURRENT_BINARY_DIR@/data_io/testinput2.root"


### PR DESCRIPTION
Some devices fail without a proper environment setup when accessing ROOT objects.

See https://github.com/FairRootGroup/FairSoft/pull/238.