### PR TITLE
Fix Warnings: sprintf and missing override

### DIFF
--- a/examples/MQ/serialization/1-simple/Ex1Sampler.h
+++ b/examples/MQ/serialization/1-simple/Ex1Sampler.h
@@ -63,7 +63,7 @@ class Ex1Sampler : public FairMQDevice
         }
     }
 
-    void Reset()
+    void Reset() override
     {
         if (fInputFile) {
             fInputFile->Close();

--- a/examples/MQ/serialization/2-multipart/Ex2Sampler.h
+++ b/examples/MQ/serialization/2-multipart/Ex2Sampler.h
@@ -75,7 +75,7 @@ class Ex2Sampler : public FairMQDevice
         }
     }
 
-    void Reset()
+    void Reset() override
     {
         if (fInputFile) {
             fInputFile->Close();

--- a/examples/simulation/rutherford/src/FairRutherfordGeo.cxx
+++ b/examples/simulation/rutherford/src/FairRutherfordGeo.cxx
@@ -29,7 +29,7 @@ const char* FairRutherfordGeo::getModuleName(Int_t m)
       ASCII file should start with FairRutherford otherwise they will
       not be constructed
   */
-    sprintf(modName, "rutherford%i", m + 1);
+    snprintf(modName, sizeof(modName), "rutherford%i", m + 1);
     return modName;
 }
 

--- a/examples/simulation/rutherford/src/FairRutherfordGeo.h
+++ b/examples/simulation/rutherford/src/FairRutherfordGeo.h
@@ -17,7 +17,7 @@ class FairRutherfordGeo : public FairGeoSet
 {
 
   protected:
-    char modName[20];   // name of module
+    char modName[22];   // name of module
     char eleName[20];   // substring for elements in module
   public:
     FairRutherfordGeo();

--- a/geobase/FairGeoRootBuilder.cxx
+++ b/geobase/FairGeoRootBuilder.cxx
@@ -127,8 +127,8 @@ Bool_t FairGeoRootBuilder::createNode(FairGeoNode* volu, Int_t hadFormat)
             tr = new TGeoTranslation(pos.getX(), pos.getY(), pos.getZ());
         } else {
             nRot++;
-            char b[10];
-            sprintf(b, "R%i", nRot);
+            char b[13];
+            snprintf(b, sizeof(b), "R%i", nRot);
             TGeoRotation* r = new TGeoRotation(b);
             Double_t a[9];
             for (Int_t i = 0; i < 9; i++) {


### PR DESCRIPTION
* Use `override` in methods that actually override base functions.

* Increase string buffers to have enough space for 32bit integeers, and use snprintf so to not overwrite any buffer boundaries.

Should fix: #1005

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
