### PR TITLE
Use unique_ptr based SetSink Around (1/2)

### DIFF
--- a/base/MQ/devices/FairMQSampler.h
+++ b/base/MQ/devices/FairMQSampler.h
@@ -100,7 +100,7 @@ class FairMQSampler : public fair::mq::Device
 
         TString output = fInputFile;
         output.Append(".out.root");
-        fFairRunAna->SetSink(new FairRootFileSink(output.Data()));
+        fFairRunAna->SetSink(std::make_unique<FairRootFileSink>(output.Data()));
 
         fFairRunAna->AddTask(fSamplerTask);
 

--- a/base/sim/FairMCApplication.cxx
+++ b/base/sim/FairMCApplication.cxx
@@ -502,7 +502,7 @@ TVirtualMCApplication* FairMCApplication::CloneForWorker() const
     // and pass some data from master FairRunSim object
     FairRunSim* workerRun = new FairRunSim(kFALSE);
     workerRun->SetName(fRun->GetName());   // Transport engine
-    workerRun->SetSink(fRun->GetSink()->CloneSink());
+    workerRun->SetSink(std::unique_ptr<FairSink>{fRun->GetSink()->CloneSink()});
 
     // Trajectories filter is created explicitly as we do not call
     // FairRunSim::Init on workers

--- a/base/steer/FairAnaSelector.cxx
+++ b/base/steer/FairAnaSelector.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -30,6 +30,7 @@
 #include <TProofOutputFile.h>   // for TProofOutputFile
 #include <TProofServ.h>         // for TProofServ
 #include <TSystem.h>            // for TSystem, gSystem
+#include <memory>               // for std::make_unique
 
 void FairAnaSelector::Init(TTree* tree)
 {
@@ -116,7 +117,7 @@ void FairAnaSelector::Init(TTree* tree)
         fRunAna->SetSource(fProofSource);
         LOG(info) << "FairAnaSelector::Init(): SetInTree done";
 
-        fRunAna->SetSink(new FairRootFileSink(fFile));
+        fRunAna->SetSink(std::make_unique<FairRootFileSink>(fFile));
         if (containerS == "kTRUE") {
             fRunAna->SetContainerStatic(kTRUE);
         } else {

--- a/examples/simulation/Tutorial1/macros/run_tutorial1.C
+++ b/examples/simulation/Tutorial1/macros/run_tutorial1.C
@@ -1,16 +1,21 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
+
+#include <TStopwatch.h>
+#include <TString.h>
+#include <TSystem.h>
+#include <memory>
+
 void run_tutorial1(Int_t nEvents = 10,
                    TString mcEngine = "TGeant3",
                    Bool_t isMT = true,
                    Bool_t loadPostInitConfig = false)
 {
-
     TString dir = getenv("VMCWORKDIR");
     TString tutdir = dir + "/simulation/Tutorial1";
 
@@ -70,7 +75,7 @@ void run_tutorial1(Int_t nEvents = 10,
         config->UsePostInitConfig();
     run->SetSimulationConfig(config);
     run->SetIsMT(isMT);                            // Multi-threading mode (Geant4 only)
-    run->SetSink(new FairRootFileSink(outFile));   // Output file
+    run->SetSink(std::make_unique<FairRootFileSink>(outFile));
     FairRuntimeDb* rtdb = run->GetRuntimeDb();
     // ------------------------------------------------------------------------
 

--- a/examples/simulation/Tutorial1/macros/run_tutorial1_binary.C
+++ b/examples/simulation/Tutorial1/macros/run_tutorial1_binary.C
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -79,7 +79,7 @@ void run_tutorial1_main(const FairSimConfig& config)
     FairRunSim run;
     run.SetName(config.GetEngine());              // Transport engine
     run.SetIsMT(config.IsMultiThreaded());        // Multi-threading mode (Geant4 only)
-    run.SetSink(new FairRootFileSink(outFile));   // Output file
+    run.SetSink(std::make_unique<FairRootFileSink>(outFile));
     FairRuntimeDb* rtdb = run.GetRuntimeDb();
     // ------------------------------------------------------------------------
 

--- a/examples/simulation/Tutorial1/macros/run_tutorial1_mesh.C
+++ b/examples/simulation/Tutorial1/macros/run_tutorial1_mesh.C
@@ -1,13 +1,18 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
+
+#include <TStopwatch.h>
+#include <TString.h>
+#include <TSystem.h>
+#include <memory>
+
 void run_tutorial1_mesh(Int_t nEvents = 10, TString mcEngine = "TGeant3")
 {
-
     TString dir = getenv("VMCWORKDIR");
     TString tutdir = dir + "/simulation/Tutorial1";
 
@@ -60,7 +65,7 @@ void run_tutorial1_mesh(Int_t nEvents = 10, TString mcEngine = "TGeant3")
     // -----   Create simulation run   ----------------------------------------
     FairRunSim* run = new FairRunSim();
     run->SetName(mcEngine);                        // Transport engine
-    run->SetSink(new FairRootFileSink(outFile));   // Output file
+    run->SetSink(std::make_unique<FairRootFileSink>(outFile));
     FairRuntimeDb* rtdb = run->GetRuntimeDb();
     // ------------------------------------------------------------------------
 

--- a/examples/simulation/Tutorial1/macros/run_tutorial1_pythia6.C
+++ b/examples/simulation/Tutorial1/macros/run_tutorial1_pythia6.C
@@ -1,13 +1,18 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
+
+#include <TStopwatch.h>
+#include <TString.h>
+#include <TSystem.h>
+#include <memory>
+
 void run_tutorial1_pythia6(Int_t nEvents = 10, TString mcEngine = "TGeant3")
 {
-
     TString dir = getenv("VMCWORKDIR");
     TString tutdir = dir + "/simulation/Tutorial1";
 
@@ -64,7 +69,7 @@ void run_tutorial1_pythia6(Int_t nEvents = 10, TString mcEngine = "TGeant3")
     // -----   Create simulation run   ----------------------------------------
     FairRunSim* run = new FairRunSim();
     run->SetName(mcEngine);                        // Transport engine
-    run->SetSink(new FairRootFileSink(outFile));   // Output file
+    run->SetSink(std::make_unique<FairRootFileSink>(outFile));
     run->SetPythiaDecayer(pythia6Config);          // Define Pythia6 as decayer
 
     FairRuntimeDb* rtdb = run->GetRuntimeDb();

--- a/examples/simulation/Tutorial1/macros/run_tutorial1_pythia8.C
+++ b/examples/simulation/Tutorial1/macros/run_tutorial1_pythia8.C
@@ -1,13 +1,17 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
+
+#include <TString.h>
+#include <TSystem.h>
+#include <memory>
+
 void run_tutorial1_pythia8(Int_t nEvents = 10, TString mcEngine = "TGeant3")
 {
-
     TString dir = getenv("VMCWORKDIR");
     TString tutdir = dir + "/simulation/Tutorial1";
 
@@ -64,7 +68,7 @@ void run_tutorial1_pythia8(Int_t nEvents = 10, TString mcEngine = "TGeant3")
     // -----   Create simulation run   ----------------------------------------
     FairRunSim* run = new FairRunSim();
     run->SetName(mcEngine);                        // Transport engine
-    run->SetSink(new FairRootFileSink(outFile));   // Output file
+    run->SetSink(std::make_unique<FairRootFileSink>(outFile));
     run->SetPythiaDecayer(pythia8Config);          // Define Pythia8 as decayer
 
     FairRuntimeDb* rtdb = run->GetRuntimeDb();

--- a/examples/simulation/Tutorial1/macros/run_tutorial1_urqmd.C
+++ b/examples/simulation/Tutorial1/macros/run_tutorial1_urqmd.C
@@ -1,13 +1,18 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
+
+#include <TStopwatch.h>
+#include <TString.h>
+#include <TSystem.h>
+#include <memory>
+
 void run_tutorial1_urqmd(Int_t nEvents = 2, TString mcEngine = "TGeant3")
 {
-
     TString dir = getenv("VMCWORKDIR");
     TString tutdir = dir + "/simulation//Tutorial1";
 
@@ -46,7 +51,7 @@ void run_tutorial1_urqmd(Int_t nEvents = 2, TString mcEngine = "TGeant3")
     // -----   Create simulation run   ----------------------------------------
     FairRunSim* run = new FairRunSim();
     run->SetName(mcEngine);                        // Transport engine
-    run->SetSink(new FairRootFileSink(outFile));   // Output file
+    run->SetSink(std::make_unique<FairRootFileSink>(outFile));
     FairRuntimeDb* rtdb = run->GetRuntimeDb();
     // ------------------------------------------------------------------------
 

--- a/examples/simulation/Tutorial2/macros/create_digis.C
+++ b/examples/simulation/Tutorial2/macros/create_digis.C
@@ -1,13 +1,21 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
+
+#include <TStopwatch.h>
+#include <TString.h>
+#include <iostream>
+#include <memory>
+
+using std::cout;
+using std::endl;
+
 void create_digis()
 {
-
     TStopwatch timer;
     timer.Start();
 
@@ -30,7 +38,7 @@ void create_digis()
     FairFileSource* fFileSource = new FairFileSource(inFile);
     fRun->SetSource(fFileSource);
 
-    fRun->SetSink(new FairRootFileSink(outFile));
+    fRun->SetSink(std::make_unique<FairRootFileSink>(outFile));
 
     // Init Simulation Parameters from Root File
     FairRuntimeDb* rtdb = fRun->GetRuntimeDb();

--- a/examples/simulation/Tutorial2/macros/create_digis_mixed.C
+++ b/examples/simulation/Tutorial2/macros/create_digis_mixed.C
@@ -1,8 +1,13 @@
+#include <TStopwatch.h>
+#include <TString.h>
+#include <iostream>
 #include <memory>
+
+using std::cout;
+using std::endl;
 
 void create_digis_mixed()
 {
-
     TStopwatch timer;
     timer.Start();
 
@@ -43,7 +48,7 @@ void create_digis_mixed()
 
     fRun->SetSource(fMixedSource);
 
-    fRun->SetSink(new FairRootFileSink(outFile));
+    fRun->SetSink(std::make_unique<FairRootFileSink>(outFile));
 
     //----- Mix using entries  ----------------------------------------
 

--- a/examples/simulation/Tutorial2/macros/read_digis.C
+++ b/examples/simulation/Tutorial2/macros/read_digis.C
@@ -1,13 +1,21 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
+
+#include <TStopwatch.h>
+#include <TString.h>
+#include <iostream>
+#include <memory>
+
+using std::cout;
+using std::endl;
+
 void read_digis()
 {
-
     TStopwatch timer;
     timer.Start();
 
@@ -27,7 +35,7 @@ void read_digis()
     FairRunAna* fRun = new FairRunAna();
     FairFileSource* fFileSource = new FairFileSource(inFile);
     fRun->SetSource(fFileSource);
-    fRun->SetSink(new FairRootFileSink(outFile));
+    fRun->SetSink(std::make_unique<FairRootFileSink>(outFile));
 
     // Init Simulation Parameters from Root File
     FairRuntimeDb* rtdb = fRun->GetRuntimeDb();

--- a/examples/simulation/Tutorial2/macros/run_background.C
+++ b/examples/simulation/Tutorial2/macros/run_background.C
@@ -1,3 +1,6 @@
+#include <TStopwatch.h>
+#include <TString.h>
+#include <TSystem.h>
 #include <memory>
 
 void run_background(Int_t nEvents = 130)
@@ -51,7 +54,7 @@ void run_background(Int_t nEvents = 130)
     // -----   Create simulation run   ----------------------------------------
     auto run = std::make_unique<FairRunSim>();
     run->SetName("TGeant4");                       // Transport engine
-    run->SetSink(new FairRootFileSink(outFile));   // Output file
+    run->SetSink(std::make_unique<FairRootFileSink>(outFile));
     FairRuntimeDb* rtdb = run->GetRuntimeDb();
     // ------------------------------------------------------------------------
 

--- a/examples/simulation/Tutorial2/macros/run_signal.C
+++ b/examples/simulation/Tutorial2/macros/run_signal.C
@@ -1,3 +1,6 @@
+#include <TStopwatch.h>
+#include <TString.h>
+#include <TSystem.h>
 #include <memory>
 
 void run_signal(Int_t fileNr, Int_t nEvents = 10)
@@ -53,7 +56,7 @@ void run_signal(Int_t fileNr, Int_t nEvents = 10)
     // -----   Create simulation run   ----------------------------------------
     auto run = std::make_unique<FairRunSim>();
     run->SetName("TGeant4");                       // Transport engine
-    run->SetSink(new FairRootFileSink(outFile));   // Output file
+    run->SetSink(std::make_unique<FairRootFileSink>(outFile));
     FairRuntimeDb* rtdb = run->GetRuntimeDb();
     // ------------------------------------------------------------------------
 

--- a/examples/simulation/Tutorial2/macros/run_tutorial2.C
+++ b/examples/simulation/Tutorial2/macros/run_tutorial2.C
@@ -1,10 +1,15 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
+
+#include <TRandom.h>
+#include <TStopwatch.h>
+#include <TString.h>
+#include <TSystem.h>
 #include <memory>
 
 void run_tutorial2(Int_t nEvents = 10, TString mcEngine = "TGeant4", Bool_t isMT = true)
@@ -62,7 +67,7 @@ void run_tutorial2(Int_t nEvents = 10, TString mcEngine = "TGeant4", Bool_t isMT
     auto run = std::make_unique<FairRunSim>();
     run->SetName(mcEngine);                        // Transport engine
     run->SetIsMT(isMT);                            // Multi-threading mode (Geant4 only)
-    run->SetSink(new FairRootFileSink(outFile));   // Output file
+    run->SetSink(std::make_unique<FairRootFileSink>(outFile));
     FairRuntimeDb* rtdb = run->GetRuntimeDb();
     // ------------------------------------------------------------------------
 

--- a/examples/simulation/Tutorial4/macros/run_reco.C
+++ b/examples/simulation/Tutorial4/macros/run_reco.C
@@ -1,10 +1,16 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
+
+#include <TStopwatch.h>
+#include <TString.h>
+#include <TSystem.h>
+#include <memory>
+
 void run_reco(TString mcEngine = "TGeant3", Bool_t AlignDone = true)
 {
     // ----  Load libraries   -------------------------------------------------
@@ -57,7 +63,7 @@ void run_reco(TString mcEngine = "TGeant3", Bool_t AlignDone = true)
     FairRunAna* fRun = new FairRunAna();
     FairFileSource* fFileSource = new FairFileSource(inFile);
     fRun->SetSource(fFileSource);
-    fRun->SetSink(new FairRootFileSink(outFile));
+    fRun->SetSink(std::make_unique<FairRootFileSink>(outFile));
 
     FairRuntimeDb* rtdb = fRun->GetRuntimeDb();
     FairParRootFileIo* parInput1 = new FairParRootFileIo();

--- a/examples/simulation/Tutorial4/macros/run_tutorial4.C
+++ b/examples/simulation/Tutorial4/macros/run_tutorial4.C
@@ -9,6 +9,7 @@
 #include <TObjString.h>
 #include <TStopwatch.h>
 #include <TSystem.h>
+#include <memory>
 
 void run_tutorial4(Int_t nEvents = 10, TString mcEngine = "TGeant3", Bool_t doAlign = true, Bool_t isMT = false)
 {
@@ -71,7 +72,7 @@ void run_tutorial4(Int_t nEvents = 10, TString mcEngine = "TGeant3", Bool_t doAl
     FairRunSim* run = new FairRunSim();
     run->SetName(mcEngine);                        // Transport engine
     run->SetIsMT(isMT);                            // Multi-threading mode (Geant4 only)
-    run->SetSink(new FairRootFileSink(outFile));   // Output file
+    run->SetSink(std::make_unique<FairRootFileSink>(outFile));
     FairRuntimeDb* rtdb = run->GetRuntimeDb();
     // ------------------------------------------------------------------------
 

--- a/examples/simulation/rutherford/macros/run_rad.C
+++ b/examples/simulation/rutherford/macros/run_rad.C
@@ -1,13 +1,18 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
+
+#include <TStopwatch.h>
+#include <TString.h>
+#include <TSystem.h>
+#include <memory>
+
 void run_rad(Int_t nEvents = 100, TString mcEngine = "TGeant4")
 {
-
     TString dir = gSystem->Getenv("VMCWORKDIR");
     TString tutdir = dir + "/simulation/rutherford/macros";
 
@@ -51,7 +56,7 @@ void run_rad(Int_t nEvents = 100, TString mcEngine = "TGeant4")
     // -----   Create simulation run   ----------------------------------------
     FairRunSim* run = new FairRunSim();
     run->SetName(mcEngine);                        // Transport engine
-    run->SetSink(new FairRootFileSink(outFile));   // Output file
+    run->SetSink(std::make_unique<FairRootFileSink>(outFile));
     FairRuntimeDb* rtdb = run->GetRuntimeDb();
     // ------------------------------------------------------------------------
 

--- a/examples/simulation/rutherford/macros/run_rutherford.C
+++ b/examples/simulation/rutherford/macros/run_rutherford.C
@@ -1,10 +1,16 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
+
+#include <TRandom.h>
+#include <TString.h>
+#include <TSystem.h>
+#include <memory>
+
 void run_rutherford(Int_t nEvents = 10, TString mcEngine = "TGeant4", Bool_t isMT = true)
 {
     TString dir = gSystem->Getenv("VMCWORKDIR");
@@ -54,7 +60,7 @@ void run_rutherford(Int_t nEvents = 10, TString mcEngine = "TGeant4", Bool_t isM
     FairRunSim* run = new FairRunSim();
     run->SetName(mcEngine);                        // Transport engine
     run->SetIsMT(isMT);                            // Multi-threading mode (Geant4 only)
-    run->SetSink(new FairRootFileSink(outFile));   // Output file
+    run->SetSink(std::make_unique<FairRootFileSink>(outFile));
     FairRuntimeDb* rtdb = run->GetRuntimeDb();
     // ------------------------------------------------------------------------
 


### PR DESCRIPTION
Now that FairRun::SetSink supports unique_ptr, use it  around to promote good style.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
