### PR TITLE
Add initial codemeta.json

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,7 +1,7 @@
 Al-Turany, Mohammad [https://orcid.org/0000-0002-8071-4497]
 Karabowicz, Radoslaw
 Klein, Dennis [https://orcid.org/0000-0003-3787-1910]
-Kresan, Dmytro
+Kresan, Dmytro [https://orcid.org/0000-0002-7537-2875]
 Rybalchenko, Alexey
 Tacke, Christian [https://orcid.org/0000-0002-5321-8404]
 Uhlig, Florian

--- a/codemeta.json
+++ b/codemeta.json
@@ -1,0 +1,51 @@
+{
+    "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
+    "@type": "SoftwareSourceCode",
+    "name": "FairRoot",
+    "description": "<p>A simulation, reconstruction and analysis framework that is based on the ROOT system. The user can create simulated data and/or perform analysis with the same framework. Geant3 and Geant4 transport engines are supported, however the user code that creates simulated data do not depend on a particular monte carlo engine. The framework delivers base classes which enable the users to construct their detectors and /or analysis tasks in a simple way, it also delivers some general functionality like track visualization. Moreover an interface for reading magnetic field maps is also implemented.</p>",
+    "license": "https://spdx.org/licenses/LGPL-3.0-only",
+    "version": "v18.2.1",
+    "datePublished": "2012-05-25",
+    "keywords": [
+        "geant4",
+        "c-plus-plus",
+        "cmake",
+        "reconstruction",
+        "vmc",
+        "modular",
+        "analysis",
+        "simulation"
+    ],
+    "contributor": [
+        {
+            "@type": "Person",
+            "familyName": "Al-Turany",
+            "givenName": "Mohammad"
+        },
+        {
+            "@type": "Person",
+            "familyName": "Karabowicz",
+            "givenName": "Radoslaw"
+        },
+        {
+            "@type": "Person",
+            "familyName": "Klein",
+            "givenName": "Dennis"
+        },
+        {
+            "@type": "Person",
+            "familyName": "Kresan",
+            "givenName": "Dmytro"
+        },
+        {
+            "@type": "Person",
+            "familyName": "Rybalchenko",
+            "givenName": "Alexey"
+        },
+        {
+            "@type": "Person",
+            "familyName": "Uhlig",
+            "givenName": "Florian"
+        }
+    ]
+}


### PR DESCRIPTION
codemeta.json is becoming a standard format for describing software. Let's start to add it.

This is also starting to get relevant in the context of ESCAPE.

I created the current codemeta.json to match the entry on zenodo as closely as possible. That means, that any issues with the zenodo entry are also issues with the codemeta data.

Helpful:
* There is a codemeta generator/viewer: https://codemeta.github.io/codemeta-generator/
  You can even paste the suggested codemeta.json there and view it.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
