### PR TITLE
Move SetSink into base class FairMQRunDevice

### DIFF
--- a/examples/MQ/pixelDetector/src/devices/FairMQRunDevice.cxx
+++ b/examples/MQ/pixelDetector/src/devices/FairMQRunDevice.cxx
@@ -27,6 +27,22 @@
 #include <mutex>   // std::mutex
 std::mutex mtx;    // mutex for critical section
 
+FairMQRunDevice::FairMQRunDevice()
+    : fair::mq::Device()
+    , fSink()
+{
+}
+
+FairMQRunDevice::~FairMQRunDevice() = default;
+
+void FairMQRunDevice::SetSink(std::unique_ptr<FairOnlineSink> sink)
+{
+    // Store it here, to later transfer into the FairRun
+    fSink = std::move(sink);
+}
+
+void FairMQRunDevice::SetupRunSink(FairRun& run) { run.SetSink(std::move(fSink)); }
+
 void FairMQRunDevice::SendObject(TObject* obj, const std::string& chan)
 {
     auto mess(NewMessage());

--- a/examples/MQ/pixelDetector/src/devices/FairMQRunDevice.h
+++ b/examples/MQ/pixelDetector/src/devices/FairMQRunDevice.h
@@ -17,25 +17,37 @@
 #define FAIRMQRUNDEVICE_H_
 
 #include "FairMQ.h"   // for fair::mq::Device
+#include "FairRun.h"
 
+#include <TObject.h>
 #include <string>
 
-class TObject;
+class FairOnlineSink;
 
 class FairMQRunDevice : public fair::mq::Device
 {
   public:
-    FairMQRunDevice() {}
-    virtual ~FairMQRunDevice() {}
+    FairMQRunDevice();
+    FairMQRunDevice(const FairMQRunDevice&) = delete;
+    FairMQRunDevice& operator=(const FairMQRunDevice&) = delete;
+    ~FairMQRunDevice() override;
 
     virtual void SendBranches();
 
+    void SetSink(std::unique_ptr<FairOnlineSink> sink);
+
   protected:
     void SendObject(TObject* obj, const std::string& chan);
+    /**
+     * Setup the run's Sink from the sink from SetSink()
+     */
+    void SetupRunSink(FairRun& run);
 
   private:
-    FairMQRunDevice(const FairMQRunDevice&);
-    FairMQRunDevice& operator=(const FairMQRunDevice&);
+    /**
+     * Handle ownership for the sink correctly
+     */
+    std::unique_ptr<FairOnlineSink> fSink;
 };
 
 #endif /* FAIRMQRUNDEVICE_H_ */

--- a/examples/MQ/pixelDetector/src/devices/FairMQSimDevice.cxx
+++ b/examples/MQ/pixelDetector/src/devices/FairMQSimDevice.cxx
@@ -48,7 +48,7 @@ void FairMQSimDevice::InitTask()
 {
     fRunSim = new FairRunSim();
 
-    fRunSim->SetSink(std::move(fSink));
+    SetupRunSink(*fRunSim);
 
     if (fFirstParameter || fSecondParameter) {
         FairRuntimeDb* rtdb = fRunSim->GetRuntimeDb();

--- a/examples/MQ/pixelDetector/src/devices/FairMQSimDevice.h
+++ b/examples/MQ/pixelDetector/src/devices/FairMQSimDevice.h
@@ -17,7 +17,6 @@
 #define FAIRMQSIMDEVICE_H_
 
 #include "FairMQRunDevice.h"
-#include "FairSink.h"
 
 #include <Rtypes.h>
 #include <TString.h>
@@ -35,7 +34,7 @@ class FairMQSimDevice : public FairMQRunDevice
 {
   public:
     FairMQSimDevice();
-    virtual ~FairMQSimDevice() {}
+    ~FairMQSimDevice() override = default;
 
     virtual void SetParamUpdateChannelName(const TString& tString) { fUpdateChannelName = tString; }
 
@@ -52,18 +51,17 @@ class FairMQSimDevice : public FairMQRunDevice
     void SetSecondParameter(FairParIo* par) { fSecondParameter = par; }
     void SetUserConfig(const TString& Config) { fUserConfig = Config; }
     void SetUserCuts(const TString& Cuts) { fUserCuts = Cuts; }
-    void SetSink(std::unique_ptr<FairSink> sink) { fSink = std::move(sink); }
     // ------ ---------- -------- ------
 
     void InitializeRun();
 
-    virtual void SendBranches();
+    void SendBranches() override;
 
   protected:
-    virtual void InitTask();
-    virtual void PreRun();
-    virtual void PostRun() {}
-    virtual bool ConditionalRun();
+    void InitTask() override;
+    void PreRun() override;
+    void PostRun() override {}
+    bool ConditionalRun() override;
 
   private:
     UInt_t fSimDeviceId;
@@ -85,7 +83,6 @@ class FairMQSimDevice : public FairMQRunDevice
     FairParIo* fSecondParameter;   // second input (used if not found in first input)
     TString fUserConfig;           //!                  /** Macro for geant configuration*/
     TString fUserCuts;             //!                  /** Macro for geant cuts*/
-    std::unique_ptr<FairSink> fSink{};
     // ------ ---------- -------- ------
 
     void UpdateParameterServer();

--- a/examples/MQ/pixelSimSplit/src/devices/FairMQTransportDevice.cxx
+++ b/examples/MQ/pixelSimSplit/src/devices/FairMQTransportDevice.cxx
@@ -73,7 +73,7 @@ void FairMQTransportDevice::InitTask()
     fRunSim->SetMCEventHeader(fMCSplitEventHeader);
     fRunSim->SetRunId(fRunSim->GetMCEventHeader()->GetRunID());
 
-    fRunSim->SetSink(std::move(fSink));
+    SetupRunSink(*fRunSim);
 
     if (fFirstParameter || fSecondParameter) {
         FairRuntimeDb* rtdb = fRunSim->GetRuntimeDb();

--- a/examples/MQ/pixelSimSplit/src/devices/FairMQTransportDevice.h
+++ b/examples/MQ/pixelSimSplit/src/devices/FairMQTransportDevice.h
@@ -17,7 +17,6 @@
 #define FAIRMQTRANSPORTDEVICE_H_
 
 #include "FairMQRunDevice.h"
-#include "FairSink.h"
 
 #include <Rtypes.h>
 #include <TString.h>
@@ -52,7 +51,6 @@ class FairMQTransportDevice : public FairMQRunDevice
     void SetSecondParameter(FairParIo* par) { fSecondParameter = par; };
     void SetUserConfig(const TString& Config) { fUserConfig = Config; }
     void SetUserCuts(const TString& Cuts) { fUserCuts = Cuts; }
-    void SetSink(std::unique_ptr<FairSink> sink) { fSink = std::move(sink); }
     // ------ ---------- -------- ------
 
     void InitializeRun();
@@ -96,7 +94,6 @@ class FairMQTransportDevice : public FairMQRunDevice
     FairParIo* fSecondParameter;   // second input (used if not found in first input)
     TString fUserConfig;           //!                  /** Macro for geant configuration*/
     TString fUserCuts;             //!                  /** Macro for geant cuts*/
-    std::unique_ptr<FairSink> fSink{};
     // ------ ---------- -------- ------
 
     FairMCSplitEventHeader* fMCSplitEventHeader;


### PR DESCRIPTION
Both FairMQSimDevice and FairMQTransportDevice implemented the same SetSink method. Move it into the base class.

Add a new SetupRunSink to setup the sink in the FairRun from the sink in the FairMQRunDevice and transfer ownership that way.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
