### PR TITLE
docs: Turn Examples into Page Hierarchy

### DIFF
--- a/base/field/FairField.h
+++ b/base/field/FairField.h
@@ -16,7 +16,7 @@
  ** @author M.Al-Turany <m.al/turany@gsi.de>
  ** @author V.Friese <v.friese@gsi.de>
  ** @since 06.01.2004
- ** @version1.0
+ ** @version 1.0
  **
  ** Abstract base class for magnetic fields in FAIR
  ** Concrete field should implement the pure virtual methods

--- a/base/steer/FairTask.h
+++ b/base/steer/FairTask.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -35,6 +35,9 @@ enum InitStatus
     kFATAL
 };
 
+/**
+ * \ingroup base_steer
+ */
 class FairTask : public TTask
 {
   public:
@@ -111,12 +114,12 @@ class FairTask : public TTask
     Bool_t fStreamProcessing;
 
     /** Intialisation at begin of run. To be implemented in the derived class.
-     *@value  Success   If not kSUCCESS, task will be set inactive.
+     * \retval  kSUCCESS   If not kSUCCESS, task will be set inactive.
      **/
     virtual InitStatus Init() { return kSUCCESS; };
 
     /** Reinitialisation. To be implemented in the derived class.
-     *@value  Success   If not kSUCCESS, task will be set inactive.
+     * \retval  kSUCCESS   If not kSUCCESS, task will be set inactive.
      **/
     virtual InitStatus ReInit() { return kSUCCESS; };
 

--- a/examples/MQ/Lmd/README.md
+++ b/examples/MQ/Lmd/README.md
@@ -1,4 +1,4 @@
-# MQ tutorial : Lmd Sampler
+# MQ tutorial : Lmd Sampler {#ex_mq_lmd}
 
 ## Introduction
 In this tutorial a sampler read an lmd file (the one in /examples/advanced/MbsTutorial) and send the binary data to an unpacker device. The unpacker device unpack the binary data and serialize the data (using TMessage data format) and send the data to a FileSink device.

--- a/examples/MQ/README.md
+++ b/examples/MQ/README.md
@@ -1,31 +1,37 @@
-# FairMQ Examples
+# FairMQ Examples {#ex_mq}
 
 Set of FairMQ examples.
 
 
-## Lmd: (GSI List Mode Data format) Lmd Sampler
+- Lmd: (GSI List Mode Data format) Lmd Sampler
+  <br/>
+  \subpage ex_mq_lmd
 
-In this tutorial a sampler read an lmd file (the one in /examples/advanced/tutorial8) and send the binary data to an unpacker device.
-
-
-## parameters: Communicating with ParameterMQServer
-
-This example shows how to communicate with the ParameterMQServer, that retrieves parameters from FairRuntimeDb.
+  In this tutorial a sampler read an lmd file (the one in /examples/advanced/tutorial8) and send the binary data to an unpacker device.
 
 
-## pixelDetector: Transport FairRoot data between devices, analyze the data using existing instances of FairTask
+- \subpage ex_mq_parameters
 
-This example shows how to send a multipart message from one device to the other. (two parts message parts - header and body).
+  This example shows how to communicate with the ParameterMQServer, that retrieves parameters from FairRuntimeDb.
 
 
-## pixelAlternative: Transport FairRoot data between devices, implement special devices to analyze data
+- pixelDetector: Transport FairRoot data between devices, analyze the data using existing instances of FairTask
+  <br/>
+  \subpage ex_mq_pixel_simsplit
+  <br/>
+  \subpage ex_mq_pixel_detector
 
-This example shows how to send a multipart message from one device to the other. (two parts message parts - header and body).
+  This example shows how to send a multipart message from one device to the other. (two parts message parts - header and body).
 
-## histogramServer
 
-TODO: fill me.
+- pixelAlternative: Transport FairRoot data between devices, implement special devices to analyze data
+  <br/>
+  \subpage ex_mq_pixel_alternative
 
-## serialization
+  This example shows how to send a multipart message from one device to the other. (two parts message parts - header and body).
 
-TODO: fill me.
+- histogramServer
+
+  TODO: fill me.
+
+- \subpage ex_mq_serialization

--- a/examples/MQ/parameters/README.md
+++ b/examples/MQ/parameters/README.md
@@ -1,4 +1,4 @@
-Example 7: Communicating with ParameterMQServer
+Example 7: Communicating with ParameterMQServer {#ex_mq_parameters}
 ===============
 
 This example shows how to communicate with the ParameterMQServer, that retrieves parameters from FairRuntimeDb.

--- a/examples/MQ/pixelAlternative/README.md
+++ b/examples/MQ/pixelAlternative/README.md
@@ -1,4 +1,4 @@
-# Move from root to FairMQ continued
+# Move from root to FairMQ continued {#ex_mq_pixel_alternative}
 
 This example bases on examples/MQ/pixelDetector.
 

--- a/examples/MQ/pixelDetector/README.md
+++ b/examples/MQ/pixelDetector/README.md
@@ -1,4 +1,4 @@
-# Move from root to FairMQ
+# Move from root to FairMQ {#ex_mq_pixel_detector}
 
 This example uses standard FairRoot analysis chain:
 

--- a/examples/MQ/pixelSimSplit/README.md
+++ b/examples/MQ/pixelSimSplit/README.md
@@ -1,4 +1,4 @@
-# MC simulations in FairMQ
+# MC simulations in FairMQ {#ex_mq_pixel_simsplit}
 
 The example shows the possibility to separate the generation of the MC events from their transport in Geant engines.
 

--- a/examples/MQ/serialization/README.md
+++ b/examples/MQ/serialization/README.md
@@ -1,4 +1,4 @@
-# Serialization Examples
+# Serialization Examples {#ex_mq_serialization}
 
 ## Quick start
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,13 +1,17 @@
-# Examples
+# Examples / Tutorials {#examples}
 
-## MQ
+- \subpage ex_mq
 
-Set of simple FairMQ examples.
+  Set of simple FairMQ examples.
 
-## Simulation
+- \subpage ex_simulation
 
-Set of simulation examples
+  Set of simulation examples
 
-## Advanced
+- \subpage ex_advanced
 
-Reconstruction examples, use of parameters, detector simulation and digitization event wise and timebased simulation, etc.
+  Reconstruction examples, use of parameters, detector simulation and digitization event wise and timebased simulation, etc.
+
+- \subpage ex_common
+
+  Common tools for all examples / tutorials

--- a/examples/advanced/MbsTutorial/README.md
+++ b/examples/advanced/MbsTutorial/README.md
@@ -1,4 +1,4 @@
-# MBS Tutorial
+# MBS Tutorial {#ex_mbstut}
 
 
 ## Quick start

--- a/examples/advanced/README.md
+++ b/examples/advanced/README.md
@@ -1,12 +1,12 @@
-# Advanced examples
+# Advanced Examples {#ex_advanced}
 
-## Tutorial3
+- \subpage ex_tutorial3
 
-Detector simulation and digitization event wise and timebased simulation.
-Use of FairMQ
+  Detector simulation and digitization event wise and timebased simulation.
+  Use of FairMQ
 
 
-## MbsTutorial
+- \subpage ex_mbstut
 
-Shows how to use MBS data unpacking with FairRunOnline steering class. FairTut8Unpack implement parsing of MBS subevents and
-creates output in form of array of FairTut8RawItem data objects.
+  Shows how to use MBS data unpacking with FairRunOnline steering class. FairTut8Unpack implement parsing of MBS subevents and
+  creates output in form of array of FairTut8RawItem data objects.

--- a/examples/advanced/Tutorial3/MQ/README.md
+++ b/examples/advanced/Tutorial3/MQ/README.md
@@ -1,3 +1,5 @@
-# Tutorial 3 - Message Queue part
+# Tutorial 3 - Message Queue part {#ex_tutorial3_mq}
 
 This part of Tutorial3 demonstrates how to transport data of Tutorial3 (FairTestDetector) via FairMQ.
+
+- \subpage ex_tutorial3_mq_dataformat

--- a/examples/advanced/Tutorial3/MQ/run/README.md
+++ b/examples/advanced/Tutorial3/MQ/run/README.md
@@ -1,4 +1,4 @@
-## Data Format
+# Data Format {#ex_tutorial3_mq_dataformat}
 
 Each device in this example implements several serialization approaches:
 

--- a/examples/advanced/Tutorial3/README.md
+++ b/examples/advanced/Tutorial3/README.md
@@ -1,11 +1,12 @@
-## Tutorial3
+# Tutorial3 {#ex_tutorial3}
 
 This example demonstrate
 
 * Detector simulation
 * Event by event digitization
 * Time based digitization
-* Message Queue based reconstruction: The Message Queue based reconstruction demonstrates the usage of FairMQ.
+* \subpage ex_tutorial3_mq
+Message Queue based reconstruction: The Message Queue based reconstruction demonstrates the usage of FairMQ.
 Any number of "sampler" processes (FairMQSampler, FairMQSamplerTask, TestDetectorDigiLoader) send the data generated in the digitization step to a number of "processor" processes which do the reconstruction with the data (FairMQProcessor, FairMQProcessorTask, FairTestDetectorMQRecoTask). After the reconstruction task, the processes send the output data to a number of "sink" processes, which write the data to disk (FairTestDetectorFileSink).
 All the communication between these processes is done via FairMQ and can be configured to run over network (tcp) or on a local machine with inter-process communication (ipc). Currently, the number of processes and their parameters are configured with bash scripts/command line parameters. The scripts are located in the MQ/run directory, together with README.md for more details on how to configure them.
 Event display

--- a/examples/advanced/Tutorial3/simulation/FairConstField.h
+++ b/examples/advanced/Tutorial3/simulation/FairConstField.h
@@ -8,7 +8,7 @@
 /** FairConstField.h
  ** @author M.Al-Turany <m.al/turany@gsi.de>
  ** @since 30.01.2007
- ** @version1.0
+ ** @version 1.0
  ** A constant  magnetic field
  **/
 

--- a/examples/common/README.md
+++ b/examples/common/README.md
@@ -1,4 +1,4 @@
-# common
+# common {#ex_common}
 
 This directory contains common stuff needed by different examples for simulation and reconstruction.
 

--- a/examples/simulation/README.md
+++ b/examples/simulation/README.md
@@ -1,16 +1,16 @@
-# Examples
+# Simulation Examples {#ex_simulation}
 
-## Tutorial1
+- \subpage ex_sim_tutorial1
 
-Implement a simple detector using the old ASCII interface to describe the geometry.
+  Implement a simple detector using the old ASCII interface to describe the geometry.
 
-## Tutorial2
+- \subpage ex_sim_tutorial2
 
-Reading and writing parameters
+  Reading and writing parameters
 
-## Tutorial4
+- \subpage ex_sim_tutorial4
 
-ROOT geometry as input for detector description
+  ROOT geometry as input for detector description
 
 ## rutherford
 

--- a/examples/simulation/Tutorial1/README.md
+++ b/examples/simulation/Tutorial1/README.md
@@ -1,4 +1,5 @@
-## Tutorial1:
+# Tutorial1 {#ex_sim_tutorial1}
+
 How to implement a simple detector using the old ASCII interface to describe the geometry (see Detector Geometry and Media for more details about this geometry interface)
 See also Adding new detector for a detailed description of the detector class implementation, MC point class and the CMakeLists.txt
 

--- a/examples/simulation/Tutorial2/README.md
+++ b/examples/simulation/Tutorial2/README.md
@@ -1,4 +1,4 @@
-## Tutorial2
+# Tutorial2 {#ex_sim_tutorial2}
 
 This example show you how to:
 

--- a/examples/simulation/Tutorial4/README.md
+++ b/examples/simulation/Tutorial4/README.md
@@ -1,4 +1,4 @@
-## Tutorial4
+# Tutorial4 {#ex_sim_tutorial4}
 
 This example demonstrate:
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,4 +1,4 @@
-templates
+Templates {#templates}
 ========
 
 The starting points for implementation of different FairRoot modules.

--- a/templates/project_root_containers/field/MyConstField.h
+++ b/templates/project_root_containers/field/MyConstField.h
@@ -14,7 +14,7 @@
 /** MyConstField.h
  ** @author M.Al-Turany <m.al/turany@gsi.de>
  ** @since 25.03.2014
- ** @version1.0
+ ** @version 1.0
  **
  ** A constant (homogeneous) magnetic field
  **/

--- a/templates/project_stl_containers/field/MyConstField.h
+++ b/templates/project_stl_containers/field/MyConstField.h
@@ -14,7 +14,7 @@
 /** MyConstField.h
  ** @author M.Al-Turany <m.al/turany@gsi.de>
  ** @since 25.03.2014
- ** @version1.0
+ ** @version 1.0
  **
  ** A constant (homogeneous) magnetic field
  **/


### PR DESCRIPTION
Doxygen has a concept of "pages". These are somewhat independent of the usual C++ stuff. Markdown files are converted to "pages".

Pages can have subpages and form a hierarchy that way. This is even shown in the left sidebar.

So turn the whole `examples/` into a proper hierarchy.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
