### PR TITLE
Calm `strncpy` Warnings in MbsApi

### DIFF
--- a/MbsAPI/fLmd.c
+++ b/MbsAPI/fLmd.c
@@ -106,6 +106,22 @@ lmdoff_t fLmdOffsetGet(sLmdControl*, uint32_t);
 void fLmdOffsetElements(sLmdControl*, uint32_t, uint32_t*, uint32_t*);
 #define OFFSET__ENTRIES 250000
 
+/**
+ * Internal Helper functions
+ */
+static void _fLmd_set_cFile(sLmdControl* pLmdControl, const char* Filename)
+{
+    int snp_res;
+
+    if ((pLmdControl == NULL) || (Filename == NULL)) {
+        return;
+    }
+    snp_res = snprintf(pLmdControl->cFile, sizeof(pLmdControl->cFile), "%s", Filename);
+    if ((snp_res < 0) || (snp_res >= sizeof(pLmdControl->cFile))) {
+        printf("Filename %s too long!", Filename);
+    }
+}
+
 //===============================================================
 uint32_t fLmdPutOpen(sLmdControl* pLmdControl,
                      char* Filename,
@@ -137,12 +153,7 @@ uint32_t fLmdPutOpen(sLmdControl* pLmdControl,
 
     pLmdControl->pMbsFileHeader->iType = LMD__TYPE_FILE_HEADER_101_1;
     pLmdControl->pMbsFileHeader->iEndian = 1;
-    size_t len = strlen(Filename);
-    if (len < sizeof(pLmdControl->cFile)) {
-        strncpy(pLmdControl->cFile, Filename, len);
-    } else {
-        strncpy(pLmdControl->cFile, Filename, sizeof(pLmdControl->cFile) - 1);
-    }
+    _fLmd_set_cFile(pLmdControl, Filename);
     // optionally allocate buffer
     if (iBytes > 0) {
         pLmdControl->pBuffer = (int16_t*)malloc(iBytes);
@@ -386,12 +397,7 @@ uint32_t fLmdConnectMbs(sLmdControl* pLmdControl,
         fLmdCleanup(pLmdControl);
         return (LMD__FAILURE);
     }
-    size_t len = strlen(Nodename);
-    if (len < sizeof(pLmdControl->cFile)) {
-        strncpy(pLmdControl->cFile, Nodename, len);
-    } else {
-        strncpy(pLmdControl->cFile, Nodename, sizeof(pLmdControl->cFile) - 1);
-    }
+    _fLmd_set_cFile(pLmdControl, Nodename);
     if (iBufferBytes == LMD__GET_EVENTS) {   // use internal buffer for fLmdGetMbsEvent
         pLmdControl->pBuffer = (int16_t*)malloc(sMbs.iMaxBytes);
         pLmdControl->iBufferWords = sMbs.iMaxBytes / 2;
@@ -422,12 +428,7 @@ uint32_t fLmdInitMbs(sLmdControl* pLmdControl,
         return (LMD__FAILURE);
     }
     pLmdControl->iPort = iPort;
-    size_t len = strlen(Nodename);
-    if (len < sizeof(pLmdControl->cFile)) {
-        strncpy(pLmdControl->cFile, Nodename, len);
-    } else {
-        strncpy(pLmdControl->cFile, Nodename, sizeof(pLmdControl->cFile) - 1);
-    }
+    _fLmd_set_cFile(pLmdControl, Nodename);
     if (pLmdControl->pBuffer == NULL) {
         pLmdControl->pBuffer = (int16_t*)malloc(iMaxBytes);
     }
@@ -585,12 +586,7 @@ uint32_t fLmdGetOpen(sLmdControl* pLmdControl,
     memset(pLmdControl->pMbsFileHeader, 0, sizeof(sMbsFileHeader));
 
     // copy file name to control structure
-    size_t len = strlen(Filename);
-    if (len < sizeof(pLmdControl->cFile)) {
-        strncpy(pLmdControl->cFile, Filename, len);
-    } else {
-        strncpy(pLmdControl->cFile, Filename, sizeof(pLmdControl->cFile) - 1);
-    }
+    _fLmd_set_cFile(pLmdControl, Filename);
     if ((pLmdControl->fFile = (FILE*)fopen64(Filename, "r")) == NULL) {
         printf("fLmdGetOpen: File not found: %s\n", Filename);
         fLmdCleanup(pLmdControl);

--- a/MbsAPI/f_evt.c
+++ b/MbsAPI/f_evt.c
@@ -1350,12 +1350,7 @@ INTS4 f_evt_put_open(CHARS* pc_file,
         exit(2);
     }
 
-    size_t len = strlen(pc_file);
-    if (len < sizeof(c_file)) {
-        strncpy(c_file, pc_file, len);
-    } else {
-        strncpy(c_file, pc_file, sizeof(c_file) - 1);
-    }
+    snprintf(c_file, sizeof(c_file), "%s", pc_file);
     if (strlen(c_file) < 5) {
         strcat(c_file, ".lmd");
     } else {
@@ -1393,13 +1388,7 @@ INTS4 f_evt_put_open(CHARS* pc_file,
             strcpy(ps_file_head->filhe_file, c_file);
             char* username = getenv("USER");
             if (username) {
-                size_t len = strlen(username);
-                // maximum length for user array in s_filhe is 30
-                if (len < sizeof(ps_file_head->filhe_user)) {
-                    strncpy(ps_file_head->filhe_user, username, len); /* user name */
-                } else {
-                    strncpy(ps_file_head->filhe_user, username, sizeof(ps_file_head->filhe_user) - 1); /* user name */
-                }
+                snprintf(ps_file_head->filhe_user, sizeof(ps_file_head->filhe_user), "%s", username);
             }
             ps_file_head->filhe_user_l = strlen(ps_file_head->filhe_user);
 


### PR DESCRIPTION
`strncpy()` is a really bad API for copying strings over. For example it always pads the destination with NUL bytes. But does not NUL terminate in case of overflow. See first stackoverflow link.

The nicest alternative to `strncpy` is `strlcpy`.  But that one is not portable.  The second simplest one is using `snprintf()`.  Yes, this feels like overkill. But it's really the by far most readable solution. So unless performance is highly critical (in which case you shouldn't be using `strncpy` anyway, as it pads!), `snprintf` should be fine.

Fixes: #1052
See: https://stackoverflow.com/questions/2114896/why-are-strlcpy-and-strlcat-considered-insecure/2115015#2115015
See: https://stackoverflow.com/questions/41869803/what-is-the-best-alternative-to-strncpy/41885173#41885173

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
