### PR TITLE
Fix for the missing magnetic field in the event display

### DIFF
--- a/examples/advanced/Tutorial3/CMakeLists.txt
+++ b/examples/advanced/Tutorial3/CMakeLists.txt
@@ -22,6 +22,7 @@ set(sources
 
   simulation/FairConstField.cxx
   simulation/FairConstPar.cxx
+  simulation/FairConstFieldCreator.cxx
   simulation/FairMapPar.cxx
   simulation/FairTestDetector.cxx
   simulation/FairTestDetectorContFact.cxx

--- a/examples/advanced/Tutorial3/FairTestDetectorLinkDef.h
+++ b/examples/advanced/Tutorial3/FairTestDetectorLinkDef.h
@@ -23,6 +23,7 @@
 #pragma link C++ class FairTestDetectorRecoTask+;
 #pragma link C++ class FairConstField+;
 #pragma link C++ class FairConstPar+;
+#pragma link C++ class FairConstFieldCreator+;
 #pragma link C++ class FairMapPar+;
 #pragma link C++ class FairTestDetectorDigiWriteoutBuffer+;
 #pragma link C++ class FairTestDetectorTimeDigiTask+;

--- a/examples/advanced/Tutorial3/simulation/FairConstFieldCreator.cxx
+++ b/examples/advanced/Tutorial3/simulation/FairConstFieldCreator.cxx
@@ -1,0 +1,63 @@
+/********************************************************************************
+ *    Copyright (C) 2020 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+// -------------------------------------------------------------------------
+// -----                FairConstFieldCreator header file              -----
+// -----                Created 12/11/2020  by R. Karabowicz           -----
+// -------------------------------------------------------------------------
+
+#include "FairConstFieldCreator.h"
+
+#include "FairConstField.h"
+#include "FairConstPar.h"
+#include "FairField.h"
+#include "FairLogger.h"
+#include "FairRunAna.h"
+#include "FairRuntimeDb.h"
+
+static FairConstFieldCreator gFairConstFieldCreator;
+
+FairConstFieldCreator::FairConstFieldCreator()
+    : FairFieldFactory()
+    , fFieldPar(NULL)
+{
+    fCreator = this;
+}
+
+FairConstFieldCreator::~FairConstFieldCreator() {}
+
+void FairConstFieldCreator::SetParm()
+{
+    FairRunAna *Run = FairRunAna::Instance();
+    FairRuntimeDb *RunDB = Run->GetRuntimeDb();
+    fFieldPar = (FairConstPar *)RunDB->getContainer("FairConstPar");
+}
+
+FairField *FairConstFieldCreator::createFairField()
+{
+    FairField *fMagneticField = 0;
+
+    if (!fFieldPar) {
+        LOG(error) << "No field parameters available!";
+    } else {
+        // Instantiate correct field type
+        Int_t fType = fFieldPar->GetType();
+        if (fType == 0)
+            fMagneticField = new FairConstField(fFieldPar);
+        else
+            LOG(warning) << "FairRunAna::GetField: Unknown field type " << fType;
+        LOG(info) << "New field at " << fMagneticField << ", type " << fType;
+        // Initialise field
+        if (fMagneticField) {
+            fMagneticField->Init();
+            fMagneticField->Print("");
+        }
+    }
+    return fMagneticField;
+}
+
+ClassImp(FairConstFieldCreator);

--- a/examples/advanced/Tutorial3/simulation/FairConstFieldCreator.h
+++ b/examples/advanced/Tutorial3/simulation/FairConstFieldCreator.h
@@ -1,0 +1,40 @@
+/********************************************************************************
+ *    Copyright (C) 2020 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+// -------------------------------------------------------------------------
+// -----                FairConstFieldCreator header file              -----
+// -----                Created 12/11/2020  by R. Karabowicz           -----
+// -------------------------------------------------------------------------
+
+#ifndef FairConstFieldCreator_H
+#define FairConstFieldCreator_H
+
+#include "FairFieldFactory.h"
+
+class FairConstPar;
+
+class FairField;
+
+class FairConstFieldCreator : public FairFieldFactory
+{
+
+  public:
+    FairConstFieldCreator();
+    virtual ~FairConstFieldCreator();
+    virtual FairField* createFairField();
+    virtual void SetParm();
+    ClassDef(FairConstFieldCreator, 1);
+
+  protected:
+    FairConstPar* fFieldPar;
+
+  private:
+    FairConstFieldCreator(const FairConstFieldCreator&);
+    FairConstFieldCreator& operator=(const FairConstFieldCreator&);
+};
+#endif   // FairConstFieldCreator_H

--- a/examples/common/eventdisplay/FairEveMCTracks.cxx
+++ b/examples/common/eventdisplay/FairEveMCTracks.cxx
@@ -13,24 +13,26 @@
  *		E-mail: daniel.wielanek@gmail.com
  *		Warsaw University of Technology, Faculty of Physics
  */
- #include "FairEveMCTracks.h"
- #include <TClonesArray.h>       // for TClonesArray
- #include <TDatabasePDG.h>       // for TDatabasePDG
- #include <TEveManager.h>        // for TEveManager, gEve
- #include <TEveTrack.h>          // for TEveTrackList
- #include <TLorentzVector.h>     // for TLorentzVector
- #include <TParticle.h>          // for TParticle
- #include <TParticlePDG.h>       // for TParticlePDG
- #include <TString.h>            // for Form
- #include <TVector3.h>           // for TVector3
- #include <fairlogger/Logger.h>  // for LOG
- #include "FairEveTrack.h"       // for FairEveTrack
- #include "FairEventManager.h"   // for FairEventManager
- #include "FairField.h"          // for FairField
- #include "FairMCTrack.h"        // for FairMCTrack
- #include "FairRKPropagator.h"   // for FairRKPropagator
- #include "FairRootManager.h"    // for FairRootManager
- #include "FairRunAna.h"         // for FairRunAna
+#include "FairEveMCTracks.h"
+
+#include "FairEveTrack.h"       // for FairEveTrack
+#include "FairEventManager.h"   // for FairEventManager
+#include "FairField.h"          // for FairField
+#include "FairMCTrack.h"        // for FairMCTrack
+#include "FairRKPropagator.h"   // for FairRKPropagator
+#include "FairRootManager.h"    // for FairRootManager
+#include "FairRunAna.h"         // for FairRunAna
+
+#include <TClonesArray.h>        // for TClonesArray
+#include <TDatabasePDG.h>        // for TDatabasePDG
+#include <TEveManager.h>         // for TEveManager, gEve
+#include <TEveTrack.h>           // for TEveTrackList
+#include <TLorentzVector.h>      // for TLorentzVector
+#include <TParticle.h>           // for TParticle
+#include <TParticlePDG.h>        // for TParticlePDG
+#include <TString.h>             // for Form
+#include <TVector3.h>            // for TVector3
+#include <fairlogger/Logger.h>   // for LOG
 
 FairEveMCTracks::FairEveMCTracks()
     : FairEveTracks(kFALSE)
@@ -83,6 +85,9 @@ Bool_t FairEveMCTracks::CheckCuts(FairMCTrack *tr)
 
 void FairEveMCTracks::DrawTrack(Int_t id)
 {
+    if (!fRK)
+        return;
+
     FairMCTrack *tr = (FairMCTrack *)fContainer->UncheckedAt(id);
     if (!CheckCuts(tr))
         return;
@@ -151,9 +156,9 @@ InitStatus FairEveMCTracks::Init()
     FairField *field = ana->GetField();
     if (field == nullptr) {
         LOG(ERROR) << "Lack of magnetic field map!";
-        field = new FairField();
+    } else {
+        fRK = new FairRKPropagator(field);
     }
-    fRK = new FairRKPropagator(field);
     fPDG = TDatabasePDG::Instance();
     return FairEveTracks::Init();
 }


### PR DESCRIPTION
When no magnetic field available from FairRunAna, the event
display crashes when drawing events.
Small fix in FairEveMCTracks fixes the issue - it will not exptrapolate tracks when no magnetic field.

Introduce the FairFieldCreator in the Tutorial3 advanced example,
which allows FairRunAna to retrieve magnetic field from the parameter file.

---

Checklist:

[ X ] Rebased against `dev` branch
[ X ] My name is in the resp. CONTRIBUTORS/AUTHORS file
[ X ] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
