### PR TITLE
clang-tidy: Check for Virtual Destructor

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,9 +2,12 @@
 HeaderFilterRegex: '.*'
 # disable clang-analyzer-core.UndefinedBinaryOperatorResult
 #   ROOT throws lots of them in their headers
+# enable cppcoreguidelines-virtual-class-destructor
+#   Avoid undefined behaviour
 # enable google-build-using-namespace
 #   "using namespace" imports a changing amount of symbols, avoid it
 Checks: >-
   -clang-analyzer-core.UndefinedBinaryOperatorResult,
+  cppcoreguidelines-virtual-class-destructor,
   modernize-make-unique,
   google-build-using-namespace

--- a/base/source/FairFileSourceBase.h
+++ b/base/source/FairFileSourceBase.h
@@ -21,6 +21,7 @@
 class FairFileSourceBase : public FairSource
 {
   public:
+    ~FairFileSourceBase() override;
     void Reset() override {}
     Source_Type GetSourceType() override { return kFILE; }
     void SetParUnpackers() override {}
@@ -32,7 +33,6 @@ class FairFileSourceBase : public FairSource
   protected:
     FairFileSourceBase()
         : FairSource(){};
-    ~FairFileSourceBase() override;
 
     std::map<TString, std::list<TString>> fCheckInputBranches{};   //!
 

--- a/eventdisplay/FairGetEventTime.h
+++ b/eventdisplay/FairGetEventTime.h
@@ -21,6 +21,11 @@
 class FairGetEventTime : public TObject
 {
   public:
+    FairGetEventTime() = default;
+    ~FairGetEventTime() override = default;
+    FairGetEventTime(const FairGetEventTime&) = delete;
+    FairGetEventTime& operator=(const FairGetEventTime&) = delete;
+
     static FairGetEventTime& Instance()
     {
         static FairGetEventTime instance;
@@ -39,16 +44,10 @@ class FairGetEventTime : public TObject
     std::vector<double> GetTimes() const { return fEventTime; }
 
   private:
-    FairGetEventTime() = default;
-    ~FairGetEventTime() = default;
-    FairGetEventTime(const FairGetEventTime&) = delete;
-    FairGetEventTime& operator=(const FairGetEventTime&) = delete;
-
-  private:
     std::vector<double> fEventTime;
     bool fRunOnce{true};
 
-    ClassDef(FairGetEventTime, 1);
+    ClassDefOverride(FairGetEventTime, 1);
 };
 
 #endif /*PndGetEventTimeTask_H_*/

--- a/fairtools/FairLogger.h
+++ b/fairtools/FairLogger.h
@@ -117,14 +117,15 @@ class FairLogger
 
     void SetScreenStreamToCerr(bool /* useCerr */) {}
 
+  protected:
+    ~FairLogger() = default;
+
   private:
     static FairLogger* instance;
 
     FairLogger();
     FairLogger(const FairLogger&);
     FairLogger operator=(const FairLogger&);
-
-    ~FairLogger() {}
 
     void Log(fair::Severity level,
              const char* file,

--- a/fairtools/FairMonitor.cxx
+++ b/fairtools/FairMonitor.cxx
@@ -61,7 +61,12 @@ FairMonitor::FairMonitor()
     , fTaskPos()
 {}
 
-FairMonitor::~FairMonitor() {}
+FairMonitor::~FairMonitor()
+{
+    if (instance == this) {
+        instance = nullptr;
+    }
+}
 
 FairMonitor* FairMonitor::GetMonitor()
 {

--- a/fairtools/FairMonitor.h
+++ b/fairtools/FairMonitor.h
@@ -29,6 +29,7 @@ class TTask;
 class FairMonitor : public TNamed
 {
   public:
+    ~FairMonitor() override;
     static FairMonitor* GetMonitor();
 
     void EnableMonitor(Bool_t tempBool = kTRUE, TString fileName = "")
@@ -63,8 +64,8 @@ class FairMonitor : public TNamed
 
     void SetCurrentTask(TTask* tTask) { fCurrentTask = tTask; }
 
-    virtual void Print(Option_t* option = "") const;
-    virtual void Draw(Option_t* option = "");
+    void Print(Option_t* option = "") const override;
+    void Draw(Option_t* option = "") override;
 
     void PrintTask(TString specString) const;
     void PrintTask(TTask* tempTask, Int_t taskLevel = 0) const;
@@ -77,7 +78,6 @@ class FairMonitor : public TNamed
   private:
     static FairMonitor* instance;
     FairMonitor();
-    ~FairMonitor();
     FairMonitor(const FairMonitor&);
     FairMonitor& operator=(const FairMonitor&);
 
@@ -113,7 +113,7 @@ class FairMonitor : public TNamed
     void GetTaskMap(TTask* tempTask);
     void AnalyzeObjectMap(TTask* tempTask);
 
-    ClassDef(FairMonitor, 0);
+    ClassDefOverride(FairMonitor, 0);
 };
 
 extern FairMonitor* gMonitor;


### PR DESCRIPTION
classes with virtual methods basically should have a virtual destructor.

C++ Core Guidelines
C.35: A base class destructor should be either public and virtual, or protected and non-virtual

https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-dtor-virtual

Check: cppcoreguidelines-virtual-class-destructor

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
