### PR TITLE
Do not use deprecated serialization methods

### DIFF
--- a/examples/MQ/histogramServer/FairMQExHistoDevice.cxx
+++ b/examples/MQ/histogramServer/FairMQExHistoDevice.cxx
@@ -52,7 +52,7 @@ bool FairMQExHistoDevice::ConditionalRun()
     fh_histo4.Fill(x, y);
 
     FairMQMessagePtr message(NewMessage());
-    Serialize<RootSerializer>(*message, &fArrayHisto);
+    RootSerializer().Serialize(*message, &fArrayHisto);
 
     for (auto& channel : fChannels) {
         Send(message, channel.first.data());

--- a/examples/MQ/histogramServer/FairMQExHistoServer.cxx
+++ b/examples/MQ/histogramServer/FairMQExHistoServer.cxx
@@ -43,7 +43,7 @@ void FairMQExHistoServer::InitTask()
 bool FairMQExHistoServer::ReceiveData(FairMQMessagePtr& msg, int index)
 {
     TObject* tempObject = nullptr;
-    Deserialize<RootSerializer>(*msg, tempObject);
+    RootSerializer().Deserialize(*msg, tempObject);
 
     if (TString(tempObject->ClassName()).EqualTo("TObjArray")) {
         std::lock_guard<std::mutex> lk(mtx);

--- a/examples/MQ/parameters/FairMQExParamsClient.cxx
+++ b/examples/MQ/parameters/FairMQExParamsClient.cxx
@@ -52,7 +52,7 @@ bool FairMQExParamsClient::ConditionalRun()
         if (Receive(rep, "data") >= 0) {
             if (rep->GetSize() != 0) {
                 FairMQExParamsParOne* par = nullptr;
-                Deserialize<RootSerializer>(*rep, par);
+                RootSerializer().Deserialize(*rep, par);
                 LOG(info) << "Received parameter from the server:";
                 par->print();
                 delete par;

--- a/examples/MQ/pixelAlternative/src/devices/FairMQPixAltTaskProcessorBin.h
+++ b/examples/MQ/pixelAlternative/src/devices/FairMQPixAltTaskProcessorBin.h
@@ -182,7 +182,7 @@ class FairMQPixAltTaskProcessorBin : public FairMQDevice
         if (Send(req, fParamChannelName) > 0) {
             if (Receive(rep, fParamChannelName) > 0) {
                 thisPar = nullptr;
-                Deserialize<RootSerializer>(*rep, thisPar);
+                RootSerializer().Deserialize(*rep, thisPar);
                 LOG(info) << "Received parameter" << paramName << " from the server (" << thisPar << ")";
                 return thisPar;
             }

--- a/examples/MQ/pixelDetector/src/devices/FairMQPixelFileSink.cxx
+++ b/examples/MQ/pixelDetector/src/devices/FairMQPixelFileSink.cxx
@@ -75,7 +75,7 @@ bool FairMQPixelFileSink::StoreData(FairMQParts& parts, int /*index*/)
 
     for (int ipart = 0; ipart < parts.Size(); ipart++) {
         fOutputObjects[ipart] = nullptr;
-        Deserialize<RootSerializer>(*parts.At(ipart), fOutputObjects[ipart]);
+        RootSerializer().Deserialize(*parts.At(ipart), fOutputObjects[ipart]);
         tempObjects.push_back(fOutputObjects[ipart]);
         if (creatingTree)
             fTree->Branch(tempObjects.back()->GetName(), tempObjects.back()->ClassName(), &fOutputObjects[ipart]);

--- a/examples/MQ/pixelDetector/src/devices/FairMQPixelMerger.cxx
+++ b/examples/MQ/pixelDetector/src/devices/FairMQPixelMerger.cxx
@@ -54,7 +54,7 @@ bool FairMQPixelMerger::MergeData(FairMQParts& parts, int /*index*/)
     // "******************************************************************************************************";
     for (int ipart = 0; ipart < parts.Size(); ipart++) {
         tempObject = nullptr;
-        Deserialize<RootSerializer>(*parts.At(ipart), tempObject);
+        RootSerializer().Deserialize(*parts.At(ipart), tempObject);
         if (strcmp(tempObject->GetName(), "EventHeader.") == 0) {
             fEventHeader = (PixelEventHeader*)tempObject;
             // LOG(debug) << "GOT PART [" << fEventHeader->GetRunId() << "][" << fEventHeader->GetMCEntryNumber() <<
@@ -144,11 +144,11 @@ bool FairMQPixelMerger::MergeData(FairMQParts& parts, int /*index*/)
         FairMQParts partsOut;
 
         FairMQMessagePtr messFEH(NewMessage());
-        Serialize<RootSerializer>(*messFEH, fEventHeader);
+        RootSerializer().Serialize(*messFEH, fEventHeader);
         partsOut.AddPart(std::move(messFEH));
         for (int iarray = 0; iarray < nofArrays; iarray++) {
             messageTCA[iarray] = NewMessage();
-            Serialize<RootSerializer>(*messageTCA[iarray], tempArrays[iarray]);
+            RootSerializer().Serialize(*messageTCA[iarray], tempArrays[iarray]);
             partsOut.AddPart(std::move(messageTCA[iarray]));
         }
         Send(partsOut, fOutputChannelName);

--- a/examples/MQ/pixelDetector/src/devices/FairMQPixelSampler.cxx
+++ b/examples/MQ/pixelDetector/src/devices/FairMQPixelSampler.cxx
@@ -105,7 +105,7 @@ bool FairMQPixelSampler::ConditionalRun()
 
     for (int iobj = 0; iobj < fNObjects; iobj++) {
         FairMQMessagePtr mess(NewMessage());
-        Serialize<RootSerializer>(*mess, fInputObjects[iobj]);
+        RootSerializer().Serialize(*mess, fInputObjects[iobj]);
         parts.AddPart(std::move(mess));
     }
 

--- a/examples/MQ/pixelDetector/src/devices/FairMQPixelTaskProcessor.h
+++ b/examples/MQ/pixelDetector/src/devices/FairMQPixelTaskProcessor.h
@@ -74,7 +74,7 @@ class FairMQPixelTaskProcessor : public FairMQDevice
         std::vector<TObject*> tempObjects;
         for (int ipart = 0; ipart < parts.Size(); ipart++) {
             TObject* obj = nullptr;
-            Deserialize<RootSerializer>(*parts.At(ipart), obj);
+            RootSerializer().Deserialize(*parts.At(ipart), obj);
             tempObjects.push_back(obj);
             // LOG(trace) << "got TObject with name \"" << tempObjects[ipart]->GetName() << "\".";
             if (strcmp(tempObjects.back()->GetName(), "EventHeader.") == 0) {
@@ -121,17 +121,17 @@ class FairMQPixelTaskProcessor : public FairMQDevice
 
         if (fEventHeader) {
             FairMQMessagePtr mess(NewMessage());
-            Serialize<RootSerializer>(*mess, fEventHeader);
+            RootSerializer().Serialize(*mess, fEventHeader);
             partsOut.AddPart(std::move(mess));
         } else if (fMCEventHeader) {
             FairMQMessagePtr mess(NewMessage());
-            Serialize<RootSerializer>(*mess, fMCEventHeader);
+            RootSerializer().Serialize(*mess, fMCEventHeader);
             partsOut.AddPart(std::move(mess));
         }
 
         for (int iobj = 0; iobj < fOutput->GetEntries(); iobj++) {
             FairMQMessagePtr mess(NewMessage());
-            Serialize<RootSerializer>(*mess, fOutput->At(iobj));
+            RootSerializer().Serialize(*mess, fOutput->At(iobj));
             partsOut.AddPart(std::move(mess));
         }
 
@@ -210,7 +210,7 @@ class FairMQPixelTaskProcessor : public FairMQDevice
         if (Send(req, fParamChannelName) > 0) {
             if (Receive(rep, fParamChannelName) > 0) {
                 thisPar = nullptr;
-                Deserialize<RootSerializer>(*rep, thisPar);
+                RootSerializer().Deserialize(*rep, thisPar);
                 LOG(info) << "Received parameter" << paramName << " from the server (" << thisPar << ")";
                 return thisPar;
             }

--- a/examples/MQ/pixelDetector/src/devices/FairMQPixelTaskProcessorBin.h
+++ b/examples/MQ/pixelDetector/src/devices/FairMQPixelTaskProcessorBin.h
@@ -232,7 +232,7 @@ class FairMQPixelTaskProcessorBin : public FairMQDevice
         if (Send(req, fParamChannelName) > 0) {
             if (Receive(rep, fParamChannelName) > 0) {
                 thisPar = nullptr;
-                Deserialize<RootSerializer>(*rep, thisPar);
+                RootSerializer().Deserialize(*rep, thisPar);
                 LOG(info) << "Received parameter" << paramName << " from the server (" << thisPar << ")";
                 return thisPar;
             }

--- a/examples/MQ/pixelDetector/src/devices/FairMQRunDevice.cxx
+++ b/examples/MQ/pixelDetector/src/devices/FairMQRunDevice.cxx
@@ -33,7 +33,7 @@ std::mutex mtx;    // mutex for critical section
 void FairMQRunDevice::SendObject(TObject* obj, const std::string& chan)
 {
     FairMQMessagePtr mess(NewMessage());
-    Serialize<RootSerializer>(*mess, obj);
+    RootSerializer().Serialize(*mess, obj);
 
     FairMQMessagePtr rep(NewMessage());
 
@@ -80,7 +80,7 @@ void FairMQRunDevice::SendBranches()
                             LOG(debug) << "FairMQRunDevice::SendBranches() the track array has "
                                        << ((TClonesArray*)(objClone))->GetEntries() << " entries.";
                             FairMQMessagePtr mess(NewMessage());
-                            Serialize<RootSerializer>(*mess, objClone);
+                            RootSerializer().Serialize(*mess, objClone);
                             parts.AddPart(std::move(mess));
                             LOG(debug) << "channel >" << mi.first.data() << "< --> >" << ObjStr->GetString().Data()
                                        << "<";
@@ -95,7 +95,7 @@ void FairMQRunDevice::SendBranches()
                     if (object) {
                         TObject* objClone = object->Clone();
                         FairMQMessagePtr mess(NewMessage());
-                        Serialize<RootSerializer>(*mess, objClone);
+                        RootSerializer().Serialize(*mess, objClone);
                         parts.AddPart(std::move(mess));
                         LOG(debug) << "channel >" << mi.first.data() << "< --> >" << ObjStr->GetString().Data() << "<";
                     } else {

--- a/examples/MQ/pixelSimSplit/src/devices/FairMQChunkMerger.cxx
+++ b/examples/MQ/pixelSimSplit/src/devices/FairMQChunkMerger.cxx
@@ -63,7 +63,7 @@ bool FairMQChunkMerger::MergeData(FairMQParts& parts, int /*index*/)
     std::vector<TClonesArray*> tcaVector;
     for (int ipart = 0; ipart < parts.Size(); ++ipart) {
         TObject* tempObject = nullptr;
-        Deserialize<RootSerializer>(*parts.At(ipart), tempObject);
+        RootSerializer().Deserialize(*parts.At(ipart), tempObject);
 
         //        LOG(INFO) << "Got object " << tempObject->ClassName() << " named " << tempObject->GetName();
         if (strcmp(tempObject->GetName(), "MCEventHeader.") == 0) {
@@ -175,12 +175,12 @@ bool FairMQChunkMerger::MergeData(FairMQParts& parts, int /*index*/)
         fMCSplitEventHeader->SetChunkStart(0);
 
         FairMQMessagePtr messEH(NewMessage());
-        Serialize<RootSerializer>(*messEH, fMCSplitEventHeader);
+        RootSerializer().Serialize(*messEH, fMCSplitEventHeader);
         partsOut.AddPart(std::move(messEH));
 
         for (int iarray = 0; iarray < tcaVector.size(); ++iarray) {
             FairMQMessagePtr mess(NewMessage());
-            Serialize<RootSerializer>(*mess, tcaVector[iarray]);
+            RootSerializer().Serialize(*mess, tcaVector[iarray]);
             partsOut.AddPart(std::move(mess));
         }
         // LOG(info) << "created output message with " << partsOut.Size() << " parts.";

--- a/examples/MQ/pixelSimSplit/src/devices/FairMQPrimaryGeneratorDevice.cxx
+++ b/examples/MQ/pixelSimSplit/src/devices/FairMQPrimaryGeneratorDevice.cxx
@@ -105,11 +105,11 @@ bool FairMQPrimaryGeneratorDevice::GenerateAndSendData()
     }
 
     FairMQMessagePtr messEH(NewMessage());
-    Serialize<RootSerializer>(*messEH, meh);
+    RootSerializer().Serialize(*messEH, meh);
     parts.AddPart(std::move(messEH));
 
     FairMQMessagePtr mess(NewMessage());
-    Serialize<RootSerializer>(*mess, prims);
+    RootSerializer().Serialize(*mess, prims);
     parts.AddPart(std::move(mess));
 
     //    LOG(INFO) << "sending event " << fEventCounter << ", chunk starts at " << fChunkPointer;

--- a/examples/MQ/pixelSimSplit/src/devices/FairMQTransportDevice.cxx
+++ b/examples/MQ/pixelSimSplit/src/devices/FairMQTransportDevice.cxx
@@ -226,7 +226,7 @@ bool FairMQTransportDevice::ConditionalRun()
 // bool FairMQTransportDevice::TransportData(FairMQMessagePtr& mPtr, int /*index*/)
 // {
 //     TClonesArray* chunk = nullptr;
-//     Deserialize<RootSerializer>(*mPtr, chunk);
+//     RootSerializer().Deserialize(*mPtr, chunk);
 //     fStack->SetParticleArray(chunk);
 //     fVMC->ProcessRun(1);
 
@@ -239,7 +239,7 @@ bool FairMQTransportDevice::TransportData(FairMQParts& mParts, int /*index*/)
     FairMCSplitEventHeader* meh = nullptr;
     for (int ipart = 0; ipart < mParts.Size(); ipart++) {
         TObject* obj = nullptr;
-        Deserialize<RootSerializer>(*mParts.At(ipart), obj);
+        RootSerializer().Deserialize(*mParts.At(ipart), obj);
         if (strcmp(obj->GetName(), "MCEvent") == 0)
             meh = dynamic_cast<FairMCSplitEventHeader*>(obj);
         else if (strcmp(obj->GetName(), "TParticles") == 0)

--- a/examples/MQ/serialization/1-simple/Ex1Processor.h
+++ b/examples/MQ/serialization/1-simple/Ex1Processor.h
@@ -28,14 +28,14 @@ class Ex1Processor : public FairMQDevice
 
                 // Deserialize
                 std::unique_ptr<TClonesArray> digis(nullptr);
-                Deserialize<RootSerializer>(*msgIn, digis);
+                RootSerializer().Deserialize(*msgIn, digis);
 
                 // Compute
                 TClonesArray hits = FindHits(*digis);
 
                 // Serialize
                 FairMQMessagePtr msgOut(NewMessageFor("data2", 0));
-                Serialize<RootSerializer>(*msgOut, &hits);
+                RootSerializer().Serialize(*msgOut, &hits);
 
                 // Send
                 if (Send(msgOut, "data2") >= 0) {

--- a/examples/MQ/serialization/1-simple/Ex1Sampler.h
+++ b/examples/MQ/serialization/1-simple/Ex1Sampler.h
@@ -46,7 +46,7 @@ class Ex1Sampler : public FairMQDevice
         for (uint64_t i = 0; i < numEvents; i++) {
             FairMQMessagePtr msg(NewMessage());
             fTree->GetEntry(i);
-            Serialize<RootSerializer>(*msg, fInput);
+            RootSerializer().Serialize(*msg, fInput);
             if (Send(msg, "data1") >= 0) {
                 sentMsgs++;
             }

--- a/examples/MQ/serialization/1-simple/Ex1Sink.h
+++ b/examples/MQ/serialization/1-simple/Ex1Sink.h
@@ -34,7 +34,7 @@ class Ex1Sink : public FairMQDevice
         while (!NewStatePending()) {
             FairMQMessagePtr msg(NewMessage());
             if (Receive(msg, "data2") > 0) {
-                Deserialize<RootSerializer>(*msg, fInput);
+                RootSerializer().Deserialize(*msg, fInput);
                 receivedMsgs++;
                 fTree.SetBranchAddress("MyHit", &fInput);
                 fTree.Fill();

--- a/examples/MQ/serialization/2-multipart/Ex2Processor.h
+++ b/examples/MQ/serialization/2-multipart/Ex2Processor.h
@@ -31,8 +31,8 @@ class Ex2Processor : public FairMQDevice
 
             if (Receive(partsIn, "data1") > 0) {
                 Ex2Header* header = nullptr;
-                Deserialize<SerializerEx2>(*(partsIn.At(0)), header);
-                Deserialize<RootSerializer>(*(partsIn.At(1)), fInput);
+                SerializerEx2().Deserialize(*(partsIn.At(0)), header);
+                RootSerializer().Deserialize(*(partsIn.At(1)), fInput);
 
                 receivedMsgs++;
 
@@ -42,8 +42,8 @@ class Ex2Processor : public FairMQDevice
                 partsOut.AddPart(std::move(partsIn.At(0)));
                 partsOut.AddPart(NewMessage());
 
-                Serialize<BoostSerializer<Ex2Header>>(*(partsOut.At(0)), *header);
-                Serialize<BoostSerializer<MyHit>>(*(partsOut.At(1)), fOutput);
+                BoostSerializer<Ex2Header>().Serialize(*(partsOut.At(0)), *header);
+                BoostSerializer<MyHit>().Serialize(*(partsOut.At(1)), fOutput);
                 if (Send(partsOut, "data2") >= 0) {
                     sentMsgs++;
                 }

--- a/examples/MQ/serialization/2-multipart/Ex2Sampler.h
+++ b/examples/MQ/serialization/2-multipart/Ex2Sampler.h
@@ -49,10 +49,10 @@ class Ex2Sampler : public FairMQDevice
             header->EventNumber = idx;
 
             FairMQMessagePtr msgHeader(NewMessage());
-            Serialize<SerializerEx2>(*msgHeader, header);
+            SerializerEx2().Serialize(*msgHeader, header);
 
             FairMQMessagePtr msg(NewMessage());
-            Serialize<RootSerializer>(*msg, fInput);
+            RootSerializer().Serialize(*msg, fInput);
 
             FairMQParts parts;
             parts.AddPart(std::move(msgHeader));

--- a/examples/MQ/serialization/2-multipart/Ex2Sink.h
+++ b/examples/MQ/serialization/2-multipart/Ex2Sink.h
@@ -35,8 +35,8 @@ class Ex2Sink : public FairMQDevice
             FairMQParts parts;
             if (Receive(parts, "data2") > 0) {
                 Ex2Header header;
-                Deserialize<BoostSerializer<Ex2Header>>(*(parts.At(0)), header);
-                Deserialize<BoostSerializer<MyHit>>(*(parts.At(1)), fInput);
+                BoostSerializer<Ex2Header>().Deserialize(*(parts.At(0)), header);
+                BoostSerializer<MyHit>().Deserialize(*(parts.At(1)), fInput);
 
                 receivedMsgs++;
                 fTree.SetBranchAddress("MyHit", &fInput);

--- a/examples/advanced/Tutorial3/MQ/fileSink/FairTestDetectorFileSinkBoost.tpl
+++ b/examples/advanced/Tutorial3/MQ/fileSink/FairTestDetectorFileSinkBoost.tpl
@@ -17,7 +17,7 @@ void FairTestDetectorFileSink<TIn, TPayloadIn>::InitTask()
     OnData(fInChannelName, [this](FairMQMessagePtr& msg, int /*index*/) {
         ++fReceivedMsgs;
 
-        Deserialize<BoostSerializer<TIn>>(*msg, fOutput);
+        BoostSerializer<TIn>().Deserialize(*msg, fOutput);
 
         if (fOutput->IsEmpty()) {
             LOG(error) << "FairTestDetectorFileSink::Run(): No Output array!";

--- a/parmq/ParameterMQServer.cxx
+++ b/parmq/ParameterMQServer.cxx
@@ -141,7 +141,7 @@ bool ParameterMQServer::ProcessRequest(FairMQMessagePtr& req, int /*index*/)
         par->print();
 
         FairMQMessagePtr rep(NewMessage());
-        Serialize<RootSerializer>(*rep, par);
+        RootSerializer().Serialize(*rep, par);
 
         if (Send(rep, fRequestChannelName, 0) < 0) {
             LOG(ERROR) << "failed sending reply";
@@ -182,7 +182,7 @@ bool ParameterMQServer::ProcessUpdate(FairMQMessagePtr& update, int /*index*/)
     } else {
         // get the run id coded in the description of FairParSet
         FairParGenericSet* newPar = nullptr;
-        Deserialize<RootSerializer>(*update, newPar);
+        RootSerializer().Deserialize(*update, newPar);
         std::string parDescr = std::string(newPar->getDescription());
         uint runId = 0;
         if (parDescr.find("RUNID") != std::string::npos) {


### PR DESCRIPTION
These methods are now deprecated in FairMQ, because they do nothing.
