### PR TITLE
ParRootFileIo: Refactor Multi File Merging

### DIFF
--- a/parbase/FairParRootFileIo.h
+++ b/parbase/FairParRootFileIo.h
@@ -84,6 +84,7 @@ class FairParRootFileIo : public FairParIo
     ~FairParRootFileIo();
     Bool_t open(const Text_t* fname, Option_t* option = "READ", const Text_t* ftitle = "", Int_t compress = 1);
     Bool_t open(const TList* fnamelist, Option_t* option = "READ", const Text_t* ftitle = "", Int_t compress = 1);
+    static void MergeFiles(TFile* newParFile, const TList* fnamelist);
     void close() override;
     void print() override;
     FairParRootFile* getParRootFile();


### PR DESCRIPTION
Refactor the part of `FairParRootFileIo::open(TList *)` that merges multiple ROOT files from a list of names into one file into a new static `mergefile` method.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
