### PR TITLE
fix: Pass `unique_ptr` by Value

### DIFF
--- a/base/steer/FairRun.cxx
+++ b/base/steer/FairRun.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -171,7 +171,7 @@ Bool_t FairRun::GetWriteRunInfoFile()
     return fGenerateRunInfo;
 }
 
-void FairRun::SetSink(std::unique_ptr<FairSink>&& newsink)
+void FairRun::SetSink(std::unique_ptr<FairSink> newsink)
 {
     fSink = std::move(newsink);
     fRootManager->SetSink(fSink.get());

--- a/base/steer/FairRun.h
+++ b/base/steer/FairRun.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -84,7 +84,7 @@ class FairRun : public TNamed
     /**
      * Set the sink
      */
-    void SetSink(std::unique_ptr<FairSink>&& newsink);
+    void SetSink(std::unique_ptr<FairSink> newsink);
     void SetSink(FairSink* tempSink);
     /**
      * return a non-owning pointer to the sink

--- a/examples/MQ/pixelDetector/src/devices/FairMQSimDevice.h
+++ b/examples/MQ/pixelDetector/src/devices/FairMQSimDevice.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2017 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2017-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *
@@ -52,7 +52,7 @@ class FairMQSimDevice : public FairMQRunDevice
     void SetSecondParameter(FairParIo* par) { fSecondParameter = par; }
     void SetUserConfig(const TString& Config) { fUserConfig = Config; }
     void SetUserCuts(const TString& Cuts) { fUserCuts = Cuts; }
-    void SetSink(std::unique_ptr<FairSink>&& sink) { fSink = std::move(sink); }
+    void SetSink(std::unique_ptr<FairSink> sink) { fSink = std::move(sink); }
     // ------ ---------- -------- ------
 
     void InitializeRun();

--- a/examples/MQ/pixelSimSplit/src/devices/FairMQTransportDevice.h
+++ b/examples/MQ/pixelSimSplit/src/devices/FairMQTransportDevice.h
@@ -52,7 +52,7 @@ class FairMQTransportDevice : public FairMQRunDevice
     void SetSecondParameter(FairParIo* par) { fSecondParameter = par; };
     void SetUserConfig(const TString& Config) { fUserConfig = Config; }
     void SetUserCuts(const TString& Cuts) { fUserCuts = Cuts; }
-    void SetSink(std::unique_ptr<FairSink>&& sink) { fSink = std::move(sink); }
+    void SetSink(std::unique_ptr<FairSink> sink) { fSink = std::move(sink); }
     // ------ ---------- -------- ------
 
     void InitializeRun();


### PR DESCRIPTION
See: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#r32-take-a-unique_ptrwidget-parameter-to-express-that-a-function-assumes-ownership-of-a-widget

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
