### PR TITLE
Support disabling `BaseMQ` and dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Some headers were cleaned up and now `#include` fewer
   other headers. You might have to add some `#includes`s
   in your code.
+* Added a new build switch `BUILD_BASEMQ` for controlling whether `FairRoot::BaseMQ` and
+  dependent targets are built. It is enabled by default and will now **require**
+  its external package dependencies FairMQ and Boost.
 
 
 ### Deprecations

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,7 @@ option(BUILD_MBS "Build MBS" OFF)
 if (BUILD_MBS)
   set(BUILD_ONLINE ON)
 endif()
+option(BUILD_BASEMQ "Build the 'FairRoot::BaseMQ' library" ON)
 
 # searches for needed packages
 # REQUIRED means that cmake will stop if this packages are not found
@@ -263,13 +264,11 @@ add_subdirectory(datamatch)
 
 add_subdirectory(templates)
 
-If (FairMQ_FOUND AND Boost_FOUND)
+if(BUILD_BASEMQ)
   add_subdirectory(fairmq)
   add_subdirectory(basemq)
   add_subdirectory(parmq)
-Else ()
-  Message(STATUS "fairmq, basemq and parmq will not be built, because FairMQ and/or Boost was not found.")
-EndIf ()
+endif()
 
 Option(BUILD_DOXYGEN "Build Doxygen" OFF)
 if(BUILD_DOXYGEN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,33 +170,44 @@ if(NOT DEFINED GTEST_ROOT)
   set(GTEST_ROOT ${SIMPATH})
 endif()
 
-find_package2(PUBLIC FairMQ VERSION 1.4.0)
+if(BUILD_BASEMQ)
+  find_package2(PUBLIC FairMQ VERSION 1.4.0 REQUIRED)
+endif()
+
 find_package2(PUBLIC DDS)
 find_package2(PUBLIC FairLogger VERSION 1.2.0 REQUIRED)
 
-if(NOT DEFINED Boost_NO_SYSTEM_PATHS)
-  Set(Boost_NO_SYSTEM_PATHS TRUE)
-endif()
-if(Boost_NO_BOOST_CMAKE)
-  # If an older version of boost is found both of the variables below are
-  # cached and in a second cmake run, a good boost version is found even
-  # if the version is to old.
-  # To overcome this problem both variables are cleared before checking
-  # for boost.
-  Unset(Boost_INCLUDE_DIR CACHE)
-  Unset(Boost_LIBRARY_DIRS CACHE)
-endif()
+if(BUILD_BASEMQ OR BUILD_UNITTESTS OR BUILD_EXAMPLES)
+  if(NOT DEFINED Boost_NO_SYSTEM_PATHS)
+    Set(Boost_NO_SYSTEM_PATHS TRUE)
+  endif()
+  if(Boost_NO_BOOST_CMAKE)
+    # If an older version of boost is found both of the variables below are
+    # cached and in a second cmake run, a good boost version is found even
+    # if the version is to old.
+    # To overcome this problem both variables are cleared before checking
+    # for boost.
+    Unset(Boost_INCLUDE_DIR CACHE)
+    Unset(Boost_LIBRARY_DIRS CACHE)
+  endif()
 
-list(APPEND boost_dependencies filesystem serialization)
+  set(boost_dependencies)
+  if(BUILD_BASEMQ)
+    list(APPEND boost_dependencies filesystem serialization program_options)
+  endif()
+  if(BUILD_UNITTESTS)
+    list(APPEND boost_dependencies unit_test_framework)
+  endif()
+  if(BUILD_EXAMPLES)
+    list(APPEND boost_dependencies program_options)
+  endif()
 
-if(BUILD_UNITTESTS)
- list(APPEND boost_dependencies unit_test_framework)
+  find_package2(PUBLIC Boost
+    VERSION 1.67
+    COMPONENTS ${boost_dependencies}
+    REQUIRED
+  )
 endif()
-
-find_package2(PUBLIC Boost
-  VERSION 1.67
-  COMPONENTS ${boost_dependencies}
-)
 
 If (Boost_FOUND)
   Set(Boost_Avail 1)

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -103,7 +103,7 @@ target_link_libraries(${target} PUBLIC
   FairRoot::FairTools
   FairRoot::ParBase
   FairRoot::GeoBase
-  Boost::serialization
+  $<$<TARGET_EXISTS:Boost::serialization>:Boost::serialization>
 
   ROOT::Core
   ROOT::EG
@@ -120,9 +120,13 @@ target_link_libraries(${target} PUBLIC
   $<$<BOOL:${ROOT_gdml_FOUND}>:ROOT::Gdml>
 )
 
-target_compile_definitions(${target} PRIVATE
+target_compile_definitions(${target}
+  PRIVATE
   $<$<BOOL:${ROOT_gdml_FOUND}>:ROOT_HAS_GDML>
   # $<$<PLATFORM_ID:Linux>:Linux>
+
+  PUBLIC
+  $<$<TARGET_EXISTS:Boost::serialization>:FAIRROOT_HAS_BOOST_SERIALIZATION>
 )
 
 if(BUILD_PROOF_SUPPORT)

--- a/base/event/FairHit.h
+++ b/base/event/FairHit.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -12,13 +12,6 @@
 
 #include <Rtypes.h>     // for Double_t, Int_t, Double32_t, etc
 #include <TVector3.h>   // for TVector3
-
-namespace boost {
-namespace serialization {
-class access;
-}
-}   // namespace boost
-#include <boost/serialization/base_object.hpp>
 
 /**
  * Abstract base class for reconstructed hits in the FAIR detectors.
@@ -67,23 +60,7 @@ class FairHit : public FairTimeStamp
     /*** Output to screen */
     virtual void Print(const Option_t*) const { ; }
 
-    template<class Archive>
-    void serialize(Archive& ar, const unsigned int)
-    {
-        ar& boost::serialization::base_object<FairTimeStamp>(*this);
-        ar& fDetectorID;
-        ar& fRefIndex;
-        ar& fX;
-        ar& fY;
-        ar& fZ;
-        ar& fDx;
-        ar& fDy;
-        ar& fDz;
-    }
-
   protected:
-    friend class boost::serialization::access;
-
     Double32_t fDx, fDy, fDz;   ///< Errors of position [cm]
     Int_t fRefIndex;            ///< Index of FairMCPoint for this hit
     Int_t fDetectorID;          ///< Detector unique identifier
@@ -124,4 +101,53 @@ inline void FairHit::SetPosition(const TVector3& pos)
     fZ = pos.Z();
 }
 
-#endif
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/split_free.hpp>
+
+namespace boost::serialization {
+
+template<class Archive>
+void load(Archive& ar, FairHit& hit, const unsigned int)
+{
+    ar& base_object<FairTimeStamp>(hit);
+
+    Int_t detectorID = 0;
+    ar& detectorID;
+    hit.SetDetectorID(detectorID);
+
+    Int_t refIndex = 0;
+    ar& refIndex;
+    hit.SetRefIndex(refIndex);
+
+    Double_t x = 0., y = 0., z = 0.;
+    ar& x;
+    ar& y;
+    ar& z;
+    hit.SetXYZ(x, y, z);
+
+    Double_t dx = 0., dy = 0., dz = 0.;
+    ar& dx;
+    ar& dy;
+    ar& dz;
+    hit.SetDxyz(dx, dy, dz);
+}
+
+template<class Archive>
+void save(Archive& ar, FairHit const& hit, const unsigned int)
+{
+    ar& base_object<FairTimeStamp>(hit);
+    ar& hit.GetDetectorID();
+    ar& hit.GetRefIndex();
+    ar& hit.GetX();
+    ar& hit.GetY();
+    ar& hit.GetZ();
+    ar& hit.GetDx();
+    ar& hit.GetDy();
+    ar& hit.GetDz();
+}
+
+}   // namespace boost::serialization
+
+BOOST_SERIALIZATION_SPLIT_FREE(FairHit)
+
+#endif   // FAIRHIT_H

--- a/base/event/FairHit.h
+++ b/base/event/FairHit.h
@@ -101,6 +101,8 @@ inline void FairHit::SetPosition(const TVector3& pos)
     fZ = pos.Z();
 }
 
+#ifdef FAIRROOT_HAS_BOOST_SERIALIZATION
+
 #include <boost/serialization/base_object.hpp>
 #include <boost/serialization/split_free.hpp>
 
@@ -149,5 +151,7 @@ void save(Archive& ar, FairHit const& hit, const unsigned int)
 }   // namespace boost::serialization
 
 BOOST_SERIALIZATION_SPLIT_FREE(FairHit)
+
+#endif   // FAIRROOT_HAS_BOOST_SERIALIZATION
 
 #endif   // FAIRHIT_H

--- a/base/event/FairMCPoint.h
+++ b/base/event/FairMCPoint.h
@@ -113,6 +113,8 @@ inline void FairMCPoint::SetPosition(const TVector3& pos)
     fZ = pos.Z();
 }
 
+#ifdef FAIRROOT_HAS_BOOST_SERIALIZATION
+
 // #include <boost/serialization/base_object.hpp>
 #include <boost/serialization/split_free.hpp>
 
@@ -181,5 +183,7 @@ void save(Archive& ar, FairMCPoint const& mcPoint, const unsigned int)
 }   // namespace boost::serialization
 
 BOOST_SERIALIZATION_SPLIT_FREE(FairMCPoint)
+
+#endif   // FAIRROOT_HAS_BOOST_SERIALIZATION
 
 #endif   // FAIRMCPOINT_H

--- a/base/event/FairMCPoint.h
+++ b/base/event/FairMCPoint.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -17,13 +17,6 @@
 
 #include <Rtypes.h>     // for Double_t, Double32_t, Int_t, etc
 #include <TVector3.h>   // for TVector3
-
-namespace boost {
-namespace serialization {
-class access;
-}
-}   // namespace boost
-#include <boost/serialization/base_object.hpp>
 
 class FairMCPoint : public FairMultiLinkedData_Interface
 {
@@ -86,27 +79,7 @@ class FairMCPoint : public FairMultiLinkedData_Interface
     /** Output to screen **/
     virtual void Print(const Option_t* opt = 0) const;
 
-    template<class Archive>
-    void serialize(Archive& ar, const unsigned int)
-    {
-        // ar & boost::serialization::base_object<FairMultiLinkedData>(*this);
-        ar& fTrackID;
-        ar& fEventId;
-        ar& fDetectorID;
-        ar& fX;
-        ar& fY;
-        ar& fZ;
-        ar& fPx;
-        ar& fPy;
-        ar& fPz;
-        ar& fTime;
-        ar& fLength;
-        ar& fELoss;
-    }
-
   protected:
-    friend class boost::serialization::access;
-
     Int_t fTrackID;             ///< Track index
     UInt_t fEventId;            ///< MC Event id
     Double32_t fPx, fPy, fPz;   ///< Momentum components [GeV]
@@ -140,4 +113,73 @@ inline void FairMCPoint::SetPosition(const TVector3& pos)
     fZ = pos.Z();
 }
 
-#endif
+// #include <boost/serialization/base_object.hpp>
+#include <boost/serialization/split_free.hpp>
+
+namespace boost::serialization {
+
+template<class Archive>
+void load(Archive& ar, FairMCPoint& mcPoint, const unsigned int)
+{
+    // ar & boost::serialization::base_object<FairMultiLinkedData>(*this);
+
+    Int_t trackID = 0;
+    ar& trackID;
+    mcPoint.SetTrackID(trackID);
+
+    Int_t eventID = 0;
+    ar& eventID;
+    mcPoint.SetEventID(eventID);
+
+    Int_t detectorID = 0;
+    ar& detectorID;
+    mcPoint.SetDetectorID(detectorID);
+
+    Double_t x = 0., y = 0., z = 0.;
+    ar& x;
+    ar& y;
+    ar& z;
+    mcPoint.SetXYZ(x, y, z);
+
+    Double_t px = 0., py = 0., pz = 0.;
+    ar& px;
+    ar& py;
+    ar& pz;
+    mcPoint.SetMomentum(TVector3(px, py, pz));
+
+    Double_t time = 0.;
+    ar& time;
+    mcPoint.SetTime(time);
+
+    Double_t length = 0.;
+    ar& length;
+    mcPoint.SetLength(length);
+
+    Double_t energyLoss = 0.;
+    ar& energyLoss;
+    mcPoint.SetLength(energyLoss);
+}
+
+template<class Archive>
+void save(Archive& ar, FairMCPoint const& mcPoint, const unsigned int)
+{
+    // ar & boost::serialization::base_object<FairMultiLinkedData>(*this);
+    ar& mcPoint.GetTrackID();
+    ar& mcPoint.GetEventID();
+    ar& mcPoint.GetDetectorID();
+    ar& mcPoint.GetX();
+    ar& mcPoint.GetY();
+    ar& mcPoint.GetZ();
+    ar& mcPoint.GetPx();
+    ar& mcPoint.GetPy();
+    ar& mcPoint.GetPz();
+    ar& mcPoint.GetTime();
+    ar& mcPoint.GetLength();
+    ar& mcPoint.GetEnergyLoss();
+}
+
+}   // namespace boost::serialization
+
+BOOST_SERIALIZATION_SPLIT_FREE(FairMCPoint)
+
+#endif   // FAIRMCPOINT_H

--- a/base/event/FairTimeStamp.h
+++ b/base/event/FairTimeStamp.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -13,13 +13,6 @@
 #include <Rtypes.h>   // for Double_t, etc
 #include <iosfwd>     // for ostream
 #include <iostream>   // for ostream, cout
-
-namespace boost {
-namespace serialization {
-class access;
-}
-}   // namespace boost
-#include <boost/serialization/base_object.hpp>
 
 class TObject;
 
@@ -87,17 +80,7 @@ class FairTimeStamp : public FairMultiLinkedData_Interface
             return false;
     }
 
-    template<class Archive>
-    void serialize(Archive& ar, const unsigned int)
-    {
-        // ar & boost::serialization::base_object<FairMultiLinkedData>(*this);
-        ar& fTimeStamp;
-        ar& fTimeStampError;
-    }
-
   protected:
-    friend class boost::serialization::access;
-
     Double_t fTimeStamp;      /** Time of digit or Hit  [ns] */
     Double_t fTimeStampError; /** Error on time stamp */
 
@@ -124,4 +107,33 @@ inline FairTimeStamp::FairTimeStamp(Double_t time, Double_t timeerror)
     , fTimeStampError(timeerror)
 {}
 
-#endif
+// #include <boost/serialization/base_object.hpp>
+#include <boost/serialization/split_free.hpp>
+
+namespace boost::serialization {
+
+template<class Archive>
+void load(Archive& ar, FairTimeStamp& time, const unsigned int)
+{
+    // ar & boost::serialization::base_object<FairMultiLinkedData>(time);
+
+    Double_t timeStamp = 0.;
+    ar& timeStamp;
+    time.SetTimeStamp(timeStamp);
+
+    Double_t timeStampError = 0.;
+    ar& timeStampError;
+    time.SetTimeStampError(timeStampError);
+}
+
+template<class Archive>
+void save(Archive& ar, FairTimeStamp const& time, const unsigned int)
+{
+    // ar & boost::serialization::base_object<FairMultiLinkedData>(time);
+    ar& time.GetTimeStamp();
+    ar& time.GetTimeStampError();
+}
+
+}   // namespace boost::serialization
+
+#endif   // FAIRTIMESTAMP_H

--- a/base/event/FairTimeStamp.h
+++ b/base/event/FairTimeStamp.h
@@ -107,6 +107,8 @@ inline FairTimeStamp::FairTimeStamp(Double_t time, Double_t timeerror)
     , fTimeStampError(timeerror)
 {}
 
+#ifdef FAIRROOT_HAS_BOOST_SERIALIZATION
+
 // #include <boost/serialization/base_object.hpp>
 #include <boost/serialization/split_free.hpp>
 
@@ -135,5 +137,9 @@ void save(Archive& ar, FairTimeStamp const& time, const unsigned int)
 }
 
 }   // namespace boost::serialization
+
+BOOST_SERIALIZATION_SPLIT_FREE(FairTimeStamp)
+
+#endif   // FAIRROOT_HAS_BOOST_SERIALIZATION
 
 #endif   // FAIRTIMESTAMP_H

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -22,10 +22,10 @@ if(Geant3_FOUND)
     add_subdirectory(common/gconfig)
   endif()
 
-  if(TARGET FairFastSim)
+  if(TARGET FairFastSim AND TARGET Boost::program_options)
     add_subdirectory(simulation/Tutorial1)
   endif()
-  if(TARGET FairRoot::EventDisplay)
+  if(TARGET FairRoot::EventDisplay AND TARGET FairRoot::BaseMQ)
     add_subdirectory(advanced/propagator)
   endif()
 


### PR DESCRIPTION
solves #1228

#### Motivation

AliceO2 does not use the `FairRoot::BaseMQ` target. Because it cannot be disabled, FairRoot pulls in quite heavy dependencies like Boost and FairMQ, which are not used through FairRoot. @ktf has requested a possibility to disable those libraries in FairRoot.

One approach is certainly to exactly define a build switch based on the request, such as `DISABLE_BOOST=ON` or similar. However, longterm maintenance of such a dependency-based build switch may grow complicated as FairRoot is a collection of dozens of libraries which may each have their own rationale when and why they want to depend on a Boost library.

Therefore, I propose to add a simple build switch `BUILD_BASEMQ=ON/OFF` which just disables the `FairRoot::BaseMQ` library and all that depends on it (`FairRoot::FairMQ`, `FairRoot::ParMQ` and some examples). Technically, `FairRoot::Base` also depended on Boost via its Boost.Serialization support for the `FairHit`, `FairMCPoint`, and `FairTimeStamp` classes. I proposed in this PR to refactor this feature into its [non-intrusive variant](https://www.boost.org/doc/libs/1_80_0/libs/serialization/doc/tutorial.html#nonintrusiveversion) and make it optional from the point of view of the `FairRoot::Base` library. When `BUILD_BASEMQ=ON` is configured, then the Boost lookup will require the Boost.Serialization library as well, effectively controlling this feature in the `FairRoot::Base` library (which is the exact use case it was introduced for in the first place).

In the last commit I change the lookup logic of the FairMQ and Boost dependencies based on build options only. Together with this change, a user like Alice may now configure FairRoot with `-DBUILD_BASEMQ=OFF -DBUILD_EXAMPLES=OFF` and effectively disable all targets that depend on either FairMQ or Boost (in future releases an existing or new FairRoot library may - of course - still opt-in to have a new dependency on FairMQ or Boost, then a user shall be ideally presented with a suitable `BUILD_<lib>` switch as well, if it makes sense).

The general motivation to provide `BUILD_<lib>` switches and then in turn `REQUIRE` dependencies is to enable reproducible builds that do not depend on the environment. The build shall fail fast (at configure time), if the given environment is not suitable for the chosen configuration. If we would chose to adopt this logic, adding a complete set of `BUILD_<lib>` switches and transforming all bits in the FairRoot build system to this scheme consistently, is out of scope of this PR - however, the general adoption of such a change should be discussed before merging this PR - otherwise it would perhaps add just more inconsistencies as there are already present.