### PR TITLE
Update add_test Syntax

### DIFF
--- a/examples/MQ/parameters/CMakeLists.txt
+++ b/examples/MQ/parameters/CMakeLists.txt
@@ -54,7 +54,8 @@ install(TARGETS ex-params-client
   RUNTIME DESTINATION ${PROJECT_INSTALL_DATADIR}/examples/MQ/parameters/bin
 )
 
-add_test(ex_MQ_parameters ${CMAKE_CURRENT_BINARY_DIR}/test-mq-ex-params.sh)
+add_test(NAME ex_MQ_parameters
+         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/test-mq-ex-params.sh)
 set_tests_properties(ex_MQ_parameters PROPERTIES
   TIMEOUT "30"
   RUN_SERIAL true

--- a/examples/MQ/pixelAlternative/run/CMakeLists.txt
+++ b/examples/MQ/pixelAlternative/run/CMakeLists.txt
@@ -43,7 +43,8 @@ install(TARGETS pixalt-sampler-bin pixalt-sink-bin pixalt-processor-bin
 
 set(maxTestTime 30)
 
-add_test(ex_MQ_pixel_alt_static ${CMAKE_CURRENT_BINARY_DIR}/startFairMQPixAlt.sh --work-dir ${CMAKE_BINARY_DIR}/examples/MQ/pixelDetector --max-index 10000 --aggregate 100 --processors 5 --command static --force-kill true)
+add_test(NAME ex_MQ_pixel_alt_static
+         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/startFairMQPixAlt.sh --work-dir ${CMAKE_BINARY_DIR}/examples/MQ/pixelDetector --max-index 10000 --aggregate 100 --processors 5 --command static --force-kill true)
 set_tests_properties(ex_MQ_pixel_alt_static PROPERTIES
   DEPENDS ex_MQ_pixel_static
   TIMEOUT ${maxTestTime}

--- a/examples/MQ/pixelDetector/macros/CMakeLists.txt
+++ b/examples/MQ/pixelDetector/macros/CMakeLists.txt
@@ -12,21 +12,24 @@ GENERATE_ROOT_TEST_SCRIPT(${CMAKE_CURRENT_SOURCE_DIR}/run_digiToBin.C)
 
 set(maxTestTime 30)
 
-add_test(ex_pixel_sim_TGeant3 ${CMAKE_CURRENT_BINARY_DIR}/run_sim.sh 10000 \"TGeant3\")
+add_test(NAME ex_pixel_sim_TGeant3
+         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_sim.sh 10000 \"TGeant3\")
 math(EXPR testTime 4*${maxTestTime})
 set_tests_properties(ex_pixel_sim_TGeant3 PROPERTIES
   TIMEOUT ${testTime}
   PASS_REGULAR_EXPRESSION "Macro finished successfully"
 )
 
-add_test(ex_pixel_digi_TGeant3 ${CMAKE_CURRENT_BINARY_DIR}/run_digi.sh \"TGeant3\")
+add_test(NAME ex_pixel_digi_TGeant3
+         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_digi.sh \"TGeant3\")
 set_tests_properties(ex_pixel_digi_TGeant3 PROPERTIES
   DEPENDS ex_pixel_sim_TGeant3
   TIMEOUT ${maxTestTime}
   PASS_REGULAR_EXPRESSION "Macro finished successfully"
 )
 
-add_test(ex_pixel_digi_to_bin_TGeant3 ${CMAKE_CURRENT_BINARY_DIR}/run_digiToBin.sh 0 \"TGeant3\")
+add_test(NAME ex_pixel_digi_to_bin_TGeant3
+         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_digiToBin.sh 0 \"TGeant3\")
 set_tests_properties(ex_pixel_digi_to_bin_TGeant3 PROPERTIES
   DEPENDS ex_pixel_digi_TGeant3
   TIMEOUT ${maxTestTime}

--- a/examples/MQ/pixelDetector/run/CMakeLists.txt
+++ b/examples/MQ/pixelDetector/run/CMakeLists.txt
@@ -121,7 +121,8 @@ set(maxTestTime 100)
 
 if(DDS_VERSION VERSION_GREATER_EQUAL 3.5
    AND FairMQ_VERSION VERSION_GREATER_EQUAL 1.4.23)
-  add_test(ex_MQ_pixel_simulation ${CMAKE_CURRENT_BINARY_DIR}/test-pixelSim.sh)
+  add_test(NAME ex_MQ_pixel_simulation
+           COMMAND ${CMAKE_CURRENT_BINARY_DIR}/test-pixelSim.sh)
   set_tests_properties(ex_MQ_pixel_simulation PROPERTIES
     DEPENDS ex_MQ_pixel_static
     TIMEOUT ${maxTestTime}
@@ -129,7 +130,8 @@ if(DDS_VERSION VERSION_GREATER_EQUAL 3.5
 )
 endif()
 
-add_test(ex_MQ_pixel_static ${CMAKE_CURRENT_BINARY_DIR}/startFairMQPixel.sh --work-dir ${CMAKE_CURRENT_BINARY_DIR}/../ -p 3 --command static --force-kill true)
+add_test(NAME ex_MQ_pixel_static
+         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/startFairMQPixel.sh --work-dir ${CMAKE_CURRENT_BINARY_DIR}/../ -p 3 --command static --force-kill true)
 set_tests_properties(ex_MQ_pixel_static PROPERTIES
   DEPENDS ex_pixel_digi_to_bin_TGeant3
   TIMEOUT ${maxTestTime}

--- a/examples/MQ/pixelSimSplit/run/CMakeLists.txt
+++ b/examples/MQ/pixelSimSplit/run/CMakeLists.txt
@@ -76,7 +76,8 @@ install(TARGETS pixel-sim-chunk-merger pixel-sim-gen pixel-sim-transport
 
 set(maxTestTime 90)
 
-add_test(ex_MQ_pixel_split ${CMAKE_CURRENT_BINARY_DIR}/test-splitMQ.sh)
+add_test(NAME ex_MQ_pixel_split
+         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/test-splitMQ.sh)
 set_tests_properties(ex_MQ_pixel_split PROPERTIES
   TIMEOUT ${maxTestTime}
   PASS_REGULAR_EXPRESSION "Shell script finished successfully"
@@ -84,7 +85,8 @@ set_tests_properties(ex_MQ_pixel_split PROPERTIES
 
 if(DDS_VERSION VERSION_GREATER_EQUAL 3.5
    AND FairMQ_VERSION VERSION_GREATER_EQUAL 1.4.23)
-  add_test(pixelSplitDDS ${CMAKE_CURRENT_BINARY_DIR}/test-splitMC.sh)
+  add_test(NAME pixelSplitDDS
+           COMMAND ${CMAKE_CURRENT_BINARY_DIR}/test-splitMC.sh)
   set_tests_properties(pixelSplitDDS PROPERTIES
     TIMEOUT ${maxTestTime}
     PASS_REGULAR_EXPRESSION "Shell script finished successfully"

--- a/examples/MQ/serialization/CMakeLists.txt
+++ b/examples/MQ/serialization/CMakeLists.txt
@@ -100,13 +100,15 @@ install(TARGETS
   RUNTIME DESTINATION ${PROJECT_INSTALL_DATADIR}/examples/MQ/serialization/bin
 )
 
-add_test(ex_MQ_serialization1 ${CMAKE_CURRENT_BINARY_DIR}/testSerializationEx1.sh)
+add_test(NAME ex_MQ_serialization1
+         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/testSerializationEx1.sh)
 set_tests_properties(ex_MQ_serialization1 PROPERTIES
   TIMEOUT "30"
   PASS_REGULAR_EXPRESSION "Received 100 and sent 100 messages!"
 )
 
-add_test(ex_MQ_serialization2 ${CMAKE_CURRENT_BINARY_DIR}/testSerializationEx2.sh)
+add_test(NAME ex_MQ_serialization2
+         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/testSerializationEx2.sh)
 set_tests_properties(ex_MQ_serialization2 PROPERTIES
   DEPENDS ex_MQ_serialization1
   TIMEOUT "30"

--- a/examples/advanced/MbsTutorial/CMakeLists.txt
+++ b/examples/advanced/MbsTutorial/CMakeLists.txt
@@ -46,7 +46,8 @@ install(FILES unpack_mbs.C DESTINATION ${PROJECT_INSTALL_DATADIR}/examples/advan
 
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_CURRENT_SOURCE_DIR}/unpack_mbs.C)
 
-add_test(ex_unpack_mbs ${CMAKE_CURRENT_BINARY_DIR}/unpack_mbs.sh)
+add_test(NAME ex_unpack_mbs
+         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/unpack_mbs.sh)
 set_tests_properties(ex_unpack_mbs PROPERTIES
   TIMEOUT "30"
   PASS_REGULAR_EXPRESSION "Macro finished successfully"

--- a/examples/advanced/Tutorial3/macro/CMakeLists.txt
+++ b/examples/advanced/Tutorial3/macro/CMakeLists.txt
@@ -16,42 +16,48 @@ GENERATE_ROOT_TEST_SCRIPT(${CMAKE_CURRENT_SOURCE_DIR}/run_reco_timebased.C)
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_CURRENT_SOURCE_DIR}/run_digi_reco_proof.C)
 
 foreach(mcEngine IN ITEMS TGeant3 TGeant4)
-  add_test(ex_tutorial3_sim_${mcEngine} ${CMAKE_CURRENT_BINARY_DIR}/run_sim.sh 100 \"${mcEngine}\")
+  add_test(NAME ex_tutorial3_sim_${mcEngine}
+           COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_sim.sh 100 \"${mcEngine}\")
   math(EXPR testTime 3*${maxTestTime})
   set_tests_properties(ex_tutorial3_sim_${mcEngine} PROPERTIES
     TIMEOUT ${testTime}
     PASS_REGULAR_EXPRESSION "Macro finished successfully"
   )
 
-  add_test(ex_tutorial3_digi_${mcEngine} ${CMAKE_CURRENT_BINARY_DIR}/run_digi.sh \"${mcEngine}\")
+  add_test(NAME ex_tutorial3_digi_${mcEngine}
+           COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_digi.sh \"${mcEngine}\")
   set_tests_properties(ex_tutorial3_digi_${mcEngine} PROPERTIES
     DEPENDS ex_tutorial3_sim_${mcEngine}
     TIMEOUT ${maxTestTime}
     PASS_REGULAR_EXPRESSION "Macro finished successfully"
   )
 
-  add_test(ex_tutorial3_reco_${mcEngine} ${CMAKE_CURRENT_BINARY_DIR}/run_reco.sh \"${mcEngine}\")
+  add_test(NAME ex_tutorial3_reco_${mcEngine}
+           COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_reco.sh \"${mcEngine}\")
   set_tests_properties(ex_tutorial3_reco_${mcEngine} PROPERTIES
     DEPENDS ex_tutorial3_digi_${mcEngine}
     TIMEOUT ${maxTestTime}
     PASS_REGULAR_EXPRESSION "Macro finished successfully"
   )
 
-  add_test(ex_tutorial3_digi_timebased_${mcEngine} ${CMAKE_CURRENT_BINARY_DIR}/run_digi_timebased.sh \"${mcEngine}\")
+  add_test(NAME ex_tutorial3_digi_timebased_${mcEngine}
+           COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_digi_timebased.sh \"${mcEngine}\")
   set_tests_properties(ex_tutorial3_digi_timebased_${mcEngine} PROPERTIES
     DEPENDS ex_tutorial3_sim_${mcEngine}
     TIMEOUT ${maxTestTime}
     PASS_REGULAR_EXPRESSION "Macro finished successfully"
   )
 
-  add_test(ex_tutorial3_reco_timebased_${mcEngine} ${CMAKE_CURRENT_BINARY_DIR}/run_reco_timebased.sh \"${mcEngine}\")
+  add_test(NAME ex_tutorial3_reco_timebased_${mcEngine}
+           COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_reco_timebased.sh \"${mcEngine}\")
   set_tests_properties(ex_tutorial3_reco_timebased_${mcEngine} PROPERTIES
     DEPENDS ex_tutorial3_digi_timebased_${mcEngine}
     TIMEOUT ${maxTestTime}
     PASS_REGULAR_EXPRESSION "Macro finished successfully"
   )
 
-  add_test(ex_tutorial3_digi_reco_proof_${mcEngine} ${CMAKE_CURRENT_BINARY_DIR}/run_digi_reco_proof.sh 1 \"${mcEngine}\")
+  add_test(NAME ex_tutorial3_digi_reco_proof_${mcEngine}
+           COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_digi_reco_proof.sh 1 \"${mcEngine}\")
   set_tests_properties(ex_tutorial3_digi_reco_proof_${mcEngine} PROPERTIES
     DEPENDS ex_tutorial3_sim_${mcEngine}
     TIMEOUT ${maxTestTime}

--- a/examples/advanced/propagator/macros/CMakeLists.txt
+++ b/examples/advanced/propagator/macros/CMakeLists.txt
@@ -11,19 +11,19 @@ GENERATE_ROOT_TEST_SCRIPT(${CMAKE_CURRENT_SOURCE_DIR}/runPull.C)
 
 set(maxTestTime 60)
 
-add_test(runPropagatorMC
-         ${CMAKE_CURRENT_BINARY_DIR}/runMC.sh)
+add_test(NAME runPropagatorMC
+         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/runMC.sh)
 set_tests_properties(runPropagatorMC PROPERTIES TIMEOUT ${maxTestTime})
 set_tests_properties(runPropagatorMC PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished successfully")
 
-add_test(runPropagator
-         ${CMAKE_CURRENT_BINARY_DIR}/runProp.sh)
+add_test(NAME runPropagator
+         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/runProp.sh)
 set_tests_properties(runPropagator PROPERTIES DEPENDS runPropagatorMC)
 set_tests_properties(runPropagator PROPERTIES TIMEOUT ${maxTestTime})
 set_tests_properties(runPropagator PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished successfully")
 
-add_test(runPropagatorPull
-         ${CMAKE_CURRENT_BINARY_DIR}/runPull.sh)
+add_test(NAME runPropagatorPull
+         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/runPull.sh)
 set_tests_properties(runPropagatorPull PROPERTIES DEPENDS runPropagator)
 set_tests_properties(runPropagatorPull PROPERTIES TIMEOUT ${maxTestTime})
 set_tests_properties(runPropagatorPull PROPERTIES PASS_REGULAR_EXPRESSION "Macro finished successfully")

--- a/examples/simulation/Tutorial1/macros/CMakeLists.txt
+++ b/examples/simulation/Tutorial1/macros/CMakeLists.txt
@@ -15,45 +15,52 @@ GENERATE_ROOT_TEST_SCRIPT(${CMAKE_CURRENT_SOURCE_DIR}/run_tutorial1.C)
 
 set(maxTestTime 60)
 
-add_test(load_all_libs ${CMAKE_CURRENT_BINARY_DIR}/load_all_libs.sh)
+add_test(NAME load_all_libs
+         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/load_all_libs.sh)
 set_tests_properties(load_all_libs PROPERTIES
   TIMEOUT ${maxTestTime}
   PASS_REGULAR_EXPRESSION "Macro finished succesfully"
 )
 
 foreach(mcEngine IN ITEMS TGeant3 TGeant4)
-  add_test(ex_sim_tutorial1_mesh_${mcEngine} ${CMAKE_CURRENT_BINARY_DIR}/run_tutorial1_mesh.sh 10 \"${mcEngine}\")
+  add_test(NAME ex_sim_tutorial1_mesh_${mcEngine}
+           COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_tutorial1_mesh.sh 10 \"${mcEngine}\")
   set_tests_properties(ex_sim_tutorial1_mesh_${mcEngine} PROPERTIES
     TIMEOUT ${maxTestTime}
     PASS_REGULAR_EXPRESSION "Macro finished successfully"
   )
 
-  add_test(ex_sim_tutorial1_pythia6_${mcEngine} ${CMAKE_CURRENT_BINARY_DIR}/run_tutorial1_pythia6.sh 10 \"${mcEngine}\")
+  add_test(NAME ex_sim_tutorial1_pythia6_${mcEngine}
+           COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_tutorial1_pythia6.sh 10 \"${mcEngine}\")
   set_tests_properties(ex_sim_tutorial1_pythia6_${mcEngine} PROPERTIES
     TIMEOUT ${maxTestTime}
     PASS_REGULAR_EXPRESSION "Macro finished successfully"
   )
 
-  add_test(ex_sim_tutorial1_pythia8_${mcEngine} ${CMAKE_CURRENT_BINARY_DIR}/run_tutorial1_pythia8.sh 10 \"${mcEngine}\")
+  add_test(NAME ex_sim_tutorial1_pythia8_${mcEngine}
+           COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_tutorial1_pythia8.sh 10 \"${mcEngine}\")
   set_tests_properties(ex_sim_tutorial1_pythia8_${mcEngine} PROPERTIES
     TIMEOUT ${maxTestTime}
     PASS_REGULAR_EXPRESSION "Macro finished successfully"
   )
 
-  add_test(ex_sim_tutorial1_urqmd_${mcEngine} ${CMAKE_CURRENT_BINARY_DIR}/run_tutorial1_urqmd.sh 2 \"${mcEngine}\")
+  add_test(NAME ex_sim_tutorial1_urqmd_${mcEngine}
+           COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_tutorial1_urqmd.sh 2 \"${mcEngine}\")
   set_tests_properties(ex_sim_tutorial1_urqmd_${mcEngine} PROPERTIES
     TIMEOUT ${maxTestTime}
     PASS_REGULAR_EXPRESSION "Macro finished successfully"
   )
 
-  add_test(ex_sim_tutorial1_${mcEngine} ${CMAKE_CURRENT_BINARY_DIR}/run_tutorial1.sh 10 \"${mcEngine}\")
+  add_test(NAME ex_sim_tutorial1_${mcEngine}
+           COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_tutorial1.sh 10 \"${mcEngine}\")
   set_tests_properties(ex_sim_tutorial1_${mcEngine} PROPERTIES
     TIMEOUT ${maxTestTime}
     PASS_REGULAR_EXPRESSION "Macro finished successfully"
   )
 endforeach()
 
-add_test(ex_tutorial1_PostInitConfig ${CMAKE_CURRENT_BINARY_DIR}/run_tutorial1.sh 1 \"TGeant4\" false true)
+add_test(NAME ex_tutorial1_PostInitConfig
+         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_tutorial1.sh 1 \"TGeant4\" false true)
 set_tests_properties(ex_tutorial1_PostInitConfig PROPERTIES
   TIMEOUT ${maxTestTime}
   PASS_REGULAR_EXPRESSION "Loading Geant4 PostInit Config."

--- a/examples/simulation/Tutorial2/macros/CMakeLists.txt
+++ b/examples/simulation/Tutorial2/macros/CMakeLists.txt
@@ -15,48 +15,55 @@ GENERATE_ROOT_TEST_SCRIPT(${CMAKE_CURRENT_SOURCE_DIR}/run_tutorial2.C)
 
 set(maxTestTime 60)
 
-add_test(ex_sim_tutorial2 ${CMAKE_CURRENT_BINARY_DIR}/run_tutorial2.sh)
+add_test(NAME ex_sim_tutorial2
+         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_tutorial2.sh)
 set_tests_properties(ex_sim_tutorial2 PROPERTIES
   TIMEOUT ${maxTestTime}
   PASS_REGULAR_EXPRESSION "Macro finished successfully"
 )
 
-add_test(ex_sim_tutorial2_create_digis ${CMAKE_CURRENT_BINARY_DIR}/create_digis.sh)
+add_test(NAME ex_sim_tutorial2_create_digis
+         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/create_digis.sh)
 set_tests_properties(ex_sim_tutorial2_create_digis PROPERTIES
   DEPENDS ex_sim_tutorial2
   TIMEOUT ${maxTestTime}
   PASS_REGULAR_EXPRESSION "Macro finished successfully"
 )
 
-add_test(ex_sim_tutorial2_read_digis ${CMAKE_CURRENT_BINARY_DIR}/read_digis.sh)
+add_test(NAME ex_sim_tutorial2_read_digis
+         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/read_digis.sh)
 set_tests_properties(ex_sim_tutorial2_read_digis PROPERTIES
   DEPENDS ex_sim_tutorial2_create_digis
   TIMEOUT ${maxTestTime}
   PASS_REGULAR_EXPRESSION "Macro finished successfully"
 )
 
-add_test(ex_sim_tutorial2_run_background ${CMAKE_CURRENT_BINARY_DIR}/run_background.sh)
+add_test(NAME ex_sim_tutorial2_run_background
+         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_background.sh)
 set_tests_properties(ex_sim_tutorial2_run_background PROPERTIES
   DEPENDS ex_sim_tutorial2_read_digis
   TIMEOUT ${maxTestTime}
   PASS_REGULAR_EXPRESSION "Macro finished successfully"
 )
 
-add_test(ex_sim_tutorial2_run_signal1 ${CMAKE_CURRENT_BINARY_DIR}/run_signal.sh 1 10)
+add_test(NAME ex_sim_tutorial2_run_signal1
+         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_signal.sh 1 10)
 set_tests_properties(ex_sim_tutorial2_run_signal1 PROPERTIES
   DEPENDS ex_sim_tutorial2_run_background
   TIMEOUT ${maxTestTime}
   PASS_REGULAR_EXPRESSION "Macro finished successfully"
 )
 
-add_test(ex_sim_tutorial2_run_signal2 ${CMAKE_CURRENT_BINARY_DIR}/run_signal.sh 2 20)
+add_test(NAME ex_sim_tutorial2_run_signal2
+         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_signal.sh 2 20)
 set_tests_properties(ex_sim_tutorial2_run_signal2 PROPERTIES
   DEPENDS ex_sim_tutorial2_run_signal1
   TIMEOUT ${maxTestTime}
   PASS_REGULAR_EXPRESSION "Macro finished successfully"
 )
 
-add_test(ex_sim_tutorial2_create_digis_mixed ${CMAKE_CURRENT_BINARY_DIR}/create_digis_mixed.sh)
+add_test(NAME ex_sim_tutorial2_create_digis_mixed
+         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/create_digis_mixed.sh)
 set_tests_properties(ex_sim_tutorial2_create_digis_mixed PROPERTIES
   DEPENDS ex_sim_tutorial2_run_signal2
   TIMEOUT ${maxTestTime}

--- a/examples/simulation/Tutorial4/macros/CMakeLists.txt
+++ b/examples/simulation/Tutorial4/macros/CMakeLists.txt
@@ -15,13 +15,15 @@ GENERATE_ROOT_TEST_SCRIPT(${CMAKE_CURRENT_SOURCE_DIR}/run_reco.C)
 set(maxTestTime 60)
 
 foreach(mcEngine IN ITEMS TGeant3 TGeant4)
-  add_test(ex_sim_tutorial4_${mcEngine} ${CMAKE_CURRENT_BINARY_DIR}/run_tutorial4.sh 10 \"${mcEngine}\")
+  add_test(NAME ex_sim_tutorial4_${mcEngine}
+           COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_tutorial4.sh 10 \"${mcEngine}\")
   set_tests_properties(ex_sim_tutorial4_${mcEngine} PROPERTIES
     TIMEOUT ${maxTestTime}
     PASS_REGULAR_EXPRESSION "Macro finished successfully"
   )
 
-  add_test(ex_sim_tutorial4_reco_${mcEngine} ${CMAKE_CURRENT_BINARY_DIR}/run_reco.sh \"${mcEngine}\")
+  add_test(NAME ex_sim_tutorial4_reco_${mcEngine}
+           COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_reco.sh \"${mcEngine}\")
   set_tests_properties(ex_sim_tutorial4_reco_${mcEngine} PROPERTIES
     DEPENDS ex_sim_tutorial4_${mcEngine}
     TIMEOUT ${maxTestTime}

--- a/examples/simulation/rutherford/macros/CMakeLists.txt
+++ b/examples/simulation/rutherford/macros/CMakeLists.txt
@@ -12,13 +12,15 @@ GENERATE_ROOT_TEST_SCRIPT(${CMAKE_CURRENT_SOURCE_DIR}/run_rutherford.C)
 set(maxTestTime 60)
 
 foreach(mcEngine IN ITEMS TGeant3 TGeant4)
-  add_test(ex_sim_rutherford_${mcEngine} ${CMAKE_CURRENT_BINARY_DIR}/run_rutherford.sh 10 \"${mcEngine}\")
+  add_test(NAME ex_sim_rutherford_${mcEngine}
+           COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_rutherford.sh 10 \"${mcEngine}\")
   set_tests_properties(ex_sim_rutherford_${mcEngine} PROPERTIES
     TIMEOUT ${maxTestTime}
     PASS_REGULAR_EXPRESSION "Macro finished successfully"
   )
 
-  add_test(ex_sim_run_rad_${mcEngine} ${CMAKE_CURRENT_BINARY_DIR}/run_rad.sh 100 \"${mcEngine}\")
+  add_test(NAME ex_sim_run_rad_${mcEngine}
+           COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_rad.sh 100 \"${mcEngine}\")
   set_tests_properties(ex_sim_run_rad_${mcEngine} PROPERTIES
     TIMEOUT ${maxTestTime}
     PASS_REGULAR_EXPRESSION "Macro finished successfully"

--- a/test/fairtools/CMakeLists.txt
+++ b/test/fairtools/CMakeLists.txt
@@ -40,5 +40,6 @@ list(APPEND tests
 foreach(test IN LISTS tests)
   add_executable(${test} ${test}.cxx)
   target_link_libraries(${test} ${dependencies})
-  add_test(${test} ${CMAKE_CURRENT_BINARY_DIR}/${test})
+  add_test(NAME ${test}
+           COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${test})
 endforeach()


### PR DESCRIPTION
There's a simple syntax
```cmake
    add_test(test_name command arg1 arg2)
```
This syntax captures *everything* after the command as arguments.

Let's use the better syntax everywhere!
```cmake
    add_test(NAME test_name COMMAND command arg1 arg2)
```
---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
