### PR TITLE
TCA's 2.0: preparation work

### DIFF
--- a/base/steer/FairTask.cxx
+++ b/base/steer/FairTask.cxx
@@ -54,11 +54,15 @@ void FairTask::InitTask()
     if (!fActive) {
         return;
     }
+    
+    for (auto fun: fOnInit)
+      fun();
+    
     InitStatus tStat = Init();
-    if (tStat == kFATAL) {
+    if (tStat & kFATAL) {
         LOG(fatal) << "Initialization of Task " << fName.Data() << " failed fatally";
     }
-    if (tStat == kERROR) {
+    if (tStat & kERROR) {
         fActive = kFALSE;
     }
     FairMonitor::GetMonitor()->SetCurrentTask(0);
@@ -257,5 +261,11 @@ Bool_t FairTask::IsOutputBranchPersistent(TString branchName)
         return kTRUE;
     }
 }
+
+void FairTask::AddOnInit(std::function<void(void)> fun)
+{
+  fOnInit.push_back(fun);
+}
+
 
 ClassImp(FairTask);

--- a/base/steer/FairTask.h
+++ b/base/steer/FairTask.h
@@ -25,6 +25,8 @@
 #include <TString.h>   // for TString
 #include <TTask.h>     // for TTask
 #include <map>
+#include <vector>
+#include <functional>
 
 class FairLogger;
 
@@ -107,6 +109,9 @@ class FairTask : public TTask
 
     void SetStreamProcessing(Bool_t val = kTRUE) { fStreamProcessing = val; }
 
+    /** Register a function to be called during InitTask() **/
+    void AddOnInit(std::function<void(void)> fun);
+
   protected:
     Int_t fVerbose;                           //  Verbosity level
     [[deprecated]] Int_t fInputPersistance;   ///< \deprecated Deprecated in v19, will be removed in v20.
@@ -150,10 +155,12 @@ class FairTask : public TTask
     /** Recursive FinishEvent of subtasks **/
     void FinishEvents();
 
+
   private:
     std::map<TString, Bool_t> fOutputPersistance;
-
-    ClassDefOverride(FairTask, 4);
+    std::vector<std::function<void(void)>> fOnInit{};
+  
+    ClassDefOverride(FairTask, 5);
 };
 
 #endif

--- a/fairtools/MCConfigurator/FairYamlVMCConfig.h
+++ b/fairtools/MCConfigurator/FairYamlVMCConfig.h
@@ -16,6 +16,11 @@
 #include "FairGenericVMCConfig.h"
 
 #include <string>
+
+// prevent yaml-cpp/node/detail/iterator.h:48:54:
+//  error: no member named 'next' in namespace 'boost'
+#include <boost/next_prior.hpp>
+
 #include <yaml-cpp/yaml.h>
 
 class FairYamlVMCConfig : public FairGenericVMCConfig


### PR DESCRIPTION
These are changes in the FairTask and FairRootManager classes to support type safe (and optionally associative) TClonesArrays. 
FairRootManager
* I did not find a good way to fetch objects registered with RegisterAny, so I make GetMemoryBranchAny public.
* FairRootManager::RegisterAny() previously took the address of the pointer passed by reference (which happened to live on my local stack) and fed that to AddMemoryBranchAny(), so GetMemoryBranchAny() later returned an pointer to the stack. I am unsure why the double pointer would be required? In my mind, the process should be simple: someone creates some object and passes FRM a pointer to it for safekeeping. Later, someone else asks FRM for the object and get the pointer back. 

FairTask:
* While we can get away with fetching TCAs used as an input on first use, we must register TCAs used for output during Init, because subsequent (old school TCA using) tasks may depend on them being around during their Init phase. Having the user maintain their Init() manually is exactly the boilerplate code I want to avoid. Thus, additionally to Init(), there is a ``std::vector<std::function<void(void)>> fOnInit`` whose functions also get executed by InitTask. A public method ``AddOnInit std::function<void(void)>`` allows to add stuff to that vector. 
* During the constructor of a FairTask, member variables which have to handle TCA creation and registration are passed the this pointer of the FairTask. In their constructor, they register (via AddOnInit) a callback to a lambda expression which does the necessary steps during Init. 
* I will give an example in the related issue I opened. 
---

Checklist:

* [X] Rebased against `dev` branch
* [ ] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [ ] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
