### PR TITLE
Use unique_ptr based SetSink Around (2/2)

### DIFF
--- a/examples/MQ/pixelDetector/macros/run_digi.C
+++ b/examples/MQ/pixelDetector/macros/run_digi.C
@@ -1,10 +1,15 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
+
+#include <TStopwatch.h>
+#include <TString.h>
+#include <memory>
+
 void run_digi(TString mcEngine = "TGeant3", Int_t fileId = 0)
 {
     // Verbosity level (0=quiet, 1=event level, 2=track level, 3=debug)
@@ -40,7 +45,7 @@ void run_digi(TString mcEngine = "TGeant3", Int_t fileId = 0)
     FairRunAna* fRun = new FairRunAna();
     FairFileSource* fFileSource = new FairFileSource(inFile);
     fRun->SetSource(fFileSource);
-    fRun->SetSink(new FairRootFileSink(outFile));
+    fRun->SetSink(std::make_unique<FairRootFileSink>(outFile));
 
     FairRuntimeDb* rtdb = fRun->GetRuntimeDb();
     FairParRootFileIo* parInput1 = new FairParRootFileIo();

--- a/examples/MQ/pixelDetector/macros/run_digiToBin.C
+++ b/examples/MQ/pixelDetector/macros/run_digiToBin.C
@@ -1,10 +1,15 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
+
+#include <TStopwatch.h>
+#include <TString.h>
+#include <memory>
+
 void run_digiToBin(Int_t divideLevel = 1, TString mcEngine = "TGeant3")
 {
     if (divideLevel < 0 || divideLevel > 2) {
@@ -39,7 +44,7 @@ void run_digiToBin(Int_t divideLevel = 1, TString mcEngine = "TGeant3")
     FairRunAna* fRun = new FairRunAna();
     FairFileSource* fFileSource = new FairFileSource(inFile);
     fRun->SetSource(fFileSource);
-    fRun->SetSink(new FairRootFileSink(outFile));
+    fRun->SetSink(std::make_unique<FairRootFileSink>(outFile));
 
     FairRuntimeDb* rtdb = fRun->GetRuntimeDb();
     FairParRootFileIo* parInput1 = new FairParRootFileIo();

--- a/examples/MQ/pixelDetector/macros/run_sim.C
+++ b/examples/MQ/pixelDetector/macros/run_sim.C
@@ -62,7 +62,7 @@ void run_sim(Int_t nEvents = 10, TString mcEngine = "TGeant3", Int_t fileId = 0,
     auto run = std::make_unique<FairRunSim>();
     run->SetName(mcEngine);   // Transport engine
     run->SetIsMT(isMT);       // Multi-threading mode (Geant4 only)
-    run->SetSink(new FairRootFileSink(outFile));
+    run->SetSink(std::make_unique<FairRootFileSink>(outFile));
     FairRuntimeDb* rtdb = run->GetRuntimeDb();
     // ------------------------------------------------------------------------
 

--- a/examples/MQ/pixelDetector/run/runMQSim.cxx
+++ b/examples/MQ/pixelDetector/run/runMQSim.cxx
@@ -67,9 +67,9 @@ std::unique_ptr<fair::mq::Device> fairGetDevice(const fair::mq::ProgOptions& con
 
     auto run = std::make_unique<FairMQSimDevice>();
 
-    FairOnlineSink* sink = new FairOnlineSink();
+    auto sink = std::make_unique<FairOnlineSink>();
     sink->SetMQRunDevice(run.get());
-    run->SetSink(sink);
+    run->SetSink(std::move(sink));
 
     run->SetParamUpdateChannelName(config.GetValue<std::string>("param-channel-name"));
 

--- a/examples/MQ/pixelDetector/src/devices/FairMQSimDevice.cxx
+++ b/examples/MQ/pixelDetector/src/devices/FairMQSimDevice.cxx
@@ -42,14 +42,13 @@ FairMQSimDevice::FairMQSimDevice()
     , fTaskArray(nullptr)
     , fFirstParameter(nullptr)
     , fSecondParameter(nullptr)
-    , fSink(nullptr)
 {}
 
 void FairMQSimDevice::InitTask()
 {
     fRunSim = new FairRunSim();
 
-    fRunSim->SetSink(fSink);
+    fRunSim->SetSink(std::move(fSink));
 
     if (fFirstParameter || fSecondParameter) {
         FairRuntimeDb* rtdb = fRunSim->GetRuntimeDb();

--- a/examples/MQ/pixelDetector/src/devices/FairMQSimDevice.h
+++ b/examples/MQ/pixelDetector/src/devices/FairMQSimDevice.h
@@ -17,10 +17,12 @@
 #define FAIRMQSIMDEVICE_H_
 
 #include "FairMQRunDevice.h"
+#include "FairSink.h"
 
 #include <Rtypes.h>
 #include <TString.h>
 #include <cstdint>
+#include <memory>
 #include <string>
 
 class FairRunSim;
@@ -28,7 +30,6 @@ class FairField;
 class FairParIo;
 class FairPrimaryGenerator;
 class TObjArray;
-class FairSink;
 
 class FairMQSimDevice : public FairMQRunDevice
 {
@@ -51,7 +52,7 @@ class FairMQSimDevice : public FairMQRunDevice
     void SetSecondParameter(FairParIo* par) { fSecondParameter = par; }
     void SetUserConfig(const TString& Config) { fUserConfig = Config; }
     void SetUserCuts(const TString& Cuts) { fUserCuts = Cuts; }
-    void SetSink(FairSink* sink) { fSink = sink; }
+    void SetSink(std::unique_ptr<FairSink>&& sink) { fSink = std::move(sink); }
     // ------ ---------- -------- ------
 
     void InitializeRun();
@@ -84,7 +85,7 @@ class FairMQSimDevice : public FairMQRunDevice
     FairParIo* fSecondParameter;   // second input (used if not found in first input)
     TString fUserConfig;           //!                  /** Macro for geant configuration*/
     TString fUserCuts;             //!                  /** Macro for geant cuts*/
-    FairSink* fSink;
+    std::unique_ptr<FairSink> fSink{};
     // ------ ---------- -------- ------
 
     void UpdateParameterServer();

--- a/examples/MQ/pixelSimSplit/run/runMQTrans.cxx
+++ b/examples/MQ/pixelSimSplit/run/runMQTrans.cxx
@@ -65,9 +65,9 @@ std::unique_ptr<fair::mq::Device> fairGetDevice(const fair::mq::ProgOptions& con
 
     //  TString outputfilename = Form("outputfile_%d.root",(int)(getpid()));
     //  FairRootFileSink* sink = new FairRootFileSink(outputfilename);
-    FairOnlineSink* sink = new FairOnlineSink();
+    auto sink = std::make_unique<FairOnlineSink>();
     sink->SetMQRunDevice(run.get());
-    run->SetSink(sink);
+    run->SetSink(std::move(sink));
 
     run->SetParamUpdateChannelName(config.GetValue<std::string>("param-channel-name"));
 

--- a/examples/MQ/pixelSimSplit/src/devices/FairMQTransportDevice.cxx
+++ b/examples/MQ/pixelSimSplit/src/devices/FairMQTransportDevice.cxx
@@ -56,7 +56,6 @@ FairMQTransportDevice::FairMQTransportDevice()
     , fTaskArray(nullptr)
     , fFirstParameter(nullptr)
     , fSecondParameter(nullptr)
-    , fSink(nullptr)
     , fMCSplitEventHeader(nullptr)
 {}
 
@@ -74,7 +73,7 @@ void FairMQTransportDevice::InitTask()
     fRunSim->SetMCEventHeader(fMCSplitEventHeader);
     fRunSim->SetRunId(fRunSim->GetMCEventHeader()->GetRunID());
 
-    fRunSim->SetSink(fSink);
+    fRunSim->SetSink(std::move(fSink));
 
     if (fFirstParameter || fSecondParameter) {
         FairRuntimeDb* rtdb = fRunSim->GetRuntimeDb();

--- a/examples/MQ/pixelSimSplit/src/devices/FairMQTransportDevice.h
+++ b/examples/MQ/pixelSimSplit/src/devices/FairMQTransportDevice.h
@@ -17,10 +17,12 @@
 #define FAIRMQTRANSPORTDEVICE_H_
 
 #include "FairMQRunDevice.h"
+#include "FairSink.h"
 
 #include <Rtypes.h>
 #include <TString.h>
 #include <cstdint>
+#include <memory>
 #include <string>
 
 class FairMCSplitEventHeader;
@@ -28,7 +30,6 @@ class FairRunSim;
 class FairField;
 class FairParIo;
 class TObjArray;
-class FairSink;
 class FairMCApplication;
 class FairGenericStack;
 class TVirtualMC;
@@ -51,7 +52,7 @@ class FairMQTransportDevice : public FairMQRunDevice
     void SetSecondParameter(FairParIo* par) { fSecondParameter = par; };
     void SetUserConfig(const TString& Config) { fUserConfig = Config; }
     void SetUserCuts(const TString& Cuts) { fUserCuts = Cuts; }
-    void SetSink(FairSink* sink) { fSink = sink; }
+    void SetSink(std::unique_ptr<FairSink>&& sink) { fSink = std::move(sink); }
     // ------ ---------- -------- ------
 
     void InitializeRun();
@@ -95,7 +96,7 @@ class FairMQTransportDevice : public FairMQRunDevice
     FairParIo* fSecondParameter;   // second input (used if not found in first input)
     TString fUserConfig;           //!                  /** Macro for geant configuration*/
     TString fUserCuts;             //!                  /** Macro for geant cuts*/
-    FairSink* fSink;
+    std::unique_ptr<FairSink> fSink{};
     // ------ ---------- -------- ------
 
     FairMCSplitEventHeader* fMCSplitEventHeader;

--- a/examples/advanced/Tutorial3/macro/run_digi.C
+++ b/examples/advanced/Tutorial3/macro/run_digi.C
@@ -1,10 +1,15 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
+
+#include <TStopwatch.h>
+#include <TString.h>
+#include <memory>
+
 void run_digi(TString mcEngine = "TGeant3")
 {
     FairLogger* logger = FairLogger::GetLogger();
@@ -37,7 +42,7 @@ void run_digi(TString mcEngine = "TGeant3")
     FairRunAna* fRun = new FairRunAna();
     FairFileSource* fFileSource = new FairFileSource(inFile);
     fRun->SetSource(fFileSource);
-    fRun->SetSink(new FairRootFileSink(outFile));
+    fRun->SetSink(std::make_unique<FairRootFileSink>(outFile));
     fRun->SetUseFairLinks(kTRUE);
     FairLinkManager::Instance()->AddIncludeType(0);
     //  FairLinkManager::Instance()->AddIncludeType(1);

--- a/examples/advanced/Tutorial3/macro/run_digi_reco_proof.C
+++ b/examples/advanced/Tutorial3/macro/run_digi_reco_proof.C
@@ -1,3 +1,9 @@
+#include <TStopwatch.h>
+#include <TString.h>
+#include <TSystem.h>
+#include <iostream>
+#include <memory>
+
 void run_digi_reco_proof(Int_t nofFiles, TString mcEngine = "TGeant3")
 {
     FairLogger* logger = FairLogger::GetLogger();
@@ -28,7 +34,7 @@ void run_digi_reco_proof(Int_t nofFiles, TString mcEngine = "TGeant3")
         fFileSource->AddFile(Form("file://%s/data/testrun_%s_f%d.root", workDir.Data(), mcEngine.Data(), ifile));
     fRun->SetSource(fFileSource);
 
-    fRun->SetSink(new FairRootFileSink(outFile));
+    fRun->SetSink(std::make_unique<FairRootFileSink>(outFile));
 
     fRun->SetProofOutputStatus("merge");
 

--- a/examples/advanced/Tutorial3/macro/run_digi_timebased.C
+++ b/examples/advanced/Tutorial3/macro/run_digi_timebased.C
@@ -1,10 +1,15 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
+
+#include <TStopwatch.h>
+#include <TString.h>
+#include <memory>
+
 void run_digi_timebased(TString mcEngine = "TGeant3")
 {
     FairLogger* logger = FairLogger::GetLogger();
@@ -38,7 +43,7 @@ void run_digi_timebased(TString mcEngine = "TGeant3")
     FairFileSource* fFileSource = new FairFileSource(inFile);
     fRun->SetSource(fFileSource);
 
-    fRun->SetSink(new FairRootFileSink(outFile));
+    fRun->SetSink(std::make_unique<FairRootFileSink>(outFile));
     fRun->SetUseFairLinks(kTRUE);
 
     fFileSource->SetEventMeanTime(50);

--- a/examples/advanced/Tutorial3/macro/run_reco.C
+++ b/examples/advanced/Tutorial3/macro/run_reco.C
@@ -1,13 +1,17 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
+
+#include <TStopwatch.h>
+#include <TString.h>
+#include <memory>
+
 void run_reco(TString mcEngine = "TGeant3")
 {
-
     FairLogger* logger = FairLogger::GetLogger();
     logger->SetLogFileName("MyLog.log");
     logger->SetLogToScreen(kTRUE);
@@ -38,7 +42,7 @@ void run_reco(TString mcEngine = "TGeant3")
     FairRunAna* fRun = new FairRunAna();
     FairFileSource* fFileSource = new FairFileSource(inFile);
     fRun->SetSource(fFileSource);
-    fRun->SetSink(new FairRootFileSink(outFile));
+    fRun->SetSink(std::make_unique<FairRootFileSink>(outFile));
     fRun->SetUseFairLinks(kTRUE);
     FairLinkManager::Instance()->AddIncludeType(0);
     //  FairLinkManager::Instance()->AddIncludeType(1);

--- a/examples/advanced/Tutorial3/macro/run_reco_timebased.C
+++ b/examples/advanced/Tutorial3/macro/run_reco_timebased.C
@@ -1,10 +1,15 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE" *
  ********************************************************************************/
+
+#include <TStopwatch.h>
+#include <TString.h>
+#include <memory>
+
 void run_reco_timebased(TString mcEngine = "TGeant3")
 {
     FairLogger *logger = FairLogger::GetLogger();
@@ -37,7 +42,7 @@ void run_reco_timebased(TString mcEngine = "TGeant3")
 
     FairRunAna *fRun = new FairRunAna();
     FairFileSource *fFileSource = new FairFileSource(inFile);
-    fRun->SetSink(new FairRootFileSink(outFile));
+    fRun->SetSink(std::make_unique<FairRootFileSink>(outFile));
     fRun->RunWithTimeStamps();
     fRun->SetUseFairLinks(kTRUE);
 

--- a/examples/advanced/Tutorial3/macro/run_sim.C
+++ b/examples/advanced/Tutorial3/macro/run_sim.C
@@ -1,10 +1,16 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
+
+#include <TStopwatch.h>
+#include <TString.h>
+#include <TSystem.h>
+#include <memory>
+
 void run_sim(Int_t nEvents = 100, TString mcEngine = "TGeant3")
 {
     TStopwatch timer;
@@ -39,7 +45,7 @@ void run_sim(Int_t nEvents = 100, TString mcEngine = "TGeant3")
     TString parFile = "data/testparams_";
     parFile = parFile + mcEngine + ".root";
 
-    fRun->SetSink(new FairRootFileSink(outFile));
+    fRun->SetSink(std::make_unique<FairRootFileSink>(outFile));
     fRun->SetGenerateRunInfo(kTRUE);   // Create FairRunInfo file
 
     // -----   Magnetic field   -------------------------------------------

--- a/examples/advanced/propagator/macros/runMC.C
+++ b/examples/advanced/propagator/macros/runMC.C
@@ -1,10 +1,17 @@
 /********************************************************************************
- *    Copyright (C) 2019 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2019-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
+
+#include <TRandom.h>
+#include <TStopwatch.h>
+#include <TString.h>
+#include <TSystem.h>
+#include <memory>
+
 int runMC(Int_t nEvents = 1000, TString mcEngine = "TGeant4", Bool_t isMT = false)
 {
     UInt_t randomSeed = 123456;
@@ -52,7 +59,7 @@ int runMC(Int_t nEvents = 1000, TString mcEngine = "TGeant4", Bool_t isMT = fals
     run->SetName(mcEngine);   // Transport engine
     //  run->SetSimulationConfig(new FairVMCConfig());
     run->SetIsMT(isMT);                            // Multi-threading mode (Geant4 only)
-    run->SetSink(new FairRootFileSink(outFile));   // Output file
+    run->SetSink(std::make_unique<FairRootFileSink>(outFile));
     FairRuntimeDb* rtdb = run->GetRuntimeDb();
     // ------------------------------------------------------------------------
 

--- a/examples/advanced/propagator/macros/runProp.C
+++ b/examples/advanced/propagator/macros/runProp.C
@@ -1,10 +1,21 @@
 /********************************************************************************
- *    Copyright (C) 2019 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2019-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
+
+#include <TStopwatch.h>
+#include <TString.h>
+#include <TSystem.h>
+#include <iostream>
+#include <memory>
+#include <string>
+
+using std::cout;
+using std::endl;
+
 int runProp(std::string propName = "rk")
 {
     if (propName != "geane" && propName != "rk") {
@@ -38,7 +49,7 @@ int runProp(std::string propName = "rk")
     // -----   Reconstruction run   -------------------------------------------
     FairRunAna* fRun = new FairRunAna();
     fRun->SetSource(new FairFileSource(inFile));
-    fRun->SetSink(new FairRootFileSink(outFile));
+    fRun->SetSink(std::make_unique<FairRootFileSink>(outFile));
 
     FairRuntimeDb* rtdb = fRun->GetRuntimeDb();
     FairParRootFileIo* parInput1 = new FairParRootFileIo();


### PR DESCRIPTION
Now that FairRun::SetSink supports unique_ptr, use it around to promote good style.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
