### PR TITLE
FairRun: Now Owns the FairSink as Well

### DIFF
--- a/base/steer/FairRun.h
+++ b/base/steer/FairRun.h
@@ -9,7 +9,8 @@
 #define FAIRRUN_H
 
 #include "FairAlignmentHandler.h"
-#include "FairRootManager.h"
+#include "FairSink.h"
+#include "FairSource.h"
 
 #include <Rtypes.h>   // for Int_t, Bool_t, etc
 #include <TMCtls.h>   // for multi-threading
@@ -21,6 +22,7 @@
 
 class FairEventHeader;
 class FairFileHeader;
+class FairRootManager;
 class FairRuntimeDb;
 class FairSink;
 class FairTask;
@@ -47,7 +49,7 @@ class FairRun : public TNamed
     /**
      * default dtor
      */
-    virtual ~FairRun();
+    ~FairRun() override;
     /**
      * static instance
      */
@@ -78,20 +80,16 @@ class FairRun : public TNamed
     /**
      * return a pointer to the RuntimeDB
      */
-    FairRuntimeDb* GetRuntimeDb(void) { return fRtdb; }
+    FairRuntimeDb* GetRuntimeDb() { return fRtdb; }
     /**
      * Set the sink
      */
-    void SetSink(FairSink* tempSink)
-    {
-        fSink = tempSink;
-        fRootManager->SetSink(tempSink);
-        fUserOutputFileName = fSink->GetFileName();
-    }
+    void SetSink(std::unique_ptr<FairSink>&& newsink);
+    void SetSink(FairSink* tempSink);
     /**
-     * return a pointer to the sink
+     * return a non-owning pointer to the sink
      */
-    FairSink* GetSink() { return fSink; }
+    FairSink* GetSink() { return fSink.get(); }
     /**
      * return the run ID for the actul run
      */
@@ -218,7 +216,7 @@ class FairRun : public TNamed
     /**IO manager */
     FairRootManager* fRootManager;
     /**Output sink*/
-    FairSink* fSink;
+    std::unique_ptr<FairSink> fSink{};   //!
     /**Output file name set by user*/
     TString fUserOutputFileName;
     /**Options for derived classes, to be set & parsed by user*/

--- a/base/steer/FairRunAnaProof.cxx
+++ b/base/steer/FairRunAnaProof.cxx
@@ -332,7 +332,7 @@ void FairRunAnaProof::RunOnProof(Int_t NStart, Int_t NStop)
     fProof->AddInput(fTask);
 
     // get file name from FairSink
-    TString fileName = fRootManager->GetSink()->GetFileName();
+    TString fileName = GetSink()->GetFileName();
     LOG(info) << " outputFileName = " << fileName.Data();
     if (fileName.Length() < 5)
         fileName = "proofOutput.root";

--- a/base/steer/FairRunOnline.cxx
+++ b/base/steer/FairRunOnline.cxx
@@ -182,7 +182,7 @@ void FairRunOnline::Init()
         return;
     }
     LOG(info) << "FairRunOnline::InitContainers: event header at " << fEvtHeader;
-    fRootManager->Register("EventHeader.", "Event", fEvtHeader, (nullptr != fRootManager->GetSink()));
+    fRootManager->Register("EventHeader.", "Event", fEvtHeader, (nullptr != GetSink()));
     fEvtHeader->SetRunId(fRunId);
 
     GetSource()->InitUnpackers();


### PR DESCRIPTION
We already moved the ownership for the FairSource from FairRootManager to FairRun. Let's do that as well for FairSink.

Also provide an additional unique_ptr based `SetSink` API, so that it is more obvious, that it takes an owning pointer.

See-Also: f7c9d7cd44ec75b4e7711be4fdc45e343f3d123b

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
