### PR TITLE
Use `TDirectory::Get<T>()` Around

### DIFF
--- a/base/MQ/policies/Sampler/SimpleTreeReader.h
+++ b/base/MQ/policies/Sampler/SimpleTreeReader.h
@@ -70,7 +70,7 @@ class BaseSimpleTreeReader
     {
         fInputFile = TFile::Open(fFileName.c_str(), "READ");
         if (fInputFile) {
-            fTree = static_cast<TTree*>(fInputFile->Get(fTreeName.c_str()));
+            fTree = fInputFile->Get<TTree>(fTreeName.c_str());
             if (fTree) {
                 fTree->SetBranchAddress(fBranchName.c_str(), &fInput);
                 fIndexMax = fTree->GetEntries();

--- a/base/MQ/policies/Storage/RootOutFileManager.h
+++ b/base/MQ/policies/Storage/RootOutFileManager.h
@@ -222,7 +222,7 @@ class RootOutFileManager
 
         // if given option is update attempt to get tree from file
         if (fFileOption == "UPDATE") {
-            fTree = static_cast<TTree*>(fOutFile->Get(fTreeName.c_str()));
+            fTree = fOutFile->Get<TTree>(fTreeName.c_str());
             if (fTree) {
                 updateTree = true;
                 LOG(info) << "Update tree";
@@ -275,7 +275,7 @@ class RootOutFileManager
         std::vector<DataType> tempObj;
 
         if (file) {
-            fTree = static_cast<TTree*>(file->Get(fTreeName.c_str()));
+            fTree = file->Get<TTree>(fTreeName.c_str());
         } else {
             LOG(error) << "Could not open file" << fTreeName.c_str();
         }
@@ -332,7 +332,7 @@ class RootOutFileManager
 
         // if given option is update attempt to get tree from file
         if (fFileOption == "UPDATE") {
-            fTree = static_cast<TTree*>(fOutFile->Get(fTreeName.c_str()));
+            fTree = fOutFile->Get<TTree>(fTreeName.c_str());
             if (fTree) {
                 updateTree = true;
                 LOG(info) << "Update tree";

--- a/base/source/FairFileSource.cxx
+++ b/base/source/FairFileSource.cxx
@@ -178,11 +178,11 @@ Bool_t FairFileSource::Init()
 
     // Get the folder structure from file which describes the input tree.
     // There are two different names possible, so check both.
-    fCbmroot = dynamic_cast<TFolder*>(fRootFile->Get(FairRootManager::GetFolderName()));
+    fCbmroot = fRootFile->Get<TFolder>(FairRootManager::GetFolderName());
     if (!fCbmroot) {
-        fCbmroot = dynamic_cast<TFolder*>(fRootFile->Get("cbmroot"));
+        fCbmroot = fRootFile->Get<TFolder>("cbmroot");
         if (!fCbmroot) {
-            fCbmroot = dynamic_cast<TFolder*>(fRootFile->Get("cbmout"));
+            fCbmroot = fRootFile->Get<TFolder>("cbmout");
             if (!fCbmroot) {
                 fCbmroot = gROOT->GetRootFolder()->AddFolder(FairRootManager::GetFolderName(), "Main Folder");
             } else {
@@ -203,7 +203,7 @@ Bool_t FairFileSource::Init()
     // branch structure. Without this check it is possible to add trees
     // with a different branch structure but the same tree name. ROOT
     // probably only checks if the name of the tree is the same.
-    TList* list = dynamic_cast<TList*>(fRootFile->Get("BranchList"));
+    auto list = fRootFile->Get<TList>("BranchList");
     if (list == 0) {
         LOG(fatal) << "No Branch list in input file";
     }
@@ -288,7 +288,7 @@ Bool_t FairFileSource::Init()
 
     AddFriendsToChain();
 
-    TList* timebasedlist = dynamic_cast<TList*>(fRootFile->Get("TimeBasedBranchList"));
+    auto timebasedlist = fRootFile->Get<TList>("TimeBasedBranchList");
     if (timebasedlist == 0) {
         LOG(warn) << "No time based branch list in input file";
     } else {
@@ -523,18 +523,17 @@ void FairFileSource::CreateNewFriendChain(TString inputFile, TString inputLevel)
     TDirectory::TContext restorecwd{};
     TFile* f = TFile::Open(inputFile);
 
-    TFolder* added = nullptr;
     TString folderName1 = FairRootManager::GetFolderName();
     TString folderName = Form("/%s", folderName1.Data());
-    added = dynamic_cast<TFolder*>(f->Get(folderName1));
+    auto added = f->Get<TFolder>(folderName1);
     if (!added) {
         folderName = "/cbmout";
         folderName1 = "cbmout";
-        added = dynamic_cast<TFolder*>(f->Get("cbmout"));
+        added = f->Get<TFolder>("cbmout");
         if (!added) {
             folderName = "/cbmroot";
             folderName1 = "cbmroot";
-            added = dynamic_cast<TFolder*>(f->Get("cbmroot"));
+            added = f->Get<TFolder>("cbmroot");
             if (!added) {
                 LOG(fatal) << "Could not find folder cbmout nor cbmroot.";
                 exit(-1);
@@ -546,7 +545,7 @@ void FairFileSource::CreateNewFriendChain(TString inputFile, TString inputLevel)
     fListFolder->Add(added);
 
     /**Get The list of branches from the friend file and add it to the actual list*/
-    TList* list = dynamic_cast<TList*>(f->Get("BranchList"));
+    auto list = f->Get<TList>("BranchList");
     TString chainName = inputLevel;
     fInputLevel.push_back(chainName);
     if (list) {

--- a/base/source/FairFileSourceBase.cxx
+++ b/base/source/FairFileSourceBase.cxx
@@ -38,7 +38,7 @@ Bool_t FairFileSourceBase::CompareBranchList(TFile* fileHandle, TString inputLev
     // the list. If in the end no branch is left in the list everything is
     // fine.
     set<TString>::iterator iter1;
-    TList* list = dynamic_cast<TList*>(fileHandle->Get("BranchList"));
+    auto list = fileHandle->Get<TList>("BranchList");
     if (list) {
         TObjString* Obj = 0;
         for (Int_t i = 0; i < list->GetEntries(); i++) {

--- a/base/source/FairMixedSource.cxx
+++ b/base/source/FairMixedSource.cxx
@@ -221,11 +221,11 @@ Bool_t FairMixedSource::Init()
 
     // Get the folder structure from file which describes the input tree.
     // There are two different names possible, so check both.
-    fCbmroot = dynamic_cast<TFolder*>(fRootFile->Get(FairRootManager::GetFolderName()));
+    fCbmroot = fRootFile->Get<TFolder>(FairRootManager::GetFolderName());
     if (!fCbmroot) {
-        fCbmroot = dynamic_cast<TFolder*>(fRootFile->Get("cbmroot"));
+        fCbmroot = fRootFile->Get<TFolder>("cbmroot");
         if (!fCbmroot) {
-            fCbmroot = dynamic_cast<TFolder*>(fRootFile->Get("cbmout"));
+            fCbmroot = fRootFile->Get<TFolder>("cbmout");
             if (!fCbmroot) {
                 fCbmroot = gROOT->GetRootFolder()->AddFolder(FairRootManager::GetFolderName(), "Main Folder");
             } else {
@@ -246,7 +246,7 @@ Bool_t FairMixedSource::Init()
     // with a different branch structure but the same tree name. ROOT
     // probably only checks if the name of the tree is the same.
 
-    TList* list = dynamic_cast<TList*>(fRootFile->Get("BranchList"));
+    auto list = fRootFile->Get<TList>("BranchList");
     if (list == 0)
         LOG(fatal) << "No Branch list in input file";
     TString chainName = fInputTitle;
@@ -488,11 +488,11 @@ Bool_t FairMixedSource::OpenBackgroundChain()
 {
     // Get the folder structure from file which describes the input tree.
     // There are two different names possible, so check both.
-    fCbmroot = dynamic_cast<TFolder*>(fRootFile->Get(FairRootManager::GetFolderName()));
+    fCbmroot = fRootFile->Get<TFolder>(FairRootManager::GetFolderName());
     if (!fCbmroot) {
-        fCbmroot = dynamic_cast<TFolder*>(fRootFile->Get("cbmroot"));
+        fCbmroot = fRootFile->Get<TFolder>("cbmroot");
         if (!fCbmroot) {
-            fCbmroot = dynamic_cast<TFolder*>(fRootFile->Get("cbmout"));
+            fCbmroot = fRootFile->Get<TFolder>("cbmout");
             if (!fCbmroot) {
                 fCbmroot = gROOT->GetRootFolder()->AddFolder(FairRootManager::GetFolderName(), "Main Folder");
             } else {
@@ -514,7 +514,7 @@ Bool_t FairMixedSource::OpenBackgroundChain()
     // with a different branch structure but the same tree name. ROOT
     // probably only checks if the name of the tree is the same.
 
-    TList* list = dynamic_cast<TList*>(fRootFile->Get("BranchList"));
+    auto list = fRootFile->Get<TList>("BranchList");
     TString chainName = "BGInChain";
     fInputLevel.push_back(chainName);
     if (list) {

--- a/examples/MQ/pixelDetector/macros/run_sim.C
+++ b/examples/MQ/pixelDetector/macros/run_sim.C
@@ -131,9 +131,9 @@ void run_sim(Int_t nEvents = 10, TString mcEngine = "TGeant3", Int_t fileId = 0,
     cout << "Real time " << rtime << " s, CPU time " << ctime << "s" << endl << endl;
 
     auto outputFile = TFile::Open(outFile);
-    auto outputTree = dynamic_cast<TTree*>(outputFile->Get("cbmsim"));
+    auto outputTree = outputFile->Get<TTree>("cbmsim");
     outputTree->Draw("PixelPoint.fTime", "", "goff");
-    auto htemp = dynamic_cast<TH1F*>(outputFile->Get("htemp"));
+    auto htemp = outputFile->Get<TH1F>("htemp");
     int outputTreeEntries = outputTree->GetEntries();
     int outputPoints = (int)(htemp->GetEntries());
     double outputTime = htemp->GetMean();

--- a/examples/MQ/serialization/1-simple/Ex1Sampler.h
+++ b/examples/MQ/serialization/1-simple/Ex1Sampler.h
@@ -34,7 +34,7 @@ class Ex1Sampler : public fair::mq::Device
         fFileName = fConfig->GetValue<std::string>("input-file");
         fInputFile = TFile::Open(fFileName.c_str(), "READ");
         if (fInputFile) {
-            fTree = static_cast<TTree*>(fInputFile->Get("cbmsim"));
+            fTree = fInputFile->Get<TTree>("cbmsim");
             if (fTree) {
                 fTree->SetBranchAddress("MyDigi", &fInput);
             } else {

--- a/examples/MQ/serialization/2-multipart/Ex2Sampler.h
+++ b/examples/MQ/serialization/2-multipart/Ex2Sampler.h
@@ -34,7 +34,7 @@ class Ex2Sampler : public fair::mq::Device
         fFileName = fConfig->GetValue<std::string>("input-file");
         fInputFile = TFile::Open(fFileName.c_str(), "READ");
         if (fInputFile) {
-            fTree = static_cast<TTree*>(fInputFile->Get("cbmsim"));
+            fTree = fInputFile->Get<TTree>("cbmsim");
             if (fTree) {
                 fTree->SetBranchAddress("MyDigi", &fInput);
             } else {

--- a/parbase/FairParRootFileIo.cxx
+++ b/parbase/FairParRootFileIo.cxx
@@ -84,7 +84,11 @@ void FairParRootFile::readVersions(FairRtdbRun* currentRun)
     // in the ROOT file
     delete run;
 
-    run = static_cast<FairRtdbRun*>(RootFile->Get((const_cast<char*>(currentRun->GetName()))));
+    run = RootFile->Get<FairRtdbRun>(currentRun->GetName());
+    if (!run) {
+        LOG(warning) << "FairParRootFile::readVersions(" << RootFile->GetName() << "): Reading run "
+                     << currentRun->GetName() << " failed";
+    }
     // cout << "-I- FairParRootFile :: readversions " << currentRun->GetName() << " : " << run << endl;
 }
 


### PR DESCRIPTION
ROOT 6.18 added `TDirectory::Get<T>(const char*)` to get a
properly checked and casted object from a File / Directory.

Use it everywhere.

See: https://root.cern/doc/v618/release-notes.html#io-libraries-1

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
