### PR TITLE
CI: Initial clang-tidy Setup

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,4 @@
+---
+# disable clang-analyzer-core.UndefinedBinaryOperatorResult
+#   ROOT throws lots of them in their headers
+Checks: '-clang-analyzer-core.UndefinedBinaryOperatorResult'

--- a/FairRoot_build_test.cmake
+++ b/FairRoot_build_test.cmake
@@ -52,8 +52,13 @@ get_filename_component(test_install_prefix "${CTEST_BINARY_DIRECTORY}/install"
 list(APPEND options
   "-DDISABLE_COLOR=ON"
   "-DCMAKE_INSTALL_PREFIX:PATH=${test_install_prefix}"
-  "-DBUILD_MBS=ON"
 )
+if ((NOT DEFINED BUILD_MBS) OR BUILD_MBS)
+  list(APPEND options "-DBUILD_MBS=ON")
+endif()
+if (USE_CLANG_TIDY)
+  list(APPEND options "-DCMAKE_CXX_CLANG_TIDY=clang-tidy")
+endif()
 if ("$ENV{CHANGE_ID}" STREQUAL "")
   # Branch build
   list(APPEND options "-DENABLE_GEANT3_TESTING:BOOL=ON")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,7 @@ def jobMatrix(String prefix, String type, List specs) {
     def ver = spec.ver
     def arch = spec.arch
     def check = spec.check
+    def extra = spec.getOrDefault("extra", null)
 
     nodes[label] = {
       node(selector) {
@@ -33,6 +34,9 @@ def jobMatrix(String prefix, String type, List specs) {
           if (type == 'check') {
             ctestcmd = "ctest -S FairRoot_${check}_test.cmake -VV"
             sh "echo \"export FAIRROOT_FORMAT_BASE=origin/\${CHANGE_TARGET}\" >> ${jobscript}"
+          }
+          if (extra) {
+            ctestcmd = ctestcmd + " " + extra
           }
           if (selector =~ /^macos/) {
             sh "echo \"export SIMPATH=\$(brew --prefix fairsoft@${fairsoft})\" >> ${jobscript}"
@@ -88,6 +92,8 @@ pipeline{
             [os: 'debian',     ver: '10',    arch: 'x86_64', compiler: 'gcc-8',           fairsoft: 'apr21_patches_mt'],
             [os: 'ubuntu',     ver: '20.04', arch: 'x86_64', compiler: 'gcc-9',           fairsoft: 'apr21_patches'],
             [os: 'ubuntu',     ver: '20.04', arch: 'x86_64', compiler: 'gcc-9',           fairsoft: 'apr21_patches_mt'],
+            [os: 'ubuntu',   ver: 'rolling', arch: 'x86_64', compiler: 'current',         fairsoft: 'dev',
+                             extra: '-DUSE_CLANG_TIDY=ON -DBUILD_MBS=OFF'],
             [os: 'fedora',     ver: '33',    arch: 'x86_64', compiler: 'gcc-10',          fairsoft: 'apr21_patches'],
             [os: 'fedora',     ver: '33',    arch: 'x86_64', compiler: 'gcc-10',          fairsoft: 'apr21_patches_mt'],
             // [os: 'macos',      ver: '10.15', arch: 'x86_64', compiler: 'apple-clang-11',  fairsoft: '20.11'],

--- a/test/ci/container/fairsoft-install.sh
+++ b/test/ci/container/fairsoft-install.sh
@@ -1,0 +1,25 @@
+#! /bin/bash
+
+set -e
+
+workdir="$(mktemp -d --tmpdir fairsoft-for-fairroot.XXXXXX)"
+cd "$workdir"
+pwd
+
+repo="https://github.com/FairRootGroup/FairSoft"
+# repo="https://github.com/ChristianTackeGSI/FairSoft"
+branch="$1"
+install_name="dev"
+
+git clone --branch "$branch" "$repo"
+./FairSoft/legacy/setup-ubuntu.sh
+
+mkdir build
+cmake -DBUILD_METHOD=legacy \
+      -DCMAKE_INSTALL_PREFIX="/opt/fairsoft/$install_name" \
+      -S FairSoft -B build
+cmake --build build -j20
+cmake --install build
+
+cd /tmp
+rm -rf "$workdir"

--- a/test/ci/container/ubuntu.rolling.def
+++ b/test/ci/container/ubuntu.rolling.def
@@ -1,0 +1,25 @@
+Bootstrap: docker
+From: ubuntu:rolling
+
+%files
+    fairsoft-install.sh /opt/fairsoft/fairsoft-install.sh
+
+%post
+    apt-get -q update
+    apt-get -q -y dist-upgrade
+    apt-get -q -y --no-install-recommends install apt-utils
+    (
+      echo "debconf debconf/frontend select Noninteractive"
+      echo "tzdata	tzdata/Areas	select	Europe"
+      echo "tzdata	tzdata/Zones/Europe	select	Berlin"
+    ) | debconf-set-selections
+    apt-get -q -y --no-install-recommends install lsb-release git ca-certificates
+
+    # Some extra tools for development/etc
+    apt-get -y --no-install-recommends install \
+        doxygen graphviz clang-format clang-tidy
+
+    chmod a+x /opt/fairsoft/fairsoft-install.sh
+    ln -s /opt/fairsoft /fairsoft
+    /opt/fairsoft/fairsoft-install.sh dev
+    apt-get -y clean


### PR DESCRIPTION
* New container based on latest Ubuntu Rolling release.
  - FairSott legacy dev branch
  - clang-tidy for the clang-tidy part
  - clang-format and doxygen for [Hfuture checks
* Initial Jenkins and CTest driver setup for clang-tidy
* No special tests on clang-tidy, just defaults
* jenkins warnings NG plugin integration

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
