### PR TITLE
Fix time setting for EventHeader in FairFileSource

### DIFF
--- a/base/source/FairFileSource.cxx
+++ b/base/source/FairFileSource.cxx
@@ -804,7 +804,7 @@ void FairFileSource::ReadBranchEvent(const char* BrName, Int_t Entry)
 
 void FairFileSource::FillEventHeader(FairEventHeader* feh)
 {
-    feh->SetEventTime(fEventTime);
+    feh->SetEventTime(GetEventTime());
     if (fEvtHeader) {
         feh->SetRunId(fEvtHeader->GetRunId());
         feh->SetMCEntryNumber(fEvtHeader->GetMCEntryNumber());


### PR DESCRIPTION
Fixes the wrong event time setting in the FairFileSource.
This merge request is connected to the issue #1023

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
