### PR TITLE
ci(warnings): Allow Some Fluctuation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,7 +66,7 @@ def jobMatrix(String prefix, String type, List specs) {
             discoverGitReferenceBuild()
             recordIssues(tools: [clangTidy(pattern: logpattern)],
                          filters: [excludeFile('build/.*/G__.*[.]cxx')],
-                         qualityGates: [[threshold: 1, type: 'NEW', unstable: true]],
+                         qualityGates: [[threshold: 3, type: 'NEW', unstable: true]],
                          skipBlames: true)
             archiveArtifacts(artifacts: logpattern, allowEmptyArchive: true, fingerprint: true)
           }


### PR DESCRIPTION
clang-tidy warning extraction in jenkins seems a bit unstable. Some warnings arrive while others / the same disappear at the same time.

So allow two new warnings compared to the reference build.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
