### PR TITLE
Fix serialization examples

### DIFF
--- a/examples/MQ/serialization/1-simple/testSerializationEx1.sh.in
+++ b/examples/MQ/serialization/1-simple/testSerializationEx1.sh.in
@@ -7,15 +7,14 @@ trap 'kill -TERM $GENERATE_PID; kill -TERM $SAMPLER_PID; kill -TERM $PROCESSOR1_
 INPUTFILE="@CMAKE_CURRENT_BINARY_DIR@/data_io/testinput1.root"
 OUTPUTFILE="@CMAKE_CURRENT_BINARY_DIR@/data_io/outputEx1Test.root"
 
-########################## start dummy data generator
 GENERATE="ex-serialization-generate-data"
 GENERATE+=" --output-file $INPUTFILE"
 GENERATE+=" --tree cbmsim"
 @CMAKE_CURRENT_BINARY_DIR@/$GENERATE &
 GENERATE_PID=$!
+
 wait $GENERATE_PID
 
-########################## start SAMPLER
 SAMPLER="ex-serialization1-sampler"
 SAMPLER+=" --id sampler1"
 SAMPLER+=" --channel-config name=data1,type=push,method=bind,address=tcp://localhost:1565"
@@ -26,32 +25,31 @@ SAMPLER+=" --verbosity veryhigh"
 @CMAKE_CURRENT_BINARY_DIR@/$SAMPLER &
 SAMPLER_PID=$!
 
-########################## start FILESINK
-FILESINK="ex-serialization1-sink"
-FILESINK+=" --id sink1"
-FILESINK+=" --channel-config name=data2,type=pull,method=bind,address=tcp://localhost:1566"
-FILESINK+=" --color false"
-FILESINK+=" --control static"
-FILESINK+=" --num-msgs 100"
-FILESINK+=" --output-file $OUTPUTFILE"
-FILESINK+=" --verbosity veryhigh"
-@CMAKE_CURRENT_BINARY_DIR@/$FILESINK &
-FILESINK_PID=$!
-
-sleep 2
-
-########################## start PROCESSOR
 PROCESSOR1="ex-serialization1-processor"
 PROCESSOR1+=" --id processor1"
 PROCESSOR1+=" --channel-config name=data1,type=pull,method=connect,address=tcp://localhost:1565"
 PROCESSOR1+="                  name=data2,type=push,method=connect,address=tcp://localhost:1566"
 PROCESSOR1+=" --color false"
 PROCESSOR1+=" --control static"
-PROCESSOR1+=" --num-msgs 100"
 PROCESSOR1+=" --verbosity veryhigh"
 @CMAKE_CURRENT_BINARY_DIR@/$PROCESSOR1 &
 PROCESSOR1_PID=$!
 
+FILESINK="ex-serialization1-sink"
+FILESINK+=" --id sink1"
+FILESINK+=" --channel-config name=data2,type=pull,method=bind,address=tcp://localhost:1566"
+FILESINK+=" --color false"
+FILESINK+=" --control static"
+FILESINK+=" --output-file $OUTPUTFILE"
+FILESINK+=" --num-msgs 100"
+FILESINK+=" --verbosity veryhigh"
+@CMAKE_CURRENT_BINARY_DIR@/$FILESINK &
+FILESINK_PID=$!
+
+wait $FILESINK_PID
+
+kill -SIGINT $SAMPLER_PID
+kill -SIGINT $PROCESSOR1_PID
+
 wait $SAMPLER_PID
 wait $PROCESSOR1_PID
-wait $FILESINK_PID

--- a/examples/MQ/serialization/2-multipart/Ex2Processor.h
+++ b/examples/MQ/serialization/2-multipart/Ex2Processor.h
@@ -17,22 +17,11 @@ class Ex2Processor : public FairMQDevice
     Ex2Processor()
         : fInput(nullptr)
         , fOutput(nullptr)
-        , fNumMsgs(0)
     {}
 
-    Ex2Processor(const Ex2Processor&);
-    Ex2Processor& operator=(const Ex2Processor&);
+    void Init() override { fOutput = new TClonesArray("MyHit"); }
 
-    virtual ~Ex2Processor() {}
-
-  protected:
-    virtual void Init()
-    {
-        fNumMsgs = fConfig->GetValue<int>("num-msgs");
-        fOutput = new TClonesArray("MyHit");
-    }
-
-    virtual void Run()
+    void Run() override
     {
         int receivedMsgs = 0;
         int sentMsgs = 0;
@@ -55,13 +44,8 @@ class Ex2Processor : public FairMQDevice
 
                 Serialize<BoostSerializer<Ex2Header>>(*(partsOut.At(0)), *header);
                 Serialize<BoostSerializer<MyHit>>(*(partsOut.At(1)), fOutput);
-                Send(partsOut, "data2");
-                sentMsgs++;
-
-                if (fNumMsgs != 0) {
-                    if (receivedMsgs == fNumMsgs) {
-                        break;
-                    }
+                if (Send(partsOut, "data2") >= 0) {
+                    sentMsgs++;
                 }
             }
         }
@@ -91,7 +75,6 @@ class Ex2Processor : public FairMQDevice
   private:
     TClonesArray* fInput;
     TClonesArray* fOutput;
-    int fNumMsgs;
 };
 
 #endif

--- a/examples/MQ/serialization/2-multipart/Ex2Sink.h
+++ b/examples/MQ/serialization/2-multipart/Ex2Sink.h
@@ -13,45 +13,22 @@ class Ex2Sink : public FairMQDevice
 {
   public:
     Ex2Sink()
-        : FairMQDevice()
-        , fInput(nullptr)
-        , fFileName()
+        : fInput(nullptr)
         , fOutFile(nullptr)
-        , fTree(nullptr)
+        , fTree("SerializationEx1", "Test output")
         , fNumMsgs(0)
     {}
 
-    Ex2Sink(const Ex2Sink&);
-    Ex2Sink& operator=(const Ex2Sink&);
-
-    virtual ~Ex2Sink()
-    {
-        if (fTree) {
-            fTree->Write("", TObject::kOverwrite);
-
-            delete fTree;
-        }
-
-        if (fOutFile) {
-            if (fOutFile->IsOpen()) {
-                fOutFile->Close();
-            }
-            delete fOutFile;
-        }
-    }
-
-  protected:
-    virtual void Init()
+    void Init() override
     {
         fNumMsgs = fConfig->GetValue<int>("num-msgs");
         fFileName = fConfig->GetValue<std::string>("output-file");
         fOutFile = TFile::Open(fFileName.c_str(), "RECREATE");
         fInput = new TClonesArray("MyHit");
-        fTree = new TTree("SerializationEx2", "output");
-        fTree->Branch("MyHit", "TClonesArray", &fInput);
+        fTree.Branch("MyHit", "TClonesArray", &fInput);
     }
 
-    virtual void Run()
+    void Run() override
     {
         int receivedMsgs = 0;
         while (!NewStatePending()) {
@@ -62,8 +39,8 @@ class Ex2Sink : public FairMQDevice
                 Deserialize<BoostSerializer<MyHit>>(*(parts.At(1)), fInput);
 
                 receivedMsgs++;
-                fTree->SetBranchAddress("MyHit", &fInput);
-                fTree->Fill();
+                fTree.SetBranchAddress("MyHit", &fInput);
+                fTree.Fill();
 
                 if (fNumMsgs != 0) {
                     if (receivedMsgs == fNumMsgs) {
@@ -72,15 +49,32 @@ class Ex2Sink : public FairMQDevice
                 }
             }
         }
+
         LOG(info) << "Received " << receivedMsgs << " messages!";
+    }
+
+    void Reset() override
+    {
+        fTree.Write("", TObject::kOverwrite);
+
+        if (fOutFile) {
+            if (fOutFile->IsOpen()) {
+                fOutFile->Close();
+            }
+            delete fOutFile;
+        }
+
+        if (fInput) {
+            delete fInput;
+        }
     }
 
   private:
     TClonesArray* fInput;
     std::string fFileName;
     TFile* fOutFile;
-    TTree* fTree;
+    TTree fTree;
     int fNumMsgs;
 };
 
-#endif
+#endif   // EX2SINK_H

--- a/examples/MQ/serialization/2-multipart/testSerializationEx2.sh.in
+++ b/examples/MQ/serialization/2-multipart/testSerializationEx2.sh.in
@@ -7,7 +7,6 @@ trap 'kill -TERM $GENERATE_PID; kill -TERM $SAMPLER_PID; kill -TERM $PROCESSOR1_
 INPUTFILE="@CMAKE_CURRENT_BINARY_DIR@/data_io/testinput2.root"
 OUTPUTFILE="@CMAKE_CURRENT_BINARY_DIR@/data_io/outputEx2Test.root"
 
-########################## start dummy data generator
 GENERATE="ex-serialization-generate-data"
 GENERATE+=" --output-file $INPUTFILE"
 GENERATE+=" --tree cbmsim"
@@ -15,7 +14,6 @@ GENERATE+=" --tree cbmsim"
 GENERATE_PID=$!
 wait $GENERATE_PID
 
-########################## start SAMPLER
 SAMPLER="ex-serialization2-sampler"
 SAMPLER+=" --id sampler1"
 SAMPLER+=" --channel-config name=data1,type=push,method=bind,address=tcp://localhost:1565"
@@ -26,7 +24,16 @@ SAMPLER+=" --verbosity veryhigh"
 @CMAKE_CURRENT_BINARY_DIR@/$SAMPLER &
 SAMPLER_PID=$!
 
-########################## start FILESINK
+PROCESSOR1="ex-serialization2-processor"
+PROCESSOR1+=" --id processor1"
+PROCESSOR1+=" --channel-config name=data1,type=pull,method=connect,address=tcp://localhost:1565"
+PROCESSOR1+="                  name=data2,type=push,method=connect,address=tcp://localhost:1566"
+PROCESSOR1+=" --color false"
+PROCESSOR1+=" --control static"
+PROCESSOR1+=" --verbosity veryhigh"
+@CMAKE_CURRENT_BINARY_DIR@/$PROCESSOR1 &
+PROCESSOR1_PID=$!
+
 FILESINK="ex-serialization2-sink"
 FILESINK+=" --id sink1"
 FILESINK+=" --channel-config name=data2,type=pull,method=bind,address=tcp://localhost:1566"
@@ -38,20 +45,10 @@ FILESINK+=" --verbosity veryhigh"
 @CMAKE_CURRENT_BINARY_DIR@/$FILESINK &
 FILESINK_PID=$!
 
-sleep 2
+wait $FILESINK_PID
 
-########################## start PROCESSOR
-PROCESSOR1="ex-serialization2-processor"
-PROCESSOR1+=" --id processor1"
-PROCESSOR1+=" --channel-config name=data1,type=pull,method=connect,address=tcp://localhost:1565"
-PROCESSOR1+="                  name=data2,type=push,method=connect,address=tcp://localhost:1566"
-PROCESSOR1+=" --color false"
-PROCESSOR1+=" --control static"
-PROCESSOR1+=" --num-msgs 100"
-PROCESSOR1+=" --verbosity veryhigh"
-@CMAKE_CURRENT_BINARY_DIR@/$PROCESSOR1 &
-PROCESSOR1_PID=$!
+kill -SIGINT $SAMPLER_PID
+kill -SIGINT $PROCESSOR1_PID
 
 wait $SAMPLER_PID
 wait $PROCESSOR1_PID
-wait $FILESINK_PID

--- a/examples/MQ/serialization/CMakeLists.txt
+++ b/examples/MQ/serialization/CMakeLists.txt
@@ -100,17 +100,15 @@ install(TARGETS
   RUNTIME DESTINATION ${PROJECT_INSTALL_DATADIR}/examples/MQ/serialization/bin
 )
 
-add_test(NAME ex_MQ_serialization1
-         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/testSerializationEx1.sh)
+add_test(NAME ex_MQ_serialization1 COMMAND ${CMAKE_CURRENT_BINARY_DIR}/testSerializationEx1.sh)
 set_tests_properties(ex_MQ_serialization1 PROPERTIES
   TIMEOUT "30"
-  PASS_REGULAR_EXPRESSION "Received 100 and sent 100 messages!"
+  PASS_REGULAR_EXPRESSION "Received 100 messages!"
 )
 
-add_test(NAME ex_MQ_serialization2
-         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/testSerializationEx2.sh)
+add_test(NAME ex_MQ_serialization2 COMMAND ${CMAKE_CURRENT_BINARY_DIR}/testSerializationEx2.sh)
 set_tests_properties(ex_MQ_serialization2 PROPERTIES
   DEPENDS ex_MQ_serialization1
   TIMEOUT "30"
-  PASS_REGULAR_EXPRESSION "Received 100 and sent 100 messages!"
+  PASS_REGULAR_EXPRESSION "Received 100 messages!"
 )


### PR DESCRIPTION
Fixes the race in the serialization examples tests, where a device could exit before transferring all the messages.

Fixes #1048.