### PR TITLE
Rutherford: Default to Geant4

### DIFF
--- a/examples/simulation/rutherford/macros/eventDisplay.C
+++ b/examples/simulation/rutherford/macros/eventDisplay.C
@@ -5,7 +5,7 @@
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
-void eventDisplay(TString mcEngine = "TGeant3")
+void eventDisplay(TString mcEngine = "TGeant4")
 {
 
     TString inFile = "data/test_" + mcEngine + ".mc.root";

--- a/examples/simulation/rutherford/macros/run_rad.C
+++ b/examples/simulation/rutherford/macros/run_rad.C
@@ -5,7 +5,7 @@
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
-void run_rad(Int_t nEvents = 100, TString mcEngine = "TGeant3")
+void run_rad(Int_t nEvents = 100, TString mcEngine = "TGeant4")
 {
 
     TString dir = gSystem->Getenv("VMCWORKDIR");

--- a/examples/simulation/rutherford/macros/run_rutherford.C
+++ b/examples/simulation/rutherford/macros/run_rutherford.C
@@ -7,7 +7,6 @@
  ********************************************************************************/
 void run_rutherford(Int_t nEvents = 10, TString mcEngine = "TGeant4", Bool_t isMT = true)
 {
-
     TString dir = gSystem->Getenv("VMCWORKDIR");
     TString tutdir = dir + "/simulation/rutherford/macros";
 
@@ -18,6 +17,7 @@ void run_rutherford(Int_t nEvents = 10, TString mcEngine = "TGeant4", Bool_t isM
     gSystem->Setenv("CONFIG_DIR", tut_configdir.Data());
 
     TString outDir = "data";
+    gSystem->MakeDirectory(outDir);
     TString outFile = outDir + "/test_";
     outFile = outFile + mcEngine + ".mc.root";
 

--- a/examples/simulation/rutherford/src/FairRutherford.cxx
+++ b/examples/simulation/rutherford/src/FairRutherford.cxx
@@ -23,37 +23,16 @@ FairRutherfordGeo* FairRutherford::fgGeo = nullptr;
 
 FairRutherford::FairRutherford()
     : FairDetector("FairRutherford", kTRUE, kFairRutherford)
-    , fTrackID(-1)
-    , fVolumeID(-1)
-    , fPos()
-    , fMom()
-    , fTime(-1.)
-    , fLength(-1.)
-    , fELoss(-1)
     , fFairRutherfordPointCollection(new TClonesArray("FairRutherfordPoint"))
 {}
 
 FairRutherford::FairRutherford(const char* name, Bool_t active)
     : FairDetector(name, active, kFairRutherford)
-    , fTrackID(-1)
-    , fVolumeID(-1)
-    , fPos()
-    , fMom()
-    , fTime(-1.)
-    , fLength(-1.)
-    , fELoss(-1)
     , fFairRutherfordPointCollection(new TClonesArray("FairRutherfordPoint"))
 {}
 
 FairRutherford::FairRutherford(const FairRutherford& rhs)
     : FairDetector(rhs)
-    , fTrackID(-1)
-    , fVolumeID(-1)
-    , fPos()
-    , fMom()
-    , fTime(-1.)
-    , fLength(-1.)
-    , fELoss(-1)
     , fFairRutherfordPointCollection(new TClonesArray("FairRutherfordPoint"))
 {}
 
@@ -107,7 +86,7 @@ Bool_t FairRutherford::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of FairRutherford points in TParticle
-        FairStack* stack = static_cast<FairStack*>(TVirtualMC::GetMC()->GetStack());
+        auto stack = static_cast<FairStack*>(TVirtualMC::GetMC()->GetStack());
         stack->AddPoint(kFairRutherford);
     }
 

--- a/examples/simulation/rutherford/src/FairRutherford.h
+++ b/examples/simulation/rutherford/src/FairRutherford.h
@@ -33,27 +33,27 @@ class FairRutherford : public FairDetector
     FairRutherford();
 
     /**       destructor     */
-    virtual ~FairRutherford();
+    ~FairRutherford() override;
 
     /**      Initialization of the detector is done here    */
-    virtual void Initialize();
+    void Initialize() override;
 
     /**       this method is called for each step during simulation
      *       (see FairMCApplication::Stepping())
      */
-    virtual Bool_t ProcessHits(FairVolume* v = 0);
+    Bool_t ProcessHits(FairVolume* v = nullptr) override;
 
     /**       Registers the produced collections in FAIRRootManager.     */
-    virtual void Register();
+    void Register() override;
 
     /** Gets the produced collections */
-    virtual TClonesArray* GetCollection(Int_t iColl) const;
+    TClonesArray* GetCollection(Int_t iColl) const override;
 
     /**      has to be called after each event to reset the containers      */
-    virtual void Reset();
+    void Reset() override;
 
     /**      Create the detector geometry        */
-    void ConstructGeometry();
+    void ConstructGeometry() override;
 
     /**      This method is an example of how to add your own point
      *       of type FairRutherfordPoint to the clones array
@@ -67,16 +67,16 @@ class FairRutherford : public FairDetector
 
     //    virtual void   CopyClones( TClonesArray* cl1,  TClonesArray* cl2 ,
     //                               Int_t offset) {;}
-    virtual void SetSpecialPhysicsCuts() {}
-    virtual void EndOfEvent();
-    virtual void FinishPrimary() {}
-    virtual void FinishRun() {}
-    virtual void BeginPrimary() {}
-    virtual void PostTrack() {}
-    virtual void PreTrack() {}
-    virtual void BeginEvent() {}
+    void SetSpecialPhysicsCuts() override {}
+    void EndOfEvent() override;
+    void FinishPrimary() override {}
+    void FinishRun() override {}
+    void BeginPrimary() override {}
+    void PostTrack() override {}
+    void PreTrack() override {}
+    void BeginEvent() override {}
 
-    virtual FairModule* CloneModule() const;
+    FairModule* CloneModule() const override;
 
   private:
     static FairRutherfordGeo* fgGeo;   //!
@@ -84,13 +84,13 @@ class FairRutherford : public FairDetector
     /** Track information to be stored until the track leaves the
     active volume.
     */
-    Int_t fTrackID;        //!  track index
-    Int_t fVolumeID;       //!  volume id
-    TLorentzVector fPos;   //!  position at entrance
-    TLorentzVector fMom;   //!  momentum at entrance
-    Double32_t fTime;      //!  time
-    Double32_t fLength;    //!  length
-    Double32_t fELoss;     //!  energy loss
+    Int_t fTrackID{-1};        //!  track index
+    Int_t fVolumeID{-1};       //!  volume id
+    TLorentzVector fPos{};     //!  position at entrance
+    TLorentzVector fMom{};     //!  momentum at entrance
+    Double32_t fTime{-1.};     //!  time
+    Double32_t fLength{-1.};   //!  length
+    Double32_t fELoss{-1};     //!  energy loss
 
     /** container for data points */
 
@@ -99,7 +99,7 @@ class FairRutherford : public FairDetector
     FairRutherford(const FairRutherford&);
     FairRutherford& operator=(const FairRutherford&);
 
-    ClassDef(FairRutherford, 1);
+    ClassDefOverride(FairRutherford, 1);
 };
 
 #endif   // CBMRUTHERFORD_H

--- a/examples/simulation/rutherford/src/FairRutherfordContFact.cxx
+++ b/examples/simulation/rutherford/src/FairRutherfordContFact.cxx
@@ -37,8 +37,7 @@ void FairRutherfordContFact::setAllContainers()
       the list of containers for the FairRutherford library.
   */
 
-    FairContainer* p =
-        new FairContainer("FairRutherfordGeoPar", "FairRutherford Geometry Parameters", "TestDefaultContext");
+    auto p = new FairContainer("FairRutherfordGeoPar", "FairRutherford Geometry Parameters", "TestDefaultContext");
     p->addContext("TestNonDefaultContext");
 
     containers->Add(p);

--- a/examples/simulation/rutherford/src/FairRutherfordContFact.h
+++ b/examples/simulation/rutherford/src/FairRutherfordContFact.h
@@ -21,9 +21,9 @@ class FairRutherfordContFact : public FairContFact
 
   public:
     FairRutherfordContFact();
-    ~FairRutherfordContFact() {}
-    FairParSet* createContainer(FairContainer*);
-    ClassDef(FairRutherfordContFact, 0);   // Factory for all FairRutherford parameter containers
+    ~FairRutherfordContFact() override {}
+    FairParSet* createContainer(FairContainer*) override;
+    ClassDefOverride(FairRutherfordContFact, 0);   // Factory for all FairRutherford parameter containers
 };
 
 #endif

--- a/examples/simulation/rutherford/src/FairRutherfordGeo.h
+++ b/examples/simulation/rutherford/src/FairRutherfordGeo.h
@@ -15,17 +15,16 @@
 
 class FairRutherfordGeo : public FairGeoSet
 {
-
   protected:
     char modName[22];   // name of module
     char eleName[20];   // substring for elements in module
   public:
     FairRutherfordGeo();
-    ~FairRutherfordGeo() {}
-    const char* getModuleName(Int_t);
-    const char* getEleName(Int_t);
-    inline Int_t getModNumInMod(const TString&);
-    ClassDef(FairRutherfordGeo, 1);
+    ~FairRutherfordGeo() override {}
+    const char* getModuleName(Int_t) override;
+    const char* getEleName(Int_t) override;
+    inline Int_t getModNumInMod(const TString&) override;
+    ClassDefOverride(FairRutherfordGeo, 1);
 };
 
 inline Int_t FairRutherfordGeo::getModNumInMod(const TString& name)

--- a/examples/simulation/rutherford/src/FairRutherfordGeoPar.cxx
+++ b/examples/simulation/rutherford/src/FairRutherfordGeoPar.cxx
@@ -18,9 +18,9 @@ FairRutherfordGeoPar ::FairRutherfordGeoPar(const char* name, const char* title,
     , fGeoPassNodes(new TObjArray())
 {}
 
-FairRutherfordGeoPar::~FairRutherfordGeoPar(void) {}
+FairRutherfordGeoPar::~FairRutherfordGeoPar() {}
 
-void FairRutherfordGeoPar::clear(void)
+void FairRutherfordGeoPar::clear()
 {
     delete fGeoSensNodes;
     delete fGeoPassNodes;

--- a/examples/simulation/rutherford/src/FairRutherfordGeoPar.h
+++ b/examples/simulation/rutherford/src/FairRutherfordGeoPar.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -30,10 +30,10 @@ class FairRutherfordGeoPar : public FairParGenericSet
     FairRutherfordGeoPar(const char* name = "FairRutherfordGeoPar",
                          const char* title = "FairRutherford Geometry Parameters",
                          const char* context = "TestDefaultContext");
-    ~FairRutherfordGeoPar(void);
-    void clear(void);
-    void putParams(FairParamList*);
-    Bool_t getParams(FairParamList*);
+    ~FairRutherfordGeoPar() override;
+    void clear() override;
+    void putParams(FairParamList*) override;
+    Bool_t getParams(FairParamList*) override;
     TObjArray* GetGeoSensitiveNodes() { return fGeoSensNodes; }
     TObjArray* GetGeoPassiveNodes() { return fGeoPassNodes; }
 
@@ -41,7 +41,7 @@ class FairRutherfordGeoPar : public FairParGenericSet
     FairRutherfordGeoPar(const FairRutherfordGeoPar&);
     FairRutherfordGeoPar& operator=(const FairRutherfordGeoPar&);
 
-    ClassDef(FairRutherfordGeoPar, 1);
+    ClassDefOverride(FairRutherfordGeoPar, 1);
 };
 
 #endif

--- a/examples/simulation/rutherford/src/FairRutherfordPoint.h
+++ b/examples/simulation/rutherford/src/FairRutherfordPoint.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -19,7 +19,6 @@ class TMemberInspector;
 
 class FairRutherfordPoint : public FairMCPoint
 {
-
   public:
     /** Default constructor **/
     FairRutherfordPoint();
@@ -45,10 +44,10 @@ class FairRutherfordPoint : public FairMCPoint
                         Double_t theta);
 
     /** Destructor **/
-    virtual ~FairRutherfordPoint();
+    ~FairRutherfordPoint() override;
 
     /** Output to screen **/
-    virtual void Print(const Option_t* opt) const;
+    void Print(const Option_t* opt) const override;
 
   private:
     Double32_t fRadius, fPhi, fTheta;
@@ -57,7 +56,7 @@ class FairRutherfordPoint : public FairMCPoint
     FairRutherfordPoint(const FairRutherfordPoint& point);
     FairRutherfordPoint operator=(const FairRutherfordPoint& point);
 
-    ClassDef(FairRutherfordPoint, 1);
+    ClassDefOverride(FairRutherfordPoint, 1);
 };
 
 #endif


### PR DESCRIPTION
eventDisplay.C already uses Geant4 by default Switch run_rutherford.C and run_rad.C to use Geant4 by default as well.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
