### PR TITLE
Handle non-existant Magnetic Field in Track Display

### DIFF
--- a/examples/common/eventdisplay/FairEveMCTracks.cxx
+++ b/examples/common/eventdisplay/FairEveMCTracks.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2020 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2020-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -41,7 +41,6 @@ FairEveMCTracks::FairEveMCTracks()
     , fShowSecondary(kTRUE)
     , fUsePdg(kFALSE)
     , fPdgCut(0)
-    , fRK(nullptr)
     , fPDG(nullptr)
 {
     SetElementNameTitle("FairMCTracks", "FairMCTracks");
@@ -155,12 +154,11 @@ InitStatus FairEveMCTracks::Init()
     FairRunAna *ana = FairRunAna::Instance();
     FairField *field = ana->GetField();
     if (field == nullptr) {
-        LOG(error) << "Lack of magnetic field map!";
-    } else {
-        fRK = new FairRKPropagator(field);
+        LOG(warning) << "Lack of magnetic field map!";
     }
+    fRK = std::make_unique<FairRKPropagator>(field);
     fPDG = TDatabasePDG::Instance();
     return FairEveTracks::Init();
 }
 
-FairEveMCTracks::~FairEveMCTracks() {}
+FairEveMCTracks::~FairEveMCTracks() = default;

--- a/examples/common/eventdisplay/FairEveMCTracks.h
+++ b/examples/common/eventdisplay/FairEveMCTracks.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2020 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2020-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -15,18 +15,21 @@
  */
 #ifndef FAIREVEMCTRACKS_H_
 #define FAIREVEMCTRACKS_H_
-#include <Rtypes.h>         // for THashConsistencyHolder, ClassDef
-#include <RtypesCore.h>     // for Bool_t, Int_t
-#include "FairEveTracks.h"  // for FairEveTracks
-#include "FairTask.h"       // for InitStatus
-class FairMCTrack;  // lines 22-22
-class FairRKPropagator;  // lines 23-23
+
+#include "FairEveTracks.h"   // for FairEveTracks
+#include "FairTask.h"        // for InitStatus
+
+#include <FairRKPropagator.h>
+#include <Rtypes.h>       // for THashConsistencyHolder, ClassDef
+#include <RtypesCore.h>   // for Bool_t, Int_t
+#include <memory>         // for std::unique_ptr
+
+class FairMCTrack;
 class TBuffer;
 class TClass;
 class TClonesArray;
-class TDatabasePDG;  // lines 24-24
+class TDatabasePDG;
 class TMemberInspector;
-
 
 class FairEveMCTracks : public FairEveTracks
 {
@@ -35,7 +38,7 @@ class FairEveMCTracks : public FairEveTracks
     Bool_t fShowSecondary;
     Bool_t fUsePdg;
     Int_t fPdgCut;
-    FairRKPropagator *fRK;
+    std::unique_ptr<FairRKPropagator> fRK{};
     TDatabasePDG *fPDG;
 
   protected:
@@ -44,7 +47,7 @@ class FairEveMCTracks : public FairEveTracks
 
   public:
     FairEveMCTracks();
-    void Repaint();
+    void Repaint() override;
     void SetPdgCut(Int_t pdg, Bool_t use)
     {
         fPdgCut = pdg;
@@ -55,9 +58,9 @@ class FairEveMCTracks : public FairEveTracks
         fShowPrimary = prim;
         fShowSecondary = sec;
     }
-    virtual InitStatus Init();
-    virtual ~FairEveMCTracks();
-    ClassDef(FairEveMCTracks, 0)
+    InitStatus Init() override;
+    ~FairEveMCTracks() override;
+    ClassDefOverride(FairEveMCTracks, 0)
 };
 
 #endif /* FAIREVEMCTRACKS_H_ */


### PR DESCRIPTION
If there is no magnetic field object, then the `FairEveMCTracks` did not try to draw any tracks.

Also `FairRKPropagator` was not able to handle that case either.

The current implementation doesn't try to be efficient for this case, as it is not expected to be the common case.

fixes: #1190

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
