### PR TITLE
Use correct flag for post init configuration

### DIFF
--- a/base/steer/FairRunSim.cxx
+++ b/base/steer/FairRunSim.cxx
@@ -296,10 +296,12 @@ void FairRunSim::SetMCConfig()
 
     fApp->InitMC("foo", "bar");
 
-    if (fUseSimSetupFunction) {
+    if (fUseSimSetupPostInitFunction) {
         fSimSetupPostInit();
     } else {
-        fSimulationConfig->SetupPostInit(GetName());
+        if (fSimulationConfig != nullptr) {
+            fSimulationConfig->SetupPostInit(GetName());
+        }
     }
 }
 


### PR DESCRIPTION
Also check if there is really a function bound.

Fixes #1041 .

The fix has also to be ported to the v18.6_patches branch. 
---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
