### PR TITLE
Avoid mandatory Fatal in FairRunOnline if no Sink defined

### DIFF
--- a/base/steer/FairRunOnline.cxx
+++ b/base/steer/FairRunOnline.cxx
@@ -182,7 +182,7 @@ void FairRunOnline::Init()
         return;
     }
     LOG(info) << "FairRunOnline::InitContainers: event header at " << fEvtHeader;
-    fRootManager->Register("EventHeader.", "Event", fEvtHeader, kTRUE);
+    fRootManager->Register("EventHeader.", "Event", fEvtHeader, (nullptr != fRootManager->GetSink()));
     fEvtHeader->SetRunId(fRunId);
 
     fRootManager->GetSource()->InitUnpackers();


### PR DESCRIPTION
This was an unintended consequence/oversight following #940 (fixing issue #935).

The newly introduced FATAL was triggered by the hard-coded `write output flag = kTRUE` (persistence) when the header object was registered in the FairRoot manager.
The change keeps the original behavior in case a Sink is existing and skip the writing otherwise, avoiding the FATAL for pure monitoring tasks without ROOT file output .

Affected branches and releases:
- master and dev
- v18.4.x
- v18.6.x

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [ ] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
