### PR TITLE
FairRootFileSink: Warn on Branch Registration

### DIFF
--- a/base/sink/FairRootFileSink.cxx
+++ b/base/sink/FairRootFileSink.cxx
@@ -248,6 +248,11 @@ void FairRootFileSink::RegisterImpl(const char* /* name */, const char* folderNa
 
 void FairRootFileSink::RegisterAny(const char* brname, const std::type_info& oi, const std::type_info& pi, void* obj)
 {
+    if (fPersistentBranchesDone) {
+        LOG(warning) << "FairRootFileSink::RegisterAny called for branch \"" << brname
+                     << "\" after FairRootFileSink::CreatePersistentBranchesAny has already completed. "
+                        "The branch will not be registered.";
+    }
     fPersistentBranchesMap[brname] = std::unique_ptr<TypeAddressPair const>(new TypeAddressPair(oi, pi, obj));
 }
 
@@ -303,6 +308,7 @@ bool FairRootFileSink::CreatePersistentBranchesAny()
         LOG(info) << "Creating branch for " << iter.first.c_str() << " with address " << obj;
         fOutTree->Branch(iter.first.c_str(), tname.c_str(), obj);
     }
+    fPersistentBranchesDone = true;
     return true;
 }
 

--- a/base/sink/FairRootFileSink.h
+++ b/base/sink/FairRootFileSink.h
@@ -93,6 +93,8 @@ class FairRootFileSink : public FairSink
     /**File Header*/
     FairFileHeader* fFileHeader;   //!
 
+    bool fPersistentBranchesDone{false};   //!
+
     ClassDef(FairRootFileSink, 1);
 };
 

--- a/base/steer/FairRootManager.h
+++ b/base/steer/FairRootManager.h
@@ -166,10 +166,6 @@ class FairRootManager : public TObject
     /** create a new branch based on an arbitrary type T (for which a dictionary must exist) **/
     template<typename T>
     void RegisterAny(const char* name, T*& obj, Bool_t toFile);
-    /// for branches which are not managed by folders, we need a special function
-    /// to trigger persistent branch creation
-    /// return true if successful; false if problem
-    bool CreatePersistentBranchesAny();
 
     void RegisterInputObject(const char* name, TObject* obj);
 
@@ -355,8 +351,6 @@ class FairRootManager : public TObject
     /// used for branches registered with RegisterAny; use of ptr here
     /// since type_info cannot be copied
     std::map<std::string, std::unique_ptr<TypeAddressPair const>> fAnyBranchMap;   //!
-    /// keeps track of branches which are supposed to be persistified
-    std::vector<std::string> fPersistentBranchesAny;
 
     /**Branch id for this run */
     Int_t fBranchSeqId;


### PR DESCRIPTION
If registering branches after they have been setup, output a warning.

This is trying to improve the situation for #1183

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
