### PR TITLE
fairtools: Add yaml vmc config option "UseFastSim"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
  ################################################################################
- #    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    #
+ # Copyright (C) 2014-2021 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
  #                                                                              #
  #              This software is distributed under the terms of the             #
  #              GNU Lesser General Public Licence (LGPL) version 3,             #
@@ -20,6 +20,8 @@ cmake_policy(VERSION 3.15...3.20)
 SET(FAIRROOT_MAJOR_VERSION 19)
 SET(FAIRROOT_MINOR_VERSION 0)
 SET(FAIRROOT_PATCH_VERSION 0)
+
+set(PROJECT_MIN_CXX_STANDARD 14)
 
 if(APPLE)
   if(NOT DEFINED CMAKE_C_COMPILER)

--- a/fairtools/MCConfigurator/FairYamlVMCConfig.h
+++ b/fairtools/MCConfigurator/FairYamlVMCConfig.h
@@ -34,7 +34,6 @@ class FairYamlVMCConfig : public FairGenericVMCConfig
         fPostInitName = stringC;
     }
 
-
   private:
     string ObtainYamlFileName(const char* mcEngine);
     void StoreYamlInfo();
@@ -49,6 +48,8 @@ class FairYamlVMCConfig : public FairGenericVMCConfig
 
     YAML::Node fYamlConfig;
     YAML::Node fYamlConfigPostInit;
+
+    static constexpr bool fUseFastSimDefault = false;
 };
 
 #endif


### PR DESCRIPTION
Open questions:
* Is fast simulation Geant4 specific? Or should we call the option rather generically just `UseFastSim`?
* Is the default value of `true` a good default?