### PR TITLE
CMake: Refine condition for yaml-cpp workaround

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,11 +272,15 @@ set(PROJECT_LIBRARY_PROPERTIES ${FAIRROOT_LIBRARY_PROPERTIES})
 
 find_package2(PUBLIC yaml-cpp)
 # Workaround missing exported include directories
-# Upstream has fixed this in https://github.com/jbeder/yaml-cpp/commit/ab5f9259a4e67d3fe0e4832bd407a9e596e2d884
-# Once an upstream release includes the fix above, adapt the following condition accordingly
-# if(yaml-cpp_FOUND AND TARGET yaml-cpp AND YAML_CPP_INCLUDE_DIR AND yaml-cpp_VERSION VERSION_LESS 0.6.2)
-if(yaml-cpp_FOUND AND TARGET yaml-cpp AND YAML_CPP_INCLUDE_DIR)
-  get_filename_component(YAML_CPP_INCLUDE_DIR "${YAML_CPP_INCLUDE_DIR}" ABSOLUTE)
+# Upstream has fixed this in https://github.com/jbeder/yaml-cpp/commit/ab5f9259a4e67d3fe0e4832bd407a9e596e2d884 (since 0.6.3)
+if(yaml-cpp_FOUND)
+  get_filename_component(YAML_CPP_INCLUDE_DIR "${YAML_CPP_INCLUDE_DIR}" REALPATH BASE_DIR "/")
+endif()
+if(    yaml-cpp_FOUND
+   AND TARGET yaml-cpp
+   AND EXISTS YAML_CPP_INCLUDE_DIR
+   AND yaml-cpp_VERSION VERSION_LESS 0.6.3
+)
   set_target_properties(yaml-cpp PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "${YAML_CPP_INCLUDE_DIR}"
   )


### PR DESCRIPTION
* Check if added include path exists, there is packaging bug in
Debian/Ubuntu, see https://bugs.launchpad.net/ubuntu/+source/yaml-cpp/+bug/1880419
* Limit workaround application up to and including version 0.6.2