### PR TITLE
Simplify FairLogger/fmt Dependency Handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,14 +190,9 @@ endif()
 find_package2(PUBLIC FairLogger  VERSION 1.2.0 REQUIRED)
 
 foreach(dep IN LISTS FairLogger_PACKAGE_DEPENDENCIES)
-if(NOT dep STREQUAL "Boost")
-  find_package2(PUBLIC ${dep} REQUIRED VERSION ${FairLogger_${dep}_VERSION})
-  set(PROJECT_${dep}_VERSION ${FairLogger_${dep}_VERSION})
-  if(dep STREQUAL "fmt") # handling of external fmt installation
-    get_target_property(FMT_INCLUDE_DIR fmt::fmt INTERFACE_INCLUDE_DIRECTORIES)
-    set(FairLogger_INCDIR ${FairLogger_INCDIR} ${FMT_INCLUDE_DIR})
+  if(NOT dep STREQUAL "Boost")
+    find_package2(PUBLIC ${dep} REQUIRED ADD_REQUIREMENTS_OF FairLogger)
   endif()
-endif()
 endforeach()
 
 find_package2(PUBLIC Pythia6)

--- a/cmake/modules/FairMacros.cmake
+++ b/cmake/modules/FairMacros.cmake
@@ -338,9 +338,14 @@ EndMacro (Generate_Version_Info)
 
 Macro (SetBasicVariables)
 IF(FAIRROOT_FOUND)
+  if(TARGET fmt::fmt)
+    get_target_property(FMT_INCLUDE_DIR fmt::fmt INTERFACE_INCLUDE_DIRECTORIES)
+  endif()
   Set(BASE_INCLUDE_DIRECTORIES
     ${FAIRROOT_INCLUDE_DIR}
     ${VMC_INCLUDE_DIRS}
+    ${FairLogger_INCDIR}
+    ${FMT_INCLUDE_DIR}
   )
   Set(SYSTEM_INCLUDE_DIRECTORIES
     ${Boost_INCLUDE_DIRS}


### PR DESCRIPTION
FairRoot itself is now fully using CMake targets.
So there is no need to setup include directories for all and everything.
find_package2's ADD_REQUIREMENTS_OF also helps simplifying things.

On the other hand, projects using FairRoot are not yet there (especially, they can't with FairRoot itself until soon).  So let's improve include directory handling for them.  This is especially useful on spack based builds.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
