### PR TITLE
FairRunAnaProof: Deprecate `::Instance()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   * If you need it, speak up NOW.
   * It is disabled by default in this release.
   * It can still be enabled with `-DBUILD_MBS=ON`.
+* Deprecate some singleton-like APIs:
+  * `FairRunAnaProof::Instance()` - keep a pointer to the
+    object after `new` in your code.
 
 ### Other Notable Changes
 * Consider calling `fairroot_check_root_cxxstd_compatibility()`

--- a/base/steer/FairRunAna.h
+++ b/base/steer/FairRunAna.h
@@ -38,9 +38,9 @@ class FairRunAna : public FairRun
     virtual ~FairRunAna();
     FairRunAna();
     /**initialize the run manager*/
-    void Init();
+    void Init() override;
     /**Run from event number NStart to event number NStop */
-    void Run(Int_t NStart = 0, Int_t NStop = 0);
+    void Run(Int_t NStart = 0, Int_t NStop = 0) override;
     /**Run over the whole input file with timpe window delta_t as unit (entry)*/
     void Run(Double_t delta_t);
     /**Run for the given single entry*/
@@ -75,7 +75,7 @@ class FairRunAna : public FairRun
     void Reinit(UInt_t runId);
     UInt_t getRunId() { return fRunId; }
     /** Get the magnetic field **/
-    FairField* GetField() { return fField; }
+    FairField* GetField() override { return fField; }
     /** Set the magnetic Field */
     void SetField(FairField* ffield) { fField = ffield; }
     /** Set external geometry file */
@@ -140,7 +140,7 @@ class FairRunAna : public FairRun
     /** Flag for Event Header Persistency */
     Bool_t fStoreEventHeader;   //!
 
-    ClassDef(FairRunAna, 6);
+    ClassDefOverride(FairRunAna, 6);
 };
 
 #endif   // FAIRRUNANA_H

--- a/base/steer/FairRunAnaProof.h
+++ b/base/steer/FairRunAnaProof.h
@@ -29,7 +29,7 @@ class FairRunAnaProof : public FairRunAna
     FairRunAnaProof(const char* proofName = "");
 
     /**initialize the run manager*/
-    void Init();
+    void Init() override;
 
     /** Init containers executed on PROOF, which is part of Init when running locally*/
     void InitContainers();
@@ -44,7 +44,7 @@ class FairRunAnaProof : public FairRunAna
     //    virtual void    SetOutputFile(TFile* f);
 
     /**Run from event number NStart to event number NStop */
-    void Run(Int_t NStart = 0, Int_t NStop = 0);
+    void Run(Int_t NStart = 0, Int_t NStop = 0) override;
     /**Run for one event, used on PROOF nodes*/
     void RunOneEvent(Long64_t entry);
     /**Run on proof from event NStart to event NStop*/
@@ -67,7 +67,7 @@ class FairRunAnaProof : public FairRunAna
     /** Set PROOF output status, possibilities: "copy","merge"*/
     void SetProofOutputStatus(TString outStat) { fProofOutputStatus = outStat; }
 
-    virtual void SetSource(FairSource* tempSource);
+    void SetSource(FairSource* tempSource) override;
 
   protected:
     static FairRunAnaProof* fRAPInstance;
@@ -91,7 +91,7 @@ class FairRunAnaProof : public FairRunAna
 
     FairFileSource* fProofFileSource;
 
-    ClassDef(FairRunAnaProof, 1);
+    ClassDefOverride(FairRunAnaProof, 1);
 };
 
 #endif   // FAIRRUNANAPROOF_H

--- a/base/steer/FairRunAnaProof.h
+++ b/base/steer/FairRunAnaProof.h
@@ -24,7 +24,7 @@
 class FairRunAnaProof : public FairRunAna
 {
   public:
-    static FairRunAnaProof* Instance();
+    [[deprecated]] static FairRunAnaProof* Instance();   ///< \deprecated
     virtual ~FairRunAnaProof();
     FairRunAnaProof(const char* proofName = "");
 

--- a/base/steer/FairRunOnline.h
+++ b/base/steer/FairRunOnline.h
@@ -35,14 +35,14 @@ class FairRunOnline : public FairRun
     FairRunOnline(FairSource* source);
 
     /**initialize the run manager*/
-    void Init();
+    void Init() override;
     /**Run for the given number of events*/
-    void Run(Int_t Ev_start, Int_t Ev_end);
+    void Run(Int_t Ev_start, Int_t Ev_end) override;
 
     void Reinit(UInt_t runId);
     UInt_t getRunId() { return fRunId; }
     /** Get the magnetic field **/
-    FairField* GetField() { return fField; }
+    FairField* GetField() override { return fField; }
     /** Set the magnetic Field */
     void SetField(FairField* ffield) { fField = ffield; }
 
@@ -108,7 +108,7 @@ class FairRunOnline : public FairRun
 
     virtual void Fill();
 
-    ClassDef(FairRunOnline, 0);
+    ClassDefOverride(FairRunOnline, 0);
 };
 
 #endif   // FAIRRUNONLINE_H

--- a/base/steer/FairRunSim.h
+++ b/base/steer/FairRunSim.h
@@ -65,11 +65,11 @@ class FairRunSim : public FairRun
     /**
      *       Initialize the Simulation
      */
-    virtual void Init();
+    void Init() override;
     /**
      *       run the  simulation
      */
-    virtual void Run(Int_t NEvents = 0, Int_t NotUsed = 0);
+    void Run(Int_t NEvents = 0, Int_t NotUsed = 0) override;
     /**
      *       Set the magnetic that has to be used for simulation field
      */
@@ -109,7 +109,7 @@ class FairRunSim : public FairRun
     TString* GetGeoModel() { return fLoaderName; }
 
     /**Get the field used in simulation*/
-    FairField* GetField() { return fField; }
+    FairField* GetField() override { return fField; }
 
     /**Get the detector specific event header*/
     FairMCEventHeader* GetMCEventHeader();
@@ -231,7 +231,7 @@ class FairRunSim : public FairRun
     bool fUseSimSetupPostInitFunction = false;
     FairGenericVMCConfig* fSimulationConfig;   //!                 /** Simulation configuration */
 
-    ClassDef(FairRunSim, 2);
+    ClassDefOverride(FairRunSim, 2);
 };
 
 #endif   // FAIRRUNSIM_H

--- a/examples/advanced/Tutorial3/macro/run_digi_reco_proof.C
+++ b/examples/advanced/Tutorial3/macro/run_digi_reco_proof.C
@@ -1,25 +1,12 @@
 void run_digi_reco_proof(Int_t nofFiles, TString mcEngine = "TGeant3")
 {
     FairLogger* logger = FairLogger::GetLogger();
-    // logger->SetLogFileName("MyLog.log");
-    // logger->SetLogToScreen(kTRUE);
-    //  logger->SetLogToFile(kTRUE);
     logger->SetLogVerbosityLevel("LOW");
-    //  logger->SetLogFileLevel("DEBUG4");
-    //  logger->SetLogScreenLevel("DEBUG");
 
     TString workDir = gSystem->WorkingDirectory();
 
     // Verbosity level (0=quiet, 1=event level, 2=track level, 3=debug)
-    Int_t iVerbose = 0;   // just forget about it, for the moment
-
-    // Input file (MC events)
-    //  TString inFile = "data/testrun_";
-    //  inFile = inFile + mcEngine + ".root";
-
-    // Parameter file
-    //  TString parFile = "data/testparams_";
-    //  parFile = parFile + mcEngine + ".root";
+    Int_t iVerbose = 0;
 
     // Output file
     TString outFile = Form("data/testDiRePr_%df_", nofFiles);
@@ -32,15 +19,17 @@ void run_digi_reco_proof(Int_t nofFiles, TString mcEngine = "TGeant3")
 
     // -----   Reconstruction run   -------------------------------------------
     FairRunAnaProof* fRun = new FairRunAnaProof("workers=4");
+
     TString inFile = Form("file://%s/data/testrun_%s_f%d.root", workDir.Data(), mcEngine.Data(), 0);
     if (nofFiles == 1)
         inFile = Form("file://%s/data/testrun_%s.root", workDir.Data(), mcEngine.Data());
     FairFileSource* fFileSource = new FairFileSource(inFile);
-    fRun->SetSource(fFileSource);
     for (Int_t ifile = 1; ifile < nofFiles; ifile++)
         fFileSource->AddFile(Form("file://%s/data/testrun_%s_f%d.root", workDir.Data(), mcEngine.Data(), ifile));
+    fRun->SetSource(fFileSource);
 
     fRun->SetSink(new FairRootFileSink(outFile));
+
     fRun->SetProofOutputStatus("merge");
 
     FairRuntimeDb* rtdb = fRun->GetRuntimeDb();


### PR DESCRIPTION
- [x] Depends on #1146

* No examples use ::Instance
* No internal code uses ::Instance

So deprecate `::Instance` method.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
