### PR TITLE
Improve Include Paths in Generated Dictionaries

### DIFF
--- a/alignment/CMakeLists.txt
+++ b/alignment/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(${target} PUBLIC
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
   LINKDEF AlignmentLinkDef.h
+  EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 
 fairroot_install_exported(TARGETS ${target})

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -143,6 +143,7 @@ target_compile_definitions(${target} PRIVATE
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
   LINKDEF FairLinkDef.h
+  EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 
 fairroot_install_exported(TARGETS ${target})

--- a/base/sim/fastsim/CMakeLists.txt
+++ b/base/sim/fastsim/CMakeLists.txt
@@ -50,6 +50,7 @@ target_link_libraries(${target} PUBLIC
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
   LINKDEF FastSimLinkDef.h
+  EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 
 fairroot_install_exported(TARGETS ${target})

--- a/base/sink/FairRootFileSink.cxx
+++ b/base/sink/FairRootFileSink.cxx
@@ -46,7 +46,7 @@ FairRootFileSink::FairRootFileSink(TFile* f, const char* Title)
     , fIsInitialized(kFALSE)
     , fFileHeader(0)
 {
-    if (fRootFile->IsZombie()) {
+    if ((!fRootFile) || fRootFile->IsZombie()) {
         LOG(fatal) << "Error opening the Input file";
     }
     LOG(debug) << "FairRootFileSink created------------";
@@ -63,7 +63,7 @@ FairRootFileSink::FairRootFileSink(const TString* RootFileName, const char* Titl
     , fFileHeader(0)
 {
     fRootFile = TFile::Open(RootFileName->Data(), "recreate");
-    if (fRootFile->IsZombie()) {
+    if ((!fRootFile) || fRootFile->IsZombie()) {
         LOG(fatal) << "Error opening the Output file";
     }
     LOG(debug) << "FairRootFileSink created------------";
@@ -80,8 +80,8 @@ FairRootFileSink::FairRootFileSink(const TString RootFileName, const char* Title
     , fFileHeader(0)
 {
     fRootFile = TFile::Open(RootFileName.Data(), "recreate");
-    if (fRootFile->IsZombie()) {
-        LOG(fatal) << "Error opening the Input file";
+    if ((!fRootFile) || fRootFile->IsZombie()) {
+        LOG(fatal) << "Error opening file " << RootFileName;
     }
     LOG(debug) << "FairRootFileSink created------------";
 }

--- a/base/source/FairFileSource.cxx
+++ b/base/source/FairFileSource.cxx
@@ -77,7 +77,7 @@ FairFileSource::FairFileSource(TFile* f, const char* Title, UInt_t)
     , fEventMeanTime(0.)
     , fCheckFileLayout(kTRUE)
 {
-    if (fRootFile->IsZombie()) {
+    if ((!fRootFile) || fRootFile->IsZombie()) {
         LOG(fatal) << "Error opening the Input file";
     }
     LOG(debug) << "FairFileSource created------------";
@@ -118,7 +118,7 @@ FairFileSource::FairFileSource(const TString* RootFileName, const char* Title, U
     , fCheckFileLayout(kTRUE)
 {
     fRootFile = TFile::Open(RootFileName->Data());
-    if (fRootFile->IsZombie()) {
+    if ((!fRootFile) || fRootFile->IsZombie()) {
         LOG(fatal) << "Error opening the Input file";
     }
     LOG(debug) << "FairFileSource created------------";
@@ -159,7 +159,7 @@ FairFileSource::FairFileSource(const TString RootFileName, const char* Title, UI
     , fCheckFileLayout(kTRUE)
 {
     fRootFile = TFile::Open(RootFileName.Data());
-    if (fRootFile->IsZombie()) {
+    if ((!fRootFile) || fRootFile->IsZombie()) {
         LOG(fatal) << "Error opening the Input file";
     }
     LOG(debug) << "FairFileSource created------------";

--- a/base/source/FairMixedSource.cxx
+++ b/base/source/FairMixedSource.cxx
@@ -77,7 +77,7 @@ FairMixedSource::FairMixedSource(TFile* f, const char* Title, UInt_t)
     , fRunIdFromSG(kFALSE)
     , fRunIdFromSG_identifier(0)
 {
-    if (fRootFile->IsZombie()) {
+    if ((!fRootFile) || fRootFile->IsZombie()) {
         LOG(fatal) << "Error opening the Input file";
     }
     LOG(info) << "FairMixedSource created------------";
@@ -131,7 +131,7 @@ FairMixedSource::FairMixedSource(const TString* RootFileName, const char* Title,
     , fRunIdFromSG_identifier(0)
 {
     fRootFile = TFile::Open(RootFileName->Data());
-    if (fRootFile->IsZombie()) {
+    if ((!fRootFile) || fRootFile->IsZombie()) {
         LOG(fatal) << "Error opening the Input file";
     }
     fRootManager = FairRootManager::Instance();
@@ -184,6 +184,9 @@ FairMixedSource::FairMixedSource(const TString RootFileName, const Int_t signalI
     , fRunIdFromSG_identifier(0)
 {
     fRootFile = TFile::Open(RootFileName.Data());
+    if ((!fRootFile) || fRootFile->IsZombie()) {
+        LOG(fatal) << "Error opening the Input file";
+    }
 
     if (signalId == 0) {
         SetBackgroundFile(RootFileName);

--- a/cmake/modules/FairRootTargetRootDictionary.cmake
+++ b/cmake/modules/FairRootTargetRootDictionary.cmake
@@ -47,7 +47,7 @@ function(fairroot_target_root_dictionary target)
                         A
                         ""
                         "LINKDEF"
-                        "HEADERS;BASENAME")
+                        "HEADERS;BASENAME;EXTRA_INCLUDE_DIRS")
   if(A_UNPARSED_ARGUMENTS)
     message(
       FATAL_ERROR "Unexpected unparsed arguments: ${A_UNPARSED_ARGUMENTS}")
@@ -73,12 +73,8 @@ function(fairroot_target_root_dictionary target)
     endif()
   endforeach()
 
-  # convert all relative paths to absolute ones. LINKDEF must be the last one.
   unset(headers)
-  foreach(h ${A_HEADERS} ${A_LINKDEF})
-    get_filename_component(habs ${CMAKE_CURRENT_SOURCE_DIR}/${h} ABSOLUTE)
-    list(APPEND headers ${habs})
-  endforeach()
+  list(APPEND headers ${A_HEADERS} ${A_LINKDEF})
 
   # check all given filepaths actually exist
   foreach(h ${headers})
@@ -119,6 +115,12 @@ function(fairroot_target_root_dictionary target)
   set(LD_LIBRARY_PATH ${ROOT_LIBRARY_DIR})
 
   set(includeDirs $<TARGET_PROPERTY:${target},INCLUDE_DIRECTORIES>)
+  set(includeDirs "$<REMOVE_DUPLICATES:${includeDirs}>")
+
+  if(A_EXTRA_INCLUDE_DIRS)
+    list(JOIN A_EXTRA_INCLUDE_DIRS ";-I" extra_includes)
+    string(PREPEND extra_includes "-I")
+  endif()
 
   # add a custom command to generate the dictionary using rootcling
   # cmake-format: off
@@ -133,6 +135,8 @@ function(fairroot_target_root_dictionary target)
       -rmf ${rootmapFile}
       -rml $<TARGET_FILE_NAME:${target}>
       -I$<JOIN:${includeDirs},$<SEMICOLON>-I>
+      ${extra_includes}
+      -excludePath "${CMAKE_BINARY_DIR}"
       $<$<BOOL:${prop}>:-D$<JOIN:${prop},$<SEMICOLON>-D>>
       ${headers}
     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/${pcmBase} ${pcmFile}

--- a/datamatch/CMakeLists.txt
+++ b/datamatch/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${target} PUBLIC
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
   LINKDEF FairMCMatchLinkDef.h
+  EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 
 fairroot_install_exported(TARGETS ${target})

--- a/eventdisplay/CMakeLists.txt
+++ b/eventdisplay/CMakeLists.txt
@@ -77,6 +77,7 @@ target_link_libraries(${target} PUBLIC
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
   LINKDEF EventDisplayLinkDef.h
+  EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 
 fairroot_install_exported(TARGETS ${target})

--- a/examples/MQ/Lmd/CMakeLists.txt
+++ b/examples/MQ/Lmd/CMakeLists.txt
@@ -38,6 +38,7 @@ target_link_libraries(${target} PUBLIC
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
   LINKDEF LmdLinkDef.h
+  EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 
 install(TARGETS ${target} LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR})

--- a/examples/MQ/histogramServer/CMakeLists.txt
+++ b/examples/MQ/histogramServer/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${target} PUBLIC
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
   LINKDEF FairMQExHistoLinkDef.h
+  EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 
 install(TARGETS ${target} LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR})

--- a/examples/MQ/parameters/CMakeLists.txt
+++ b/examples/MQ/parameters/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(${target} PUBLIC
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
   LINKDEF FairMQExParamsLinkDef.h
+  EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 
 install(TARGETS ${target} LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR})

--- a/examples/MQ/pixelAlternative/src/CMakeLists.txt
+++ b/examples/MQ/pixelAlternative/src/CMakeLists.txt
@@ -55,6 +55,7 @@ target_link_libraries(${target} PUBLIC
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
   LINKDEF PixelAltLinkDef.h
+  EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 
 install(TARGETS ${target} LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR})

--- a/examples/MQ/pixelDetector/run/runPixelSampler.cxx
+++ b/examples/MQ/pixelDetector/run/runPixelSampler.cxx
@@ -14,6 +14,7 @@
 #include "FairMQPixelSampler.h"
 
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -37,7 +38,7 @@ FairMQDevicePtr getDevice(const FairMQProgOptions& config)
     std::string samplerType = config.GetValue<std::string>("sampler-type");
     std::vector<std::string> filename = config.GetValue<std::vector<std::string>>("file-name");
 
-    FairMQPixelSampler* sampler = new FairMQPixelSampler();
+    auto sampler = std::make_unique<FairMQPixelSampler>();
 
     if (samplerType == "FairFileSource") {
     } else if (samplerType == "PixelDigiSource") {
@@ -56,5 +57,5 @@ FairMQDevicePtr getDevice(const FairMQProgOptions& config)
         return nullptr;
     }
 
-    return sampler;
+    return sampler.release();
 }

--- a/examples/MQ/pixelDetector/src/CMakeLists.txt
+++ b/examples/MQ/pixelDetector/src/CMakeLists.txt
@@ -91,6 +91,7 @@ target_link_libraries(${target} PUBLIC
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
   LINKDEF PixelLinkDef.h
+  EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 
 install(TARGETS ${target} LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR})

--- a/examples/MQ/pixelSimSplit/src/CMakeLists.txt
+++ b/examples/MQ/pixelSimSplit/src/CMakeLists.txt
@@ -53,6 +53,7 @@ target_link_libraries(${target} PUBLIC
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
   LINKDEF SimMQLinkDef.h
+  EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 
 install(TARGETS ${target} LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR})

--- a/examples/MQ/serialization/CMakeLists.txt
+++ b/examples/MQ/serialization/CMakeLists.txt
@@ -49,6 +49,7 @@ target_link_libraries(${target} PUBLIC
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
   LINKDEF SerializationExampleLinkDef.h
+  EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 
 install(TARGETS ${target} LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR})

--- a/examples/advanced/MbsTutorial/CMakeLists.txt
+++ b/examples/advanced/MbsTutorial/CMakeLists.txt
@@ -37,6 +37,7 @@ target_link_libraries(${target} PUBLIC
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
   LINKDEF MbsTutorialLinkDef.h
+  EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 
 install(TARGETS ${target} LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR})

--- a/examples/advanced/Tutorial3/CMakeLists.txt
+++ b/examples/advanced/Tutorial3/CMakeLists.txt
@@ -137,6 +137,7 @@ target_link_libraries(${target} PUBLIC
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
   LINKDEF FairTestDetectorLinkDef.h
+  EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 
 install(TARGETS ${target} LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR})

--- a/examples/advanced/propagator/src/CMakeLists.txt
+++ b/examples/advanced/propagator/src/CMakeLists.txt
@@ -60,6 +60,7 @@ target_link_libraries(${target} PUBLIC
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
   LINKDEF TutPropLinkDef.h
+  EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 
 install(TARGETS ${target} LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR})

--- a/examples/common/eventdisplay/CMakeLists.txt
+++ b/examples/common/eventdisplay/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${target} PUBLIC
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
   LINKDEF EventDisplayExampleLinkDef.h
+  EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 
 install(TARGETS ${target} LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR})

--- a/examples/common/gconfig/CMakeLists.txt
+++ b/examples/common/gconfig/CMakeLists.txt
@@ -36,6 +36,7 @@ target_link_libraries(${target} PUBLIC
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
   LINKDEF GConfigLinkDef.h
+  EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 
 install(TARGETS ${target} LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR})

--- a/examples/common/mcstack/CMakeLists.txt
+++ b/examples/common/mcstack/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(${target} PUBLIC
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
   LINKDEF MCStackLinkDef.h
+  EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 
 install(TARGETS ${target} LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR})

--- a/examples/common/passive/CMakeLists.txt
+++ b/examples/common/passive/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(${target} PUBLIC
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
   LINKDEF PassiveLinkDef.h
+  EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 
 install(TARGETS ${target} LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR})

--- a/examples/simulation/Tutorial1/src/CMakeLists.txt
+++ b/examples/simulation/Tutorial1/src/CMakeLists.txt
@@ -50,6 +50,7 @@ target_link_libraries(${target} PUBLIC
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
   LINKDEF Tutorial1LinkDef.h
+  EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 
 install(TARGETS ${target} LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR})

--- a/examples/simulation/Tutorial2/src/CMakeLists.txt
+++ b/examples/simulation/Tutorial2/src/CMakeLists.txt
@@ -45,6 +45,7 @@ target_link_libraries(${target} PUBLIC
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
   LINKDEF Tutorial2LinkDef.h
+  EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 
 install(TARGETS ${target} LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR})

--- a/examples/simulation/Tutorial4/src/CMakeLists.txt
+++ b/examples/simulation/Tutorial4/src/CMakeLists.txt
@@ -70,6 +70,7 @@ target_link_libraries(${target} PUBLIC
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
   LINKDEF Tutorial4LinkDef.h
+  EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 
 install(TARGETS ${target} LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR})

--- a/examples/simulation/rutherford/src/CMakeLists.txt
+++ b/examples/simulation/rutherford/src/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(${target} PUBLIC
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
   LINKDEF FairRutherfordLinkDef.h
+  EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 
 install(TARGETS ${target} LIBRARY DESTINATION ${PROJECT_INSTALL_LIBDIR})

--- a/fairtools/CMakeLists.txt
+++ b/fairtools/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(${target} PUBLIC
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
   LINKDEF FairToolsLinkDef.h
+  EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 
 fairroot_install_exported(TARGETS ${target})

--- a/fairtools/MCConfigurator/CMakeLists.txt
+++ b/fairtools/MCConfigurator/CMakeLists.txt
@@ -38,6 +38,7 @@ target_link_libraries(${target} PUBLIC
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
   LINKDEF MCConfiguratorLinkDef.h
+  EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 
 fairroot_install_exported(TARGETS ${target})

--- a/geane/CMakeLists.txt
+++ b/geane/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${target} PUBLIC
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
   LINKDEF GeaneLinkDef.h
+  EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 
 fairroot_install_exported(TARGETS ${target})

--- a/generators/CMakeLists.txt
+++ b/generators/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(${target} PUBLIC
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
   LINKDEF GenLinkDef.h
+  EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 
 fairroot_install_exported(TARGETS ${target})

--- a/geobase/CMakeLists.txt
+++ b/geobase/CMakeLists.txt
@@ -65,6 +65,7 @@ target_link_libraries(${target} PUBLIC
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
   LINKDEF GeoBaseLinkDef.h
+  EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 
 fairroot_install_exported(TARGETS ${target})

--- a/parbase/CMakeLists.txt
+++ b/parbase/CMakeLists.txt
@@ -45,6 +45,7 @@ target_link_libraries(${target} PUBLIC
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
   LINKDEF ParBaseLinkDef.h
+  EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 
 fairroot_install_exported(TARGETS ${target})

--- a/trackbase/CMakeLists.txt
+++ b/trackbase/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(${target} PUBLIC
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
   LINKDEF TrackBaseLinkDef.h
+  EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 
 fairroot_install_exported(TARGETS ${target})


### PR DESCRIPTION
General notes:

- We do not want source or build directory names in the generated dictionaries. Those paths might not exist after installing, or might contain other content (worse: it could be malicious content).

- dictionaries have an "include path list" which gets appended to ROOT's include search list at loading of the dictionary. This list should have sensible entries.

So:

- Add the final install include dir to the include search path of generated dictionaries.

  Note: It looks like extracting the install include paths from a target is a nontrivial task in CMake. So we need to explicitly pass it in.

- It is generally a better idea to pass non-absolute header paths to rootcling.  It sometimes stores the given path in the dictionary.

  Preferably this should be the relative path used in `#include` statements.
  So do not make those paths absolute.

- Strip source and build directory entries from the generated dictionaries include path list.

- Deduplicate the include path list.

Also some small fixes for error handling and the pixel test.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
