### PR TITLE
Improve pixel test specificity

### DIFF
--- a/examples/MQ/pixelAlternative/run/CMakeLists.txt
+++ b/examples/MQ/pixelAlternative/run/CMakeLists.txt
@@ -44,7 +44,7 @@ install(TARGETS pixalt-sampler-bin pixalt-sink-bin pixalt-processor-bin
 set(maxTestTime 30)
 
 add_test(NAME ex_MQ_pixel_alt_static
-         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/startFairMQPixAlt.sh --work-dir ${CMAKE_BINARY_DIR}/examples/MQ/pixelDetector --max-index 10000 --aggregate 100 --processors 5 --command static --force-kill true)
+         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/startFairMQPixAlt.sh --work-dir ${CMAKE_BINARY_DIR}/examples/MQ/pixelDetector --max-index 1000 --aggregate 10 --processors 5 --command static --force-kill true)
 set_tests_properties(ex_MQ_pixel_alt_static PROPERTIES
   FIXTURES_REQUIRED fixtures.ex_MQ_pixel_static
   TIMEOUT ${maxTestTime}

--- a/examples/MQ/pixelDetector/macros/CMakeLists.txt
+++ b/examples/MQ/pixelDetector/macros/CMakeLists.txt
@@ -13,7 +13,7 @@ GENERATE_ROOT_TEST_SCRIPT(${CMAKE_CURRENT_SOURCE_DIR}/run_digiToBin.C)
 set(maxTestTime 30)
 
 add_test(NAME ex_pixel_sim_${pixel_simulation_engine}
-         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_sim.sh 10000 \"${pixel_simulation_engine}\")
+         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_sim.sh 1000 \"${pixel_simulation_engine}\")
 math(EXPR testTime 4*${maxTestTime})
 set_tests_properties(ex_pixel_sim_${pixel_simulation_engine} PROPERTIES
   TIMEOUT ${testTime}

--- a/examples/MQ/pixelDetector/macros/run_sim.C
+++ b/examples/MQ/pixelDetector/macros/run_sim.C
@@ -129,6 +129,40 @@ void run_sim(Int_t nEvents = 10, TString mcEngine = "TGeant3", Int_t fileId = 0,
     cout << "Output file is " << outFile << endl;
     cout << "Parameter file is " << parFile << endl;
     cout << "Real time " << rtime << " s, CPU time " << ctime << "s" << endl << endl;
+
+    auto outputFile = TFile::Open(outFile);
+    auto outputTree = dynamic_cast<TTree*>(outputFile->Get("cbmsim"));
+    outputTree->Draw("PixelPoint.fTime", "", "goff");
+    auto htemp = dynamic_cast<TH1F*>(outputFile->Get("htemp"));
+    int outputTreeEntries = outputTree->GetEntries();
+    int outputPoints = (int)(htemp->GetEntries());
+    double outputTime = htemp->GetMean();
+    delete htemp;
+    delete outputTree;
+    outputFile->Close();
+    delete outputFile;
+
+    cout << endl;
+    cout << "<DartMeasurement name=\"TreeEntries\" type=\"numeric/int\">";
+    cout << outputTreeEntries;
+    cout << "</DartMeasurement>" << endl;
+    cout << "<DartMeasurement name=\"NumberOfPoints\" type=\"numeric/int\">";
+    cout << outputPoints;
+    cout << "</DartMeasurement>" << endl;
+    cout << "<DartMeasurement name=\"PointTimeMean\" type=\"numeric/double\">";
+    cout << outputTime;
+    cout << "</DartMeasurement>" << endl;
+    cout << endl;
+
+    if (outputTreeEntries < nEvents) {
+        cout << "Not enough events (" << outputTreeEntries << ") in the output tree." << endl;
+        return;
+    }
+    if (outputPoints < 7. * nEvents) {
+        cout << "Not enough points (" << outputPoints << ") in the output tree." << endl;
+        return;
+    }
+
     cout << "Macro finished successfully." << endl;
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION
(Cherry picked from #889, thanks @karabowi)

This improvement is useful without #889 and we should have it in the tree sooner than later.

Original commit text:

> ### Modify the pixelDetector run_sim macro
> 
> Implement test for the content of the output root file.
> The test will fail if not enough entries or if not enough points is registered in the output tree.
> 
> Added three dart measurements points: number of entries, number of points, and, just as an example, points' mean time.
> 
> Reduce the number of events in the pixel examples.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
