### PR TITLE
Deprecate `FairGeoVector::round`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   * `FairRunAnaProof::Instance()` - keep a pointer to the
     object after `new` in your code.
   * `FairRadMapManager::Instance`, `FairRadLenManager::Instance`
+* Deprecated some other APIs
+  `FairGeoVector::round` was nonfunctional and never did anything.
 * Many items were already deprecated in prior versions.
   Marked them with proper C++14 deprecation warnings.
   Scheduled them for removal in v20.

--- a/geobase/FairGeoVector.h
+++ b/geobase/FairGeoVector.h
@@ -22,7 +22,10 @@ class FairGeoVector : public TObject
     Double_t x;
     Double_t y;
     Double_t z;
-    inline void round(Double_t d, Int_t n);
+    /**
+     * \deprecated Deprecated in v19, will be removed in v20.
+     */
+    [[deprecated("This method never did anything")]] void round(Double_t, Int_t) {}
 
   public:
     FairGeoVector(Double_t dx = 0, Double_t dy = 0, Double_t dz = 0)
@@ -37,7 +40,7 @@ class FairGeoVector : public TObject
         , y(v.getY())
         , z(v.getZ())
     {}
-    ~FairGeoVector() {}
+    ~FairGeoVector() override = default;
     Double_t& X() { return x; }
     Double_t& Y() { return y; }
     Double_t& Z() { return z; }
@@ -96,10 +99,13 @@ class FairGeoVector : public TObject
     Double_t length() const { return sqrt(x * x + y * y + z * z); }
     void clear() { x = y = z = 0.; }
     void print() const { printf("%10.3f%10.3f%10.3f\n", x, y, z); }
-    inline void round(Int_t n);
+    /**
+     * \deprecated Deprecated in v19, will be removed in v20.
+     */
+    [[deprecated("This method never did anything")]] void round(Int_t) {}
     inline friend std::ostream& operator<<(std::ostream& put, const FairGeoVector& v);
     inline friend std::istream& operator>>(std::istream& get, FairGeoVector& v);
-    ClassDef(FairGeoVector, 1);   // vector with 3 components
+    ClassDefOverride(FairGeoVector, 1);   // vector with 3 components
 };
 
 // -------------------- inlines ---------------------------
@@ -242,24 +248,6 @@ inline FairGeoVector FairGeoVector::vectorProduct(const FairGeoVector& v) const
 {
     FairGeoVector p(y * v.getZ() - z * v.getY(), z * v.getX() - x * v.getZ(), x * v.getY() - y * v.getX());
     return p;
-}
-
-inline void FairGeoVector::round(Double_t d, Int_t n)
-{
-    // rounds d to a precision with n digits
-    if (d > 0) {
-        d = floor(d * pow(10., n) + 0.5) / pow(10., n);
-    } else {
-        d = -floor((-d) * pow(10., n) + 0.5) / pow(10., n);
-    }
-}
-
-inline void FairGeoVector::round(Int_t n)
-{
-    // rounds every component to a precision with n digits
-    round(x, n);
-    round(y, n);
-    round(z, n);
 }
 
 inline std::ostream& operator<<(std::ostream& put, const FairGeoVector& v)


### PR DESCRIPTION
round(d, n) modifies `d` but didn't take it as a reference.
So it used to do nothing.

round(n) just called round(d, n) for all three coordinates.
So it effectively did nothing also.

Deprecate both and tell people why.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
