### PR TITLE
FMCApp: Do not Leak FairRunSim

### DIFF
--- a/base/sim/FairMCApplication.h
+++ b/base/sim/FairMCApplication.h
@@ -71,9 +71,15 @@ class FairMCApplication : public TVirtualMCApplication
     /** default constructor
      */
     FairMCApplication();
+
+    FairMCApplication(const FairMCApplication&) = delete;
+    FairMCApplication& operator=(const FairMCApplication&) = delete;
+    FairMCApplication(FairMCApplication&&) = delete;
+    FairMCApplication& operator=(FairMCApplication&&) = delete;
+
     /** default destructor
      */
-    virtual ~FairMCApplication();
+    ~FairMCApplication() override;
     /** Singelton instance
      */
     static FairMCApplication* Instance();
@@ -297,8 +303,8 @@ class FairMCApplication : public TVirtualMCApplication
     /** Pointer to the current MC engine //!
      */
     TVirtualMC* fMC;
-    /** Pointer to FairRunSim //! */
-    FairRunSim* fRun;
+
+    FairRunSim* fRun{nullptr};   //!
 
     /** Flag if the current event should be saved */
     Bool_t fSaveCurrentEvent;
@@ -309,15 +315,16 @@ class FairMCApplication : public TVirtualMCApplication
     ClassDefOverride(FairMCApplication, 5);
 
   private:
-    /** Protected copy constructor, needed for CloneForWorker */
-    FairMCApplication(const FairMCApplication&);
-    /* delete all the others */
-    FairMCApplication& operator=(const FairMCApplication&) = delete;
-    FairMCApplication(FairMCApplication&&) = delete;
-    FairMCApplication& operator=(FairMCApplication&&) = delete;
+    /** Private special copy constructor, needed for CloneForWorker */
+    FairMCApplication(const FairMCApplication&, std::unique_ptr<FairRunSim>);
 
     FairRunInfo fRunInfo;   //!
     Bool_t fGeometryIsInitialized;
+
+    /**
+     * Clean up the FairRunSim created in CloneForWorker
+     */
+    std::unique_ptr<FairRunSim> fWorkerRunSim;   //!
 };
 
 // inline functions

--- a/base/steer/FairRun.cxx
+++ b/base/steer/FairRun.cxx
@@ -96,7 +96,10 @@ FairRun::~FairRun()
         delete fTask;   // There is another tasklist in MCApplication,
     }
     // but this should be independent
-    delete fRtdb;   // who is responsible for the RuntimeDataBase
+    if (fIsMaster) {
+        // who is responsible for the RuntimeDataBase?
+        delete fRtdb;
+    }
     delete fEvtHeader;
     if (fRunInstance == this) {
         // Do not point to a destructed object!


### PR DESCRIPTION
CloneForWorker creates a FairRunSim. But this was not cleaned up anywhere.

So clean it up during destruction of FairMCApplication.

Also use the fRun member variable more instead of FairRun{,Sim}::Instance.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
