### PR TITLE
clang-tidy on headers, geobase: `override` and value member variable

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,5 @@
 ---
+HeaderFilterRegex: '.*'
 # disable clang-analyzer-core.UndefinedBinaryOperatorResult
 #   ROOT throws lots of them in their headers
 Checks: '-clang-analyzer-core.UndefinedBinaryOperatorResult'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,10 +62,13 @@ def jobMatrix(String prefix, String type, List specs) {
             sh "./slurm-submit.sh \"FairRoot \${JOB_BASE_NAME} ${label}\" ${jobscript}"
           }
           if (check == "warnings") {
+            def logpattern = 'build/Testing/Temporary/*.log'
             discoverGitReferenceBuild()
-            recordIssues(tools: [clangTidy(pattern: 'build/Testing/Temporary/*.log')],
+            recordIssues(tools: [clangTidy(pattern: logpattern)],
+                         filters: [excludeFile('build/.*/G__.*[.]cxx')],
                          qualityGates: [[threshold: 1, type: 'NEW', unstable: true]],
                          skipBlames: true)
+            archiveArtifacts(artifacts: logpattern, allowEmptyArchive: true, fingerprint: true)
           }
 
           deleteDir()

--- a/geobase/FairGeoAsciiIo.cxx
+++ b/geobase/FairGeoAsciiIo.cxx
@@ -37,28 +37,17 @@ FairGeoAsciiIo::FairGeoAsciiIo()
     , filename("")
     , filedir("")
     , writable(kFALSE)
-    , file(nullptr)
 {
     // Constructor
 }
 
-FairGeoAsciiIo::~FairGeoAsciiIo()
-{
-    // Destructor
-    close();
-    delete file;
-    file = 0;
-}
+FairGeoAsciiIo::~FairGeoAsciiIo() {}
 
 Bool_t FairGeoAsciiIo::open(const char* fname, const Text_t* status)
 {
     // Opens the file fname
     close();
-    if (!file) {
-        file = new std::fstream();
-    } else {
-        (file->clear());
-    }
+    file.clear();
     if (!filedir.IsNull()) {
         filename = filedir + "/" + fname;
     } else {
@@ -66,18 +55,18 @@ Bool_t FairGeoAsciiIo::open(const char* fname, const Text_t* status)
     }
     filename = filename.Strip();
     if (strcmp(status, "in") == 0) {
-        file->open(filename, ios::in);
+        file.open(filename, ios::in);
         writable = kFALSE;
     } else {
         if (strcmp(status, "out") == 0) {
-            file->open(filename, ios::in);
+            file.open(filename, ios::in);
             if (!isOpen()) {
-                file->close();
-                file->clear();
-                file->open(filename, ios::out);
+                file.close();
+                file.clear();
+                file.open(filename, ios::out);
                 writable = kTRUE;
             } else {
-                file->close();
+                file.close();
                 Error("open", "Output file %s exists already and will not be recreated.", filename.Data());
                 return kFALSE;
             }
@@ -85,7 +74,7 @@ Bool_t FairGeoAsciiIo::open(const char* fname, const Text_t* status)
             Error("open", "Invalid file option!");
         }
     }
-    if (file->rdbuf()->is_open() == 0) {
+    if (!file.is_open()) {
         Fatal("open", "Failed to open file %s", filename.Data());
         return kFALSE;
     }
@@ -95,7 +84,7 @@ Bool_t FairGeoAsciiIo::open(const char* fname, const Text_t* status)
 Bool_t FairGeoAsciiIo::isOpen()
 {
     // Returns kTRUE, if the file is open
-    if (file && file->rdbuf()->is_open() == 1) {
+    if (file.is_open()) {
         return kTRUE;
     }
     return kFALSE;
@@ -114,7 +103,7 @@ void FairGeoAsciiIo::close()
 {
     // Closes the file
     if (isOpen()) {
-        file->close();
+        file.close();
         filename = "";
     }
 }
@@ -139,7 +128,7 @@ Bool_t FairGeoAsciiIo::read(FairGeoMedia* media)
     if (!isOpen() || writable || media == 0) {
         return kFALSE;
     }
-    media->read(*file);
+    media->read(file);
     return kTRUE;
 }
 
@@ -149,7 +138,7 @@ Bool_t FairGeoAsciiIo::read(FairGeoSet* set, FairGeoMedia* media)
     if (!isOpen() || writable || set == 0) {
         return kFALSE;
     }
-    set->read(*file, media);
+    set->read(file, media);
     return kTRUE;
 }
 
@@ -159,7 +148,7 @@ Bool_t FairGeoAsciiIo::write(FairGeoMedia* media)
     if (!isOpen() || !writable || media == 0) {
         return kFALSE;
     }
-    media->write(*file);
+    media->write(file);
     return kTRUE;
 }
 
@@ -169,7 +158,7 @@ Bool_t FairGeoAsciiIo::write(FairGeoSet* set)
     if (!isOpen() || !writable || set == 0) {
         return kFALSE;
     }
-    set->write(*file);
+    set->write(file);
     return kTRUE;
 }
 
@@ -182,8 +171,8 @@ Bool_t FairGeoAsciiIo::readGeomConfig(FairGeoInterface* interface)
     TString buf(256);
     TString simRefRun, historyDate;
     Int_t k = -1;
-    while (!(*file).eof()) {
-        buf.ReadLine(*file);
+    while (!file.eof()) {
+        buf.ReadLine(file);
         buf = buf.Strip(buf.kBoth);
         if (!buf.IsNull() && buf(0, 2) != "//" && buf(0, 1) != "*") {
             if (buf.Contains(".geo") || buf.Contains("_gdb")) {
@@ -236,8 +225,8 @@ Bool_t FairGeoAsciiIo::readDetectorSetup(FairGeoInterface* interface)
     Int_t maxModules = 0, secNo = -1;
     Int_t* mod = 0;
     const char d[] = " ";
-    while (!(*file).eof()) {
-        (*file).getline(buf, maxbuf);
+    while (!file.eof()) {
+        file.getline(buf, maxbuf);
         if (strlen(buf) >= 3 && buf[1] != '/') {
             if (buf[0] == '[') {
                 set = 0;

--- a/geobase/FairGeoAsciiIo.h
+++ b/geobase/FairGeoAsciiIo.h
@@ -35,24 +35,24 @@ class FairGeoAsciiIo : public FairGeoIo
     void setDirectory(const char* fDir) { filedir = fDir; }
     const char* getDirectory() { return filedir.Data(); }
     const char* getFilename() { return filename.Data(); }
-    Bool_t open(const char*, const Text_t* status = "in");
-    Bool_t isOpen();
-    Bool_t isWritable();
-    void close();
-    void print();
-    Bool_t read(FairGeoMedia*);
-    Bool_t read(FairGeoSet*, FairGeoMedia*);
-    Bool_t write(FairGeoMedia*);
-    Bool_t write(FairGeoSet* set);
-    Bool_t readGeomConfig(FairGeoInterface*);
+    Bool_t open(const char*, const Text_t* status = "in") override;
+    Bool_t isOpen() override;
+    Bool_t isWritable() override;
+    void close() override;
+    void print() override;
+    Bool_t read(FairGeoMedia*) override;
+    Bool_t read(FairGeoSet*, FairGeoMedia*) override;
+    Bool_t write(FairGeoMedia*) override;
+    Bool_t write(FairGeoSet* set) override;
+    Bool_t readGeomConfig(FairGeoInterface*) override;
     Bool_t readDetectorSetup(FairGeoInterface*);
-    Bool_t setSimulRefRun(const char*) { return kTRUE; }
-    Bool_t setHistoryDate(const char*) { return kTRUE; }
+    Bool_t setSimulRefRun(const char*) override { return kTRUE; }
+    Bool_t setHistoryDate(const char*) override { return kTRUE; }
 
   private:
     FairGeoAsciiIo(const FairGeoAsciiIo&);
     FairGeoAsciiIo& operator=(const FairGeoAsciiIo&);
-    ClassDef(FairGeoAsciiIo, 0);   // Class for geometry I/O from ASCII file
+    ClassDefOverride(FairGeoAsciiIo, 0);   // Class for geometry I/O from ASCII file
 };
 
 #endif /* !FAIRGEOASCIIIO_H */

--- a/geobase/FairGeoAsciiIo.h
+++ b/geobase/FairGeoAsciiIo.h
@@ -12,7 +12,7 @@
 
 #include <Rtypes.h>    // for Bool_t, etc
 #include <TString.h>   // for TString
-#include <iosfwd>      // for fstream
+#include <fstream>     // for fstream
 
 class FairGeoSet;
 class FairGeoMedia;
@@ -27,7 +27,7 @@ class FairGeoAsciiIo : public FairGeoIo
     TString filename;
     TString filedir;
     Bool_t writable;
-    std::fstream* file;
+    std::fstream file{};   //!
 
   public:
     FairGeoAsciiIo();

--- a/geobase/FairGeoAssembly.h
+++ b/geobase/FairGeoAssembly.h
@@ -22,13 +22,13 @@ class FairGeoAssembly : public FairGeoBasicShape
   public:
     FairGeoAssembly();
     ~FairGeoAssembly();
-    TArrayD* calcVoluParam(FairGeoVolume*);
-    void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&);
-    Int_t readPoints(std::fstream* pFile, FairGeoVolume* volu);
-    Bool_t writePoints(std::fstream*, FairGeoVolume*);
-    void printPoints(FairGeoVolume* volu);
+    TArrayD* calcVoluParam(FairGeoVolume*) override;
+    void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&) override;
+    Int_t readPoints(std::fstream* pFile, FairGeoVolume* volu) override;
+    Bool_t writePoints(std::fstream*, FairGeoVolume*) override;
+    void printPoints(FairGeoVolume* volu) override;
 
-    ClassDef(FairGeoAssembly, 0);   // class for geometry shape ASSEMBLY
+    ClassDefOverride(FairGeoAssembly, 0);   // class for geometry shape ASSEMBLY
 };
 
 #endif /* !FAIRGEOASSEMBLY_H */

--- a/geobase/FairGeoBrik.h
+++ b/geobase/FairGeoBrik.h
@@ -21,9 +21,9 @@ class FairGeoBrik : public FairGeoBasicShape
   public:
     FairGeoBrik();
     ~FairGeoBrik();
-    TArrayD* calcVoluParam(FairGeoVolume*);
-    void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&);
-    ClassDef(FairGeoBrik, 0);   // class for geometry shape BOX or BRIK
+    TArrayD* calcVoluParam(FairGeoVolume*) override;
+    void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&) override;
+    ClassDefOverride(FairGeoBrik, 0);   // class for geometry shape BOX or BRIK
 };
 
 #endif /* !FAIRGEOBRIK_H */

--- a/geobase/FairGeoCompositeVolume.h
+++ b/geobase/FairGeoCompositeVolume.h
@@ -29,9 +29,9 @@ class FairGeoCompositeVolume : public FairGeoVolume
     FairGeoVolume* getComponent(const Int_t);
     void createComponents(const Int_t);
     void setComponent(FairGeoVolume*, const Int_t);
-    void clear();
-    void print();
-    ClassDef(FairGeoCompositeVolume, 1);
+    void clear() override;
+    void print() override;
+    ClassDefOverride(FairGeoCompositeVolume, 1);
 
   private:
     FairGeoCompositeVolume(const FairGeoCompositeVolume&);

--- a/geobase/FairGeoCone.h
+++ b/geobase/FairGeoCone.h
@@ -25,12 +25,12 @@ class FairGeoCone : public FairGeoBasicShape
   public:
     FairGeoCone();
     ~FairGeoCone();
-    TArrayD* calcVoluParam(FairGeoVolume*);
-    void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&);
-    Int_t readPoints(std::fstream*, FairGeoVolume*);
-    Bool_t writePoints(std::fstream*, FairGeoVolume*);
-    void printPoints(FairGeoVolume* volu);
-    ClassDef(FairGeoCone, 0);
+    TArrayD* calcVoluParam(FairGeoVolume*) override;
+    void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&) override;
+    Int_t readPoints(std::fstream*, FairGeoVolume*) override;
+    Bool_t writePoints(std::fstream*, FairGeoVolume*) override;
+    void printPoints(FairGeoVolume* volu) override;
+    ClassDefOverride(FairGeoCone, 0);
 };
 
 #endif /* !FAIRGEOCONE_H */

--- a/geobase/FairGeoCons.h
+++ b/geobase/FairGeoCons.h
@@ -25,13 +25,13 @@ class FairGeoCons : public FairGeoBasicShape
   public:
     FairGeoCons();
     ~FairGeoCons();
-    TArrayD* calcVoluParam(FairGeoVolume*);
-    void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&);
-    Int_t readPoints(std::fstream*, FairGeoVolume*);
-    Bool_t writePoints(std::fstream*, FairGeoVolume*);
-    void printPoints(FairGeoVolume* volu);
+    TArrayD* calcVoluParam(FairGeoVolume*) override;
+    void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&) override;
+    Int_t readPoints(std::fstream*, FairGeoVolume*) override;
+    Bool_t writePoints(std::fstream*, FairGeoVolume*) override;
+    void printPoints(FairGeoVolume* volu) override;
 
-    ClassDef(FairGeoCons, 0);
+    ClassDefOverride(FairGeoCons, 0);
 };
 
 #endif /* !FAIRGEOCONS_H */

--- a/geobase/FairGeoEltu.h
+++ b/geobase/FairGeoEltu.h
@@ -26,12 +26,12 @@ class FairGeoEltu : public FairGeoBasicShape
   public:
     FairGeoEltu();
     ~FairGeoEltu();
-    TArrayD* calcVoluParam(FairGeoVolume*);
-    void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&);
-    Int_t readPoints(std::fstream*, FairGeoVolume*);
-    Bool_t writePoints(std::fstream*, FairGeoVolume*);
-    void printPoints(FairGeoVolume* volu);
-    ClassDef(FairGeoEltu, 0);
+    TArrayD* calcVoluParam(FairGeoVolume*) override;
+    void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&) override;
+    Int_t readPoints(std::fstream*, FairGeoVolume*) override;
+    Bool_t writePoints(std::fstream*, FairGeoVolume*) override;
+    void printPoints(FairGeoVolume* volu) override;
+    ClassDefOverride(FairGeoEltu, 0);
 };
 
 #endif /* !FAIRGEOELTU_H */

--- a/geobase/FairGeoNode.h
+++ b/geobase/FairGeoNode.h
@@ -97,8 +97,8 @@ class FairGeoNode : public FairGeoVolume
     void setLabTransform(FairGeoTransform&);
     Bool_t calcModuleTransform(FairGeoTransform&);
     Bool_t calcRefPos(FairGeoVector&);
-    void clear();
-    void print();
+    void clear() override;
+    void print() override;
     Bool_t write(std::fstream&);
     Int_t compare(FairGeoNode&);
 
@@ -112,7 +112,7 @@ class FairGeoNode : public FairGeoVolume
         }
     }
 
-    ClassDef(FairGeoNode, 1);   //
+    ClassDefOverride(FairGeoNode, 1);   //
 };
 
 // -------------------- inlines --------------------------

--- a/geobase/FairGeoOldAsciiIo.cxx
+++ b/geobase/FairGeoOldAsciiIo.cxx
@@ -42,30 +42,17 @@ FairGeoOldAsciiIo::FairGeoOldAsciiIo()
     , filename("")
     , filedir("")
     , writable(kFALSE)
-    , file(nullptr)
 {
     // Constructor
 }
 
-FairGeoOldAsciiIo::~FairGeoOldAsciiIo()
-{
-    // Destructor
-    close();
-    if (file) {
-        delete file;
-        file = 0;
-    }
-}
+FairGeoOldAsciiIo::~FairGeoOldAsciiIo() {}
 
 Bool_t FairGeoOldAsciiIo::open(const char* fname, const Text_t* status)
 {
     // Opens the file fname
     close();
-    if (!file) {
-        file = new std::fstream();
-    } else {
-        (file->clear());
-    }
+    file.clear();
     if (!filedir.IsNull()) {
         filename = filedir + "/" + fname;
     } else {
@@ -73,18 +60,18 @@ Bool_t FairGeoOldAsciiIo::open(const char* fname, const Text_t* status)
     }
     filename = filename.Strip();
     if (strcmp(status, "in") == 0) {
-        file->open(filename, ios::in);
+        file.open(filename, ios::in);
         writable = kFALSE;
     } else {
         if (strcmp(status, "out") == 0) {
-            file->open(filename, ios::in);
+            file.open(filename, ios::in);
             if (!isOpen()) {
-                file->close();
-                file->clear();
-                file->open(filename, ios::out);
+                file.close();
+                file.clear();
+                file.open(filename, ios::out);
                 writable = kTRUE;
             } else {
-                file->close();
+                file.close();
                 Error("open", "Output file %s exists already and will not be recreated.", filename.Data());
                 return kFALSE;
             }
@@ -92,7 +79,7 @@ Bool_t FairGeoOldAsciiIo::open(const char* fname, const Text_t* status)
             Error("open", "Invalid file option!");
         }
     }
-    if (file->rdbuf()->is_open() == 0) {
+    if (!file.is_open()) {
         Error("open", "Failed to open file %s", filename.Data());
         return kFALSE;
     }
@@ -102,7 +89,7 @@ Bool_t FairGeoOldAsciiIo::open(const char* fname, const Text_t* status)
 Bool_t FairGeoOldAsciiIo::isOpen()
 {
     // Returns kTRUE, if the file is open
-    if (file && file->rdbuf()->is_open() == 1) {
+    if (file.is_open()) {
         return kTRUE;
     }
     return kFALSE;
@@ -121,7 +108,7 @@ void FairGeoOldAsciiIo::close()
 {
     // Closes the file
     if (isOpen()) {
-        file->close();
+        file.close();
         filename = "";
     }
 }
@@ -146,7 +133,7 @@ Bool_t FairGeoOldAsciiIo::read(FairGeoSet* set, FairGeoMedia* media)
     if (!isOpen() || writable || set == 0) {
         return kFALSE;
     }
-    std::fstream& fin = *file;
+    std::fstream& fin = file;
     fin.clear();
     fin.seekg(0, ios::beg);
     FairGeoNode* volu = 0;

--- a/geobase/FairGeoOldAsciiIo.h
+++ b/geobase/FairGeoOldAsciiIo.h
@@ -12,7 +12,7 @@
 
 #include <Rtypes.h>    // for Bool_t, kFALSE, etc
 #include <TString.h>   // for TString
-#include <iosfwd>      // for fstream
+#include <fstream>     // for fstream
 
 class FairGeoInterface;
 class FairGeoMedia;
@@ -28,7 +28,7 @@ class FairGeoOldAsciiIo : public FairGeoIo
     TString filename;
     TString filedir;
     Bool_t writable;
-    std::fstream* file;
+    std::fstream file{};   //!
 
   public:
     FairGeoOldAsciiIo();

--- a/geobase/FairGeoOldAsciiIo.h
+++ b/geobase/FairGeoOldAsciiIo.h
@@ -36,26 +36,26 @@ class FairGeoOldAsciiIo : public FairGeoIo
     void setDirectory(const char* fDir) { filedir = fDir; }
     const char* getDirectory() { return filedir.Data(); }
     const char* getFilename() { return filename.Data(); }
-    Bool_t open(const char*, const Text_t* status = "in");
-    Bool_t isOpen();
-    Bool_t isWritable();
-    void close();
-    void print();
-    Bool_t read(FairGeoMedia*) { return kFALSE; }
-    Bool_t read(FairGeoSet*, FairGeoMedia*);
-    Bool_t write(FairGeoMedia*) { return kFALSE; }
-    Bool_t write(FairGeoSet*) { return kFALSE; }
-    Bool_t readGeomConfig(FairGeoInterface*) { return kFALSE; }
+    Bool_t open(const char*, const Text_t* status = "in") override;
+    Bool_t isOpen() override;
+    Bool_t isWritable() override;
+    void close() override;
+    void print() override;
+    Bool_t read(FairGeoMedia*) override { return kFALSE; }
+    Bool_t read(FairGeoSet*, FairGeoMedia*) override;
+    Bool_t write(FairGeoMedia*) override { return kFALSE; }
+    Bool_t write(FairGeoSet*) override { return kFALSE; }
+    Bool_t readGeomConfig(FairGeoInterface*) override { return kFALSE; }
     Bool_t readDetectorSetup(FairGeoInterface*) { return kFALSE; }
-    Bool_t setSimulRefRun(const char*) { return kTRUE; }
-    Bool_t setHistoryDate(const char*) { return kTRUE; }
+    Bool_t setSimulRefRun(const char*) override { return kTRUE; }
+    Bool_t setHistoryDate(const char*) override { return kTRUE; }
 
   private:
     Bool_t calculateShapePoints(Double_t*, FairGeoNode*);
     FairGeoOldAsciiIo(const FairGeoOldAsciiIo&);
     FairGeoOldAsciiIo& operator=(const FairGeoOldAsciiIo&);
 
-    ClassDef(FairGeoOldAsciiIo, 0);   //
+    ClassDefOverride(FairGeoOldAsciiIo, 0);   //
 };
 
 #endif /* !FAIRGEOOLDASCIIIO_H */

--- a/geobase/FairGeoPcon.h
+++ b/geobase/FairGeoPcon.h
@@ -26,12 +26,12 @@ class FairGeoPcon : public FairGeoBasicShape
   public:
     FairGeoPcon();
     ~FairGeoPcon();
-    TArrayD* calcVoluParam(FairGeoVolume*);
-    void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&);
-    Int_t readPoints(std::fstream*, FairGeoVolume*);
-    Bool_t writePoints(std::fstream*, FairGeoVolume*);
-    void printPoints(FairGeoVolume* volu);
-    ClassDef(FairGeoPcon, 0);   //
+    TArrayD* calcVoluParam(FairGeoVolume*) override;
+    void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&) override;
+    Int_t readPoints(std::fstream*, FairGeoVolume*) override;
+    Bool_t writePoints(std::fstream*, FairGeoVolume*) override;
+    void printPoints(FairGeoVolume* volu) override;
+    ClassDefOverride(FairGeoPcon, 0);   //
 };
 
 #endif /* !FAIRGEOPCON_H */

--- a/geobase/FairGeoPgon.h
+++ b/geobase/FairGeoPgon.h
@@ -26,12 +26,12 @@ class FairGeoPgon : public FairGeoBasicShape
   public:
     FairGeoPgon();
     ~FairGeoPgon();
-    TArrayD* calcVoluParam(FairGeoVolume*);
-    void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&);
-    Int_t readPoints(std::fstream*, FairGeoVolume*);
-    Bool_t writePoints(std::fstream*, FairGeoVolume*);
-    void printPoints(FairGeoVolume* volu);
-    ClassDef(FairGeoPgon, 0);   //
+    TArrayD* calcVoluParam(FairGeoVolume*) override;
+    void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&) override;
+    Int_t readPoints(std::fstream*, FairGeoVolume*) override;
+    Bool_t writePoints(std::fstream*, FairGeoVolume*) override;
+    void printPoints(FairGeoVolume* volu) override;
+    ClassDefOverride(FairGeoPgon, 0);   //
 };
 
 #endif /* !FAIRGEOPGON_H */

--- a/geobase/FairGeoRootBuilder.h
+++ b/geobase/FairGeoRootBuilder.h
@@ -34,11 +34,11 @@ class FairGeoRootBuilder : public FairGeoBuilder
     FairGeoRootBuilder(const char*, const char*);
     ~FairGeoRootBuilder() {}
     void setGeoManager(TGeoManager* me) { geoManager = me; }
-    Bool_t createNode(FairGeoNode*, Int_t hadFormat = 0);
-    Int_t createMedium(FairGeoMedium*);
-    void finalize();
+    Bool_t createNode(FairGeoNode*, Int_t hadFormat = 0) override;
+    Int_t createMedium(FairGeoMedium*) override;
+    void finalize() override;
     void checkOverlaps(Double_t ovlp = 0.0001);
-    ClassDef(FairGeoRootBuilder, 0);   //
+    ClassDefOverride(FairGeoRootBuilder, 0);   //
 };
 
 #endif /* !FAIRGEOROOTBUILDER_H */

--- a/geobase/FairGeoSphe.h
+++ b/geobase/FairGeoSphe.h
@@ -26,12 +26,12 @@ class FairGeoSphe : public FairGeoBasicShape
   public:
     FairGeoSphe();
     ~FairGeoSphe();
-    TArrayD* calcVoluParam(FairGeoVolume*);
-    void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&);
-    Int_t readPoints(std::fstream*, FairGeoVolume*);
-    Bool_t writePoints(std::fstream*, FairGeoVolume*);
-    void printPoints(FairGeoVolume* volu);
-    ClassDef(FairGeoSphe, 0);   //
+    TArrayD* calcVoluParam(FairGeoVolume*) override;
+    void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&) override;
+    Int_t readPoints(std::fstream*, FairGeoVolume*) override;
+    Bool_t writePoints(std::fstream*, FairGeoVolume*) override;
+    void printPoints(FairGeoVolume* volu) override;
+    ClassDefOverride(FairGeoSphe, 0);   //
 };
 
 #endif /* !FAIRGEOSPHE_H */

--- a/geobase/FairGeoTorus.h
+++ b/geobase/FairGeoTorus.h
@@ -22,13 +22,13 @@ class FairGeoTorus : public FairGeoBasicShape
   public:
     FairGeoTorus();
     ~FairGeoTorus();
-    TArrayD* calcVoluParam(FairGeoVolume*);
-    void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&);
-    Int_t readPoints(std::fstream* pFile, FairGeoVolume* volu);
-    Bool_t writePoints(std::fstream*, FairGeoVolume*);
-    void printPoints(FairGeoVolume* volu);
+    TArrayD* calcVoluParam(FairGeoVolume*) override;
+    void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&) override;
+    Int_t readPoints(std::fstream* pFile, FairGeoVolume* volu) override;
+    Bool_t writePoints(std::fstream*, FairGeoVolume*) override;
+    void printPoints(FairGeoVolume* volu) override;
 
-    ClassDef(FairGeoTorus, 0);   // class for geometry shape TORUS
+    ClassDefOverride(FairGeoTorus, 0);   // class for geometry shape TORUS
 };
 
 #endif /* !FAIRGEOTORUS_H */

--- a/geobase/FairGeoTrap.h
+++ b/geobase/FairGeoTrap.h
@@ -25,9 +25,9 @@ class FairGeoTrap : public FairGeoBasicShape
   public:
     FairGeoTrap();
     ~FairGeoTrap();
-    TArrayD* calcVoluParam(FairGeoVolume*);
-    void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&);
-    ClassDef(FairGeoTrap, 0);   // class for geometry shape TRAP
+    TArrayD* calcVoluParam(FairGeoVolume*) override;
+    void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&) override;
+    ClassDefOverride(FairGeoTrap, 0);   // class for geometry shape TRAP
 };
 
 #endif /* !FAIRGEOTRAP_H */

--- a/geobase/FairGeoTrd1.h
+++ b/geobase/FairGeoTrd1.h
@@ -25,10 +25,10 @@ class FairGeoTrd1 : public FairGeoBasicShape
   public:
     FairGeoTrd1();
     ~FairGeoTrd1();
-    TArrayD* calcVoluParam(FairGeoVolume*);
-    void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&);
+    TArrayD* calcVoluParam(FairGeoVolume*) override;
+    void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&) override;
 
-    ClassDef(FairGeoTrd1, 0);   // class for geometry shape TRD1
+    ClassDefOverride(FairGeoTrd1, 0);   // class for geometry shape TRD1
 };
 
 #endif /* !FAIRGEOTRD1_H */

--- a/geobase/FairGeoTube.h
+++ b/geobase/FairGeoTube.h
@@ -22,12 +22,12 @@ class FairGeoTube : public FairGeoBasicShape
   public:
     FairGeoTube();
     ~FairGeoTube();
-    TArrayD* calcVoluParam(FairGeoVolume*);
-    void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&);
-    Int_t readPoints(std::fstream*, FairGeoVolume*);
-    Bool_t writePoints(std::fstream*, FairGeoVolume*);
-    void printPoints(FairGeoVolume* volu);
-    ClassDef(FairGeoTube, 0);   // class for geometry shape TUBE
+    TArrayD* calcVoluParam(FairGeoVolume*) override;
+    void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&) override;
+    Int_t readPoints(std::fstream*, FairGeoVolume*) override;
+    Bool_t writePoints(std::fstream*, FairGeoVolume*) override;
+    void printPoints(FairGeoVolume* volu) override;
+    ClassDefOverride(FairGeoTube, 0);   // class for geometry shape TUBE
 };
 
 #endif /* !FAIRGEOTUBE_H */

--- a/geobase/FairGeoTubs.h
+++ b/geobase/FairGeoTubs.h
@@ -22,12 +22,12 @@ class FairGeoTubs : public FairGeoBasicShape
   public:
     FairGeoTubs();
     ~FairGeoTubs();
-    TArrayD* calcVoluParam(FairGeoVolume*);
-    void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&);
-    Int_t readPoints(std::fstream*, FairGeoVolume*);
-    Bool_t writePoints(std::fstream*, FairGeoVolume*);
-    void printPoints(FairGeoVolume* volu);
-    ClassDef(FairGeoTubs, 0);   // class for geometry shape TUBS
+    TArrayD* calcVoluParam(FairGeoVolume*) override;
+    void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&) override;
+    Int_t readPoints(std::fstream*, FairGeoVolume*) override;
+    Bool_t writePoints(std::fstream*, FairGeoVolume*) override;
+    void printPoints(FairGeoVolume* volu) override;
+    ClassDefOverride(FairGeoTubs, 0);   // class for geometry shape TUBS
 };
 
 #endif /* !FAIRGEOTUBS_H */


### PR DESCRIPTION
* Use `override` around in geobase
* Instead of pointing to an `std::fstream` just include it.
* clang-tidy on headers, not on root dictionaries

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
