### PR TITLE
Pixel: Use Fixtures Instead of Depends

### DIFF
--- a/examples/MQ/pixelAlternative/run/CMakeLists.txt
+++ b/examples/MQ/pixelAlternative/run/CMakeLists.txt
@@ -46,7 +46,7 @@ set(maxTestTime 30)
 add_test(NAME ex_MQ_pixel_alt_static
          COMMAND ${CMAKE_CURRENT_BINARY_DIR}/startFairMQPixAlt.sh --work-dir ${CMAKE_BINARY_DIR}/examples/MQ/pixelDetector --max-index 10000 --aggregate 100 --processors 5 --command static --force-kill true)
 set_tests_properties(ex_MQ_pixel_alt_static PROPERTIES
-  DEPENDS ex_MQ_pixel_static
+  FIXTURES_REQUIRED fixtures.ex_MQ_pixel_static
   TIMEOUT ${maxTestTime}
   PASS_REGULAR_EXPRESSION "Shell script finished successfully"
 )

--- a/examples/MQ/pixelDetector/macros/CMakeLists.txt
+++ b/examples/MQ/pixelDetector/macros/CMakeLists.txt
@@ -18,22 +18,25 @@ math(EXPR testTime 4*${maxTestTime})
 set_tests_properties(ex_pixel_sim_TGeant3 PROPERTIES
   TIMEOUT ${testTime}
   PASS_REGULAR_EXPRESSION "Macro finished successfully"
+  FIXTURES_SETUP fixtures.ex_pixel_sim_TGeant3
 )
 
 add_test(NAME ex_pixel_digi_TGeant3
          COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_digi.sh \"TGeant3\")
 set_tests_properties(ex_pixel_digi_TGeant3 PROPERTIES
-  DEPENDS ex_pixel_sim_TGeant3
+  FIXTURES_REQUIRED fixtures.ex_pixel_sim_TGeant3
   TIMEOUT ${maxTestTime}
   PASS_REGULAR_EXPRESSION "Macro finished successfully"
+  FIXTURES_SETUP fixtures.ex_pixel_digi_TGeant3
 )
 
 add_test(NAME ex_pixel_digi_to_bin_TGeant3
          COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_digiToBin.sh 0 \"TGeant3\")
 set_tests_properties(ex_pixel_digi_to_bin_TGeant3 PROPERTIES
-  DEPENDS ex_pixel_digi_TGeant3
+  FIXTURES_REQUIRED fixtures.ex_pixel_digi_TGeant3
   TIMEOUT ${maxTestTime}
   PASS_REGULAR_EXPRESSION "Macro finished successfully"
+  FIXTURES_SETUP fixtures.ex_pixel_digi_to_bin_TGeant3
 )
 
 install(FILES run_sim.C run_digi.C run_tracks.C run_reco.C run_digiToAscii.C run_digiToBin.C run_dAsciiSource.C run_dBinSource.C

--- a/examples/MQ/pixelDetector/run/CMakeLists.txt
+++ b/examples/MQ/pixelDetector/run/CMakeLists.txt
@@ -124,7 +124,7 @@ if(DDS_VERSION VERSION_GREATER_EQUAL 3.5
   add_test(NAME ex_MQ_pixel_simulation
            COMMAND ${CMAKE_CURRENT_BINARY_DIR}/test-pixelSim.sh)
   set_tests_properties(ex_MQ_pixel_simulation PROPERTIES
-    DEPENDS ex_MQ_pixel_static
+    FIXTURES_REQUIRED fixtures.ex_MQ_pixel_static
     TIMEOUT ${maxTestTime}
     PASS_REGULAR_EXPRESSION "Shell script finished successfully"
 )
@@ -133,8 +133,9 @@ endif()
 add_test(NAME ex_MQ_pixel_static
          COMMAND ${CMAKE_CURRENT_BINARY_DIR}/startFairMQPixel.sh --work-dir ${CMAKE_CURRENT_BINARY_DIR}/../ -p 3 --command static --force-kill true)
 set_tests_properties(ex_MQ_pixel_static PROPERTIES
-  DEPENDS ex_pixel_digi_to_bin_TGeant3
+  FIXTURES_REQUIRED fixtures.ex_pixel_digi_to_bin_TGeant3
   TIMEOUT ${maxTestTime}
   RUN_SERIAL ON
   PASS_REGULAR_EXPRESSION "Shell script finished successfully"
+  FIXTURES_SETUP fixtures.ex_MQ_pixel_static
 )


### PR DESCRIPTION
It is not the order of the Pixel tests that
matter, but the existance of the output data
of the previous stages.

---

Checklist:

[ X ] Rebased against `dev` branch
[ X ] My name is in the resp. CONTRIBUTORS/AUTHORS file
[ X ] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
