### PR TITLE
Deprecate FairGeaneApplication::Instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
     * Note that `fair_pad` needs the width argument to be incremented by 1,
       and the COLOR option takes no argument.
 * Dropped `CheckCXX11Features`
-  * FairRoot assumes a recent compiler that fully supports C++11.
+  * FairRoot assumes a recent compiler that fully supports C++17.
   * Remove the following things from your `CMakeLists.txt`:
     * ```cmake
       Set(CheckSrcDir "${FAIRROOTPATH}/share/fairbase/cmake/checks")`
@@ -58,8 +58,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   It has been deprecated since 18.0.0.
 * `FairRootManager::Get{Tree,Folder}Name()` now return `const char *`.
   Do NOT `delete` the returned pointer!
+* Some headers were cleaned up and now `#include` fewer
+  other headers. You might have to add some `#includes`s
+  in your code.
 
-### Deprecated
+
+### Deprecations
+
+This release of FairRoot deprecates many APIs for various
+reasons. If you think you really require some API, please
+file an issue, so that we can see how to handle this.
+
 * Deprecating MbsAPI
   * This release deprecates MbsAPI. We plan to remove it completely in the next major release.
   * If you need it, speak up NOW.
@@ -67,7 +76,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   * It can still be enabled with `-DBUILD_MBS=ON`.
 * Deprecate some singleton-like APIs:
   * `FairRunAnaProof::Instance()` - keep a pointer to the
-    object after `new` in your code.
+    object after instantiating it in your code.
   * `FairRadGridManager::Instance()` - Consider using the
     `GetRadGridMan()` method on `FairMCApplcation`.
   * `FairRadMapManager::Instance`, `FairRadLenManager::Instance`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   * `FairRadGridManager::Instance()` - Consider using the
     `GetRadGridMan()` method on `FairMCApplcation`.
   * `FairRadMapManager::Instance`, `FairRadLenManager::Instance`
+  * `FairGeaneApplication::Instance`
 * Deprecated some other APIs
   * `FairGeoVector::round` was nonfunctional and never did anything.
   * `FairTask::*InputPersistance`:

--- a/base/sim/FairGeaneApplication.h
+++ b/base/sim/FairGeaneApplication.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -48,9 +48,14 @@ class FairGeaneApplication : public TVirtualMCApplication
     /** Define action at each step, dispatch the action to the corresponding detectors */
     void GeaneStepping() override;   // MC Application
     void ConstructGeometry() override;
-    /** Singelton instance
+    /**
+     * Singelton instance
+     * \deprecated Deprecated in v19, will be removed in v20.
      */
-    static FairGeaneApplication* Instance();
+    [[deprecated]] static FairGeaneApplication* Instance()
+    {
+        return static_cast<FairGeaneApplication*>(TVirtualMCApplication::Instance());
+    }
 
     /**pure virtual functions that hasve to be implimented */
 
@@ -82,12 +87,5 @@ class FairGeaneApplication : public TVirtualMCApplication
     FairGeaneApplication(const FairGeaneApplication&);
     FairGeaneApplication& operator=(const FairGeaneApplication&);
 };
-
-// inline functions
-
-inline FairGeaneApplication* FairGeaneApplication::Instance()
-{
-    return static_cast<FairGeaneApplication*>(TVirtualMCApplication::Instance());
-}
 
 #endif

--- a/geane/FairGeanePro.cxx
+++ b/geane/FairGeanePro.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -11,7 +11,6 @@
 //
 #include "FairGeanePro.h"
 
-#include "FairGeaneApplication.h"   // for FairGeaneApplication
 #include "FairGeaneUtil.h"          // for FairGeaneUtil
 #include "FairLogger.h"
 #include "FairTrackPar.h"    // for FairTrackPar
@@ -52,10 +51,9 @@ FairGeanePro::FairGeanePro()
     , ftrklength(0.)
     , ftrktime(0.)
     , flag(0)
-    , fApp(FairGeaneApplication::Instance())
     , fPrintErrors(kTRUE)
 {
-    if (gMC3 == NULL) {
+    if (gMC3 == nullptr) {
         LOG(fatal) << "FairGeanePro::TGeant3 has not been initialized! ABORTING!";
         throw;
     }
@@ -82,12 +80,11 @@ FairGeanePro::FairGeanePro()
   fwire2 = TVector3(0., 0., 0.);
   */
 
-    for (int i = 0; i < 5; i++)
+    for (int i = 0; i < 5; i++) {
         for (int j = 0; j < 5; j++) {
             trpmat[i][j] = 0.;
         }
-
-    //  fApp = FairGeaneApplication::Instance();
+    }
 
     //   fPropOption = "";
     for (int i = 0; i < 15; i++) {
@@ -128,7 +125,7 @@ FairGeanePro::FairGeanePro()
   */
 }
 
-FairGeanePro::~FairGeanePro() {}
+FairGeanePro::~FairGeanePro() = default;
 
 bool FairGeanePro::Propagate(FairTrackParH* TParam, FairTrackParH* TEnd, int PDG)
 {
@@ -380,7 +377,6 @@ bool FairGeanePro::Propagate(FairTrackParH* /*TStart*/, FairTrackParP* /*TEnd*/,
 
 bool FairGeanePro::Propagate(float* X1, float* P1, float* X2, float* P2, int PDG)
 {
-    //  fApp->GeanePreTrack(X1, P1, PDG);
     GeantCode = fdbPDG->ConvertPdgToGeant3(PDG);
     xlf[0] = 1000;
     gMC3->Eufill(1, ein, xlf);
@@ -400,7 +396,7 @@ bool FairGeanePro::Propagate(int PDG)
 
     GeantCode = fdbPDG->ConvertPdgToGeant3(PDG);
     // LOG(info) <<  " FairGeanePro::Propagate ---------------------------"<< "  " << x1[0]<< " "<< x1[1]<< "  "<<
-    // x1[2]; fApp->GeanePreTrack(x1, p1, PDG);
+    // x1[2];
     gMC3->Ertrak(x1, p1, x2, p2, GeantCode, fPropOption.Data());
     if (x2[0] < -1.E29) {
         return kFALSE;
@@ -1555,10 +1551,11 @@ void FairGeanePro::Track3ToPoint(TVector3 X1,
 
 void FairGeanePro::GetTransportMatrix(double trm[5][5])
 {
-    for (int i = 0; i < 5; i++)
+    for (int i = 0; i < 5; i++) {
         for (int j = 0; j < 5; j++) {
             trm[i][j] = trpmat[i][j];
         }
+    }
 }
 
 ClassImp(FairGeanePro);

--- a/geane/FairGeanePro.h
+++ b/geane/FairGeanePro.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -12,16 +12,15 @@
 #ifndef FAIRGEANEPRO_H
 #define FAIRGEANEPRO_H 1
 
-#include "FairLogger.h"
 #include "FairPropagator.h"   // for TNamed
-#include "TGeant3.h"          // for Ertrio_t, etc
-#include "TString.h"          // for TString
-#include "TVector3.h"         // for TVector3
+
+#include <TGeant3.h>   // for Ertrio_t, etc
+#include <TString.h>
+#include <TVector3.h>
 
 class FairTrackPar;
 class FairTrackParP;
 class FairTrackParH;
-class FairGeaneApplication;
 class TDatabasePDG;
 
 class FairGeanePro : public FairPropagator
@@ -31,42 +30,42 @@ class FairGeanePro : public FairPropagator
     FairGeanePro();
 
     /** Destructor **/
-    ~FairGeanePro();
+    ~FairGeanePro() override;
 
     /* Old methods that still should be working */
-    virtual bool Propagate(FairTrackParH* TStart, FairTrackParH* TEnd, int PDG);
-    virtual bool Propagate(FairTrackParP* TStart, FairTrackParH* TEnd, int PDG);
-    virtual bool Propagate(FairTrackParP* TStart, FairTrackParP* TEnd, int PDG);
-    virtual bool Propagate(FairTrackParH* TStart, FairTrackParP* TEnd, int PDG);
-    virtual bool Propagate(float* x1, float* p1, float* x2, float* p2, int PDG);
+    bool Propagate(FairTrackParH* TStart, FairTrackParH* TEnd, int PDG) override;
+    bool Propagate(FairTrackParP* TStart, FairTrackParH* TEnd, int PDG) override;
+    bool Propagate(FairTrackParP* TStart, FairTrackParP* TEnd, int PDG) override;
+    bool Propagate(FairTrackParH* TStart, FairTrackParP* TEnd, int PDG) override;
+    bool Propagate(float* x1, float* p1, float* x2, float* p2, int PDG) override;
 
     /* Old methods that still should be working */
 
     /**New method to set the plane to propagate particles to
      @v0 v1 v2  Plane defining vectors
     */
-    virtual bool SetDestinationPlane(const TVector3& v0, const TVector3& v1, const TVector3& v2);
+    bool SetDestinationPlane(const TVector3& v0, const TVector3& v1, const TVector3& v2) override;
 
     /**New method to set the plane to propagate particles from
      @v0 v1     Plane defining vectors
     */
-    virtual bool SetOriginPlane(const TVector3& v0, const TVector3& v1);
+    bool SetOriginPlane(const TVector3& v0, const TVector3& v1) override;
 
     /**New method to set the volume to propagate particles to
        @volName Volume name
        @copyNo  Copy number
        @option  Option
     */
-    virtual bool SetDestinationVolume(std::string volName, int copyNo, int option);
+    bool SetDestinationVolume(std::string volName, int copyNo, int option) override;
 
     /**New method to set the length to propagate particles to
        @length  Track length
     */
-    virtual bool SetDestinationLength(float length);
+    bool SetDestinationLength(float length) override;
 
     /**New method to set to propagate only parameters
      */
-    virtual bool SetPropagateOnlyParameters();
+    bool SetPropagateOnlyParameters() override;
 
     /* ====== Depracated functions ====== */
     /** \deprecated Deprecated pre-v19, will be removed in v20. */
@@ -87,7 +86,7 @@ class FairGeanePro : public FairPropagator
         PropagateOnlyParameters();
     /* ====== ====== ====== ====== ====== */
 
-    void Init(FairTrackPar* TParam);
+    void Init(FairTrackPar* TParam) override;
     bool Propagate(int PDG);
 
   private:
@@ -196,14 +195,10 @@ class FairGeanePro : public FairPropagator
 
     void setBackProp() { fPropOption = "BPE"; }
 
-    virtual bool SetPCAPropagation(int pca, int dir = 1, FairTrackParP* par = nullptr);
+    bool SetPCAPropagation(int pca, int dir = 1, FairTrackParP* par = nullptr) override;
 
-    virtual PCAOutputStruct FindPCA(int PCA,
-                                    int PDGCode,
-                                    TVector3 Point,
-                                    TVector3 Wire1,
-                                    TVector3 Wire2,
-                                    double MaxDistance);
+    PCAOutputStruct FindPCA(int PCA, int PDGCode, TVector3 Point, TVector3 Wire1, TVector3 Wire2, double MaxDistance)
+        override;
 
     // transport matrix
     void GetTransportMatrix(double trm[5][5]);
@@ -245,7 +240,6 @@ class FairGeanePro : public FairPropagator
     float ftrklength;
     float ftrktime;
     int flag;
-    FairGeaneApplication* fApp;
     double trpmat[5][5];
 
     // if kFALSE --> do not print the ABORT messages
@@ -254,7 +248,7 @@ class FairGeanePro : public FairPropagator
     FairGeanePro(const FairGeanePro&);
     FairGeanePro& operator=(const FairGeanePro&);
 
-    ClassDef(FairGeanePro, 2);
+    ClassDefOverride(FairGeanePro, 2);
 };
 
 #endif


### PR DESCRIPTION
It's not used in any relevant places.

And if access to it is needed, then a new getter on FairGeane should be implemented.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
