### PR TITLE
fix(cmake): Handle Double CMake in Using Projects

### DIFF
--- a/cmake/modules/FindFairRoot.cmake
+++ b/cmake/modules/FindFairRoot.cmake
@@ -1,5 +1,5 @@
  ################################################################################
- #    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    #
+ # Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
  #                                                                              #
  #              This software is distributed under the terms of the             # 
  #              GNU Lesser General Public Licence (LGPL) version 3,             #  
@@ -8,24 +8,34 @@
 # Find FairRoot installation 
 # Check the environment variable "FAIRROOTPATH"
 
-if(FairRoot_DIR)
-  set(FAIRROOTPATH ${FairRoot_DIR})
-else()
-  if(NOT DEFINED ENV{FAIRROOTPATH})
-    set(user_message "You did not define the environment variable FAIRROOTPATH which is needed to find FairRoot.\
-         Please set this variable and execute cmake again." )
-    if(FairRoot_FIND_REQUIRED)
-      MESSAGE(FATAL_ERROR ${user_message})
-    else(FairRoot_FIND_REQUIRED)
-      MESSAGE(WARNING ${user_message})
-      return()
-    endif(FairRoot_FIND_REQUIRED)
-  endif(NOT DEFINED ENV{FAIRROOTPATH})
+include(FindPackageHandleStandardArgs)
 
-  set(FAIRROOTPATH $ENV{FAIRROOTPATH})
+if(NOT FAIRROOTPATH)
+  set(FAIRROOTPATH "$ENV{FAIRROOTPATH}")
 endif()
 
+if(FAIRROOTPATH)
+  list(PREPEND CMAKE_PREFIX_PATH "${FAIRROOTPATH}")
+else()
+  message(STATUS "INFO: FAIRROOTPATH not set, CMAKE_PREFIX_PATH should have the needed entries")
+endif()
+
+# recursive config mode find_package to
+# find the new main config mode package
+find_package(FairRoot CONFIG)
+
+if(NOT FairRoot_FOUND)
+  message(STATUS "FairRoot not found in config mode. Why?")
+  message(STATUS "CMAKE_PREFIX_PATH = ${CMAKE_PREFIX_PATH}")
+  find_package_handle_standard_args(FairRoot CONFIG_MODE)
+  return()
+endif()
+set(FAIRROOTPATH "${FairRoot_PREFIX}")
+
 MESSAGE(STATUS "Setting FairRoot environment:")
+message(STATUS "  FairRoot Version           : ${FairRoot_VERSION}")
+message(STATUS "  FairRoot CXX Standard      : ${FairRoot_CXX_STANDARD}")
+message(STATUS "  FairRoot prefix            : ${FairRoot_PREFIX}")
 
 FIND_PATH(FAIRROOT_INCLUDE_DIR NAMES FairRun.h PATHS
   ${FAIRROOTPATH}/include
@@ -50,22 +60,14 @@ if(_fairroot_fairmq_cmake)
     include(${_fairroot_fairmq_cmake})
 endif()
 
-if(FAIRROOT_INCLUDE_DIR AND FAIRROOT_LIBRARY_DIR)
+find_package_handle_standard_args(FairRoot CONFIG_MODE
+                                  REQUIRED_VARS FAIRROOT_INCLUDE_DIR
+                                                FAIRROOT_LIBRARY_DIR)
+if(FairRoot_FOUND)
    set(FAIRROOT_FOUND TRUE)
-   MESSAGE(STATUS "  FairRoot prefix            : ${FAIRROOTPATH}")
    MESSAGE(STATUS "  FairRoot Library directory : ${FAIRROOT_LIBRARY_DIR}")
    MESSAGE(STATUS "  FairRoot Include path      : ${FAIRROOT_INCLUDE_DIR}")
    MESSAGE(STATUS "  FairRoot Cmake Modules     : ${FAIRROOT_CMAKEMOD_DIR}")
-
-else(FAIRROOT_INCLUDE_DIR AND FAIRROOT_LIBRARY_DIR)
+else()
    set(FAIRROOT_FOUND FALSE)
-   MESSAGE(FATAL_ERROR "FairRoot installation not found")
-endif (FAIRROOT_INCLUDE_DIR AND FAIRROOT_LIBRARY_DIR)
-
-# recursive config mode find_package to
-# get some package variables
-list(PREPEND CMAKE_PREFIX_PATH "${FAIRROOTPATH}")
-find_package(FairRoot CONFIG)
-
-message(STATUS "  FairRoot Version           : ${FairRoot_VERSION}")
-message(STATUS "  FairRoot CXX Standard      : ${FairRoot_CXX_STANDARD}")
+endif()

--- a/templates/CMakeLists.txt
+++ b/templates/CMakeLists.txt
@@ -1,16 +1,32 @@
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/test_project_root_containers.sh.in ${CMAKE_CURRENT_BINARY_DIR}/test_project_root_containers.sh)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/test_project_root_containers.sh.in
+               ${CMAKE_CURRENT_BINARY_DIR}/test_project_root_containers.sh
+               @ONLY)
 add_test(NAME project_root_containers
          COMMAND ${CMAKE_CURRENT_BINARY_DIR}/test_project_root_containers.sh)
 set_tests_properties(project_root_containers PROPERTIES
   TIMEOUT "300"
   PASS_REGULAR_EXPRESSION "Test successful."
 )
+add_test(NAME project_root_containers_double
+         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/test_project_root_containers.sh --double-configure)
+set_tests_properties(project_root_containers_double PROPERTIES
+  TIMEOUT "300"
+  PASS_REGULAR_EXPRESSION "Test successful."
+)
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/test_project_stl_containers.sh.in ${CMAKE_CURRENT_BINARY_DIR}/test_project_stl_containers.sh)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/test_project_stl_containers.sh.in
+               ${CMAKE_CURRENT_BINARY_DIR}/test_project_stl_containers.sh
+               @ONLY)
 add_test(NAME project_stl_containers
          COMMAND ${CMAKE_CURRENT_BINARY_DIR}/test_project_stl_containers.sh)
 set_tests_properties(project_stl_containers PROPERTIES
+  TIMEOUT "300"
+  PASS_REGULAR_EXPRESSION "Test successful."
+)
+add_test(NAME project_stl_containers_double
+         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/test_project_stl_containers.sh --double-configure)
+set_tests_properties(project_stl_containers_double PROPERTIES
   TIMEOUT "300"
   PASS_REGULAR_EXPRESSION "Test successful."
 )

--- a/templates/project_root_containers/CMakeLists.txt
+++ b/templates/project_root_containers/CMakeLists.txt
@@ -21,10 +21,6 @@ IF(NOT DEFINED ENV{FAIRROOTPATH})
   MESSAGE(FATAL_ERROR "You did not define the environment variable FAIRROOTPATH which is needed to find FairRoot. Please set this variable and execute cmake again.")
 ENDIF(NOT DEFINED ENV{FAIRROOTPATH})
 
-IF(NOT DEFINED ENV{SIMPATH})
-   MESSAGE(FATAL_ERROR "You did not define the environment variable SIMPATH which is nedded to find the external packages. Please set this variable and execute cmake again.")
-ENDIF(NOT DEFINED ENV{SIMPATH})
-
 SET(SIMPATH $ENV{SIMPATH})
 SET(FAIRROOTPATH $ENV{FAIRROOTPATH})
 
@@ -40,7 +36,7 @@ find_package(FairCMakeModules 0.2 QUIET REQUIRED)
 include(FairFindPackage2)
 include(FairSummary)
 
-find_package2(PUBLIC FairRoot)
+find_package2(PUBLIC FairRoot VERSION 19.0 REQUIRED)
 
 # Load some basic macros which are needed later on
 include(FairMacros)

--- a/templates/project_root_containers/MyProjData/MyProjMCTrack.cxx
+++ b/templates/project_root_containers/MyProjData/MyProjMCTrack.cxx
@@ -138,6 +138,7 @@ Double_t MyProjMCTrack::GetRapidity() const
 // -----   Public method GetNPoints   --------------------------------------
 Int_t MyProjMCTrack::GetNPoints(DetectorId detId) const
 {
+    return 0;
     /*  // TODO: Where does this come from
   if      ( detId == kREF  ) { return (  fNPoints &   1); }
   else if ( detId == kTutDet  ) { return ( (fNPoints & ( 7 <<  1) ) >>  1); }

--- a/templates/project_root_containers/NewDetector/NewDetector.cxx
+++ b/templates/project_root_containers/NewDetector/NewDetector.cxx
@@ -88,7 +88,8 @@ void NewDetector::Initialize()
 
     FairDetector::Initialize();
     FairRuntimeDb* rtdb = FairRun::Instance()->GetRuntimeDb();
-    NewDetectorGeoPar* par = (NewDetectorGeoPar*)(rtdb->getContainer("NewDetectorGeoPar"));
+    auto par = (NewDetectorGeoPar*)(rtdb->getContainer("NewDetectorGeoPar"));
+    (void)par;   // stop warning about unused variable
 }
 
 Bool_t NewDetector::ProcessHits(FairVolume* vol)

--- a/templates/project_root_containers/passive/MyMagnet.cxx
+++ b/templates/project_root_containers/passive/MyMagnet.cxx
@@ -55,8 +55,8 @@ void MyMagnet::ConstructGeometry()
     TGeoMedium *Fe = new TGeoMedium("Fe", 5, matFe);
 
     // magnet yoke
-    TGeoBBox *magyoke1 = new TGeoBBox("magyoke1", 350, 350, 125);
-    TGeoBBox *magyoke2 = new TGeoBBox("magyoke2", 250, 250, 126);
+    new TGeoBBox("magyoke1", 350, 350, 125);
+    new TGeoBBox("magyoke2", 250, 250, 126);
 
     TGeoCompositeShape *magyokec = new TGeoCompositeShape("magyokec", "magyoke1-magyoke2");
     TGeoVolume *magyoke = new TGeoVolume("magyoke", magyokec, Fe);
@@ -65,10 +65,10 @@ void MyMagnet::ConstructGeometry()
     top->AddNode(magyoke, 1, new TGeoTranslation(0, 0, 0));
 
     // magnet
-    TGeoTubeSeg *magnet1a = new TGeoTubeSeg("magnet1a", 250, 300, 35, 45, 135);
-    TGeoTubeSeg *magnet1b = new TGeoTubeSeg("magnet1b", 250, 300, 35, 45, 135);
-    TGeoTubeSeg *magnet1c = new TGeoTubeSeg("magnet1c", 250, 270, 125, 45, 60);
-    TGeoTubeSeg *magnet1d = new TGeoTubeSeg("magnet1d", 250, 270, 125, 120, 135);
+    new TGeoTubeSeg("magnet1a", 250, 300, 35, 45, 135);
+    new TGeoTubeSeg("magnet1b", 250, 300, 35, 45, 135);
+    new TGeoTubeSeg("magnet1c", 250, 270, 125, 45, 60);
+    new TGeoTubeSeg("magnet1d", 250, 270, 125, 120, 135);
 
     // magnet composite shape matrices
     TGeoTranslation *m1 = new TGeoTranslation(0, 0, 160);

--- a/templates/project_stl_containers/CMakeLists.txt
+++ b/templates/project_stl_containers/CMakeLists.txt
@@ -21,10 +21,6 @@ IF(NOT DEFINED ENV{FAIRROOTPATH})
   MESSAGE(FATAL_ERROR "You did not define the environment variable FAIRROOTPATH which is needed to find FairRoot. Please set this variable and execute cmake again.")
 ENDIF(NOT DEFINED ENV{FAIRROOTPATH})
 
-IF(NOT DEFINED ENV{SIMPATH})
-   MESSAGE(FATAL_ERROR "You did not define the environment variable SIMPATH which is nedded to find the external packages. Please set this variable and execute cmake again.")
-ENDIF(NOT DEFINED ENV{SIMPATH})
-
 SET(SIMPATH $ENV{SIMPATH})
 SET(FAIRROOTPATH $ENV{FAIRROOTPATH})
 
@@ -40,7 +36,7 @@ find_package(FairCMakeModules 0.2 QUIET REQUIRED)
 include(FairFindPackage2)
 include(FairSummary)
 
-find_package2(PUBLIC FairRoot)
+find_package2(PUBLIC FairRoot VERSION 19.0 REQUIRED)
 
 # Load some basic macros which are needed later on
 include(FairMacros)

--- a/templates/project_stl_containers/MyProjData/MyProjMCTrack.cxx
+++ b/templates/project_stl_containers/MyProjData/MyProjMCTrack.cxx
@@ -138,6 +138,7 @@ Double_t MyProjMCTrack::GetRapidity() const
 // -----   Public method GetNPoints   --------------------------------------
 Int_t MyProjMCTrack::GetNPoints(DetectorId detId) const
 {
+    return 0;
     /*  // TODO: Where does this come from
   if      ( detId == kREF  ) { return (  fNPoints &   1); }
   else if ( detId == kTutDet  ) { return ( (fNPoints & ( 7 <<  1) ) >>  1); }

--- a/templates/project_stl_containers/NewDetector/NewDetector.cxx
+++ b/templates/project_stl_containers/NewDetector/NewDetector.cxx
@@ -87,7 +87,8 @@ void NewDetector::Initialize()
 
     FairDetector::Initialize();
     FairRuntimeDb* rtdb = FairRun::Instance()->GetRuntimeDb();
-    NewDetectorGeoPar* par = (NewDetectorGeoPar*)(rtdb->getContainer("NewDetectorGeoPar"));
+    auto par = (NewDetectorGeoPar*)(rtdb->getContainer("NewDetectorGeoPar"));
+    (void)par;   // stop warning about unused variable
 }
 
 Bool_t NewDetector::ProcessHits(FairVolume* vol)

--- a/templates/project_stl_containers/passive/MyMagnet.cxx
+++ b/templates/project_stl_containers/passive/MyMagnet.cxx
@@ -55,8 +55,8 @@ void MyMagnet::ConstructGeometry()
     TGeoMedium *Fe = new TGeoMedium("Fe", 5, matFe);
 
     // magnet yoke
-    TGeoBBox *magyoke1 = new TGeoBBox("magyoke1", 350, 350, 125);
-    TGeoBBox *magyoke2 = new TGeoBBox("magyoke2", 250, 250, 126);
+    new TGeoBBox("magyoke1", 350, 350, 125);
+    new TGeoBBox("magyoke2", 250, 250, 126);
 
     TGeoCompositeShape *magyokec = new TGeoCompositeShape("magyokec", "magyoke1-magyoke2");
     TGeoVolume *magyoke = new TGeoVolume("magyoke", magyokec, Fe);
@@ -65,10 +65,10 @@ void MyMagnet::ConstructGeometry()
     top->AddNode(magyoke, 1, new TGeoTranslation(0, 0, 0));
 
     // magnet
-    TGeoTubeSeg *magnet1a = new TGeoTubeSeg("magnet1a", 250, 300, 35, 45, 135);
-    TGeoTubeSeg *magnet1b = new TGeoTubeSeg("magnet1b", 250, 300, 35, 45, 135);
-    TGeoTubeSeg *magnet1c = new TGeoTubeSeg("magnet1c", 250, 270, 125, 45, 60);
-    TGeoTubeSeg *magnet1d = new TGeoTubeSeg("magnet1d", 250, 270, 125, 120, 135);
+    new TGeoTubeSeg("magnet1a", 250, 300, 35, 45, 135);
+    new TGeoTubeSeg("magnet1b", 250, 300, 35, 45, 135);
+    new TGeoTubeSeg("magnet1c", 250, 270, 125, 45, 60);
+    new TGeoTubeSeg("magnet1d", 250, 270, 125, 120, 135);
 
     // magnet composite shape matrices
     TGeoTranslation *m1 = new TGeoTranslation(0, 0, 160);

--- a/templates/test_project_root_containers.sh.in
+++ b/templates/test_project_root_containers.sh.in
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -x
+set -x -e
 
 CURRENT_DIR=`pwd`
 SOURCE_DIR=@CMAKE_SOURCE_DIR@
@@ -15,7 +15,17 @@ cd build
 export SIMPATH=@SIMPATH@
 export FAIRROOTPATH=@CMAKE_INSTALL_PREFIX@
 cmake -DCMAKE_CXX_STANDARD=@CMAKE_CXX_STANDARD@ ..
+
+if [ "$1" = "--double-configure" ]
+then
+    echo "*** Calling cmake configure again:"
+    # Check if all the cache variables
+    # are good for a reconfiguration step
+    cmake -DCMAKE_CXX_STANDARD=@CMAKE_CXX_STANDARD@ ..
+fi
+
 make
+
 if [ $? -eq 0 ]; then
     echo 'Test successful.'
 fi

--- a/templates/test_project_stl_containers.sh.in
+++ b/templates/test_project_stl_containers.sh.in
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -x
+set -x -e
 
 CURRENT_DIR=`pwd`
 SOURCE_DIR=@CMAKE_SOURCE_DIR@
@@ -12,10 +12,20 @@ cd project_stl_containers
 ./rename.sh TestProj Tst det
 mkdir build
 cd build
-export SIMPATH=@SIMPATH@
+export CMAKE_PREFIX_PATH="@SIMPATH@${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}"
 export FAIRROOTPATH=@CMAKE_INSTALL_PREFIX@
 cmake -DCMAKE_CXX_STANDARD=@CMAKE_CXX_STANDARD@ ..
+
+if [ "$1" = "--double-configure" ]
+then
+    echo "*** Calling cmake configure again:"
+    # Check if all the cache variables
+    # are good for a reconfiguration step
+    cmake ..
+fi
+
 make
+
 if [ $? -eq 0 ]; then
     echo 'Test successful.'
 fi


### PR DESCRIPTION
A typical "ExperimentRoot" project uses FairRoot by using its find-Module (by adding the right path) and calling find_package(FairRoot).

This setup worked for the first call to CMake (configure step), but reconfiguring (running CMake again) did not work correctly.

Add a test for this (that failed without this fix).

The find module recursively calls find_package(FairRoot CONFIG) to load the new config mode package.
This sets FairRoot_DIR to the directory containing the config mode package. This variable is a cache variable and persists into the next run of CMake.

The old find module used to think, that FairRoot_DIR could be the prefix of the FairRoot installation.

Rewrite:

* Use FAIRROOTPATH and ENV{FAIRROOTPATH} only to extend CMAKE_PREFIX_PATH to search the config mode package
* Use FairRoot_PREFIX from the config mode package to guide further old style detection
* Use FindPackageHandleStandardArgs

fixes: #1203

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
