### PR TITLE
cmake: Add `-Wall` to all Build Types for GCC

### DIFF
--- a/cmake/modules/CheckCompiler.cmake
+++ b/cmake/modules/CheckCompiler.cmake
@@ -67,16 +67,17 @@ if (CMAKE_SYSTEM_NAME MATCHES Linux)
 
      # Configure build types
      set(CMAKE_CONFIGURATION_TYPES "RELWITHDEBINFO" "NIGHTLY" "TEST" "RELEASE" "DEBUG" "DEBUGFULL" "PROFILE" "ARRAY_CHECK")
+     set(_FR_COMMON_CXX_FLAGS "-Wshadow -Wall")
 
-     set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -Wshadow")
-     set(CMAKE_CXX_FLAGS_NIGHTLY        "-O0 -g -Wshadow")
-     set(CMAKE_CXX_FLAGS_TEST           "-O2 -g -Wshadow")
-     set(CMAKE_CXX_FLAGS_RELEASE        "-O2 -Wshadow ")
+     set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${_FR_COMMON_CXX_FLAGS} -O2 -g")
+     set(CMAKE_CXX_FLAGS_NIGHTLY        "${_FR_COMMON_CXX_FLAGS} -O0 -g")
+     set(CMAKE_CXX_FLAGS_TEST           "${_FR_COMMON_CXX_FLAGS} -O2 -g")
+     set(CMAKE_CXX_FLAGS_RELEASE        "${_FR_COMMON_CXX_FLAGS} -O2")
 
-     set(CMAKE_CXX_FLAGS_DEBUG          "-g -Wshadow ")
-     set(CMAKE_CXX_FLAGS_DEBUGFULL      "-g3 -fno-inline -Wnon-virtual-dtor -Wno-long-long -ansi -Wundef -Wcast-align -Wchar-subscripts -Wall -W -Wpointer-arith -Wformat-security -fno-exceptions -fno-check-new -fno-common -fexceptions")
-     set(CMAKE_CXX_FLAGS_PROFILE        "-g3 -fno-inline -ftest-coverage -fprofile-arcs -Wshadow -Wall -Wextra -Wunused-variable")
-     set(CMAKE_CXX_FLAGS_ARRAY_CHECK    "-g3 -fno-inline -ftest-coverage -fprofile-arcs -fstack-protector")
+     set(CMAKE_CXX_FLAGS_DEBUG          "${_FR_COMMON_CXX_FLAGS} -g")
+     set(CMAKE_CXX_FLAGS_DEBUGFULL      "${_FR_COMMON_CXX_FLAGS} -g3 -fno-inline -Wnon-virtual-dtor -Wno-long-long -ansi -Wundef -Wcast-align -Wchar-subscripts -W -Wpointer-arith -Wformat-security -fno-exceptions -fno-check-new -fno-common -fexceptions")
+     set(CMAKE_CXX_FLAGS_PROFILE        "${_FR_COMMON_CXX_FLAGS} -g3 -fno-inline -ftest-coverage -fprofile-arcs -Wextra -Wunused-variable")
+     set(CMAKE_CXX_FLAGS_ARRAY_CHECK    "${_FR_COMMON_CXX_FLAGS} -g3 -fno-inline -ftest-coverage -fprofile-arcs -fstack-protector")
 
      set(CMAKE_C_FLAGS_RELWITHDEBINFO   "-O2 -g")
      set(CMAKE_C_FLAGS_RELEASE          "-O2")

--- a/eventdisplay/FairEventManagerEditor.cxx
+++ b/eventdisplay/FairEventManagerEditor.cxx
@@ -229,7 +229,6 @@ void FairEventManagerEditor::StartAnimation()
             FairTask* pMainTask = ana->GetMainTask();
             TList* taskList = pMainTask->GetListOfTasks();
 
-            Int_t ntask = ana->GetNTasks();
             Bool_t runOnce = true;
             for (Double_t i = start; i < end; i += step) {
                 if (runOnce == true) {   // Clear the buffer at the beginning of an animation run

--- a/eventdisplay/datasource/FairTimebasedSource.h
+++ b/eventdisplay/datasource/FairTimebasedSource.h
@@ -20,8 +20,8 @@ class FairTimebasedSource : public FairDataSourceI
     FairTimebasedSource();
     FairTimebasedSource(TString branchName, Double_t windowMinus, Double_t windowPlus)
         : FairDataSourceI(branchName)
-        , fTimeWindowMinus(windowMinus)
-        , fTimeWindowPlus(windowPlus){};
+        , fTimeWindowPlus(windowMinus)
+        , fTimeWindowMinus(windowPlus){};
     virtual ~FairTimebasedSource();
 
     virtual void RetrieveData(double time);

--- a/examples/MQ/pixelSimSplit/src/devices/FairMQChunkMerger.cxx
+++ b/examples/MQ/pixelSimSplit/src/devices/FairMQChunkMerger.cxx
@@ -104,7 +104,7 @@ bool FairMQChunkMerger::MergeData(FairMQParts& parts, int /*index*/)
             LOG(debug) << "+ [" << fEvRIPair.second << "][" << fEvRIPair.first << "][" << fEvCOPair.first << "] "
                        << tca_elem->GetName();
             fEvCOPair.second = tca_elem;
-            fObjectMap.insert(std::pair<std::pair<int, int>, std::pair<int, TObject*>>(fEvRIPair, fEvCOPair));
+            fObjectMap.insert(std::make_pair(fEvRIPair, fEvCOPair));
         }
         //        LOG(info) << "                 now we have fObjectMap (size = " << fObjectMap.size() << ")";
         if (printInfo)

--- a/examples/MQ/pixelSimSplit/src/devices/FairMQChunkMerger.h
+++ b/examples/MQ/pixelSimSplit/src/devices/FairMQChunkMerger.h
@@ -16,6 +16,7 @@
 #define FAIRMQCHUNKMERGER_H_
 
 #include <FairMQDevice.h>
+#include <Rtypes.h>   // for UInt_t
 #include <map>
 #include <string>
 #include <utility>   // pair
@@ -23,7 +24,7 @@
 class TObject;
 class FairMCSplitEventHeader;
 
-typedef std::multimap<std::pair<int, int>, std::pair<int, TObject*>> MultiMapDef;
+typedef std::multimap<std::pair<UInt_t, UInt_t>, std::pair<UInt_t, TObject*>> MultiMapDef;
 
 class FairMQChunkMerger : public FairMQDevice
 {
@@ -44,8 +45,8 @@ class FairMQChunkMerger : public FairMQDevice
     std::map<std::pair<int, int>, int> fNofPartsPerEventMap;   // number of parts for pair<event number,run id>
     MultiMapDef fObjectMap;   // TObjects for given pair<pair<event number, run,id>part>
 
-    std::pair<int, int> fEvRIPair;
-    std::pair<int, TObject*> fEvCOPair;
+    std::pair<UInt_t, UInt_t> fEvRIPair;
+    std::pair<UInt_t, TObject*> fEvCOPair;
     std::pair<MultiMapDef::iterator, MultiMapDef::iterator> fRet;
 
     int fNofReceivedMessages;

--- a/examples/MQ/serialization/2-multipart/Ex2Sampler.h
+++ b/examples/MQ/serialization/2-multipart/Ex2Sampler.h
@@ -40,10 +40,10 @@ class Ex2Sampler : public FairMQDevice
     void Run() override
     {
         uint64_t sentMsgs = 0;
-        const uint64_t numEvents = fTree->GetEntries();
+        const Long64_t numEvents = fTree->GetEntries();
         LOG(info) << "Number of events to process: " << numEvents;
 
-        for (int64_t idx = 0; idx < numEvents; idx++) {
+        for (Long64_t idx = 0; idx < numEvents; idx++) {
             fTree->GetEntry(idx);
             Ex2Header* header = new Ex2Header();
             header->EventNumber = idx;

--- a/examples/advanced/propagator/src/FairTutPropTrack.cxx
+++ b/examples/advanced/propagator/src/FairTutPropTrack.cxx
@@ -37,8 +37,8 @@ void FairTutPropTrack::Print()
     LOG(info) << "FirstTrackPar:";
     fTrackParamFirst.Print();
     LOG(info) << "hits:";
-    for (int ih = 0; ih < fHitsIndices.size(); ih++) {
-        LOG(info) << fHitsIndices[ih].first << " / " << fHitsIndices[ih].second;
+    for (const auto &hitind_elem : fHitsIndices) {
+        LOG(info) << hitind_elem.first << " / " << hitind_elem.second;
     }
     LOG(info) << "-------------------";
 }

--- a/parbase/FairRuntimeDb.cxx
+++ b/parbase/FairRuntimeDb.cxx
@@ -435,7 +435,7 @@ Bool_t FairRuntimeDb::writeContainer(FairParSet* cont, FairRtdbRun* run, FairRtd
     return kTRUE;
 }
 
-Bool_t FairRuntimeDb::initContainers(Int_t runId, Int_t refId, const Text_t* fileName)
+Bool_t FairRuntimeDb::initContainers(UInt_t runId, Int_t refId, const Text_t* fileName)
 {
     // loops over the list of containers and calls the init() function of each
     // container if it is not static

--- a/parbase/FairRuntimeDb.h
+++ b/parbase/FairRuntimeDb.h
@@ -67,7 +67,7 @@ class FairRuntimeDb : public TObject
     FairParSet* findContainer(const char*);
     void removeContainer(Text_t*);
     void removeAllContainers(void);
-    Bool_t initContainers(Int_t runId, Int_t refId = -1, const Text_t* fileName = "");
+    Bool_t initContainers(UInt_t runId, Int_t refId = -1, const Text_t* fileName = "");
     void setContainersStatic(Bool_t f = kTRUE);
     Bool_t writeContainers(void);
     Bool_t writeContainer(FairParSet*, FairRtdbRun*, FairRtdbRun* refRun = 0);


### PR DESCRIPTION
* Add `-Wall` to all GCC based build types
* Fix most of the low hanging fruits of warnings

This gives 6 new warnings in a typical build that aren't completely easy to fix.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
