### PR TITLE
fix: Do not Point to Destructed Objects

### DIFF
--- a/base/field/FairFieldFactory.cxx
+++ b/base/field/FairFieldFactory.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -12,7 +12,7 @@
 
 #include "FairFieldFactory.h"
 
-FairFieldFactory* FairFieldFactory::fgRinstance = 0;
+FairFieldFactory* FairFieldFactory::fgRinstance = nullptr;
 
 FairFieldFactory::FairFieldFactory()
     : fCreator(0)
@@ -20,7 +20,13 @@ FairFieldFactory::FairFieldFactory()
     fgRinstance = this;
 }
 
-FairFieldFactory::~FairFieldFactory() {}
+FairFieldFactory::~FairFieldFactory()
+{
+    if (fgRinstance == this) {
+        // Do not point to a destructed object!
+        fgRinstance = nullptr;
+    }
+}
 
 FairFieldFactory* FairFieldFactory::Instance() { return fgRinstance; }
 

--- a/base/steer/FairRun.cxx
+++ b/base/steer/FairRun.cxx
@@ -32,7 +32,7 @@
 #include <TROOT.h>     // fot gROOT
 #include <cassert>     // for... well, assert
 
-TMCThreadLocal FairRun* FairRun::fRunInstance = 0;
+TMCThreadLocal FairRun* FairRun::fRunInstance = nullptr;
 
 FairRun* FairRun::Instance() { return fRunInstance; }
 
@@ -98,6 +98,10 @@ FairRun::~FairRun()
     // but this should be independent
     delete fRtdb;   // who is responsible for the RuntimeDataBase
     delete fEvtHeader;
+    if (fRunInstance == this) {
+        // Do not point to a destructed object!
+        fRunInstance = nullptr;
+    }
     LOG(debug) << "Leave Destructor of FairRun";
 }
 

--- a/base/steer/FairRunAna.cxx
+++ b/base/steer/FairRunAna.cxx
@@ -57,7 +57,7 @@ void FRA_handler_ctrlc(int)
 //_____________________________________________________________________________
 
 //_____________________________________________________________________________
-FairRunAna* FairRunAna::fgRinstance = 0;
+FairRunAna* FairRunAna::fgRinstance = nullptr;
 //_____________________________________________________________________________
 FairRunAna* FairRunAna::Instance() { return fgRinstance; }
 //_____________________________________________________________________________
@@ -80,9 +80,7 @@ FairRunAna::FairRunAna()
     , fFileSource(0)
     , fMixedSource(0)
     , fStoreEventHeader(kTRUE)
-
 {
-
     fgRinstance = this;
     fAna = kTRUE;
 }
@@ -99,6 +97,10 @@ FairRunAna::~FairRunAna()
             gGeoManager->GetListOfShapes()->Delete();
         }
         delete gGeoManager;
+    }
+    if (fgRinstance == this) {
+        // Do not point to a destructed object!
+        fgRinstance = nullptr;
     }
 }
 

--- a/base/steer/FairRunAnaProof.cxx
+++ b/base/steer/FairRunAnaProof.cxx
@@ -30,7 +30,7 @@
 #include <TProof.h>
 #include <TROOT.h>
 
-FairRunAnaProof* FairRunAnaProof::fRAPInstance = 0;
+FairRunAnaProof* FairRunAnaProof::fRAPInstance = nullptr;
 
 FairRunAnaProof* FairRunAnaProof::Instance() { return fRAPInstance; }
 
@@ -59,7 +59,13 @@ FairRunAnaProof::FairRunAnaProof(const char* proofName)
     fAna = kTRUE;
 }
 
-FairRunAnaProof::~FairRunAnaProof() {}
+FairRunAnaProof::~FairRunAnaProof()
+{
+    if (fRAPInstance == this) {
+        // Do not point to a destructed object!
+        fRAPInstance = nullptr;
+    }
+}
 
 void FairRunAnaProof::Init()
 {

--- a/base/steer/FairRunOnline.cxx
+++ b/base/steer/FairRunOnline.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -41,7 +41,7 @@
 using std::cout;
 using std::endl;
 
-FairRunOnline* FairRunOnline::fgRinstance = 0;
+FairRunOnline* FairRunOnline::fgRinstance = nullptr;
 
 FairRunOnline* FairRunOnline::Instance() { return fgRinstance; }
 
@@ -88,6 +88,10 @@ FairRunOnline::~FairRunOnline()
         delete gGeoManager;
     }
     delete fServer;
+    if (fgRinstance == this) {
+        // Do not point to a destructed object!
+        fgRinstance = nullptr;
+    }
 }
 
 Bool_t gIsInterrupted;

--- a/base/steer/FairRunSim.cxx
+++ b/base/steer/FairRunSim.cxx
@@ -109,6 +109,10 @@ FairRunSim::~FairRunSim()
     // Not owner of the field
     delete fGen;
     delete fMCEvHead;
+    if (fginstance == this) {
+        // Do not point to a destructed object!
+        fginstance = nullptr;
+    }
 }
 
 FairRunSim* FairRunSim::Instance() { return fginstance; }
@@ -363,4 +367,4 @@ FairMCEventHeader* FairRunSim::GetMCEventHeader()
     return fMCEvHead;
 }
 
-TMCThreadLocal FairRunSim* FairRunSim::fginstance = 0;
+TMCThreadLocal FairRunSim* FairRunSim::fginstance = nullptr;

--- a/eventdisplay/FairEventManager.cxx
+++ b/eventdisplay/FairEventManager.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -41,7 +41,7 @@
 
 ClassImp(FairEventManager);
 
-FairEventManager *FairEventManager::fgRinstance = 0;
+FairEventManager *FairEventManager::fgRinstance = nullptr;
 
 FairEventManager *FairEventManager::Instance() { return fgRinstance; }
 
@@ -224,7 +224,13 @@ void FairEventManager::Init(Int_t visopt, Int_t vislvl, Int_t maxvisnds)
 
 void FairEventManager::UpdateEditor() {}
 
-FairEventManager::~FairEventManager() {}
+FairEventManager::~FairEventManager()
+{
+    if (fgRinstance == this) {
+        // Do not point to a destructed object!
+        fgRinstance = nullptr;
+    }
+}
 
 void FairEventManager::Open() {}
 

--- a/geobase/FairGeoLoader.cxx
+++ b/geobase/FairGeoLoader.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -25,7 +25,7 @@
 using std::cout;
 using std::endl;
 
-FairGeoLoader* FairGeoLoader::fgInstance = 0;
+FairGeoLoader* FairGeoLoader::fgInstance = nullptr;
 
 FairGeoLoader* FairGeoLoader::Instance() { return fgInstance; }
 
@@ -62,6 +62,13 @@ FairGeoLoader::FairGeoLoader(const char* Name, const char* title)
     fInterface->setGeomBuilder(fGeoBuilder);
 }
 
-FairGeoLoader::~FairGeoLoader() { delete fInterface; }
+FairGeoLoader::~FairGeoLoader()
+{
+    delete fInterface;
+    if (fgInstance == this) {
+        // Do not point to a destructed object!
+        fgInstance = nullptr;
+    }
+}
 
 ClassImp(FairGeoLoader);


### PR DESCRIPTION
The singleton like pattern in FairRoot has globals pointing to an instance that was created by `new`.

If those instances get destructed (for example by `delete`) then the global variable is now invalid.

So reset it to nullptr in the destructor.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
