### PR TITLE
Fix a bug in FairYamlVMCConfig

### DIFF
--- a/fairtools/MCConfigurator/FairYamlVMCConfig.cxx
+++ b/fairtools/MCConfigurator/FairYamlVMCConfig.cxx
@@ -35,7 +35,6 @@ FairYamlVMCConfig::FairYamlVMCConfig()
     : FairGenericVMCConfig()
     , fMCEngine("")
 {
-    UsePostInitConfig();
 }
 
 void FairYamlVMCConfig::Setup(const char* mcEngine)


### PR DESCRIPTION
By mistake a PostInitConfig was called by default.
Removed the wrong line from the constructor.

---

Checklist:

[X] Rebased against `dev` branch
[X] My name is in the resp. CONTRIBUTORS/AUTHORS file
[X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
