### PR TITLE
Fix the bug in FairIon::SetMass function

### DIFF
--- a/base/sim/FairIon.cxx
+++ b/base/sim/FairIon.cxx
@@ -15,8 +15,6 @@
 #include <TDatabasePDG.h>
 #include <TParticlePDG.h>
 
-const Double_t FairIon::amu = 0.931494028;   // Gev/c**2
-
 FairIon::FairIon()
     : TNamed()
     , fZ(0)

--- a/base/sim/FairIon.h
+++ b/base/sim/FairIon.h
@@ -83,9 +83,13 @@ class FairIon : public TNamed
      */
     void SetExcEnergy(Double_t eExc) { fExcEnergy = eExc; }
     /**
+     * Set the atomic mass, use SetMass to set the mass of the ion
+     */
+    void SetA(Int_t a) { fA = a; }
+    /**
      * Set the mass in GeV
      */
-    void SetMass(Double_t mass) { fMass = mass * amu; }
+    void SetMass(Double_t mass) { fMass = mass; }
 
   private:
     static Int_t fgNIon;         //! /// Number of ions instantiated. One per generator.
@@ -95,7 +99,6 @@ class FairIon : public TNamed
     Double_t fExcEnergy;         /// Excitation energy [GeV]
     Double_t fMass;              /// Mass [GeV]
     FairLogger* fLogger;         //! /// FairLogger
-    static const Double_t amu;   ///  .931494028 Gev/c**2
 
     FairIon(const FairIon&);
     FairIon& operator=(const FairIon&);


### PR DESCRIPTION
FairIon::SetA()    - set the atomic mass of the ion, to set the mass use SetMass()
FairIon::SetMass() - set the mass of the ion in GeV/c2

The buggy version had SetMass() that scaled the value with AMU before setting the mass.
Removed the amu constant from the class completely.

Addresses the issue #1007.

---

Checklist:

[ X ] Rebased against `dev` branch
[ X ] My name is in the resp. CONTRIBUTORS/AUTHORS file
[ X ] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
