### PR TITLE
Add GH action to rebase nightly branches

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,29 @@
+name: Nightly
+
+on:
+  schedule:
+    # timezone is UTC
+    - cron:  '45 23 * * *'
+  # Allows to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  snapshot-nightly-branches:
+    name: Snapshot nightly branch
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [master, dev]
+    env:
+      nightly: 'nightly_${{ matrix.target }}'
+    steps:
+      - name: Clone repository and checkout branch ${{ matrix.target }}
+        run: |
+          git clone -b ${{ matrix.target }} --single-branch --progress \
+          https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }} .
+      - name: Snapshot current ${{ matrix.target }} branch in branch ${{ env.nightly }}
+        run: git switch -C ${{ env.nightly }} ${{ matrix.target }}
+      - name: Print snapshotted HEAD
+        run: git log --oneline HEAD~1..HEAD
+      - name: Push ${{ env.nightly }} branch to origin
+        run: git push -f origin ${{ env.nightly }}


### PR DESCRIPTION
Rebase the branches nightly_dev and nightly_master at
23:45 UTC such that they are available for the nightly tests.

Currently the rebasing of the nightly branches is implemented as cron job in one of my machines. Somehow I messed up my keys on that machine such that the nightly branches were only rebased locally but couldn't be uploaded to GitHub. 
This problem went unnoticed for 2 or 3 month. To avoid such a situation again I implemented the rebase as a GitHub action which is executed on their infrastructure each night at 23:45 UTC.
This allows each of our developers to take care about the task and update it if needed.

---

Checklist:

* [ ] Rebased against `dev` branch
  For this MR this is not possible since scheduled actions need to be defined in the master branch.

* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
