### PR TITLE
Deprecate `FairRadGridManager::Instance`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Deprecate some singleton-like APIs:
   * `FairRunAnaProof::Instance()` - keep a pointer to the
     object after `new` in your code.
+  * `FairRadGridManager::Instance()` - Consider using the
+    `GetRadGridMan()` method on `FairMCApplcation`.
   * `FairRadMapManager::Instance`, `FairRadLenManager::Instance`
 * Many items were already deprecated in prior versions.
   Marked them with proper C++14 deprecation warnings.

--- a/base/sim/FairMCApplication.h
+++ b/base/sim/FairMCApplication.h
@@ -210,6 +210,11 @@ class FairMCApplication : public TVirtualMCApplication
      */
     FairMCApplicationState GetState() const { return fState; }
 
+    /**
+     * Return non-owning pointer to FairRadGridManager
+     */
+    auto GetRadGridMan() { return fRadGridMan.get(); }
+
   private:
     // methods
     Int_t GetIonPdg(Int_t z, Int_t a) const;

--- a/base/steer/FairRadGridManager.h
+++ b/base/steer/FairRadGridManager.h
@@ -32,7 +32,6 @@ class FairRadGridManager
     /**
      * Default constructor.
      * Creates the singleton object of FairRadGridManager class.
-     * The pointer to this object can be reached via FairRadGridManager::Instance().
      */
     FairRadGridManager();
     /**
@@ -112,8 +111,9 @@ class FairRadGridManager
      * This function is used to access the methods of the class.
      * @return Pointer to the singleton FairRadGridManager object, created
      * with FairRadGridManager::FairRadGridManager().
+     * \deprecated Deprecated in v19, will be removed in v20.
      */
-    static FairRadGridManager* Instance();
+    [[deprecated("Maybe use FairMCApplcation::GetRadGridMan()")]] static FairRadGridManager* Instance();
 };
 
 #endif

--- a/base/steer/FairRunSim.h
+++ b/base/steer/FairRunSim.h
@@ -189,6 +189,11 @@ class FairRunSim : public FairRun
 
     void StopMCRun() { fApp->StopMCRun(); }
 
+    /**
+     * Get non-owning pointer to FairMCApplication
+     */
+    auto GetMCApplication() { return fApp; }
+
   private:
     FairRunSim(const FairRunSim& M);
     FairRunSim& operator=(const FairRunSim&) { return *this; }

--- a/examples/simulation/Tutorial1/macros/run_tutorial1_mesh.C
+++ b/examples/simulation/Tutorial1/macros/run_tutorial1_mesh.C
@@ -117,7 +117,7 @@ void run_tutorial1_mesh(Int_t nEvents = 10, TString mcEngine = "TGeant3")
 
     // -----   Initialize simulation run   ------------------------------------
     run->Init();
-    FairRadGridManager::Instance()->SetOutputFileName("radGridResults.root");
+    run->GetMCApplication()->GetRadGridMan()->SetOutputFileName("radGridResults.root");
     // ------------------------------------------------------------------------
 
     // -----   Runtime database   ---------------------------------------------


### PR DESCRIPTION
Introduce getter to allow accessing FairRadGridManager on FairMCApplication.

And introduce getter to access FairMCApplication on FairRunSim.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
