### PR TITLE
chore: Turn Deprecations into C++ Ones; Schedule Removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Deprecate some singleton-like APIs:
   * `FairRunAnaProof::Instance()` - keep a pointer to the
     object after `new` in your code.
+* Many items were already deprecated in prior versions.
+  Marked them with proper C++14 deprecation warnings.
+  Scheduled them for removal in v20.
 
 ### Other Notable Changes
 * Consider calling `fairroot_check_root_cxxstd_compatibility()`

--- a/base/sim/FairModule.h
+++ b/base/sim/FairModule.h
@@ -68,9 +68,11 @@ class FairModule : public TNamed
     virtual void ConstructRootGeometry(TGeoMatrix* shiftM = nullptr);
     /**construct geometry from standard ASSCII files (Hades Format)*/
     virtual void ConstructASCIIGeometry();
-    /** Modify the geometry for the simulation run using methods of the Root geometry package */
-    virtual void ModifyGeometry()
-        __attribute__((deprecated("Use FairAlignmentHandler instead, see Tutorial4 for examples")))
+    /**
+     * Modify the geometry for the simulation run using methods of the Root geometry package
+     * \deprecated Deprecated pre-v19, will be removed in v20.
+     */
+    [[deprecated("Use FairAlignmentHandler instead, see Tutorial4 for examples")]] virtual void ModifyGeometry()
     {
         LOG(warn) << "This function is deprecated. Use FairAlignmentHandler instead, see Tutorial4 for examples.";
     }

--- a/base/steer/FairRun.cxx
+++ b/base/steer/FairRun.cxx
@@ -146,7 +146,7 @@ void FairRun::SetUseFairLinks(Bool_t val) { fRootManager->SetUseFairLinks(val); 
 
 void FairRun::SetWriteRunInfoFile(Bool_t write)
 {
-    LOG(warn) << "Function FairRun::SetWriteRunInfoFile(Bool_t) is depcrecated and will vanish in future versions of "
+    LOG(warn) << "Function FairRun::SetWriteRunInfoFile(Bool_t) is deprecated and will vanish in future versions of "
                  "FairRoot.\n";
     LOG(warn) << "Please use FairRun::SetGenerateRunInfo(Bool_t) instead.";
 
@@ -156,7 +156,7 @@ void FairRun::SetWriteRunInfoFile(Bool_t write)
 Bool_t FairRun::GetWriteRunInfoFile()
 {
     LOG(warn)
-        << "Function FairRun::GetWriteRunInfoFile() is depcrecated and will vanish in future versions of FairRoot.\n";
+        << "Function FairRun::GetWriteRunInfoFile() is deprecated and will vanish in future versions of FairRoot.\n";
     LOG(warn) << "Please use FairRun::IsRunInfoGenerated() instead.";
 
     return fGenerateRunInfo;

--- a/base/steer/FairRun.h
+++ b/base/steer/FairRun.h
@@ -124,14 +124,22 @@ class FairRun : public TNamed
     /**Create a new file and save the TGeoManager to it*/
     void CreateGeometryFile(const char* geofile);
 
-    //** Set if RunInfo file should be written */
-    void SetWriteRunInfoFile(Bool_t write);
+    /**
+     * Set if RunInfo file should be written
+     * \deprecated Use SetGenerateRunInfo() instead.
+     *   Deprecated pre-v19, will be removed in v20.
+     */
+    [[deprecated]] void SetWriteRunInfoFile(Bool_t write);
 
     //** Set if RunInfo should be generated */
     void SetGenerateRunInfo(Bool_t write) { fGenerateRunInfo = write; }
 
-    //** Get info if RunInfo file is written */
-    Bool_t GetWriteRunInfoFile();
+    /**
+     * Get info if RunInfo file is written
+     * \deprecated Use \ref IsRunInfoGenerated() instead.
+     *   Deprecated pre-v19, will be removed in v20.
+     */
+    [[deprecated]] Bool_t GetWriteRunInfoFile();
 
     //** Get info if RunInfo file is written */
     Bool_t IsRunInfoGenerated() { return fGenerateRunInfo; }
@@ -151,21 +159,29 @@ class FairRun : public TNamed
     //** Set option string */
     void SetOptions(const TString& s) { fOptions = s; };
 
-    // vvvvvvvvvv depracted functions, replaced by FairSink vvvvvvvvvv
     /**
      * Set the output file name for analysis or simulation
+     * \deprecated Use \ref FairSink and \ref SetSink().
+     *   Deprecated pre-v19, will be removed in v20.
      */
-    virtual void SetOutputFile(const char* fname);
+    [[deprecated]] virtual void SetOutputFile(const char* fname);
     /**
      * Set the output file for analysis or simulation
+     * \deprecated Use \ref FairSink and \ref SetSink().
+     *   Deprecated pre-v19, will be removed in v20.
      */
-    virtual void SetOutputFile(TFile* f);
+    [[deprecated]] virtual void SetOutputFile(TFile* f);
     /**
      * Set the  output file name without creating the file
+     * \deprecated Use \ref FairSink and \ref SetSink().
+     *   Deprecated pre-v19, will be removed in v20.
      */
-    void SetOutputFileName(const TString& name);
-    TFile* GetOutputFile();
-    // ^^^^^^^^^^ depracted functions, replaced by FairSink ^^^^^^^^^^
+    [[deprecated]] void SetOutputFileName(const TString& name);
+    /**
+     * \deprecated Use \ref FairSink and \ref SetSink().
+     *   Deprecated pre-v19, will be removed in v20.
+     */
+    [[deprecated]] TFile* GetOutputFile();
 
     /**
      * New functions which allow to postpone creating a new Sink in MT

--- a/base/steer/FairRunAnaProof.cxx
+++ b/base/steer/FairRunAnaProof.cxx
@@ -370,19 +370,4 @@ void FairRunAnaProof::RunOnProof(Int_t NStart, Int_t NStop)
     return;
 }
 
-// // void FairRunAnaProof::SetOutputFile(const char* fname)
-// {
-//   fOutname=fname;
-// }
-//
-// // void FairRunAnaProof::SetOutputFile(TFile* f)
-// {
-//   if (! fRootManager) return;
-
-//   fOutname=f->GetName();
-//   fRootManager->OpenOutFile(f);
-//   fOutFile = f;
-
-// }
-//
 ClassImp(FairRunAnaProof);

--- a/base/steer/FairRunAnaProof.h
+++ b/base/steer/FairRunAnaProof.h
@@ -34,15 +34,6 @@ class FairRunAnaProof : public FairRunAna
     /** Init containers executed on PROOF, which is part of Init when running locally*/
     void InitContainers();
 
-    /**
-     * Set the output file name for analysis or simulation
-     */
-    //    virtual void    SetOutputFile(const char* fname);
-    /**
-     * Set the output file for analysis or simulation
-     */
-    //    virtual void    SetOutputFile(TFile* f);
-
     /**Run from event number NStart to event number NStop */
     void Run(Int_t NStart = 0, Int_t NStop = 0) override;
     /**Run for one event, used on PROOF nodes*/

--- a/base/steer/FairRunAnaProof.h
+++ b/base/steer/FairRunAnaProof.h
@@ -24,7 +24,8 @@
 class FairRunAnaProof : public FairRunAna
 {
   public:
-    [[deprecated]] static FairRunAnaProof* Instance();   ///< \deprecated
+    /** \deprecated Deprecated in v19, will be removed in v20. */
+    [[deprecated]] static FairRunAnaProof* Instance();
     virtual ~FairRunAnaProof();
     FairRunAnaProof(const char* proofName = "");
 

--- a/examples/simulation/rutherford/macros/run_rutherford.C
+++ b/examples/simulation/rutherford/macros/run_rutherford.C
@@ -58,7 +58,7 @@ void run_rutherford(Int_t nEvents = 10, TString mcEngine = "TGeant4", Bool_t isM
     FairRuntimeDb* rtdb = run->GetRuntimeDb();
     // ------------------------------------------------------------------------
 
-    run->SetWriteRunInfoFile(kFALSE);
+    run->SetGenerateRunInfo(kFALSE);
     // -----   Create media   -------------------------------------------------
     run->SetMaterials("media.geo");   // Materials
     // ------------------------------------------------------------------------

--- a/geane/FairGeanePro.h
+++ b/geane/FairGeanePro.h
@@ -69,16 +69,21 @@ class FairGeanePro : public FairPropagator
     virtual bool SetPropagateOnlyParameters();
 
     /* ====== Depracated functions ====== */
-    __attribute__((deprecated("Function PropagateToPlane depracated, use SetDestinationPlane."))) bool
+    /** \deprecated Deprecated pre-v19, will be removed in v20. */
+    [[deprecated("Function PropagateToPlane depracated, use SetDestinationPlane.")]] bool
         PropagateToPlane(const TVector3& v0, const TVector3& v1, const TVector3& v2);
-    __attribute__((deprecated("Function PropagateFromPlane depracated, use SetOriginPlane."))) bool PropagateFromPlane(
+    /** \deprecated Deprecated pre-v19, will be removed in v20. */
+    [[deprecated("Function PropagateFromPlane depracated, use SetOriginPlane.")]] bool PropagateFromPlane(
         const TVector3& v1,
         const TVector3& v2);
-    __attribute__((deprecated("Function PropagateToVolume depracated, use SetDestinationVolume."))) bool
+    /** \deprecated Deprecated pre-v19, will be removed in v20. */
+    [[deprecated("Function PropagateToVolume depracated, use SetDestinationVolume.")]] bool
         PropagateToVolume(TString VolName, int CopyNo, int option);
-    __attribute__((deprecated("Function PropagateToLength depracated, use SetDestinationLength."))) bool
-        PropagateToLength(float length);
-    __attribute__((deprecated("Function PropagateOnlyParameters depracated, use SetPropagateOnlyParameters."))) bool
+    /** \deprecated Deprecated pre-v19, will be removed in v20. */
+    [[deprecated("Function PropagateToLength depracated, use SetDestinationLength.")]] bool PropagateToLength(
+        float length);
+    /** \deprecated Deprecated pre-v19, will be removed in v20. */
+    [[deprecated("Function PropagateOnlyParameters depracated, use SetPropagateOnlyParameters.")]] bool
         PropagateOnlyParameters();
     /* ====== ====== ====== ====== ====== */
 
@@ -125,8 +130,9 @@ class FairGeanePro : public FairPropagator
 
   public:
     /* ====== Depracated functions ====== */
-    __attribute__((deprecated("Function FindPCA(many parameters) depracated, it is replaced by PCAOutputStruct "
-                              "FindPCA(pca, PDGCode, point, wire1, wire2, maxdistance)."))) int
+    /** \deprecated Deprecated pre-v19, will be removed in v20. */
+    [[deprecated("Function FindPCA(many parameters) depracated, it is replaced by PCAOutputStruct "
+                 "FindPCA(pca, PDGCode, point, wire1, wire2, maxdistance).")]] int
         FindPCA(int pca,
                 int PDGCode,
                 TVector3 point,
@@ -139,49 +145,52 @@ class FairGeanePro : public FairPropagator
                 double& Di,
                 float& trklength);
 
-    __attribute__((deprecated("Function SetWire depracated, contact FairRoot group if you need it."))) bool SetWire(
+    /** \deprecated Deprecated pre-v19, will be removed in v20. */
+    [[deprecated("Function SetWire depracated, contact FairRoot group if you need it.")]] bool SetWire(
         TVector3 extremity1,
         TVector3 extremity2);
-    __attribute__((deprecated("Function SetPoint depracated, contact FairRoot group if you need it."))) bool SetPoint(
-        TVector3 pnt);
-    __attribute__((deprecated("Function PropagateToPCA depracated, use SetPCAPropagation."))) bool PropagateToPCA(
-        int pca);
-    __attribute__((deprecated("Function PropagateToPCA depracated, use SetPCAPropagation."))) bool PropagateToPCA(
-        int pca,
-        int dir);
+    /** \deprecated Deprecated pre-v19, will be removed in v20. */
+    [[deprecated("Function SetPoint depracated, contact FairRoot group if you need it.")]] bool SetPoint(TVector3 pnt);
+    /** \deprecated Deprecated pre-v19, will be removed in v20. */
+    [[deprecated("Function PropagateToPCA depracated, use SetPCAPropagation.")]] bool PropagateToPCA(int pca);
+    /** \deprecated Deprecated pre-v19, will be removed in v20. */
+    [[deprecated("Function PropagateToPCA depracated, use SetPCAPropagation.")]] bool PropagateToPCA(int pca, int dir);
     // function to call the FindPCA alone to retrieve
     // the PCA.
-    __attribute__((deprecated("Function ActualFindPCA depracated, use SetPCAPropagation."))) bool
-        ActualFindPCA(int pca, FairTrackParP* par, int dir);
+    /** \deprecated Deprecated pre-v19, will be removed in v20. */
+    [[deprecated("Function ActualFindPCA depracated, use SetPCAPropagation.")]] bool ActualFindPCA(int pca,
+                                                                                                   FairTrackParP* par,
+                                                                                                   int dir);
 
-    TVector3 GetPCAOnWire()
-        __attribute__((deprecated("Function GetPCAOnWire obsolete, contact FairRoot group if you need it.")))
+    /** \deprecated Deprecated pre-v19, will be removed in v20. */
+    [[deprecated("Function GetPCAOnWire obsolete, contact FairRoot group if you need it.")]] TVector3 GetPCAOnWire()
     {
         return fvwi;
     }
-    TVector3 GetPCAOnTrack()
-        __attribute__((deprecated("Function GetPCAOnTrack obsolete, contact FairRoot group if you need it.")))
+    /** \deprecated Deprecated pre-v19, will be removed in v20. */
+    [[deprecated("Function GetPCAOnTrack obsolete, contact FairRoot group if you need it.")]] TVector3 GetPCAOnTrack()
     {
         return fvpf;
     }
-    float GetLengthAtPCA()
-        __attribute__((deprecated("Function GetLengthAtPCA obsolete, contact FairRoot group if you need it.")))
+    /** \deprecated Deprecated pre-v19, will be removed in v20. */
+    [[deprecated("Function GetLengthAtPCA obsolete, contact FairRoot group if you need it.")]] float GetLengthAtPCA()
     {
         return ftrklength;
     }
-    float GetTimeAtPCA()
-        __attribute__((deprecated("Function GetTimeAtPCA obsolete, contact FairRoot group if you need it.")))
+    /** \deprecated Deprecated pre-v19, will be removed in v20. */
+    [[deprecated("Function GetTimeAtPCA obsolete, contact FairRoot group if you need it.")]] float GetTimeAtPCA()
     {
         return ftrktime;
     }
 
-    __attribute__((
-        deprecated("Function PropagateToVirtualPlaneAtPCA questionable, contact FairRoot if you need it."))) bool
+    /** \deprecated Deprecated pre-v19, will be removed in v20. */
+    [[deprecated("Function PropagateToVirtualPlaneAtPCA questionable, contact FairRoot if you need it.")]] bool
         PropagateToVirtualPlaneAtPCA(int pca);
-    __attribute__((deprecated("Function BackTrackToVertex questionable, contact FairRoot if you need it."))) bool
+    /** \deprecated Deprecated pre-v19, will be removed in v20. */
+    [[deprecated("Function BackTrackToVertex questionable, contact FairRoot if you need it.")]] bool
         BackTrackToVertex();
-    __attribute__((
-        deprecated("Function BackTrackToVirtualPlaneAtPCA questionable, contact FairRoot if you need it."))) bool
+    /** \deprecated Deprecated pre-v19, will be removed in v20. */
+    [[deprecated("Function BackTrackToVirtualPlaneAtPCA questionable, contact FairRoot if you need it.")]] bool
         BackTrackToVirtualPlaneAtPCA(int pca);
     /* ====== ====== ====== ====== ====== */
 


### PR DESCRIPTION
Many methods in FairRun have already been deprecated by runtime warnings (and partly notes in the .h).

Turn all of them into C++ `[[deprecated]]` attributes. Also mark them with the doxygen `\deprecated` qualifier and note that they will go away in FairRoot 20.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
