### PR TITLE
Fix cmake for external CLHEP

### DIFF
--- a/cmake/modules/FindGeant4.cmake
+++ b/cmake/modules/FindGeant4.cmake
@@ -22,6 +22,7 @@ if(Geant4_FOUND AND Geant4_INCLUDE_DIRS AND Geant4_VERSION VERSION_LESS "10.6")
     endif()
   endforeach()
   if(TARGET CLHEP::CLHEP AND TARGET G4global AND Geant4_system_clhep_FOUND)
-    set_target_properties(G4global INTERFACE_LINK_LIBRARIES CLHEP::CLHEP)
+    set_property(TARGET G4global APPEND PROPERTY
+                 INTERFACE_LINK_LIBRARIES CLHEP::CLHEP)
   endif()
 endif()


### PR DESCRIPTION
Replace set_target_properties syntax that doesn't seem to work on many platforms with `set_property(TARGET … APPEND PROPERTY …)` which seems to work better.

Fixes: https://cdash.gsi.de/testDetails.php?test=7336361&build=250931

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
