### PR TITLE
FairRun: Now Owns the FairSource

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -59,6 +59,7 @@ set(sources
   source/FairMixedSource.cxx
   source/FairOnlineSource.cxx
   source/FairSource.cxx
+  source/FairUnpack.cxx
 
   steer/FairAnaSelector.cxx
   steer/FairLinkManager.cxx
@@ -86,7 +87,6 @@ if(BUILD_MBS)
     source/FairMbsSource.cxx
     source/FairMbsStreamSource.cxx
     source/FairRemoteSource.cxx
-    source/FairUnpack.cxx
     source/MRevBuffer.cxx
     source/rclose.c
     source/swaplw.c

--- a/base/FairLinkDef.h
+++ b/base/FairLinkDef.h
@@ -77,6 +77,7 @@
 #pragma link C++ class FairFileSource;
 #pragma link C++ class FairMixedSource;
 #pragma link C++ class FairOnlineSource;
+#pragma link C++ class FairUnpack;
 
 #pragma link C++ class FairSink;
 #pragma link C++ class FairRootFileSink;
@@ -85,7 +86,6 @@
 #pragma link C++ class FairRemoteSource;
 #pragma link C++ class FairMbsStreamSource;
 #pragma link C++ class FairLmdSource;
-#pragma link C++ class FairUnpack;
 #pragma link C++ class MRevBuffer;
 #pragma link C++ class REvent;
 #endif

--- a/base/steer/FairRun.cxx
+++ b/base/steer/FairRun.cxx
@@ -29,6 +29,7 @@
 #endif
 #include <TList.h>     // for TList
 #include <TObject.h>   // for TObject
+#include <TROOT.h>     // fot gROOT
 #include <cassert>     // for... well, assert
 
 TMCThreadLocal FairRun* FairRun::fRunInstance = 0;
@@ -89,7 +90,11 @@ FairRun::~FairRun()
     // So that FairRootManager does not try to delete it, because we will do that:
     fRootManager->SetSource(nullptr);
 
-    delete fTask;   // There is another tasklist in MCApplication,
+    if (fTask) {
+        // FairRunAna added it, but let's remove it here, because we own it
+        gROOT->GetListOfBrowsables()->Remove(fTask);
+        delete fTask;   // There is another tasklist in MCApplication,
+    }
     // but this should be independent
     delete fRtdb;   // who is responsible for the RuntimeDataBase
     delete fEvtHeader;

--- a/base/steer/FairRun.cxx
+++ b/base/steer/FairRun.cxx
@@ -85,6 +85,10 @@ FairRun::FairRun(Bool_t isMaster)
 FairRun::~FairRun()
 {
     LOG(debug) << "Enter Destructor of FairRun";
+
+    // So that FairRootManager does not try to delete it, because we will do that:
+    fRootManager->SetSource(nullptr);
+
     delete fTask;   // There is another tasklist in MCApplication,
     // but this should be independent
     delete fRtdb;   // who is responsible for the RuntimeDataBase
@@ -208,6 +212,12 @@ void FairRun::AlignGeometry() const { fAlignmentHandler.AlignGeometry(); }
 void FairRun::AddAlignmentMatrices(const std::map<std::string, TGeoHMatrix>& alignmentMatrices, bool invertMatrices)
 {
     fAlignmentHandler.AddAlignmentMatrices(alignmentMatrices, invertMatrices);
+}
+
+void FairRun::SetSource(FairSource* othersource)
+{
+    fRootManager->SetSource(othersource);
+    fSource.reset(othersource);
 }
 
 ClassImp(FairRun);

--- a/base/steer/FairRun.h
+++ b/base/steer/FairRun.h
@@ -16,6 +16,7 @@
 #include <TNamed.h>   // for TNamed
 #include <TString.h>
 #include <map>
+#include <memory>
 #include <string>
 
 class FairEventHeader;
@@ -176,6 +177,15 @@ class FairRun : public TNamed
 
     void AddAlignmentMatrices(const std::map<std::string, TGeoHMatrix>& alignmentMatrices, bool invertMatrices = false);
 
+    /**
+     * \brief Set the input signal file
+     *
+     * Takes an owning pointer!
+     */
+    virtual void SetSource(FairSource* tempSource);
+    /** Return non-owning pointer to source **/
+    FairSource* GetSource() { return fSource.get(); }
+
   private:
     FairRun(const FairRun& M);
     FairRun& operator=(const FairRun&) { return *this; }
@@ -214,8 +224,10 @@ class FairRun : public TNamed
 
     FairAlignmentHandler fAlignmentHandler;
 
+    std::unique_ptr<FairSource> fSource{};   //!
+
     void AlignGeometry() const;
 
-    ClassDef(FairRun, 5);
+    ClassDefOverride(FairRun, 5);
 };
 #endif   // FAIRRUN_H

--- a/base/steer/FairRunAna.h
+++ b/base/steer/FairRunAna.h
@@ -62,12 +62,6 @@ class FairRunAna : public FairRun
     void RunOnTBData();
     /** finish tasks, write output*/
     void TerminateRun();
-    /**Set the input signal file
-     *@param name :        signal file name
-     *@param identifier :  Unsigned integer which identify the signal file
-     */
-
-    virtual void SetSource(FairSource* tempSource) { fRootManager->SetSource(tempSource); }
 
     /** Switch On/Off the storing of FairEventHeader in output file*/
     void SetEventHeaderPersistence(Bool_t flag) { fStoreEventHeader = flag; }

--- a/base/steer/FairRunAnaProof.cxx
+++ b/base/steer/FairRunAnaProof.cxx
@@ -268,7 +268,7 @@ void FairRunAnaProof::SetSource(FairSource* tempSource)
     if (strncmp(tempSource->GetName(), "FairFileSource", 14) != 0) {
         LOG(warn) << "FairRunAnaProof. Seems you are trying to set different source than FairFileSource";
     }
-    fRootManager->SetSource(tempSource);
+    FairRunAna::SetSource(tempSource);
     fProofFileSource = static_cast<FairFileSource*>(tempSource);
 }
 

--- a/base/steer/FairRunOnline.cxx
+++ b/base/steer/FairRunOnline.cxx
@@ -70,7 +70,7 @@ FairRunOnline::FairRunOnline(FairSource* source)
     , fServer(nullptr)
     , fServerRefreshRate(0)
 {
-    fRootManager->SetSource(source);
+    SetSource(source);
     fgRinstance = this;
     fAna = kTRUE;
     LOG(info) << "FairRunOnline constructed at " << this;
@@ -116,7 +116,7 @@ void FairRunOnline::Init()
     // Add a Generated run ID to the FairRunTimeDb for input data which contain a FairMCEventHeader
     // The call doesn't make sense for online sources which doesn't contain a  FairMCEventHeader
 
-    if (kONLINE != fRootManager->GetSource()->GetSourceType()) {
+    if (kONLINE != GetSource()->GetSourceType()) {
         fRootManager->ReadEvent(0);
     }
 
@@ -131,14 +131,14 @@ void FairRunOnline::Init()
             // Generate unique Run ID
             FairRunIdGenerator genid;
             fRunId = genid.generateId();
-            fRootManager->GetSource()->SetRunId(fRunId);
+            GetSource()->SetRunId(fRunId);
         } else {
             // Use Run ID from source
             fRunId = fEvtHeader->GetRunId();
         }
     } else {
         // Run ID was set in the run manager - propagate to source
-        fRootManager->GetSource()->SetRunId(fRunId);
+        GetSource()->SetRunId(fRunId);
     }
 
     fRtdb->addRun(fRunId);
@@ -171,7 +171,7 @@ void FairRunOnline::Init()
 
     fRootManager->WriteFileHeader(fFileHeader);
 
-    fRootManager->GetSource()->SetParUnpackers();
+    GetSource()->SetParUnpackers();
     fTask->SetParTask();
     fRtdb->initContainers(fRunId);
 
@@ -185,7 +185,7 @@ void FairRunOnline::Init()
     fRootManager->Register("EventHeader.", "Event", fEvtHeader, (nullptr != fRootManager->GetSink()));
     fEvtHeader->SetRunId(fRunId);
 
-    fRootManager->GetSource()->InitUnpackers();
+    GetSource()->InitUnpackers();
 
     // Now call the User initialize for Tasks
     fTask->InitTask();
@@ -246,7 +246,7 @@ Int_t FairRunOnline::EventLoop()
         LOG(info) << "FairRunOnline::EventLoop() Call Reinit due to changed RunID (from " << fRunId << " to " << tmpId;
         fRunId = tmpId;
         Reinit(fRunId);
-        fRootManager->GetSource()->ReInitUnpackers();
+        GetSource()->ReInitUnpackers();
         fTask->ReInitTask();
     }
 
@@ -344,7 +344,7 @@ void FairRunOnline::Finish()
     fTask->FinishTask();
     fRootManager->LastFill();
     fRootManager->Write();
-    fRootManager->GetSource()->Close();
+    GetSource()->Close();
 
     fRootManager->CloseSink();
 }

--- a/base/steer/FairRunOnline.h
+++ b/base/steer/FairRunOnline.h
@@ -50,10 +50,6 @@ class FairRunOnline : public FairRun
         run functuion
     **/
     void SetAutoFinish(Bool_t val) { fAutomaticFinish = val; }
-    /** Set the source which should be used **/
-    void SetSource(FairSource* source) { fRootManager->SetSource(source); }
-    /** Return pointer to source **/
-    FairSource* GetSource() { return fRootManager->GetSource(); }
 
     /** Initialization of parameter container is set to static, i.e: the run id is
      *  is not checked anymore after initialization

--- a/examples/simulation/Tutorial2/macros/create_digis_mixed.C
+++ b/examples/simulation/Tutorial2/macros/create_digis_mixed.C
@@ -1,3 +1,5 @@
+#include <memory>
+
 void create_digis_mixed()
 {
 
@@ -5,9 +7,6 @@ void create_digis_mixed()
     timer.Start();
 
     gDebug = 0;
-
-    TString dir = getenv("VMCWORKDIR");
-    TString tutdir = dir + "/simulation/Tutorial2";
 
     TString BGinFile = "./tutorial2_pions.mc_p2.000_t0_n130.bg.root";
     TString SG1inFile = "./tutorial2_pions.mc_p2.000_t0_n10.sg1.root";
@@ -24,11 +23,11 @@ void create_digis_mixed()
     cout << "Background    File: " << BGinFile << endl;
     cout << "First  Signal File: " << SG1inFile << endl;
     cout << "Second signal File: " << SG2inFile << endl;
-    cout << "ParamFile: " << parFile << endl;
-    cout << "OutFile: " << outFile << endl;
+    cout << "ParamFile:          " << parFile << endl;
+    cout << "OutFile:            " << outFile << endl;
     cout << "******************************" << endl;
 
-    FairRunAna* fRun = new FairRunAna();
+    auto fRun = std::make_unique<FairRunAna>();
 
     //** Create a mixed source and set BG file *//
     FairMixedSource* fMixedSource = new FairMixedSource(BGinFile.Data(), 0);


### PR DESCRIPTION
FairRunAna and FairRunOnline both had a SetSource method. Both used to just call SetSource on FairRootManager. Move this into FairRun.
    
FairRootManager deletes the source in its destructor. As FairRootManager is a singleton, this happens very late in the process lifetime. Too late for some ROOT interpreter use cases.
So move the ownership to FairRun. FairRun makes sure that FairRootManager does not have a pointer to delete.

Fixes: #1154 

This also contains a small fix for non-mbs builds.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
