### PR TITLE
build/ci: Remove some Apple Special Cases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,15 +23,6 @@ SET(FAIRROOT_PATCH_VERSION 0)
 
 set(PROJECT_MIN_CXX_STANDARD 14)
 
-if(APPLE)
-  if(NOT DEFINED CMAKE_C_COMPILER)
-    set(CMAKE_C_COMPILER clang)
-  endif()
-  if(NOT DEFINED CMAKE_CXX_COMPILER)
-    set(CMAKE_CXX_COMPILER clang++)
-  endif()
-endif()
-
 # Set name of our project to "FAIRROOT".
 # Has to be done after check of cmake version
 # This also sets ${FAIRROOT_VERSION} to the provided VERSION value, which would be empty if not set here explicitly

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,9 +39,6 @@ def jobMatrix(String prefix, String type, List specs) {
           } else {
             sh "echo \"export SIMPATH=/fairsoft/${fairsoft}\" >> ${jobscript}"
           }
-          if (selector =~ /^macos-10\.15/) {
-            sh "echo \"export SDKROOT=\$(xcrun --show-sdk-path)\" >> ${jobscript}"
-          }
           sh "echo \"export LABEL=\\\"\${JOB_BASE_NAME} ${label}\\\"\" >> ${jobscript}"
           if (selector =~ /^macos/) {
             sh "echo \"${ctestcmd}\" >> ${jobscript}"


### PR DESCRIPTION
cmake: it doesn't look like setting the compiler variables is still needed any more. So remove it.

ci: SDKROOT setting has been moved onto the ci machine's internal setup. It's really a host specific setup.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
