### PR TITLE
Implement the gConfig PostInit

### DIFF
--- a/base/sim/FairGenericVMCConfig.h
+++ b/base/sim/FairGenericVMCConfig.h
@@ -10,6 +10,8 @@
 // -----            Created 2019.02.19 by R. Karabowicz                -----
 // -------------------------------------------------------------------------
 
+#include <string>   // for string
+
 #ifndef FAIR_GENERIC_VMC_CONFIG_H
 #define FAIR_GENERIC_VMC_CONFIG_H
 
@@ -20,6 +22,17 @@ class FairGenericVMCConfig
     virtual ~FairGenericVMCConfig();
 
     virtual void Setup(const char* mcEngine);
+    virtual void SetupPostInit(const char* mcEngine);
+
+    virtual void UsePostInitConfig(bool useC = true, const char* stringC = "g4ConfigPostInit.C")
+    {
+        fPostInitFlag = useC;
+        fPostInitName = stringC;
+    }
+
+  protected:
+    bool fPostInitFlag;
+    std::string fPostInitName;
 };
 
 #endif

--- a/base/steer/FairRunSim.cxx
+++ b/base/steer/FairRunSim.cxx
@@ -295,6 +295,12 @@ void FairRunSim::SetMCConfig()
     }
 
     fApp->InitMC("foo", "bar");
+
+    if (fUseSimSetupFunction) {
+        fSimSetupPostInit();
+    } else {
+        fSimulationConfig->SetupPostInit(GetName());
+    }
 }
 
 void FairRunSim::Run(Int_t NEvents, Int_t) { fApp->RunMC(NEvents); }

--- a/base/steer/FairRunSim.h
+++ b/base/steer/FairRunSim.h
@@ -172,6 +172,11 @@ class FairRunSim : public FairRun
         fSimSetup = f;
         fUseSimSetupFunction = true;
     }
+    void SetSimSetupPostInit(std::function<void()> f)
+    {
+        fSimSetupPostInit = f;
+        fUseSimSetupPostInitFunction = true;
+    }
 
     void SetSimulationConfig(FairGenericVMCConfig* tconf) { fSimulationConfig = tconf; }
     FairGenericVMCConfig* GetSimulationConfig() { return fSimulationConfig; }
@@ -221,6 +226,9 @@ class FairRunSim : public FairRun
     std::function<void()> fSimSetup;   //!                          /** A user provided function to do sim setup /
                                        //!                          instead of using macros **/
     bool fUseSimSetupFunction = false;
+    std::function<void()> fSimSetupPostInit;   //!                          /** A user provided function to do sim setup
+                                               //!                          / instead of using macros **/
+    bool fUseSimSetupPostInitFunction = false;
     FairGenericVMCConfig* fSimulationConfig;   //!                 /** Simulation configuration */
 
     ClassDef(FairRunSim, 2);

--- a/examples/common/gconfig/g4ConfigPostInit.C
+++ b/examples/common/gconfig/g4ConfigPostInit.C
@@ -1,0 +1,18 @@
+/********************************************************************************
+ *    Copyright (C) 2021 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+// Configuration macro for Geant4 VirtualMC PostInit
+void ConfigPostInit()
+{
+    TString configm(gSystem->Getenv("VMCWORKDIR"));
+    TString configm1 = configm + "/common/gconfig/g4configPostInit.in";
+    cout << " -I g4ConfigPostInit() using g4conf  macro: " << configm1 << endl;
+
+    // set geant4 specific stuff
+    TGeant4 *geant4 = (TGeant4*)(TVirtualMC::GetMC());
+    geant4->ProcessGeantMacro(configm1.Data());
+}

--- a/examples/common/gconfig/g4ConfigPostInit.yaml
+++ b/examples/common/gconfig/g4ConfigPostInit.yaml
@@ -1,0 +1,9 @@
+################################################################################
+#    Copyright (C) 2021 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    #
+#                                                                              #
+#              This software is distributed under the terms of the             #
+#              GNU Lesser General Public Licence (LGPL) version 3,             #
+#                  copied verbatim in the file "LICENSE"                       #
+################################################################################
+Geant4_PostInit_Commands:
+ - /tracking/verbose 1

--- a/examples/common/gconfig/g4configPostInit.in
+++ b/examples/common/gconfig/g4configPostInit.in
@@ -1,0 +1,15 @@
+################################################################################
+#    Copyright (C) 2021 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    #
+#                                                                              #
+#              This software is distributed under the terms of the             #
+#              GNU Lesser General Public Licence (LGPL) version 3,             #
+#                  copied verbatim in the file "LICENSE"                       #
+################################################################################
+# Created by Radoslaw Karabowicz
+# on 15.02.2021
+# based on:
+# Geant4 configuration macro for Example06 
+
+# Tracking verbosity may be set in standard config.
+# Here only for demonstration
+/tracking/verbose 1

--- a/examples/simulation/Tutorial1/macros/run_tutorial1.C
+++ b/examples/simulation/Tutorial1/macros/run_tutorial1.C
@@ -62,7 +62,9 @@ void run_tutorial1(Int_t nEvents = 10, TString mcEngine = "TGeant3", Bool_t isMT
     // -----   Create simulation run   ----------------------------------------
     FairRunSim* run = new FairRunSim();
     run->SetName(mcEngine);   // Transport engine
-    //  run->SetSimulationConfig(new FairVMCConfig());
+    FairGenericVMCConfig* config = new FairGenericVMCConfig();
+    //config->UsePostInitConfig();
+    run->SetSimulationConfig(config);
     run->SetIsMT(isMT);                            // Multi-threading mode (Geant4 only)
     run->SetSink(new FairRootFileSink(outFile));   // Output file
     FairRuntimeDb* rtdb = run->GetRuntimeDb();

--- a/fairtools/MCConfigurator/FairYamlVMCConfig.h
+++ b/fairtools/MCConfigurator/FairYamlVMCConfig.h
@@ -15,9 +15,10 @@
 
 #include "FairGenericVMCConfig.h"
 
+#include <string>
 #include <yaml-cpp/yaml.h>
 
-class TString;
+using namespace std;
 
 class FairYamlVMCConfig : public FairGenericVMCConfig
 {
@@ -26,10 +27,19 @@ class FairYamlVMCConfig : public FairGenericVMCConfig
     virtual ~FairYamlVMCConfig() {}
 
     virtual void Setup(const char* mcEngine);
+    virtual void SetupPostInit(const char* mcEngine);
+
+    virtual void UsePostInitConfig(bool useC = true, const char* stringC = "g4ConfigPostInit.yaml") {
+        fPostInitFlag = useC;
+        fPostInitName = stringC;
+    }
+
 
   private:
-    TString ObtainYamlFileName(const char* mcEngine);
+    string ObtainYamlFileName(const char* mcEngine);
     void StoreYamlInfo();
+
+    string fMCEngine;
 
   protected:
     void SetupGeant3();
@@ -38,6 +48,7 @@ class FairYamlVMCConfig : public FairGenericVMCConfig
     void SetCuts();
 
     YAML::Node fYamlConfig;
+    YAML::Node fYamlConfigPostInit;
 };
 
 #endif

--- a/trackbase/FairRKPropagator.cxx
+++ b/trackbase/FairRKPropagator.cxx
@@ -5,21 +5,22 @@
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
- #include "FairRKPropagator.h"
- #include <TGenericClassInfo.h>  // for TGenericClassInfo
- #include <TParticlePDG.h>       // for TParticlePDG
- #include <fairlogger/Logger.h>  // for LOG
- #include <math.h>               // for sqrt
- #include <stdio.h>              // for printf
- #include <stdlib.h>             // for abs
- #include "FairField.h"          // for FairField
- #include "FairTrackParH.h"      // for FairTrackParH
- #include "FairTrackParP.h"      // for FairTrackParP
- #include "TDatabasePDG.h"       // for TDatabasePDG
- #include "TMath.h"              // for Sqrt
- #include "TMathBase.h"          // for Abs
- #include "TVector3.h"           // for TVector3, operator-, operator*
+#include "FairRKPropagator.h"
 
+#include "FairField.h"       // for FairField
+#include "FairTrackParH.h"   // for FairTrackParH
+#include "FairTrackParP.h"   // for FairTrackParP
+#include "TDatabasePDG.h"    // for TDatabasePDG
+#include "TMath.h"           // for Sqrt
+#include "TMathBase.h"       // for Abs
+#include "TVector3.h"        // for TVector3, operator-, operator*
+
+#include <TGenericClassInfo.h>   // for TGenericClassInfo
+#include <TParticlePDG.h>        // for TParticlePDG
+#include <fairlogger/Logger.h>   // for LOG
+#include <math.h>                // for sqrt
+#include <stdio.h>               // for printf
+#include <stdlib.h>              // for abs
 
 ClassImp(FairRKPropagator);
 

--- a/trackbase/FairRKPropagator.h
+++ b/trackbase/FairRKPropagator.h
@@ -14,13 +14,14 @@
 
 #ifndef RKPropagator
 #define RKPropagator
-#include <Rtypes.h>          // for THashConsistencyHolder, ClassDef
-#include <TVector3.h>        // for TVector3
-#include <iosfwd>            // for string
-#include "FairPropagator.h"  // for FairPropagator, PCAOutputStruct
-class FairField;  // lines 20-20
+#include "FairPropagator.h"   // for FairPropagator, PCAOutputStruct
+
+#include <Rtypes.h>     // for THashConsistencyHolder, ClassDef
+#include <TVector3.h>   // for TVector3
+#include <iosfwd>       // for string
+class FairField;        // lines 20-20
 class FairTrackParH;
-class FairTrackParP;  // lines 21-21
+class FairTrackParP;   // lines 21-21
 class TBuffer;
 class TClass;
 class TMemberInspector;


### PR DESCRIPTION
Introduce the gConfig PostInit in the configuration of MC simulation.
Added both the old implementation with the C macro and .in file,
as well as the new one based on yaml.

This change is triggered by the introduction of setup flags
in G4_VMC which can only be set after initilization.

It addresses the issue #1031.

---

Checklist:

[ X ] Rebased against `dev` branch
[ X ] My name is in the resp. CONTRIBUTORS/AUTHORS file
[ X ] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
