### PR TITLE
CI: Disable Geant3 Tests by Default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Consider calling `fairroot_check_root_cxxstd_compatibility()`
   in your `CMakeLists.txt`.
 * `fairsoft-config` isn't searched for and not needed any more.
+* Tests using Geant3 have been disabled by default, because
+  those tests have a probability > 0 for failing.
+  If you want to run them anyways, pass
+  `-DENABLE_GEANT3_TESTING=ON` to CMake.
 
 ### Example Changes in Experiment Repos
 * https://github.com/R3BRootGroup/R3BRoot/pull/413

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,7 @@ ENDIF(NOT UNIX)
 
 # Set option(s)
 option(BUILD_UNITTESTS "Build all unittests and add them as new tests" OFF)
+option(ENABLE_GEANT3_TESTING "Enable tests utilizing Geant3" OFF)
 option(BUILD_MBS "Build MBS" OFF)
 
 # searches for needed packages

--- a/FairRoot_build_test.cmake
+++ b/FairRoot_build_test.cmake
@@ -54,6 +54,10 @@ list(APPEND options
   "-DCMAKE_INSTALL_PREFIX:PATH=${test_install_prefix}"
   "-DBUILD_MBS=ON"
 )
+if ("$ENV{CHANGE_ID}" STREQUAL "")
+  # Branch build
+  list(APPEND options "-DENABLE_GEANT3_TESTING:BOOL=ON")
+endif()
 ctest_configure(OPTIONS "${options}")
 
 ctest_build(FLAGS "-j${NCPUS}" TARGET install
@@ -62,7 +66,10 @@ ctest_build(FLAGS "-j${NCPUS}" TARGET install
 
 unset(repeat)
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
-  set(repeat REPEAT UNTIL_PASS:7)
+  if ("$ENV{CHANGE_ID}" STREQUAL "")
+    # Branch build
+    set(repeat REPEAT UNTIL_PASS:7)
+  endif()
 endif()
 if(_ctest_build_ret_val OR _ctest_build_num_errs)
   message(STATUS "Skipping tests, because build failed"

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,7 +6,12 @@
 #                  copied verbatim in the file "LICENSE"                       #
 ################################################################################
 
+set(mcEngine_list TGeant4)
+
 if(Geant3_FOUND)
+  if(ENABLE_GEANT3_TESTING)
+    list(APPEND mcEngine_list TGeant3)
+  endif()
   add_subdirectory(common/passive)
   add_subdirectory(common/mcstack)
   if(TARGET FairRoot::EventDisplay)

--- a/examples/MQ/pixelAlternative/run/CMakeLists.txt
+++ b/examples/MQ/pixelAlternative/run/CMakeLists.txt
@@ -41,12 +41,14 @@ install(TARGETS pixalt-sampler-bin pixalt-sink-bin pixalt-processor-bin
   RUNTIME DESTINATION ${PROJECT_INSTALL_DATADIR}/examples/MQ/pixelAlternative/bin
 )
 
-set(maxTestTime 30)
+if(ENABLE_GEANT3_TESTING)
+  set(maxTestTime 30)
 
-add_test(NAME ex_MQ_pixel_alt_static
-         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/startFairMQPixAlt.sh --work-dir ${CMAKE_BINARY_DIR}/examples/MQ/pixelDetector --max-index 10000 --aggregate 100 --processors 5 --command static --force-kill true)
-set_tests_properties(ex_MQ_pixel_alt_static PROPERTIES
-  FIXTURES_REQUIRED fixtures.ex_MQ_pixel_static
-  TIMEOUT ${maxTestTime}
-  PASS_REGULAR_EXPRESSION "Shell script finished successfully"
-)
+  add_test(NAME ex_MQ_pixel_alt_static
+           COMMAND ${CMAKE_CURRENT_BINARY_DIR}/startFairMQPixAlt.sh --work-dir ${CMAKE_BINARY_DIR}/examples/MQ/pixelDetector --max-index 10000 --aggregate 100 --processors 5 --command static --force-kill true)
+  set_tests_properties(ex_MQ_pixel_alt_static PROPERTIES
+    FIXTURES_REQUIRED fixtures.ex_MQ_pixel_static
+    TIMEOUT ${maxTestTime}
+    PASS_REGULAR_EXPRESSION "Shell script finished successfully"
+  )
+endif()

--- a/examples/MQ/pixelAlternative/run/scripts/startFairMQPixAlt.sh.in
+++ b/examples/MQ/pixelAlternative/run/scripts/startFairMQPixAlt.sh.in
@@ -204,10 +204,10 @@ if [ "$COMMAND" == "static" ]; then
         fi
     fi
 
-    $SERVER &> server_$DATESTRING.out.log &
+    $SERVER > server_$DATESTRING.out.log &
     SERVER_PID=$!
 
-    $SAMPLER &> sampler_$DATESTRING.out.log &
+    $SAMPLER > sampler_$DATESTRING.out.log &
     SAMPLER_PID=$!
 
     for (( i=0 ; i<$NOFPROCESSORS ; i++ ))
@@ -216,7 +216,7 @@ if [ "$COMMAND" == "static" ]; then
         APROCESSOR_PID[i]=$!
     done
 
-    $FILESINK &> fileSink_$DATESTRING.out.log &
+    $FILESINK > fileSink_$DATESTRING.out.log &
     FILESINK_PID=$!
 
     RUN_STRING="Running"

--- a/examples/MQ/pixelDetector/CMakeLists.txt
+++ b/examples/MQ/pixelDetector/CMakeLists.txt
@@ -6,7 +6,9 @@
 #                  copied verbatim in the file "LICENSE"                       #
 ################################################################################
 
-add_subdirectory(src)
-add_subdirectory(macros)
-add_subdirectory(run)
 add_subdirectory(param)
+add_subdirectory(src)
+if(ENABLE_GEANT3_TESTING)
+  add_subdirectory(macros)
+endif()
+add_subdirectory(run)

--- a/examples/MQ/pixelDetector/run/CMakeLists.txt
+++ b/examples/MQ/pixelDetector/run/CMakeLists.txt
@@ -117,25 +117,27 @@ install(TARGETS pixel-sampler pixel-processor pixel-sink pixel-sampler-bin pixel
   RUNTIME DESTINATION ${PROJECT_INSTALL_DATADIR}/examples/MQ/pixelDetector/bin
 )
 
-set(maxTestTime 100)
+if(ENABLE_GEANT3_TESTING)
+  set(maxTestTime 100)
 
-if(DDS_VERSION VERSION_GREATER_EQUAL 3.5
-   AND FairMQ_VERSION VERSION_GREATER_EQUAL 1.4.23)
-  add_test(NAME ex_MQ_pixel_simulation
-           COMMAND ${CMAKE_CURRENT_BINARY_DIR}/test-pixelSim.sh)
-  set_tests_properties(ex_MQ_pixel_simulation PROPERTIES
-    FIXTURES_REQUIRED fixtures.ex_MQ_pixel_static
+  if(DDS_VERSION VERSION_GREATER_EQUAL 3.5
+     AND FairMQ_VERSION VERSION_GREATER_EQUAL 1.4.23)
+    add_test(NAME ex_MQ_pixel_simulation
+             COMMAND ${CMAKE_CURRENT_BINARY_DIR}/test-pixelSim.sh)
+    set_tests_properties(ex_MQ_pixel_simulation PROPERTIES
+      FIXTURES_REQUIRED fixtures.ex_MQ_pixel_static
+      TIMEOUT ${maxTestTime}
+      PASS_REGULAR_EXPRESSION "Shell script finished successfully"
+  )
+  endif()
+
+  add_test(NAME ex_MQ_pixel_static
+           COMMAND ${CMAKE_CURRENT_BINARY_DIR}/startFairMQPixel.sh --work-dir ${CMAKE_CURRENT_BINARY_DIR}/../ -p 3 --command static --force-kill true)
+  set_tests_properties(ex_MQ_pixel_static PROPERTIES
+    FIXTURES_REQUIRED fixtures.ex_pixel_digi_to_bin_TGeant3
     TIMEOUT ${maxTestTime}
+    RUN_SERIAL ON
     PASS_REGULAR_EXPRESSION "Shell script finished successfully"
-)
+    FIXTURES_SETUP fixtures.ex_MQ_pixel_static
+  )
 endif()
-
-add_test(NAME ex_MQ_pixel_static
-         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/startFairMQPixel.sh --work-dir ${CMAKE_CURRENT_BINARY_DIR}/../ -p 3 --command static --force-kill true)
-set_tests_properties(ex_MQ_pixel_static PROPERTIES
-  FIXTURES_REQUIRED fixtures.ex_pixel_digi_to_bin_TGeant3
-  TIMEOUT ${maxTestTime}
-  RUN_SERIAL ON
-  PASS_REGULAR_EXPRESSION "Shell script finished successfully"
-  FIXTURES_SETUP fixtures.ex_MQ_pixel_static
-)

--- a/examples/MQ/pixelDetector/src/devices/FairMQPixelFileSinkBin.cxx
+++ b/examples/MQ/pixelDetector/src/devices/FairMQPixelFileSinkBin.cxx
@@ -63,6 +63,10 @@ void FairMQPixelFileSinkBin::Init()
     fTreeName = "cbmsim";
 
     fOutFile = TFile::Open(fFileName.c_str(), fFileOption.c_str());
+    if (!fOutFile) {
+        LOG(error) << "Could not open file" << fFileName.c_str();
+        return;
+    }
 
     fTree = new TTree(fTreeName.c_str(), "/cbmout");
 

--- a/examples/advanced/Tutorial3/macro/CMakeLists.txt
+++ b/examples/advanced/Tutorial3/macro/CMakeLists.txt
@@ -15,7 +15,7 @@ GENERATE_ROOT_TEST_SCRIPT(${CMAKE_CURRENT_SOURCE_DIR}/run_digi_timebased.C)
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_CURRENT_SOURCE_DIR}/run_reco_timebased.C)
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_CURRENT_SOURCE_DIR}/run_digi_reco_proof.C)
 
-foreach(mcEngine IN ITEMS TGeant3 TGeant4)
+foreach(mcEngine IN LISTS mcEngine_list)
   add_test(NAME ex_tutorial3_sim_${mcEngine}
            COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_sim.sh 100 \"${mcEngine}\")
   math(EXPR testTime 3*${maxTestTime})

--- a/examples/simulation/Tutorial1/macros/CMakeLists.txt
+++ b/examples/simulation/Tutorial1/macros/CMakeLists.txt
@@ -14,7 +14,7 @@ GENERATE_ROOT_TEST_SCRIPT(${CMAKE_CURRENT_SOURCE_DIR}/run_tutorial1.C)
 
 set(maxTestTime 60)
 
-foreach(mcEngine IN ITEMS TGeant3 TGeant4)
+foreach(mcEngine IN LISTS mcEngine_list)
   add_test(NAME ex_sim_tutorial1_mesh_${mcEngine}
            COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_tutorial1_mesh.sh 10 \"${mcEngine}\")
   set_tests_properties(ex_sim_tutorial1_mesh_${mcEngine} PROPERTIES

--- a/examples/simulation/Tutorial4/macros/CMakeLists.txt
+++ b/examples/simulation/Tutorial4/macros/CMakeLists.txt
@@ -14,7 +14,7 @@ GENERATE_ROOT_TEST_SCRIPT(${CMAKE_CURRENT_SOURCE_DIR}/run_reco.C)
 
 set(maxTestTime 60)
 
-foreach(mcEngine IN ITEMS TGeant3 TGeant4)
+foreach(mcEngine IN LISTS mcEngine_list)
   add_test(NAME ex_sim_tutorial4_${mcEngine}
            COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_tutorial4.sh 10 \"${mcEngine}\")
   set_tests_properties(ex_sim_tutorial4_${mcEngine} PROPERTIES

--- a/examples/simulation/rutherford/macros/CMakeLists.txt
+++ b/examples/simulation/rutherford/macros/CMakeLists.txt
@@ -11,7 +11,7 @@ GENERATE_ROOT_TEST_SCRIPT(${CMAKE_CURRENT_SOURCE_DIR}/run_rutherford.C)
 
 set(maxTestTime 60)
 
-foreach(mcEngine IN ITEMS TGeant3 TGeant4)
+foreach(mcEngine IN LISTS mcEngine_list)
   add_test(NAME ex_sim_rutherford_${mcEngine}
            COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_rutherford.sh 10 \"${mcEngine}\")
   set_tests_properties(ex_sim_rutherford_${mcEngine} PROPERTIES


### PR DESCRIPTION
The Geant3 based tests are highly unstable.
Rerunning tests like 10 times to get a stable result is no good.

So introduce a new option to enable/disable these tests:
    `ENABLE_GEANT3_TESTING`

The default is OFF.

Only branch CI builds will run these tests.

Fixes: #995

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
