### PR TITLE
Change EveDisplay check for tracks to fatal

### DIFF
--- a/eventdisplay/tracks/FairEveGeoTracks.cxx
+++ b/eventdisplay/tracks/FairEveGeoTracks.cxx
@@ -48,9 +48,11 @@ FairEveGeoTracks::FairEveGeoTracks()
 InitStatus FairEveGeoTracks::Init()
 {
     FairRootManager *mngr = FairRootManager::Instance();
-    fContainer = (TClonesArray *)mngr->GetObject("GeoTracks");
-    if (fContainer == nullptr)
-        return kFATAL;
+    fContainer = dynamic_cast<TClonesArray *>(mngr->GetObject("GeoTracks"));
+    if (!fContainer) {
+        LOG(warning) << "Geo tracks not found ! FairGeoTracksDraw will be deactivated.";
+        return kERROR;
+    }
     fBranch = mngr->GetInTree()->GetBranch("GeoTracks");
     FairGetEventTime::Instance().Init();
     return FairEveTracks::Init();
@@ -99,8 +101,8 @@ void FairEveGeoTracks::DrawAnimatedTrack(TGeoTrack *tr, double t0)
     FairEveTrack *track = new FairEveTrack(p, p->GetPdgCode(), trList->GetPropagator());
     track->SetElementTitle(Form("p={%4.3f,%4.3f,%4.3f}", p->Px(), p->Py(), p->Pz()));
     track->SetMainColor(color);
-    Double_t x, y, z, t;       // currentPoint
-    Double_t xp, yp, zp, tp;   // previousPoint
+    Double_t x, y, z, t;                       // currentPoint
+    Double_t xp = 0, yp = 0, zp = 0, tp = 0;   // previousPoint
     bool firstPoint = true;
     bool previousPoint = false;
     for (int i = 0; i < tr->GetNpoints(); i++) {

--- a/examples/common/eventdisplay/FairEveMCTracks.cxx
+++ b/examples/common/eventdisplay/FairEveMCTracks.cxx
@@ -148,9 +148,17 @@ void FairEveMCTracks::Repaint()
 InitStatus FairEveMCTracks::Init()
 {
     FairRootManager *mngr = FairRootManager::Instance();
-    fContainer = (TClonesArray *)mngr->GetObject("MCTrack");
-    if (fContainer == nullptr)
-        return kFATAL;
+    fContainer = dynamic_cast<TClonesArray *>(mngr->GetObject("MCTrack"));
+    if (!fContainer) {
+        LOG(warning) << "MCTrack branch not found ! FairMCTrackDraw will be deactivated.";
+        return kERROR;
+    }
+    TClass *classTrack = fContainer->GetClass();
+    if (classTrack && !classTrack->InheritsFrom("FairMCTrack")) {
+        LOG(warning)
+            << "MCTrack branch found but does not contain FairMCTrack objects! FairMCTrackDraw will be deactivated.";
+        return kERROR;
+    }
     FairRunAna *ana = FairRunAna::Instance();
     FairField *field = ana->GetField();
     if (field == nullptr) {


### PR DESCRIPTION
Describe your proposal.
1. When FairGeoTracksDraw/FairMCTrackDraw does not find data, it returns kFATAL - which closes the event display. I propose to change it into the kERROR - thanks to this rest of the event display tasks should still work.
2. Another change is using TClass to check if MCTrack branch contains FairMCTrack-based class - if not - then deactivate the task. This prevents the situation when branch "MCTrack" is present but contains a different class (which leads to unexpected behavior).




Mention any issue this PR is resolves or is related to.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [ ] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
