### PR TITLE
cmake: Drop some variables, little cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,13 +354,6 @@ if(BUILD_UNITTESTS)
   add_subdirectory(test)
 endif()
 
-if(BUILD_EXAMPLES)
-  install(DIRECTORY
-    examples/common/gconfig
-    examples/common/geometry
-    DESTINATION ${PROJECT_INSTALL_DATADIR}/examples/common
-  )
-endif(BUILD_EXAMPLES)
 
 install(FILES ${CMAKE_BINARY_DIR}/config.sh_install
   DESTINATION bin

--- a/cmake/modules/FairMacros.cmake
+++ b/cmake/modules/FairMacros.cmake
@@ -348,35 +348,6 @@ IF(FAIRROOT_FOUND)
   Set(ROOT_INCLUDE_PATH
       ${FAIRROOT_INCLUDE_DIR}
      )
-
-ELSE(FAIRROOT_FOUND)
-  Set(BASE_INCLUDE_DIRECTORIES
-    ${CMAKE_SOURCE_DIR}/logger
-    ${CMAKE_SOURCE_DIR}/fairtools
-    ${CMAKE_SOURCE_DIR}/geobase
-    ${CMAKE_SOURCE_DIR}/parbase
-    ${CMAKE_SOURCE_DIR}/base
-    ${CMAKE_SOURCE_DIR}/base/steer
-    ${CMAKE_SOURCE_DIR}/base/event
-    ${CMAKE_SOURCE_DIR}/base/field
-    ${CMAKE_SOURCE_DIR}/base/sim
-    ${CMAKE_SOURCE_DIR}/base/sink
-    ${CMAKE_SOURCE_DIR}/base/source
-    ${CMAKE_SOURCE_DIR}/dbase
-    ${CMAKE_SOURCE_DIR}/dbase/dbInterface
-    ${CMAKE_SOURCE_DIR}/dbase/dbValidation
-    ${CMAKE_SOURCE_DIR}/dbase/dbUtils
-    ${CMAKE_SOURCE_DIR}/input/db
-    ${CMAKE_SOURCE_DIR}/dbase/dbInput
-    ${CMAKE_SOURCE_DIR}/dbase/dbIO
-    ${CMAKE_SOURCE_DIR}/alignment
-  )
-  Set(SYSTEM_INCLUDE_DIRECTORIES
-    ${Boost_INCLUDE_DIRS}
-  )
-  Set(ROOT_INCLUDE_PATH
-      ${BASE_INCLUDE_DIRECTORIES}
-  )
 ENDIF(FAIRROOT_FOUND)
 
 IF(FAIRROOT_FOUND)
@@ -386,8 +357,10 @@ ELSE(FAIRROOT_FOUND)
 ENDIF(FAIRROOT_FOUND)
 Set(LD_LIBRARY_PATH  ${FAIRLIBDIR} ${LD_LIBRARY_PATH})
 
-include_directories(${BASE_INCLUDE_DIRECTORIES})
-include_directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
+if(FAIRROOT_FOUND)
+  include_directories(${BASE_INCLUDE_DIRECTORIES})
+  include_directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
+endif()
 
 EndMacro (SetBasicVariables)
 

--- a/cmake/modules/FairRootTargetRootDictionary.cmake
+++ b/cmake/modules/FairRootTargetRootDictionary.cmake
@@ -117,11 +117,6 @@ function(fairroot_target_root_dictionary target)
   # Need at least root core library
   # get_filename_component(LD_LIBRARY_PATH ROOT::Core DIRECTORY)
   set(LD_LIBRARY_PATH ${ROOT_LIBRARY_DIR})
-  # and possibly toolchain libs if we are using a toolchain
-  if(DEFINED ENV{GCC_TOOLCHAIN_ROOT})
-    set(LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:$ENV{GCC_TOOLCHAIN_ROOT}/lib")
-    set(LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:$ENV{GCC_TOOLCHAIN_ROOT}/lib64")
-  endif()
 
   set(includeDirs $<TARGET_PROPERTY:${target},INCLUDE_DIRECTORIES>)
 

--- a/cmake/modules/FindHEPMC.cmake
+++ b/cmake/modules/FindHEPMC.cmake
@@ -15,14 +15,12 @@
 
 FIND_PATH(HEPMC_INCLUDE_DIR NAMES HepMC/HepMCDefs.h PATHS
   ${HEPMC_DIR}/include
-  ${AlFa_DIR}/include
   ${SIMPATH}/include/
   NO_DEFAULT_PATH
 )
 
 FIND_PATH(HEPMC_LIB_DIR  NAMES libHepMC.so libHepMC.dylib PATHS
   ${HEPMC_DIR}/lib
-  ${AlFa_DIR}/lib
   ${SIMPATH}/lib
   NO_DEFAULT_PATH
 )

--- a/cmake/modules/FindPythia8.cmake
+++ b/cmake/modules/FindPythia8.cmake
@@ -16,11 +16,8 @@
 ################################################################################
 
 set(_pythia8dirs
-    ${PYTHIA8}
-    $ENV{PYTHIA8}
     ${PYTHIA8_DIR}
     $ENV{PYTHIA8_DIR}
-    $ENV{PYTHIA_ROOT}
     ${SIMPATH}
     ${SIMPATH}/generators
     /usr
@@ -45,7 +42,7 @@ find_library(PYTHIA8_LIBRARY
              DOC "Specify the Pythia8 library here.")
 
 find_path(PYTHIA8_LIB_DIR  NAMES libpythia8.so libpythia8.dylib PATHS
-               $ENV{PYTHIA_ROOT}/lib
+               $ENV{PYTHIA8_DIR}/lib
                ${PYTHIA8_DIR}/lib
                ${SIMPATH}/lib
                ${SIMPATH}/generators/lib

--- a/cmake/modules/FindPythia8.cmake
+++ b/cmake/modules/FindPythia8.cmake
@@ -21,7 +21,6 @@ set(_pythia8dirs
     ${PYTHIA8_DIR}
     $ENV{PYTHIA8_DIR}
     $ENV{PYTHIA_ROOT}
-    ${AlFa_DIR}
     ${SIMPATH}
     ${SIMPATH}/generators
     /usr
@@ -48,7 +47,6 @@ find_library(PYTHIA8_LIBRARY
 find_path(PYTHIA8_LIB_DIR  NAMES libpythia8.so libpythia8.dylib PATHS
                $ENV{PYTHIA_ROOT}/lib
                ${PYTHIA8_DIR}/lib
-               ${AlFa_DIR}/lib
                ${SIMPATH}/lib
                ${SIMPATH}/generators/lib
                NO_DEFAULT_PATH

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -46,3 +46,9 @@ if(FairMQ_FOUND AND Boost_FOUND)
   endif()
   add_subdirectory(MQ/histogramServer)
 endif()
+
+install(DIRECTORY
+  common/gconfig
+  common/geometry
+  DESTINATION ${PROJECT_INSTALL_DATADIR}/examples/common
+)


### PR DESCRIPTION
* Drop AlFa_DIR variable 
* Drop GCC_TOOLCHAIN_ROOT variable
* Clean up Pythia8 env usage
* Move example installation into examples/
* Drop global include directories


---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
