### PR TITLE
Fix some Simple Doxygen Warnings

### DIFF
--- a/base/field/FairField.h
+++ b/base/field/FairField.h
@@ -64,7 +64,7 @@ class FairField : public TVirtualMagField
     /** Get x component of magnetic field [kG]
      ** @param x,y,z    Position [cm]
      **/
-    virtual Double_t GetBx(Double_t, Double_t, Double_t)
+    virtual Double_t GetBx([[maybe_unused]] Double_t x, [[maybe_unused]] Double_t y, [[maybe_unused]] Double_t z)
     {
         LOG(warn) << "FairField::GetBx Should be implemented in User class";
         return 0;
@@ -73,7 +73,7 @@ class FairField : public TVirtualMagField
     /** Get y component of magnetic field [kG]
      ** @param x,y,z    Position [cm]
      **/
-    virtual Double_t GetBy(Double_t, Double_t, Double_t)
+    virtual Double_t GetBy([[maybe_unused]] Double_t x, [[maybe_unused]] Double_t y, [[maybe_unused]] Double_t z)
     {
         LOG(warn) << "FairField::GetBy Should be implemented in User class";
         return 0;
@@ -82,7 +82,7 @@ class FairField : public TVirtualMagField
     /** Get z component of magnetic field [kG]
      ** @param x,y,z    Position [cm]
      **/
-    virtual Double_t GetBz(Double_t, Double_t, Double_t)
+    virtual Double_t GetBz([[maybe_unused]] Double_t x, [[maybe_unused]] Double_t y, [[maybe_unused]] Double_t z)
     {
         LOG(warn) << "FairField::GetBz Should be implemented in User class";
         return 0;

--- a/examples/MQ/serialization/README.md
+++ b/examples/MQ/serialization/README.md
@@ -4,7 +4,7 @@
 
 ### Generate input file
 Start the script startSerializationGenerateData.sh (in FairRoot/build/bin/) to generate and store random data.
-A file inputGenEx.root will be produce in the directory <build_dir>/examples/MQ/GenericDevices/data_io.
+A file `inputGenEx.root` will be produce in the directory `<build_dir>/examples/MQ/GenericDevices/data_io`.
 Use the help command line :
 ```bash
 ./startSerializationGenerateData.sh --help

--- a/examples/advanced/Tutorial3/simulation/FairConstField.h
+++ b/examples/advanced/Tutorial3/simulation/FairConstField.h
@@ -65,9 +65,6 @@ class FairConstField : public FairField
      **/
     void SetField(Double_t bX, Double_t bY, Double_t bZ);
 
-    /** Get components of field at a given point
-     ** @param x,y,z   Point coordinates [cm]
-     **/
     Double_t GetBx(Double_t x, Double_t y, Double_t z) override;
     Double_t GetBy(Double_t x, Double_t y, Double_t z) override;
     Double_t GetBz(Double_t x, Double_t y, Double_t z) override;


### PR DESCRIPTION
These two show up often in unrelated PRs

* Fix simple formatting of `<...>` which doxygen's markdown parser might consider for HTML
* Drop docs on overriden member functions, if the base class has good docs.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
