### PR TITLE
Small parbase Cleanup

### DIFF
--- a/parbase/FairContFact.h
+++ b/parbase/FairContFact.h
@@ -42,7 +42,7 @@ class FairContainer : public TNamed
     void print();
     TString getConcatName();
     const char* getContext();
-    ClassDef(FairContainer, 0);   // class for list elements in class FairContFact
+    ClassDefOverride(FairContainer, 0);   // class for list elements in class FairContFact
 };
 
 class FairContFact : public TNamed
@@ -66,7 +66,7 @@ class FairContFact : public TNamed
     }
     /** Fair Logger */
     FairLogger* fLogger;         //!
-    ClassDef(FairContFact, 0);   // base class of all factories for parameter containers
+    ClassDefOverride(FairContFact, 0);   // base class of all factories for parameter containers
 
   private:
     FairContFact(const FairContFact&);

--- a/parbase/FairDetParAsciiFileIo.h
+++ b/parbase/FairDetParAsciiFileIo.h
@@ -22,7 +22,6 @@ class FairDetParAsciiFileIo : public FairDetParIo
     TString fHeader;       //! header of container output in file
     TString sepLine;       //! comment line
     std::fstream* pFile;   //! pointer to ascii file
-    // virtual Bool_t write(HDetector*) {return kTRUE;}
     Bool_t findContainer(const Text_t* name);
     Bool_t checkAllFound(Int_t*, Int_t);
     void writeHeader(const Text_t*,
@@ -31,24 +30,16 @@ class FairDetParAsciiFileIo : public FairDetParIo
                      const Text_t* description = "");
     void writeComment(FairParSet*);
     void readComment(const Char_t*, FairParSet*);
-    // Bool_t readLabPositions(const Text_t*,HDetGeomPar*,Int_t*,Int_t,Int_t);
-    // Bool_t readVolumes(const Text_t*,HDetGeomPar*);
-    // void readTransform(HGeomTransform&);
-    // Bool_t readVolume(HGeomVolume*,HGeomShapes*,Text_t*);
-    // void writeTransform(const HGeomTransform&);
-    // void writeVolume(HGeomVolume*,HGeomShapes*);
 
   public:
     FairDetParAsciiFileIo(std::fstream* f);
     virtual ~FairDetParAsciiFileIo() {}
-    // Bool_t read(HDetGeomPar*,Int_t*);
-    // Int_t writeFile(HDetGeomPar*);
 
   private:
     FairDetParAsciiFileIo& operator=(const FairDetParAsciiFileIo&);
     FairDetParAsciiFileIo(const FairDetParAsciiFileIo&);
 
-    ClassDef(FairDetParAsciiFileIo, 0);   // Class for detector parameter I/O from ascii file
+    ClassDefOverride(FairDetParAsciiFileIo, 0);   // Class for detector parameter I/O from ascii file
 };
 
 #endif /* !FAIRDETPARASCIIFILEIO_H */

--- a/parbase/FairDetParIo.h
+++ b/parbase/FairDetParIo.h
@@ -34,7 +34,7 @@ class FairDetParIo : public TNamed
     // writes parameter container to output
     virtual Int_t write(FairParSet*) { return kFALSE; }
 
-    ClassDef(FairDetParIo, 0);   // Base class for detector parameter IO
+    ClassDefOverride(FairDetParIo, 0);   // Base class for detector parameter IO
 };
 
 #endif /* !HDETPARIO_H */

--- a/parbase/FairDetParRootFileIo.h
+++ b/parbase/FairDetParRootFileIo.h
@@ -25,8 +25,7 @@ class FairDetParRootFileIo : public FairDetParIo
     FairDetParRootFileIo(FairParRootFile* f);
     virtual ~FairDetParRootFileIo() {}
     virtual Bool_t read(FairParSet*);
-    Int_t write(FairParSet*);
-    // Bool_t read(HDetGeomPar*,Int_t*);
+    Int_t write(FairParSet*) override;
 
   protected:
     Int_t findInputVersion(Text_t* contName);
@@ -37,7 +36,7 @@ class FairDetParRootFileIo : public FairDetParIo
     FairDetParRootFileIo(const FairDetParRootFileIo&);
     FairDetParRootFileIo& operator=(const FairDetParRootFileIo&);
 
-    ClassDef(FairDetParRootFileIo, 0);   // detector base class for parameter I/O from ROOT file
+    ClassDefOverride(FairDetParRootFileIo, 0);   // detector base class for parameter I/O from ROOT file
 };
 
 #endif /* !FAIRDETPARROOTFILEIO_H */

--- a/parbase/FairGenericParAsciiFileIo.h
+++ b/parbase/FairGenericParAsciiFileIo.h
@@ -22,12 +22,12 @@ class FairGenericParAsciiFileIo : public FairDetParAsciiFileIo
   public:
     FairGenericParAsciiFileIo(std::fstream* f = 0);
     ~FairGenericParAsciiFileIo() {}
-    Bool_t init(FairParSet*);
-    Int_t write(FairParSet*);
+    Bool_t init(FairParSet*) override;
+    Int_t write(FairParSet*) override;
 
   private:
-    ClassDef(FairGenericParAsciiFileIo,
-             0)   // I/O from Ascii file for parameter containers derived from FairParGenericSet
+    ClassDefOverride(FairGenericParAsciiFileIo,
+                     0)   // I/O from Ascii file for parameter containers derived from FairParGenericSet
         Bool_t readGenericSet(FairParGenericSet* pPar);
     Int_t writeGenericSet(FairParGenericSet* pPar);
 

--- a/parbase/FairGenericParRootFileIo.h
+++ b/parbase/FairGenericParRootFileIo.h
@@ -20,9 +20,9 @@ class FairGenericParRootFileIo : public FairDetParRootFileIo
   public:
     FairGenericParRootFileIo(FairParRootFile* f = 0);
     ~FairGenericParRootFileIo() {}
-    Bool_t init(FairParSet*);
-    ClassDef(FairGenericParRootFileIo,
-             0)   // I/O from ROOT file for parameter containers derived from FairParGenericSet
+    Bool_t init(FairParSet*) override;
+    ClassDefOverride(FairGenericParRootFileIo,
+                     0)   // I/O from ROOT file for parameter containers derived from FairParGenericSet
 };
 
 #endif /* !FAIRGENERICPARROOTFILEIO_H */

--- a/parbase/FairParAsciiFileIo.h
+++ b/parbase/FairParAsciiFileIo.h
@@ -38,10 +38,10 @@ class FairParAsciiFileIo : public FairParIo
     Bool_t open(const TList* fnamelist, const Text_t* status = "in");
 
     // closes file
-    void close();
+    void close() override;
 
     // returns kTRUE if file is open
-    Bool_t check()
+    Bool_t check() override
     {
         if (file) {
             return (file->rdbuf()->is_open() == 1);
@@ -51,7 +51,7 @@ class FairParAsciiFileIo : public FairParIo
     }
 
     // prints information about the file and the detector I/Os
-    void print();
+    void print() override;
 
     std::fstream* getFile();
 
@@ -59,7 +59,7 @@ class FairParAsciiFileIo : public FairParIo
     FairParAsciiFileIo(const FairParAsciiFileIo&);
     FairParAsciiFileIo& operator=(const FairParAsciiFileIo&);
 
-    ClassDef(FairParAsciiFileIo, 0);   // Parameter I/O from ASCII files
+    ClassDefOverride(FairParAsciiFileIo, 0);   // Parameter I/O from ASCII files
 };
 
 #endif /* !FAIRPARASCIIFILEIO_H */

--- a/parbase/FairParGenericSet.h
+++ b/parbase/FairParGenericSet.h
@@ -26,18 +26,14 @@ class FairParGenericSet : public FairParSet
     virtual Bool_t getParams(FairParamList*) = 0;
     virtual void printParams();
 
-    Bool_t init(FairParIo* inp);
-    Int_t write(FairParIo* output);
-
-    // DB add on
-    void fill(UInt_t){};
-    void store(UInt_t){};
+    Bool_t init(FairParIo* inp) override;
+    Int_t write(FairParIo* output) override;
 
   protected:
     FairParGenericSet()
         : FairParSet()
     {}
-    ClassDef(FairParGenericSet, 1);   // Base class for generic-style parameter containers
+    ClassDefOverride(FairParGenericSet, 1);   // Base class for generic-style parameter containers
 };
 
 #endif /* !FAIRPARGENERICSET_H */

--- a/parbase/FairParIo.h
+++ b/parbase/FairParIo.h
@@ -61,7 +61,7 @@ class FairParIo : public TObject
     FairParIo(const FairParIo&);
     FairParIo& operator=(const FairParIo&);
 
-    ClassDef(FairParIo, 0);   // Base class for all parameter I/Os
+    ClassDefOverride(FairParIo, 0);   // Base class for all parameter I/Os
 };
 
 #endif /* !FAIRPARIO_H */

--- a/parbase/FairParRootFileIo.h
+++ b/parbase/FairParRootFileIo.h
@@ -45,7 +45,7 @@ class FairParRootFile : public TNamed
     FairParRootFile(const FairParRootFile&);
     FairParRootFile& operator=(const FairParRootFile&);
 
-    ClassDef(FairParRootFile, 0);   // ROOT file for Parameter I/O
+    ClassDefOverride(FairParRootFile, 0);   // ROOT file for Parameter I/O
 };
 
 class FairParRootFileIo : public FairParIo
@@ -60,12 +60,12 @@ class FairParRootFileIo : public FairParIo
     ~FairParRootFileIo();
     Bool_t open(const Text_t* fname, Option_t* option = "READ", const Text_t* ftitle = "", Int_t compress = 1);
     Bool_t open(const TList* fnamelist, Option_t* option = "READ", const Text_t* ftitle = "", Int_t compress = 1);
-    void close();
-    void print();
+    void close() override;
+    void print() override;
     FairParRootFile* getParRootFile();
-    void readVersions(FairRtdbRun*);
+    void readVersions(FairRtdbRun*) override;
     TList* getKeys();
-    Bool_t check()
+    Bool_t check() override
     {
         // returns kTRUE if file is open
         if (file) {
@@ -74,7 +74,7 @@ class FairParRootFileIo : public FairParIo
             return kFALSE;
         }
     }
-    void cd()
+    void cd() override
     {
         // sets the global ROOT file pointer gFile
         if (file) {
@@ -91,7 +91,7 @@ class FairParRootFileIo : public FairParIo
     FairParRootFileIo(const FairParRootFileIo&);
     FairParRootFileIo& operator=(const FairParRootFileIo&);
 
-    ClassDef(FairParRootFileIo, 0);   // Parameter I/O from ROOT files
+    ClassDefOverride(FairParRootFileIo, 0);   // Parameter I/O from ROOT files
 };
 
 #endif /* !FAIRPARROOTFILEIO_H */

--- a/parbase/FairParSet.h
+++ b/parbase/FairParSet.h
@@ -35,8 +35,8 @@ class FairParSet : public TObject
     FairParSet(const char* name = "", const char* title = "", const char* context = "", Bool_t owner = kFALSE);
     virtual ~FairParSet() {}
 
-    virtual const char* GetName() const { return static_cast<const char*>(fName.Data()); }
-    virtual const char* GetTitle() const { return static_cast<const char*>(fTitle.Data()); }
+    const char* GetName() const override { return static_cast<const char*>(fName.Data()); }
+    const char* GetTitle() const override { return static_cast<const char*>(fTitle.Data()); }
 
     virtual Bool_t init();
     virtual Bool_t init(FairParIo*) { return kFALSE; }
@@ -86,13 +86,16 @@ class FairParSet : public TObject
         description = r.getDescription();
     }
 
+    // TODO These two methods are not used in FairRoot at all.
+    // They probably should be marked deprecated (or final, or = delete)
+    // and later removed.
     virtual void fill(UInt_t){};
     virtual void store(UInt_t){};
 
     FairParSet& operator=(const FairParSet&);
     FairParSet(const FairParSet&);
 
-    ClassDef(FairParSet, 2);   // Base class for all parameter containers
+    ClassDefOverride(FairParSet, 2);   // Base class for all parameter containers
 };
 
 #endif /* !FAIRPARSET_H */

--- a/parbase/FairParamList.h
+++ b/parbase/FairParamList.h
@@ -75,7 +75,7 @@ class FairParamObj : public TNamed
     FairParamObj& operator=(const FairParamObj&);
 
     // Class for binary parameter object (name + binary array)
-    ClassDef(FairParamObj, 0);
+    ClassDefOverride(FairParamObj, 0);
 };
 
 class FairParamList : public TObject
@@ -141,7 +141,7 @@ class FairParamList : public TObject
     FairParamList& operator=(const FairParamList&);
 
     // Class for lists of parameters (of type FairParamObj)
-    ClassDef(FairParamList, 4);
+    ClassDefOverride(FairParamList, 4);
 };
 
 #endif /* !FAIRPARAMLIST_H */

--- a/parbase/FairRtdbRun.h
+++ b/parbase/FairRtdbRun.h
@@ -52,7 +52,7 @@ class FairParVersion : public TNamed
     }
     void setRootVersion(Int_t v) { rootVersion = v; }
     Int_t getRootVersion() { return rootVersion; }
-    ClassDef(FairParVersion, 1);   // Class for parameter versions
+    ClassDefOverride(FairParVersion, 1);   // Class for parameter versions
 };
 
 class FairRtdbRun : public TNamed
@@ -82,7 +82,7 @@ class FairRtdbRun : public TNamed
   private:
     FairRtdbRun& operator=(const FairRtdbRun&);
 
-    ClassDef(FairRtdbRun, 1);   // Class for parameter version management of a run
+    ClassDefOverride(FairRtdbRun, 1);   // Class for parameter version management of a run
 };
 
 // -------------------- inlines ---------------------------

--- a/parbase/FairRuntimeDb.cxx
+++ b/parbase/FairRuntimeDb.cxx
@@ -365,7 +365,6 @@ Bool_t FairRuntimeDb::writeContainer(FairParSet* cont, FairRtdbRun* run, FairRtd
     const Text_t* c = cont->GetName();
     LOG(debug) << "RuntimeDb: write container: " << cont->GetName();
     FairParVersion* vers = run->getParVersion(c);
-    Bool_t rc = kTRUE;
     Int_t cv = 0;
     if (getOutput() && output->check() && output->isAutoWritable()) {
         switch (ioType) {
@@ -433,7 +432,7 @@ Bool_t FairRuntimeDb::writeContainer(FairParSet* cont, FairRtdbRun* run, FairRtd
             refVers->setRootVersion(cv);
         }
     }
-    return rc;
+    return kTRUE;
 }
 
 Bool_t FairRuntimeDb::initContainers(Int_t runId, Int_t refId, const Text_t* fileName)

--- a/parbase/FairRuntimeDb.h
+++ b/parbase/FairRuntimeDb.h
@@ -112,7 +112,7 @@ class FairRuntimeDb : public TObject
     FairRuntimeDb& operator=(const FairRuntimeDb&) { return *this; }
     Bool_t initContainers(void);
 
-    ClassDef(FairRuntimeDb, 0);   // Class for runtime database
+    ClassDefOverride(FairRuntimeDb, 0);   // Class for runtime database
 };
 
 #endif /* !FAIRRUNTIMEDB_H */


### PR DESCRIPTION
* Lots of `override`
* Use `ClassDefOverride` when deriving from a class already using `ClassDef`
* Mark `fill`/`store` for deprecation
* Little cleanup of `FairRuntimeDb::writeContainer`
* Drop commented out `HDetector*`, `HDet*`, `HGeom*`

I would like to put a `[[deprecated("Not used in FairRoot, will be removed soon")]]` on `fill`/`store`. But that would require to bump to C++14.

See: #1088

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
