### PR TITLE
Drop ROOT_GENERATE_ROOTMAP; Improve ChangeLog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Dropped `CHECK_EXTERNAL_PACKAGE_INSTALL_DIR`
   * Just remove it from your `CMakeLists.txt`.
 * Dropped `USE_PATH_INFO` CMake option. It was an anti-pattern. Don't use it!
+* Dropped `ROOT_GENERATE_ROOTMAP`. It was used on ROOT 5.x.
+  * Rewrite your build system, if you still use it.
 
 ### Deprecated
 * Deprecating MbsAPI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,20 +8,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Breaking Changes
 * We have moved away from our custom ROOT find module, and now use the native cmake package of ROOT.
-  * This means, that all library depedencies of the type `Core` are either not working at all, or might not work as expected. Please upgrade all of them to be like `ROOT::Core` .
-  * This also means, that you need to add an `include(ROOTMacros)` after your `find_package2(? ROOT ?)`.
-  * `ROOT_VERSION_NUMBER` is gone. Use `ROOT_VERSION` (which is the dotted version number) and VERSION_GREATER/etc now.
-* `find_package2` has been externalized into [FairCMakeModules](https://github.com/FairRootGroup/FairCMakeModules) and is not any more installed together with FairRoot
-  * Please highly consider installing FairCMakeModules as a dependency of FairRoot and for your own usage. FairSoft will ship it soon.
-  * After installation, it should be as easy as this in your own code:
+  * This means, that all library dependencies of the type `Core` are either not working at all, or might not work as expected. Please upgrade all of them to be like `ROOT::Core` .
+  * This also means, that you need to add an `include(ROOTMacros)` after your `find_package2(... ROOT ...)`.
+  * `ROOT_VERSION_NUMBER` is gone. Use `ROOT_VERSION` (which is the dotted version number) and `VERSION_GREATER`/etc now.
+* Many CMake related tools have been externalized into
+  [FairCMakeModules](https://github.com/FairRootGroup/FairCMakeModules)
+  and partly rewritten
+  * You need to install it before installing FairRoot. FairSoft provides it.
+  * `find_package2` has moved to `FairFindPackage2`.
+    To use it in your code, perform something like this:
     ```cmake
-    find_package(FairCMakeModules 0.2 REQUIRED)
+    find_package(FairCMakeModules 1.0 REQUIRED)
     include(FairFindPackage2)
     ```
-* Dropped Color Codes and `pad()`
-  * Use `FairFormattedOutput` from FairCMakeModules
-  * Note that `fair_pad` needs the width argument to be incremented by 1,
-    and the COLOR option takes no argument.
+  * Dropped Color Codes and `pad()`
+    * Use `FairFormattedOutput` from FairCMakeModules
+    * Note that `fair_pad` needs the width argument to be incremented by 1,
+      and the COLOR option takes no argument.
 * Dropped `CheckCXX11Features`
   * FairRoot assumes a recent compiler that fully supports C++11.
   * Remove the following things from your `CMakeLists.txt`:
@@ -29,7 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
       Set(CheckSrcDir "${FAIRROOTPATH}/share/fairbase/cmake/checks")`
       ```
     * ```cmake
-      include(CheckCXX11Features)`
+      include(CheckCXX11Features)
       ```
     * ```cmake
       IF(HAS_CXX11_SHAREDPOINTER)

--- a/cmake/modules/ROOTMacros.cmake
+++ b/cmake/modules/ROOTMacros.cmake
@@ -224,47 +224,6 @@ MACRO (GENERATE_ROOT_TEST_SCRIPT SCRIPT_FULL_NAME)
 ENDMACRO (GENERATE_ROOT_TEST_SCRIPT)
 
 
-Macro(ROOT_GENERATE_ROOTMAP)
-
-  # All Arguments needed for this new version of the macro are defined
-  # in the parent scope, namely in the CMakeLists.txt of the submodule
-  if (DEFINED LINKDEF)
-    foreach(l ${LINKDEF})
-      If( IS_ABSOLUTE ${l})
-        Set(Int_LINKDEF ${Int_LINKDEF} ${l})
-      Else( IS_ABSOLUTE ${l})
-        Set(Int_LINKDEF ${Int_LINKDEF} ${CMAKE_CURRENT_SOURCE_DIR}/${l})
-      EndIf( IS_ABSOLUTE ${l})
-    endforeach()
-
-    foreach(d ${DEPENDENCIES})
-      get_filename_component(_ext ${d} EXT)
-      If(NOT _ext MATCHES a$)
-        if(_ext)
-          set(Int_DEPENDENCIES ${Int_DEPENDENCIES} ${d})
-        else()
-          set(Int_DEPENDENCIES ${Int_DEPENDENCIES} lib${d}.so)
-        endif()
-      Else()
-        Message("Found Static library with extension ${_ext}")
-      EndIf()
-    endforeach()
-
-    set(Int_LIB ${LIBRARY_NAME})
-    set(Int_OUTFILE ${LIBRARY_OUTPUT_PATH}/lib${Int_LIB}.rootmap)
-
-    add_custom_command(OUTPUT ${Int_OUTFILE}
-                       COMMAND ${RLIBMAP_EXECUTABLE} -o ${Int_OUTFILE} -l ${Int_LIB}
-                               -d ${Int_DEPENDENCIES} -c ${Int_LINKDEF}
-                       DEPENDS ${Int_LINKDEF} ${RLIBMAP_EXECUTABLE} )
-    add_custom_target( lib${Int_LIB}.rootmap ALL DEPENDS  ${Int_OUTFILE})
-    set_target_properties(lib${Int_LIB}.rootmap PROPERTIES FOLDER RootMaps )
-    #---Install the rootmap file------------------------------------
-    #install(FILES ${Int_OUTFILE} DESTINATION lib COMPONENT libraries)
-    install(FILES ${Int_OUTFILE} DESTINATION lib)
-  endif(DEFINED LINKDEF)
-EndMacro(ROOT_GENERATE_ROOTMAP)
-
 Macro(GENERATE_LIBRARY)
 
   # TODO: remove this backwards-compatibility check when no longer needed
@@ -314,11 +273,6 @@ Macro(GENERATE_LIBRARY)
        PROPERTIES COMPILE_FLAGS "-Wno-old-style-cast"
     )
   EndIf(LINKDEF)
-
-
-  If (ROOT_FOUND_VERSION LESS 59999)
-    ROOT_GENERATE_ROOTMAP()
-  EndIf()
 
   set(Int_DEPENDENCIES)
   foreach(d ${DEPENDENCIES})


### PR DESCRIPTION
ROOT_GENERATE_ROOTMAP is only called for ROOT 5.x.

If anybody uses it nowadays, they should rewrite their build system.

Also improve the ChangeLog a bit.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
