### PR TITLE
Improve geometry state after alignment

### DIFF
--- a/alignment/FairAlignmentHandler.h
+++ b/alignment/FairAlignmentHandler.h
@@ -15,6 +15,8 @@ class FairAlignmentHandler
 
     void AddAlignmentMatrices(const std::map<std::string, TGeoHMatrix>& alignmentMatrices, bool invertMatrices);
 
+    void RecomputePhysicalAssmbBbox() const;
+
   public:
     FairAlignmentHandler();
     virtual ~FairAlignmentHandler();

--- a/examples/simulation/Tutorial4/macros/plots.C
+++ b/examples/simulation/Tutorial4/macros/plots.C
@@ -128,7 +128,13 @@ int plots(Int_t nEvents = 1000, Int_t iout = 1, TString mcEngine = "align_TGeant
     }   // event loop end
 
     auto pullx_Ent = pullx->GetEntries();
+    auto pullx_Mea = pullx->GetMean();
+    auto pully_Mea = pully->GetMean();
+    auto pullz_Mea = pullz->GetMean();
     auto pullx_Dev = pullx->GetStdDev();
+    auto pully_Dev = pully->GetStdDev();
+    auto pullz_Dev = pullz->GetStdDev();
+    cout << "Mean (" << pullx_Mea << ", " << pully_Mea << ", " << pullz_Mea << ") " << endl;
 
     // save histos to file
     // TFile *fHist = TFile::Open("data/auaumbias.hst.root","RECREATE");
@@ -164,13 +170,13 @@ int plots(Int_t nEvents = 1000, Int_t iout = 1, TString mcEngine = "align_TGeant
     cout << "Parameter file is " << ParFile << endl;
     cout << "Real time " << rtime << " s, CPU time " << ctime << "s" << endl << endl;
 
-    if (nevent >= 10 && pullx_Ent > nevent * 35 && abs(pullx_Dev - 0.1) < 0.03)
+    if (nevent >= 10 && pullx_Ent > nevent * 35 && abs(pullx_Dev - 0.1) < 0.03 && abs(pully_Dev - 0.1) < 0.04)
         cout << "Macro finished successfully. Number of events (" << nevent << "), hist entries (" << pullx_Ent
-             << ") and deviation (" << pullx_Dev << ") inside limits." << endl;
+             << ") and deviation (" << pullx_Dev << ", " << pully_Dev << ", " << pullz_Dev << ") inside limits."
+             << endl;
     else
         cout << "Macro failed. Number of events (" << nevent << "), hist entries (" << pullx_Ent << ") or deviation ("
-             << pullx_Dev << ") too far off." << endl;
-
+             << pullx_Dev << ", " << pully_Dev << ", " << pullz_Dev << ") too far off." << endl;
     // ------------------------------------------------------------------------
 
     return 0;


### PR DESCRIPTION
1. Refresh the geometry once done (needed in any case)
2. Fix for GeoAssembly bounding box having 0 dx/dy after alignment (#1243)

Fix could be removed once proper fix is done in Root, should not hurt if done twice

Should be backported to the next v18.6.x if accepted as probably needed for next CbmRoot release.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
