### PR TITLE
Use `unique_ptr` API for SimulationConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   It has been deprecated since 18.0.0.
 * `FairRootManager::Get{Tree,Folder}Name()` now return `const char *`.
   Do NOT `delete` the returned pointer!
+* `FairRunSim::SetSimulationConfig()` now takes a
+  `unique_ptr` instead of a raw pointer with unknown
+  ownership.
 * Some headers were cleaned up and now `#include` fewer
   other headers. You might have to add some `#includes`s
   in your code.

--- a/base/steer/FairRunSim.cxx
+++ b/base/steer/FairRunSim.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -74,8 +74,6 @@ FairRunSim::FairRunSim(Bool_t isMaster)
     , fUserCuts("SetCuts.C")
     , fIsMT(kFALSE)
     , fImportTGeoToVMC(kTRUE)
-    , fSimulationConfig(nullptr)
-
 {
     if (fginstance) {
         Fatal("FairRun", "Singleton instance already exists.");
@@ -289,8 +287,9 @@ void FairRunSim::SetMCConfig()
     if (fUseSimSetupFunction) {
         fSimSetup();
     } else {
-        if (fSimulationConfig == nullptr)   // RKRKRK COMMENT
-            fSimulationConfig = new FairGenericVMCConfig();
+        if (!fSimulationConfig) {
+            fSimulationConfig = std::make_unique<FairGenericVMCConfig>();
+        }
         fSimulationConfig->Setup(GetName());
     }
 
@@ -299,7 +298,7 @@ void FairRunSim::SetMCConfig()
     if (fUseSimSetupPostInitFunction) {
         fSimSetupPostInit();
     } else {
-        if (fSimulationConfig != nullptr) {
+        if (fSimulationConfig) {
             fSimulationConfig->SetupPostInit(GetName());
         }
     }

--- a/base/steer/FairRunSim.h
+++ b/base/steer/FairRunSim.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -8,6 +8,7 @@
 #ifndef FAIRRUNSIM_H
 #define FAIRRUNSIM_H
 
+#include "FairGenericVMCConfig.h"
 #include "FairIon.h"             // for FairIon
 #include "FairMCApplication.h"   // for FairMCApplication
 #include "FairParticle.h"        // for FairParticle
@@ -18,13 +19,14 @@
 #include <TObjArray.h>   // for TObjArray
 #include <TString.h>     // for TString
 #include <functional>
+#include <memory>
+#include <utility>
 
 class FairField;
 class FairMCEventHeader;
 class FairMesh;
 class FairModule;
 class FairPrimaryGenerator;
-class FairGenericVMCConfig;
 
 /**
  * Configure the Simulation session
@@ -38,7 +40,7 @@ class FairRunSim : public FairRun
     /** default ctor*/
     FairRunSim(Bool_t isMaster = kTRUE);
     /** default dtor*/
-    virtual ~FairRunSim();
+    ~FairRunSim() override;
     /** Singelton instance*/
     static FairRunSim* Instance();
     /**
@@ -178,8 +180,11 @@ class FairRunSim : public FairRun
         fUseSimSetupPostInitFunction = true;
     }
 
-    void SetSimulationConfig(FairGenericVMCConfig* tconf) { fSimulationConfig = tconf; }
-    FairGenericVMCConfig* GetSimulationConfig() { return fSimulationConfig; }
+    void SetSimulationConfig(std::unique_ptr<FairGenericVMCConfig> tconf) { fSimulationConfig = std::move(tconf); }
+    /**
+     * Get non-owning pointer
+     */
+    FairGenericVMCConfig* GetSimulationConfig() { return fSimulationConfig.get(); }
 
     void SetIsMT(Bool_t isMT) { fIsMT = isMT; }
     Bool_t IsMT() const { return fIsMT; }
@@ -234,7 +239,7 @@ class FairRunSim : public FairRun
     std::function<void()> fSimSetupPostInit;   //!                          /** A user provided function to do sim setup
                                                //!                          / instead of using macros **/
     bool fUseSimSetupPostInitFunction = false;
-    FairGenericVMCConfig* fSimulationConfig;   //!                 /** Simulation configuration */
+    std::unique_ptr<FairGenericVMCConfig> fSimulationConfig{};   //!                 /** Simulation configuration */
 
     ClassDefOverride(FairRunSim, 2);
 };

--- a/examples/simulation/Tutorial1/macros/run_tutorial1.C
+++ b/examples/simulation/Tutorial1/macros/run_tutorial1.C
@@ -10,6 +10,7 @@
 #include <TString.h>
 #include <TSystem.h>
 #include <memory>
+#include <utility>
 
 void run_tutorial1(Int_t nEvents = 10,
                    TString mcEngine = "TGeant3",
@@ -68,12 +69,12 @@ void run_tutorial1(Int_t nEvents = 10,
     // ------------------------------------------------------------------------
 
     // -----   Create simulation run   ----------------------------------------
-    FairRunSim* run = new FairRunSim();
+    auto run = std::make_unique<FairRunSim>();
     run->SetName(mcEngine);   // Transport engine
-    FairGenericVMCConfig* config = new FairGenericVMCConfig();
+    auto config = std::make_unique<FairGenericVMCConfig>();
     if (loadPostInitConfig)
         config->UsePostInitConfig();
-    run->SetSimulationConfig(config);
+    run->SetSimulationConfig(std::move(config));
     run->SetIsMT(isMT);                            // Multi-threading mode (Geant4 only)
     run->SetSink(std::make_unique<FairRootFileSink>(outFile));
     FairRuntimeDb* rtdb = run->GetRuntimeDb();


### PR DESCRIPTION
Switch `FairRunSim::SetSimulationConfig()` to `unique_ptr` (from raw pointer with unknown ownership).

Base idea by @karabowi in #1236

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
