### PR TITLE
cmake: Introduce fairroot_library_settings()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,12 +92,6 @@ Set(CheckSrcDir "${CMAKE_SOURCE_DIR}/cmake/checks")
 include(CheckCXX11Features)
 include(CheckSymbolExists)
 
-# FairRoot only uses C++11 or later, so we need an compiler which supports C++11
-# Check if the used compiler support C++11. If not stop with an error message
-If(NOT _HAS_CXX11_FLAG)
-  Message(FATAL_ERROR "The used C++ compiler (${CMAKE_CXX_COMPILER}) does not support C++11. CbmRoot can only be compiled with compilers supporting C++11. Please install such a compiler.")
-EndIf()
-
 # Load some basic macros which are needed later on
 find_package(FairCMakeModules 0.1 QUIET)
 if(NOT FairCMakeModules_FOUND)
@@ -106,6 +100,7 @@ if(NOT FairCMakeModules_FOUND)
   list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/fallback")
 endif()
 include(FairFindPackage2)
+include(FairRootTargets)
 include(FairRootSummary)
 include(FairMacros)
 include(WriteConfigFile)

--- a/MbsAPI/CMakeLists.txt
+++ b/MbsAPI/CMakeLists.txt
@@ -35,8 +35,7 @@ list(APPEND headers
 )
 
 add_library(${target} SHARED ${sources} ${headers})
-add_library(FairRoot::${target} ALIAS ${target})
-set_target_properties(${target} PROPERTIES ${PROJECT_LIBRARY_PROPERTIES})
+fairroot_library_settings(${target})
 
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL "9")
   target_compile_options(${target} PRIVATE "-Wno-stringop-overflow")

--- a/alignment/CMakeLists.txt
+++ b/alignment/CMakeLists.txt
@@ -15,8 +15,7 @@ set(sources
 fair_change_extensions_if_exists(.cxx .h FILES "${sources}" OUTVAR headers)
 
 add_library(${target} SHARED ${sources} ${headers})
-add_library(FairRoot::${target} ALIAS ${target})
-set_target_properties(${target} PROPERTIES ${PROJECT_LIBRARY_PROPERTIES})
+fairroot_library_settings(${target})
 
 target_include_directories(${target} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -96,8 +96,7 @@ endif()
 fair_change_extensions_if_exists(.cxx .h FILES "${sources}" OUTVAR headers)
 
 add_library(${target} SHARED ${sources} ${headers})
-add_library(FairRoot::${target} ALIAS ${target})
-set_target_properties(${target} PROPERTIES ${PROJECT_LIBRARY_PROPERTIES})
+fairroot_library_settings(${target})
 
 target_include_directories(${target} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/steer>

--- a/base/MQ/CMakeLists.txt
+++ b/base/MQ/CMakeLists.txt
@@ -35,8 +35,7 @@ list(APPEND headers
 )
 
 add_library(${target} SHARED ${sources} ${headers})
-add_library(FairRoot::${target} ALIAS ${target})
-set_target_properties(${target} PROPERTIES ${PROJECT_LIBRARY_PROPERTIES})
+fairroot_library_settings(${target})
 
 target_include_directories(${target} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/devices>

--- a/base/sim/fastsim/CMakeLists.txt
+++ b/base/sim/fastsim/CMakeLists.txt
@@ -18,8 +18,7 @@ set(sources
 fair_change_extensions_if_exists(.cxx .h FILES "${sources}" OUTVAR headers)
 
 add_library(${target} SHARED ${sources} ${headers})
-add_library(FairRoot::${target} ALIAS ${target})
-set_target_properties(${target} PROPERTIES ${PROJECT_LIBRARY_PROPERTIES})
+fairroot_library_settings(${target})
 
 target_include_directories(${target} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/cmake/private/FairRootTargets.cmake
+++ b/cmake/private/FairRootTargets.cmake
@@ -1,0 +1,38 @@
+################################################################################
+# Copyright (C) 2021 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH       #
+#                                                                              #
+#              This software is distributed under the terms of the             #
+#              GNU Lesser General Public Licence (LGPL) version 3,             #
+#                  copied verbatim in the file "LICENSE"                       #
+################################################################################
+
+
+# Set the C++ language level on exported targets
+#
+# This is only meaningful on targets that later on are
+# exported.
+# It sets the C++ language level to CMAKE_CXX_STANDARD /
+# PROJECT_MIN_CXX_STANDARD, so that projects that import the
+# target use at least that language level to compile
+# things.
+function(fairroot_compile_features target)
+  if (DEFINED CMAKE_CXX_STANDARD)
+    set(standard ${CMAKE_CXX_STANDARD})
+  elseif(DEFINED PROJECT_MIN_CXX_STANDARD)
+    set(standard ${PROJECT_MIN_CXX_STANDARD})
+  else()
+    set(standard 11)
+  endif()
+  target_compile_features("${target}" INTERFACE cxx_std_${standard})
+endfunction()
+
+
+# Set some generic / general settings on exported targets
+# - Export C++ language level
+# - Set namespaced ALIAS to allow consistent target use
+# - Set some generic PROPERTIES (VERSION, SOVERSION)
+function(fairroot_library_settings target)
+  fairroot_compile_features("${target}")
+  add_library(FairRoot::${target} ALIAS ${target})
+  set_target_properties(${target} PROPERTIES ${PROJECT_LIBRARY_PROPERTIES})
+endfunction()

--- a/datamatch/CMakeLists.txt
+++ b/datamatch/CMakeLists.txt
@@ -24,8 +24,7 @@ set(sources
 fair_change_extensions_if_exists(.cxx .h FILES "${sources}" OUTVAR headers)
 
 add_library(${target} SHARED ${sources} ${headers})
-add_library(FairRoot::${target} ALIAS ${target})
-set_target_properties(${target} PROPERTIES ${PROJECT_LIBRARY_PROPERTIES})
+fairroot_library_settings(${target})
 
 target_include_directories(${target} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/eventdisplay/CMakeLists.txt
+++ b/eventdisplay/CMakeLists.txt
@@ -44,8 +44,7 @@ set(sources
 fair_change_extensions_if_exists(.cxx .h FILES "${sources}" OUTVAR headers)
 
 add_library(${target} SHARED ${sources} ${headers})
-add_library(FairRoot::${target} ALIAS ${target})
-set_target_properties(${target} PROPERTIES ${PROJECT_LIBRARY_PROPERTIES})
+fairroot_library_settings(${target})
 
 target_include_directories(${target} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/fairtools/CMakeLists.txt
+++ b/fairtools/CMakeLists.txt
@@ -23,8 +23,7 @@ set(sources
 fair_change_extensions_if_exists(.cxx .h FILES "${sources}" OUTVAR headers)
 
 add_library(${target} SHARED ${sources} ${headers})
-add_library(FairRoot::${target} ALIAS ${target})
-set_target_properties(${target} PROPERTIES ${PROJECT_LIBRARY_PROPERTIES})
+fairroot_library_settings(${target})
 
 target_include_directories(${target} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/fairtools/MCConfigurator/CMakeLists.txt
+++ b/fairtools/MCConfigurator/CMakeLists.txt
@@ -15,8 +15,7 @@ set(sources
 fair_change_extensions_if_exists(.cxx .h FILES "${sources}" OUTVAR headers)
 
 add_library(${target} SHARED ${sources} ${headers})
-add_library(FairRoot::${target} ALIAS ${target})
-set_target_properties(${target} PROPERTIES ${PROJECT_LIBRARY_PROPERTIES})
+fairroot_library_settings(${target})
 
 target_include_directories(${target} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/fairtools/MCStepLogger/CMakeLists.txt
+++ b/fairtools/MCStepLogger/CMakeLists.txt
@@ -9,8 +9,7 @@ set(sources
 )
 
 add_library(${target} SHARED ${sources})
-add_library(FairRoot::${target} ALIAS ${target})
-set_target_properties(${target} PROPERTIES ${PROJECT_LIBRARY_PROPERTIES})
+fairroot_library_settings(${target})
 
 target_include_directories(${target} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/geane/CMakeLists.txt
+++ b/geane/CMakeLists.txt
@@ -16,8 +16,7 @@ set(sources
 fair_change_extensions_if_exists(.cxx .h FILES "${sources}" OUTVAR headers)
 
 add_library(${target} SHARED ${sources} ${headers})
-add_library(FairRoot::${target} ALIAS ${target})
-set_target_properties(${target} PROPERTIES ${PROJECT_LIBRARY_PROPERTIES})
+fairroot_library_settings(${target})
 
 target_include_directories(${target} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/generators/CMakeLists.txt
+++ b/generators/CMakeLists.txt
@@ -23,8 +23,7 @@ set(sources
 fair_change_extensions_if_exists(.cxx .h FILES "${sources}" OUTVAR headers)
 
 add_library(${target} SHARED ${sources} ${headers})
-add_library(FairRoot::${target} ALIAS ${target})
-set_target_properties(${target} PROPERTIES ${PROJECT_LIBRARY_PROPERTIES})
+fairroot_library_settings(${target})
 
 target_include_directories(${target} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/geobase/CMakeLists.txt
+++ b/geobase/CMakeLists.txt
@@ -46,8 +46,7 @@ set(sources
 fair_change_extensions_if_exists(.cxx .h FILES "${sources}" OUTVAR headers)
 
 add_library(${target} SHARED ${sources} ${headers})
-add_library(FairRoot::${target} ALIAS ${target})
-set_target_properties(${target} PROPERTIES ${PROJECT_LIBRARY_PROPERTIES})
+fairroot_library_settings(${target})
 
 target_include_directories(${target} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/parbase/CMakeLists.txt
+++ b/parbase/CMakeLists.txt
@@ -28,8 +28,7 @@ set(sources
 fair_change_extensions_if_exists(.cxx .h FILES "${sources}" OUTVAR headers)
 
 add_library(${target} SHARED ${sources} ${headers})
-add_library(FairRoot::${target} ALIAS ${target})
-set_target_properties(${target} PROPERTIES ${PROJECT_LIBRARY_PROPERTIES})
+fairroot_library_settings(${target})
 
 target_include_directories(${target} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/parmq/CMakeLists.txt
+++ b/parmq/CMakeLists.txt
@@ -15,8 +15,7 @@ set(sources
 fair_change_extensions_if_exists(.cxx .h FILES "${sources}" OUTVAR headers)
 
 add_library(${target} SHARED ${sources} ${headers})
-add_library(FairRoot::${target} ALIAS ${target})
-set_target_properties(${target} PROPERTIES ${PROJECT_LIBRARY_PROPERTIES})
+fairroot_library_settings(${target})
 
 target_include_directories(${target} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/test/testlib/CMakeLists.txt
+++ b/test/testlib/CMakeLists.txt
@@ -16,8 +16,7 @@ set(sources
 fair_change_extensions_if_exists(.cxx .h FILES "${sources}" OUTVAR headers)
 
 add_library(${target} SHARED ${sources} ${headers})
-add_library(FairRoot::${target} ALIAS ${target})
-set_target_properties(${target} PROPERTIES ${PROJECT_LIBRARY_PROPERTIES})
+fairroot_library_settings(${target})
 
 target_include_directories(${target} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/trackbase/CMakeLists.txt
+++ b/trackbase/CMakeLists.txt
@@ -21,8 +21,7 @@ set(sources
 fair_change_extensions_if_exists(.cxx .h FILES "${sources}" OUTVAR headers)
 
 add_library(${target} SHARED ${sources} ${headers})
-add_library(FairRoot::${target} ALIAS ${target})
-set_target_properties(${target} PROPERTIES ${PROJECT_LIBRARY_PROPERTIES})
+fairroot_library_settings(${target})
 
 target_include_directories(${target} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>


### PR DESCRIPTION
This is an internal function only.  It encapsulates things that already happened and one new.

It is meant for all those libraries that get installed and are expected to be used by other projects.
It is explicitly not meant for the examples. Because they're not meant to be consumed by other projects.

Already happened:
* Add the FairRoot::${target} alias
* Set PROJECT_LIBRARY_PROPERTIES properties

New: fairroot_compile_features()

This sets cxx_std_* on the target.  This isn't very granular, but hopefully fits the current development model better.
The value being used depends on CMAKE_CXX_STANDARD or PROJECT_MIN_CXX_STANDARD.
So when exported targets come, consumers will at least use the CMAKE_CXX_STANDARD.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)