### PR TITLE
Treename fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   * In your template consider using `source @FairRoot_BINDIR/FairRootConfig.sh`
 * Drop deprecated `FairRootManager::GetOut{File,Tree}`
   It has been deprecated since 18.0.0.
+* `FairRootManager::Get{Tree,Folder}Name()` now return `const char *`.
+  Do NOT `delete` the returned pointer!
 
 ### Deprecated
 * Deprecating MbsAPI

--- a/base/steer/FairRootManager.h
+++ b/base/steer/FairRootManager.h
@@ -264,9 +264,11 @@ class FairRootManager : public TObject
     void SetFinishRun(Bool_t val = kTRUE) { fFinishRun = val; }
     Bool_t FinishRun() { return fFinishRun; }
 
-    static char* GetTreeName();
+    static void SetTreeName(const std::string& tname) { fTreeName = tname; }
+    static void SetFolderName(const std::string& tname) { fFolderName = tname; }
 
-    static char* GetFolderName();
+    const static char* GetTreeName();
+    const static char* GetFolderName();
 
     /**public Members for multi-threading */
     Int_t GetInstanceId() const { return fId; }
@@ -343,6 +345,12 @@ class FairRootManager : public TObject
      */
     std::map<TString, TObject*> fMap;   //!
 
+    /**folder name variable*/
+    static std::string fFolderName;   //!
+    /**tree name variable*/
+    static std::string fTreeName;   //!
+    static std::string GetNameFromFile(const char* namekind);
+
     /// A map of branchnames to typeinformation + memory address;
     /// used for branches registered with RegisterAny; use of ptr here
     /// since type_info cannot be copied
@@ -386,7 +394,7 @@ class FairRootManager : public TObject
 
     FairSource* fSource;
 
-    TChain* fSourceChain;
+    TChain* fSourceChain = nullptr;
     std::map<UInt_t, TChain*> fSignalChainList;   //!
 
     FairEventHeader* fEventHeader;


### PR DESCRIPTION
Add SetTreeName and SetFolderName setters

Reworked the setting of the tree and folder names.
Added the possibility to set these names in the macro
by calling either FairRootManager::Instance()->SetTreeName()
or FairRootManager::Instance()->SetFolderName().
These setters have to be called before calling run->Init().
    
Addresses issue #1111.

---

Checklist:

[ x ] Rebased against `dev` branch
[ x ] My name is in the resp. CONTRIBUTORS/AUTHORS file
[ x ] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
