### PR TITLE
Make rtdb less restrictive regarding backends

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -15,6 +15,7 @@ Kollegger, Thorsten
 Koenig, Ilse
 Krzewicki, Mikolaj
 Lavezzi, Lia
+Lavrik, Evgeny
 Lantwin, Oliver
 Manafov, Anar
 Mayer, Jan

--- a/parbase/FairRuntimeDb.cxx
+++ b/parbase/FairRuntimeDb.cxx
@@ -361,12 +361,12 @@ Bool_t FairRuntimeDb::writeContainer(FairParSet* container, FairRtdbRun* run, Fa
     // The output might be suppressed if the changes is due an initialisation from a
     //   ROOT file which serves also as output or if it was already written
     const Text_t* containerName = container->GetName();
-    const Text_t* outputName = output->GetName();
     LOG(debug) << "RuntimeDb: write container: " << containerName;
 
     FairParVersion* vers = run->getParVersion(containerName);
     Int_t containerVersion = 0;
     if (getOutput() && output->check() && output->isAutoWritable()) {
+        const Text_t* outputName = output->GetName();
         if (container->hasChanged()) {
             containerVersion = container->write(output);
             if (containerVersion == -1) {

--- a/parbase/FairRuntimeDb.cxx
+++ b/parbase/FairRuntimeDb.cxx
@@ -74,7 +74,6 @@ FairRuntimeDb::FairRuntimeDb(void)
     , versionsChanged(kFALSE)
     , isRootFileOutput(kFALSE)
     , fLogger(FairLogger::GetLogger())
-    , ioType(UNKNOWN_Type)
 {
     gRtdb = this;
 }
@@ -749,12 +748,7 @@ Bool_t FairRuntimeDb::setOutput(FairParIo* op)
     if (output->check() == kTRUE) {
         resetOutputVersions();
         if (strcmp(output->IsA()->GetName(), "FairParRootFileIo") == 0) {
-            ioType = RootFileOutput;
             isRootFileOutput = kTRUE;
-        } else if (strcmp(output->IsA()->GetName(), "FairParTSQLIo") == 0) {
-            ioType = RootTSQLOutput;
-        } else {   // ASCII
-            ioType = AsciiFileOutput;
         }
         return kTRUE;
     } else {
@@ -852,11 +846,6 @@ void FairRuntimeDb::activateParIo(FairParIo* io)
                 new FairGenericParAsciiFileIo((static_cast<FairParAsciiFileIo*>(io))->getFile());
             io->setDetParIo(pn);
         }
-        // else if(strcmp(ioName,"FairParTSQLIo") == 0) {
-        //  std::cout << "\n\n\n\t TSQL versie is called en nu de rest \n\n";
-        //  FairDetParTSQLIo* pn = new FairGenericParTSQLIo();
-        //  io->setDetParIo(pn);
-        //}
     }
     TIter next(&contFactories);
     FairContFact* fact;

--- a/parbase/FairRuntimeDb.h
+++ b/parbase/FairRuntimeDb.h
@@ -40,18 +40,6 @@ class FairRuntimeDb : public TObject
     /** Fair Logger */
     FairLogger* fLogger;   //!
 
-    /**
-     * Select which IO type to use.
-     */
-    typedef enum
-    {
-        UNKNOWN_Type = 0,
-        AsciiFileOutput = 1,   // Ascii in-out-put
-        RootFileOutput = 2,    // Root Files
-        RootTSQLOutput = 3     // Use a TSQL db
-    } ParamIOType;
-    ParamIOType ioType;   // IO Type
-
   public:
     static FairRuntimeDb* instance(void);
     ~FairRuntimeDb(void);


### PR DESCRIPTION
I went ahead and implemented the small changes requested in #1079 against 18.2.1 used in CbmRoot.

This way I was able to create an RTDB backend in an external project and properly use it.

If possible I'd like to request a new 18.2.2 release with this code, so we can use it in current CbmRoot.

The same changes are also available for current master and can be proposed in a separate PR.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
