### PR TITLE
Deprecate fCreator in FairFieldFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ file an issue, so that we can see how to handle this.
     There's no getter for `fInputPersistance`,
     no other code in FairRoot uses the setters,
     we're not aware of anyone using it.
+  * `FairFieldFactory::fCreator` points to `this`.
 * Many items were already deprecated in prior versions.
   Marked them with proper C++14 deprecation warnings.
   Scheduled them for removal in v20.

--- a/base/field/FairFieldFactory.cxx
+++ b/base/field/FairFieldFactory.cxx
@@ -14,11 +14,14 @@
 
 FairFieldFactory* FairFieldFactory::fgRinstance = nullptr;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 FairFieldFactory::FairFieldFactory()
-    : fCreator(0)
+    : fCreator(nullptr)
 {
     fgRinstance = this;
 }
+#pragma GCC diagnostic pop
 
 FairFieldFactory::~FairFieldFactory()
 {

--- a/base/field/FairFieldFactory.h
+++ b/base/field/FairFieldFactory.h
@@ -23,23 +23,14 @@ class FairFieldFactory
     static FairFieldFactory* Instance();
     FairFieldFactory();
     virtual ~FairFieldFactory();
-    virtual FairField* createFairField()
-    {
-        FairField* field = 0;
-        if (fCreator) {
-            field = fCreator->createFairField();
-        }
-        return field;
-    };
-    virtual void SetParm()
-    {
-        if (fCreator) {
-            fCreator->SetParm();
-        }
-    }
+    virtual FairField* createFairField() = 0;
+    virtual void SetParm() {}
 
   protected:
-    FairFieldFactory* fCreator;
+    /**
+     * \deprecated Deprecated in v19, will be removed in v20.
+     */
+    [[deprecated]] FairFieldFactory* fCreator;
     static FairFieldFactory* fgRinstance;
 
     ClassDef(FairFieldFactory, 1);

--- a/examples/advanced/Tutorial3/simulation/FairConstFieldCreator.cxx
+++ b/examples/advanced/Tutorial3/simulation/FairConstFieldCreator.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2020 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2020-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -23,9 +23,8 @@ static FairConstFieldCreator gFairConstFieldCreator;
 
 FairConstFieldCreator::FairConstFieldCreator()
     : FairFieldFactory()
-    , fFieldPar(NULL)
+    , fFieldPar(nullptr)
 {
-    fCreator = this;
 }
 
 FairConstFieldCreator::~FairConstFieldCreator() {}

--- a/templates/project_root_containers/field/MyFieldCreator.cxx
+++ b/templates/project_root_containers/field/MyFieldCreator.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -27,9 +27,8 @@ static MyFieldCreator gMyFieldCreator;
 
 MyFieldCreator::MyFieldCreator()
     : FairFieldFactory()
-    , fFieldPar(NULL)
+    , fFieldPar(nullptr)
 {
-    fCreator = this;
 }
 
 MyFieldCreator::~MyFieldCreator() {}

--- a/templates/project_stl_containers/field/MyFieldCreator.cxx
+++ b/templates/project_stl_containers/field/MyFieldCreator.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -27,9 +27,8 @@ static MyFieldCreator gMyFieldCreator;
 
 MyFieldCreator::MyFieldCreator()
     : FairFieldFactory()
-    , fFieldPar(NULL)
+    , fFieldPar(nullptr)
 {
-    fCreator = this;
 }
 
 MyFieldCreator::~MyFieldCreator() {}


### PR DESCRIPTION
fCreator is a normal member variable inside each instance that points to that exact instance.

Deprecate this.

And some default member functions used to have infinite recursion that way.
* createFairField is now abstract.  You really have to override it.
* SetParm is now a noop, If you need it, override it.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
