### PR TITLE
Use WriteTObject instead of cd + Write

### DIFF
--- a/base/event/FairRunInfo.cxx
+++ b/base/event/FairRunInfo.cxx
@@ -16,6 +16,7 @@
 #include <TString.h>     // for TString
 #include <TSystem.h>     // for ProcInfo_t, TSystem, etc
 #include <algorithm>     // for sort
+#include <memory>        // for unique_ptr
 
 ClassImp(FairRunInfo);
 
@@ -177,14 +178,13 @@ void FairRunInfo::WriteHistosToFile(TList* histoList)
     filename += ".root";
     LOG(debug) << "Filename: " << filename.Data();
 
-    TFile* f1 = TFile::Open(filename, "recreate");
-    f1->cd();
+    std::unique_ptr<TFile> f1{TFile::Open(filename, "recreate")};
 
     TIterator* listIter = histoList->MakeIterator();
     listIter->Reset();
     TObject* obj = nullptr;
     while ((obj = listIter->Next())) {
-        obj->Write();
+        f1->WriteTObject(obj);
     }
 
     delete listIter;
@@ -192,7 +192,6 @@ void FairRunInfo::WriteHistosToFile(TList* histoList)
     delete histoList;
 
     f1->Close();
-    f1->Delete();
     gFile = oldfile;
 }
 

--- a/base/event/FairRunInfo.cxx
+++ b/base/event/FairRunInfo.cxx
@@ -9,14 +9,15 @@
 
 #include "FairLogger.h"   // for FairLogger
 
-#include <TFile.h>       // for TFile, gFile
-#include <TH1.h>         // for TH1F
-#include <TIterator.h>   // for TIterator
-#include <TList.h>       // for TList
-#include <TString.h>     // for TString
-#include <TSystem.h>     // for ProcInfo_t, TSystem, etc
-#include <algorithm>     // for sort
-#include <memory>        // for unique_ptr
+#include <TDirectory.h>   // for TDirectory::TContext
+#include <TFile.h>        // for TFile, gFile
+#include <TH1.h>          // for TH1F
+#include <TIterator.h>    // for TIterator
+#include <TList.h>        // for TList
+#include <TString.h>      // for TString
+#include <TSystem.h>      // for ProcInfo_t, TSystem, etc
+#include <algorithm>      // for sort
+#include <memory>         // for unique_ptr
 
 ClassImp(FairRunInfo);
 
@@ -154,7 +155,7 @@ void FairRunInfo::WriteHistosToFile(TList* histoList)
     // can't be read any longer. Because of this problem the histos
     // are written to a separate file instead
 
-    TFile* oldfile = gFile;
+    TDirectory::TContext restorecwd{};
 
     TString directory = gFile->GetName();
     LOG(debug) << "Name: " << gFile->GetName();
@@ -192,7 +193,6 @@ void FairRunInfo::WriteHistosToFile(TList* histoList)
     delete histoList;
 
     f1->Close();
-    gFile = oldfile;
 }
 
 void FairRunInfo::Reset() { GetInfo(); }

--- a/base/sim/FairModule.cxx
+++ b/base/sim/FairModule.cxx
@@ -26,6 +26,7 @@
 
 #include <TBuffer.h>           // for TBuffer, operator<<, etc
 #include <TCollection.h>       // for TIter
+#include <TDirectory.h>        // for TDirectory::TContext
 #include <TFile.h>             // for TFile
 #include <TGeoManager.h>       // for TGeoManager, gGeoManager
 #include <TGeoMaterial.h>      // for TGeoMaterial
@@ -466,7 +467,7 @@ void FairModule::ConstructRootGeometry(TGeoMatrix* shiftM)
 void FairModule::ConstructGDMLGeometry(__attribute__((unused)) TGeoMatrix* posrot)
 {
     // Parse the GDML file
-    TFile* old = gFile;
+    TDirectory::TContext restorecwd{};
     TGDMLParse parser;
     TGeoVolume* gdmlTop;
     gdmlTop = parser.GDMLReadFile(GetGeometryFileName());
@@ -477,7 +478,6 @@ void FairModule::ConstructGDMLGeometry(__attribute__((unused)) TGeoMatrix* posro
     // Add volume to the cave and go through it recursively
     gGeoManager->GetTopVolume()->AddNode(gdmlTop, 1, posrot);
     ExpandNodeForGDML(gGeoManager->GetTopVolume()->GetNode(gGeoManager->GetTopVolume()->GetNdaughters() - 1));
-    gFile = old;
 }
 
 void FairModule::ExpandNodeForGDML(TGeoNode* curNode)

--- a/base/sink/FairRootFileSink.cxx
+++ b/base/sink/FairRootFileSink.cxx
@@ -312,11 +312,7 @@ void FairRootFileSink::WriteObject(TObject* f, const char* name, Int_t option)
     f->Write(name, option);
 }
 
-void FairRootFileSink::WriteGeometry()
-{
-    fRootFile->cd();
-    gGeoManager->Write();
-}
+void FairRootFileSink::WriteGeometry() { fRootFile->WriteTObject(gGeoManager); }
 
 void FairRootFileSink::Fill()
 {
@@ -342,8 +338,7 @@ Int_t FairRootFileSink::Write(const char*, Int_t, Int_t)
         fRootFile = fOutTree->GetCurrentFile();
         FairMonitor::GetMonitor()->StoreHistograms(fRootFile);
         LOG(debug) << "FairRootFileSink::Write to file: " << fRootFile->GetName();
-        fRootFile->cd();
-        fOutTree->Write();
+        fRootFile->WriteTObject(fOutTree);
     } else {
         LOG(info) << "No Output Tree";
     }

--- a/base/source/FairFileSource.cxx
+++ b/base/source/FairFileSource.cxx
@@ -25,6 +25,7 @@
 #include <TChainElement.h>
 #include <TClass.h>
 #include <TCollection.h>   // for TIter
+#include <TDirectory.h>    // for TDirectory::TContext
 #include <TFolder.h>
 #include <TList.h>
 #include <TObjArray.h>
@@ -248,9 +249,7 @@ Bool_t FairFileSource::Init()
     // Add all additional input files to the input chain and do a
     // consitency check
     for (auto fileName : fInputChainList) {
-        // Store global gFile pointer for safety reasons.
-        // Set gFile to old value at the end of the routine.R
-        TFile* temp = gFile;
+        TDirectory::TContext restorecwd{};
 
         // Temporarily open the input file to extract information which
         // is needed to bring the friend trees in the correct order
@@ -275,9 +274,8 @@ Bool_t FairFileSource::Init()
         // Add the file to the input chain
         fInChain->Add(fileName);
 
-        // Close the temporarly file and restore the gFile pointer.
+        // Close the temporarly file
         inputFile->Close();
-        gFile = temp;
     }
     fNoOfEntries = fInChain->GetEntries();
 
@@ -371,7 +369,7 @@ void FairFileSource::AddFriendsToChain()
     // TODO: print a warning if it was neccessary to remove a filname from the
     // list. This can be chacked by comparing the size of both list
 
-    TFile* temp = gFile;
+    TDirectory::TContext restorecwd{};
 
     Int_t friendType = 1;
     // Loop over all files which have been added as friends
@@ -412,7 +410,6 @@ void FairFileSource::AddFriendsToChain()
         TChain* chain = static_cast<TChain*>(fFriendTypeList[inputLevel]);
         chain->AddFile(fileName, 1234567890, FairRootManager::GetTreeName());
     }
-    gFile = temp;
 
     // Check if all friend chains have the same runids and the same
     // number of event numbers as the corresponding input chain
@@ -534,7 +531,7 @@ void FairFileSource::CheckFriendChains()
 
 void FairFileSource::CreateNewFriendChain(TString inputFile, TString inputLevel)
 {
-    TFile* temp = gFile;
+    TDirectory::TContext restorecwd{};
     TFile* f = TFile::Open(inputFile);
 
     TFolder* added = nullptr;
@@ -577,7 +574,6 @@ void FairFileSource::CreateNewFriendChain(TString inputFile, TString inputLevel)
     fFriendTypeList[inputLevel] = chain;
 
     f->Close();
-    gFile = temp;
 }
 
 Bool_t FairFileSource::CompareBranchList(TFile* fileHandle, TString inputLevel)

--- a/base/source/FairFileSource.cxx
+++ b/base/source/FairFileSource.cxx
@@ -248,34 +248,36 @@ Bool_t FairFileSource::Init()
 
     // Add all additional input files to the input chain and do a
     // consitency check
-    for (auto fileName : fInputChainList) {
+    {
         TDirectory::TContext restorecwd{};
 
-        // Temporarily open the input file to extract information which
-        // is needed to bring the friend trees in the correct order
-        TFile* inputFile = TFile::Open(fileName);
-        if (inputFile->IsZombie()) {
-            LOG(fatal) << "Error opening the file " << fileName.Data()
-                       << " which should be added to the input chain or as friend chain";
-        }
-
-        if (fCheckFileLayout) {
-            // Check if the branchlist is the same as for the first input file.
-            Bool_t isOk = CompareBranchList(inputFile, chainName);
-            if (!isOk) {
-                LOG(fatal) << "Branch structure of the input file " << fRootFile->GetName()
-                           << " and the file to be added " << fileName.Data() << " are different.";
-                return kFALSE;
+        for (auto fileName : fInputChainList) {
+            // Temporarily open the input file to extract information which
+            // is needed to bring the friend trees in the correct order
+            TFile* inputFile = TFile::Open(fileName);
+            if (inputFile->IsZombie()) {
+                LOG(fatal) << "Error opening the file " << fileName.Data()
+                           << " which should be added to the input chain or as friend chain";
             }
+
+            if (fCheckFileLayout) {
+                // Check if the branchlist is the same as for the first input file.
+                Bool_t isOk = CompareBranchList(inputFile, chainName);
+                if (!isOk) {
+                    LOG(fatal) << "Branch structure of the input file " << fRootFile->GetName()
+                               << " and the file to be added " << fileName.Data() << " are different.";
+                    return kFALSE;
+                }
+            }
+
+            // Add the runid information for all files in the chain.
+            // GetRunIdInfo(inputFile->GetName(), chainName);
+            // Add the file to the input chain
+            fInChain->Add(fileName);
+
+            // Close the temporarly file
+            inputFile->Close();
         }
-
-        // Add the runid information for all files in the chain.
-        // GetRunIdInfo(inputFile->GetName(), chainName);
-        // Add the file to the input chain
-        fInChain->Add(fileName);
-
-        // Close the temporarly file
-        inputFile->Close();
     }
     fNoOfEntries = fInChain->GetEntries();
 

--- a/base/source/FairMixedSource.cxx
+++ b/base/source/FairMixedSource.cxx
@@ -21,6 +21,7 @@
 #include "FairRootManager.h"
 #include "FairRuntimeDb.h"   // for FairRuntimeDb
 
+#include <TDirectory.h>   // for TDirectory::TContext
 #include <TFolder.h>
 #include <TList.h>
 #include <TObjArray.h>
@@ -287,9 +288,7 @@ Bool_t FairMixedSource::Init()
 
     // Add all additional input files to the input chain and do a consitency check
     for (auto fileName : fInputChainList) {
-        // Store global gFile pointer for safety reasons.
-        // Set gFile to old value at the end of the routine.R
-        TFile* temp = gFile;
+        TDirectory::TContext restorecwd{};
 
         // Temporarily open the input file to extract information which
         // is needed to bring the friend trees in the correct order
@@ -312,9 +311,8 @@ Bool_t FairMixedSource::Init()
         // Add the file to the input chain
         fBackgroundChain->Add(fileName);
 
-        // Close the temporarly file and restore the gFile pointer.
+        // Close the temporarly file
         inputFile->Close();
-        gFile = temp;
     }
     fNoOfEntries = fBackgroundChain->GetEntries();
     FairRootManager::Instance()->SetInChain(fBackgroundChain, 0);

--- a/base/steer/FairRootManager.cxx
+++ b/base/steer/FairRootManager.cxx
@@ -30,6 +30,7 @@
 #include <TBranch.h>        // for TBranch
 #include <TClonesArray.h>   // for TClonesArray
 #include <TCollection.h>    // for TCollection, TIter
+#include <TDirectory.h>     // for TDirectory::TContext
 #include <TFile.h>          // for TFile
 #include <TFolder.h>        // for TFolder
 #include <TGeoManager.h>    // for TGeoManager, gGeoManager
@@ -412,11 +413,10 @@ void FairRootManager::CreateGeometryFile(const char* geofile)
      *  framework. The geomanager used by the framework is still
      *  stored in the parameter file or database
      */
-    TFile* oldfile = gFile;
+    TDirectory::TContext restorecwd{};
     std::unique_ptr<TFile> file{TFile::Open(geofile, "RECREATE")};
     file->WriteTObject(gGeoManager);
     file->Close();
-    gFile = oldfile;
 }
 
 void FairRootManager::WriteFolder()

--- a/base/steer/FairRootManager.cxx
+++ b/base/steer/FairRootManager.cxx
@@ -48,6 +48,7 @@
 #include <iostream>   // for operator<<, basic_ostream, etc
 #include <list>       // for _List_iterator, list, etc
 #include <map>        // for map, _Rb_tree_iterator, etc
+#include <memory>     // for unique_ptr
 #include <set>        // for set, set<>::iterator
 #include <stdlib.h>   // for exit
 #include <utility>    // for pair
@@ -412,11 +413,9 @@ void FairRootManager::CreateGeometryFile(const char* geofile)
      *  stored in the parameter file or database
      */
     TFile* oldfile = gFile;
-    TFile* file = TFile::Open(geofile, "RECREATE");
-    file->cd();
-    gGeoManager->Write();
+    std::unique_ptr<TFile> file{TFile::Open(geofile, "RECREATE")};
+    file->WriteTObject(gGeoManager);
     file->Close();
-    file->Delete();
     gFile = oldfile;
 }
 

--- a/base/steer/FairRunAna.cxx
+++ b/base/steer/FairRunAna.cxx
@@ -29,7 +29,8 @@
 #include "signal.h"
 
 #include <TCollection.h>      // for TIter
-#include <TFile.h>            // for TFile, gFile
+#include <TDirectory.h>       // for TDirectory::TContext
+#include <TFile.h>            // for TFile
 #include <TGeoManager.h>      // for gGeoManager, TGeoManager
 #include <TKey.h>             // for TKey
 #include <TList.h>            // for TList
@@ -109,8 +110,7 @@ void FairRunAna::SetGeomFile(const char* GeoFileName)
         LOG(fatal) << "Geometry file has to be set before Run::Init !";
         exit(-1);
     } else {
-
-        TFile* CurrentFile = gFile;
+        TDirectory::TContext restorecwd{};
         fInputGeoFile = TFile::Open(GeoFileName);
         if (fInputGeoFile->IsZombie()) {
             LOG(error) << "Error opening Geometry Input file";
@@ -118,7 +118,6 @@ void FairRunAna::SetGeomFile(const char* GeoFileName)
         }
         LOG(info) << "Opening Geometry input file: " << GeoFileName;
         fLoadGeo = kTRUE;
-        gFile = CurrentFile;
     }
 }
 
@@ -161,7 +160,7 @@ void FairRunAna::Init()
         // check that the geometry was loaded if not try all connected files!
         if (fLoadGeo && gGeoManager == 0) {
             LOG(info) << "Geometry was not found in the input file we will look in the friends if any!";
-            TFile* currentfile = gFile;
+            TDirectory::TContext restorecwd{};
             TFile* nextfile = 0;
             TSeqCollection* fileList = gROOT->GetListOfFiles();
             for (Int_t k = 0; k < fileList->GetEntries(); k++) {
@@ -173,7 +172,6 @@ void FairRunAna::Init()
                     break;
                 }
             }
-            gFile = currentfile;
         }
     } else {   //  if(fInputFile )
         // NO input file but there is a geometry file

--- a/base/steer/FairRunAnaProof.cxx
+++ b/base/steer/FairRunAnaProof.cxx
@@ -24,6 +24,7 @@
 #include "FairTask.h"
 #include "FairTrajFilter.h"
 
+#include <TDirectory.h>   // for TDirectory::TContext
 #include <TGeoManager.h>
 #include <TKey.h>
 #include <TProof.h>
@@ -111,7 +112,7 @@ void FairRunAnaProof::Init()
             // check that the geometry was loaded if not try all connected files!
             if (fLoadGeo && gGeoManager == 0) {
                 LOG(info) << "Geometry was not found in the input file we will look in the friends if any!";
-                TFile* currentfile = gFile;
+                TDirectory::TContext restorecwd{};
                 TFile* nextfile = 0;
                 TSeqCollection* fileList = gROOT->GetListOfFiles();
                 for (Int_t k = 0; k < fileList->GetEntries(); k++) {
@@ -123,7 +124,6 @@ void FairRunAnaProof::Init()
                         break;
                     }
                 }
-                gFile = currentfile;
             }
         }
     } else {   //  if(fInputFile )

--- a/parbase/FairParRootFileIo.cxx
+++ b/parbase/FairParRootFileIo.cxx
@@ -176,8 +176,7 @@ Bool_t FairParRootFileIo::open(const TList* fnamelist, Option_t* option, const T
         while ((inpKey = static_cast<TKey*>(keyIter.Next()))) {
             TObject* tempObj = inFile->Get(inpKey->GetName());
 
-            newParFile->cd();
-            tempObj->Write();
+            newParFile->WriteTObject(tempObj);
         }
     }
 

--- a/parbase/FairParamList.cxx
+++ b/parbase/FairParamList.cxx
@@ -19,6 +19,7 @@
 #include <TBufferFile.h>     // for TBufferFile
 #include <TClass.h>          // for TClass
 #include <TCollection.h>     // for TIter
+#include <TDirectory.h>      // for TDirectory::TContext
 #include <TStreamerInfo.h>   // for TStreamerInfo
 #include <iostream>          // for operator<<, ostream, cout, etc
 #include <string.h>          // for memcpy, strcmp, strlen
@@ -581,7 +582,7 @@ void FairParamList::addObject(const Text_t* name, TObject* obj)
     FairParamObj* o = new FairParamObj(name);
     o->setParamType(obj->IsA()->GetName());
     o->setClassVersion(obj->IsA()->GetClassVersion());
-    TFile* filesave = gFile;
+    TDirectory::TContext restorecwd{};
     FairParamTFile* paramFile = new FairParamTFile();
     gFile = paramFile;
     const Int_t bufsize = 10000;
@@ -627,7 +628,6 @@ void FairParamList::addObject(const Text_t* name, TObject* obj)
     delete paramFile;
     paramList.Add(o);
     delete buffer;
-    gFile = filesave;
 }
 
 void FairParamList::print()
@@ -922,7 +922,7 @@ Bool_t FairParamList::fillObject(const Text_t* name, TObject* obj)
         //      Warning("FairParamList::fill",
         //              "\n       Read Class Version = %i does not match actual version = %i",
         //              o->getClassVersion(),obj->IsA()->GetClassVersion());
-        TFile* filesave = gFile;
+        TDirectory::TContext restorecwd{};
         gFile = 0;
         TBufferFile* buf = 0;
 
@@ -954,7 +954,6 @@ Bool_t FairParamList::fillObject(const Text_t* name, TObject* obj)
         buf->MapObject(obj);
         obj->Streamer(*buf);
         delete buf;
-        gFile = filesave;
         return len;
     }
     LOG(error) << "Could not find parameter " << name;


### PR DESCRIPTION
Instead of
```c++
tfile->cd();
tobj->Write();
```
one can also do
```c++
tfile->WriteTObject(tobj);
```

This has the advantage that it does not modify the global gDirectory/gFile (which the calling code might want to keep).

See-Also: https://root.cern/root/htmldoc/guides/users-guide/InputOutput.html#saving-objects-to-disk

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
