### PR TITLE
Add tgeo test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,6 +306,8 @@ if(BUILD_UNITTESTS)
   message(STATUS "Building the unit tests.")
   add_subdirectory(test)
 endif()
+add_subdirectory(test/tgeo)
+
 
 find_package2_implicit_dependencies()
 

--- a/test/tgeo/CMakeLists.txt
+++ b/test/tgeo/CMakeLists.txt
@@ -1,0 +1,17 @@
+################################################################################
+# Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
+#                                                                              #
+#              This software is distributed under the terms of the             #
+#              GNU Lesser General Public Licence (LGPL) version 3,             #
+#                  copied verbatim in the file "LICENSE"                       #
+################################################################################
+GENERATE_ROOT_TEST_SCRIPT(${CMAKE_CURRENT_SOURCE_DIR}/test_tgeo_units.C)
+
+set(maxTestTime 20)
+
+add_test(NAME test_tgeo_units
+         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/test_tgeo_units.sh
+        )
+set_tests_properties(test_tgeo_units PROPERTIES
+                     TIMEOUT ${maxTestTime}
+                    )

--- a/test/tgeo/test_tgeo_units.C
+++ b/test/tgeo/test_tgeo_units.C
@@ -1,0 +1,42 @@
+int test_tgeo_units()
+{
+    // Between root version v6.18.02 and v6.25.01 a differnt unit
+    // system (from Geant4) was used which results in problems.
+    // To work around the problem in the main steering class FairRunAna
+    // the ROOT unit system is set as default.
+    // When using tye wrong unit system the radiation length and the
+    // interaction lenght has a value which is a factor 10 smaller than
+    // when using the correct unit system.
+    // This tests checks if the proper unit system is used.
+
+    Int_t root_version = gROOT->GetVersionInt();
+    cout << "Root Version: " << root_version << endl;
+
+    FairRunSim* run = new FairRunSim();
+
+    // Define the values for the correct unit system
+    Double_t correctRadLengthAl{8.87561};
+    Double_t correctIntLengthAl{38.8622};
+
+    TGeoManager* geom = new TGeoManager("test_tgeo_units", "Test if the radiation lengtyh is the expected one");
+    cout << endl;
+
+    // Create a new material with the propertoes of aluminum
+    // and get the radiation and interaction length values from it
+    TGeoMaterial* matAl = new TGeoMaterial("BP_aluminium", 26.9815386, 13, 2.7, 24.01);
+    Double_t radLength = matAl->GetRadLen();
+    Double_t intLength = matAl->GetIntLen();
+
+    // Compare the expected values with the actual ones and fail the test
+    // if they are not equal
+    if (((correctRadLengthAl - radLength) < 0.001) && ((correctIntLengthAl - intLength) < 0.001)) {
+        return 0;
+    } else {
+        cout << "Radiation or interaction length differnt from expectation" << endl;
+        cout << "Expected radiation length   : " << correctRadLengthAl << endl;
+        cout << "Radiation length            : " << radLength << endl;
+        cout << "Expected Interaction length : " << correctIntLengthAl << endl;
+        cout << "Interaction length          : " << intLength << endl;
+        return 1;
+    }
+}


### PR DESCRIPTION
Add a test which checks if the correct unit system is used in the TGeoManager.
The test should fail for the moment for some versions of FairSoft. A bug was introduced in the contained ROOT versions which changed the default unit system used in FairRoot.


Checklist:

* [x ] Rebased against `dev` branch
* [ x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [ x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
