### PR TITLE
fix: new boost does not play nice with old-boost system yaml-cpp

### DIFF
--- a/fairtools/MCConfigurator/FairYamlVMCConfig.h
+++ b/fairtools/MCConfigurator/FairYamlVMCConfig.h
@@ -15,6 +15,10 @@
 
 #include "FairGenericVMCConfig.h"
 
+// in case system yaml-cpp was compiled with an older boost version where boost::next was defined
+// in utility.hpp:
+#include <boost/next_prior.hpp>
+
 #include <string>
 #include <yaml-cpp/yaml.h>
 


### PR DESCRIPTION
While trying to compile FairRoot on lxir136.gsi.de using FairSoft release from april 2022 (using gcc9):
```
[ 66%] Generating G__MCConfigurator.cxx, ../../lib/G__MCConfigurator_rdict.pcm, ../../lib/libMCConfigurator.rootmap
In file included from input_line_9:120:
In file included from /usr/include/yaml-cpp/yaml.h:17:
In file included from /usr/include/yaml-cpp/node/impl.h:11:
In file included from /usr/include/yaml-cpp/node/iterator.h:13:
/usr/include/yaml-cpp/node/detail/iterator.h:48:54: error: no member named 'next' in namespace 'boost'
  void increment() { this->base_reference() = boost::next(this->base()); }
                                              ~~~~~~~^
Error: /u/land/klenze/2022-06/inst/FairSoft/bin/rootcint: compilation failure (/u/land/klenze/2022-06/src/FairRoot/build/fairtools/MCConfigurator/G__MCConfigurator39d6ad62e4_dictUmbrella.h)
fairtools/MCConfigurator/CMakeFiles/MCConfigurator.dir/build.make:74: recipe for target 'fairtools/MCConfigurator/G__MCConfigurator.cxx' failed
make[2]: *** [fairtools/MCConfigurator/G__MCConfigurator.cxx] Error 1
CMakeFiles/Makefile2:1250: recipe for target 'fairtools/MCConfigurator/CMakeFiles/MCConfigurator.dir/all' failed
make[1]: *** [fairtools/MCConfigurator/CMakeFiles/MCConfigurator.dir/all] Error 2
Makefile:145: recipe for target 'all' failed
make: *** [all] Error 2

```
(Side note: Could you please make the LinkDef depend on all the object files of the current library, thus making sure that the first compiler parsing the code is a grown-up compiler which is actually able to tell the top level file? Handling rootcint errors is bad enough when they are actually rootcint specific. For code rejected even by decent compilers, a decent error message should be generated. Do you expect every user to know that they need VERBOSE=1 make to get any idea what went wrong with rootcint?)

If we are using a system yaml-cpp which was compiled with an older version of boost, it might just include boost utility instead of boost/next_prior.hpp, which will not play well with the latest and greatest version of boost included in FairSoft. Manually included correct header for boost::next so yaml-cpp/yaml.h does not crash & burn.

(Side remark: YAML for configuration? Even when ROOT does not yet provide a pointless TYAML interface class? What happened to "ROOT macros are the ideal format to store configuration settings"? Just kidding.)

---

Checklist:

* [ ] Rebased against `dev` branch -> Nah, it's a fix for a released version. 
* [ ] My name is in the resp. CONTRIBUTORS/AUTHORS file -> Not for a 1 line change.
* [ ] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules) -> Possibly, accidentially?
