### PR TITLE
[18.8] build: Let Target Names be Nicer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,12 +83,13 @@ file an issue, so that we can see how to handle this.
   for libraries are now exported.
   Some have names different from the filesystem library name.
 
-  | Old Library Name | Target Name           |
-  | ---              | ---                   |
-  | TrkBase          | `FairRoot::TrackBase` |
-  | FairDataMatch    | `FairRoot::DataMatch` |
-  | FairTools        | `FairRoot::Tools`     |
-  | FairFastSim      | `FairRoot::FastSim`   |
+  | Old Library Name | Target Name              |
+  | ---              | ---                      |
+  | TrkBase          | `FairRoot::TrackBase`    |
+  | FairDataMatch    | `FairRoot::DataMatch`    |
+  | FairTools        | `FairRoot::Tools`        |
+  | FairFastSim      | `FairRoot::FastSim`      |
+  | FairMCStepLogger | `FairRoot::MCStepLogger` |
 
   All those not listed here have the library name prefixed
   with `FairRoot::` as the target name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ file an issue, so that we can see how to handle this.
   | ---              | ---                   |
   | TrkBase          | `FairRoot::TrackBase` |
   | FairDataMatch    | `FairRoot::DataMatch` |
+  | FairTools        | `FairRoot::Tools`     |
 
   All those not listed here have the library name prefixed
   with `FairRoot::` as the target name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ file an issue, so that we can see how to handle this.
   | TrkBase          | `FairRoot::TrackBase` |
   | FairDataMatch    | `FairRoot::DataMatch` |
   | FairTools        | `FairRoot::Tools`     |
+  | FairFastSim      | `FairRoot::FastSim`   |
 
   All those not listed here have the library name prefixed
   with `FairRoot::` as the target name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,19 @@ file an issue, so that we can see how to handle this.
   Scheduled them for removal in v20.
 
 ### Other Notable Changes
+* CMake [targets](https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html)
+  for libraries are now exported.
+  Some have names different from the filesystem library name.
+
+  | Old Library Name | Target Name           |
+  | ---              | ---                   |
+  | TrkBase          | `FairRoot::TrackBase` |
+
+  All those not listed here have the library name prefixed
+  with `FairRoot::` as the target name.
+* Note that the library filesystem name is scheduled to be
+  changed in 19.2 to a `fairroot-trackbase` style naming.
+  For those using the targets this change will not be visible.
 * Tests using Geant3 have been disabled by default, because
   those tests have a probability > 0 for failing.
   If you want to run them anyways, pass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ file an issue, so that we can see how to handle this.
   | Old Library Name | Target Name           |
   | ---              | ---                   |
   | TrkBase          | `FairRoot::TrackBase` |
+  | FairDataMatch    | `FairRoot::DataMatch` |
 
   All those not listed here have the library name prefixed
   with `FairRoot::` as the target name.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,7 +68,6 @@ def jobMatrix(String prefix, String type, List specs) {
           if (check == "warnings") {
             recordIssues(tools: [clangTidy(pattern: logpattern)],
                          filters: [excludeFile('build/.*/G__.*[.]cxx')],
-                         qualityGates: [[threshold: 3, type: 'NEW', unstable: true]],
                          ignoreFailedBuilds: false,
                          skipBlames: true)
             archiveArtifacts(artifacts: logpattern, allowEmptyArchive: true, fingerprint: true)

--- a/alignment/CMakeLists.txt
+++ b/alignment/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (C) 2014-2019 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
+# Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
@@ -26,7 +26,7 @@ target_include_directories(${target} PUBLIC
 )
 
 target_link_libraries(${target} PUBLIC
-  FairRoot::FairTools
+  FairRoot::Tools
 
   ROOT::Geom
 )

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -103,7 +103,7 @@ target_include_directories(${target} PUBLIC
 
 target_link_libraries(${target} PUBLIC
   FairRoot::Alignment
-  FairRoot::FairTools
+  FairRoot::Tools
   FairRoot::ParBase
   FairRoot::GeoBase
   $<$<TARGET_EXISTS:Boost::serialization>:Boost::serialization>

--- a/base/sim/fastsim/CMakeLists.txt
+++ b/base/sim/fastsim/CMakeLists.txt
@@ -6,7 +6,7 @@
 #                  copied verbatim in the file "LICENSE"                       #
 ################################################################################
 
-set(target FairFastSim)
+set(target FastSim)
 
 set(sources
   FairFastSimDetector.cxx
@@ -19,6 +19,8 @@ fair_change_extensions_if_exists(.cxx .h FILES "${sources}" OUTVAR headers)
 
 add_library(${target} SHARED ${sources} ${headers})
 fairroot_library_settings(${target})
+# Keep old filesystem name
+set_target_properties(${target} PROPERTIES OUTPUT_NAME FairFastSim)
 
 target_include_directories(${target} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
@@ -52,7 +54,7 @@ target_link_libraries(${target} PUBLIC
 
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
-  LINKDEF FastSimLinkDef.h
+  LINKDEF LinkDef.h
   EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 

--- a/base/sim/fastsim/CMakeLists.txt
+++ b/base/sim/fastsim/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (C) 2014-2019 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
+# Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
@@ -36,7 +36,7 @@ else()
 endif()
 
 target_link_libraries(${target} PUBLIC
-  FairRoot::FairTools
+  FairRoot::Tools
   FairRoot::Base # FairDetector,
   FairRoot::GeoBase
 

--- a/base/sim/fastsim/LinkDef.h
+++ b/base/sim/fastsim/LinkDef.h
@@ -1,8 +1,8 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
- *              This software is distributed under the terms of the             * 
- *              GNU Lesser General Public Licence (LGPL) version 3,             *  
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
 // -------------------------------------------------------------------------
@@ -15,13 +15,10 @@
 #pragma link off all globals;
 #pragma link off all classes;
 #pragma link off all functions;
- 
+// clang-format off
+
 #pragma link C++ class  FairFastSimRunConfiguration+;
 #pragma link C++ class  FairFastSimDetector+;
 
+// clang-format on
 #endif
-
-
-
-
-

--- a/basemq/CMakeLists.txt
+++ b/basemq/CMakeLists.txt
@@ -55,7 +55,7 @@ target_include_directories(${target} PUBLIC
 target_link_libraries(${target} PUBLIC
   FairRoot::Base # FairTask, FairRunAna, FairRootFileSink, FairFileSource
   FairRoot::ParBase # FairParRootFileIo, FairRuntimeDb
-  FairRoot::FairTools
+  FairRoot::Tools
   $<$<BOOL:${BUILD_MBS}>:FairRoot::MbsAPI>
   FairRoot::FairMQ
 

--- a/datamatch/CMakeLists.txt
+++ b/datamatch/CMakeLists.txt
@@ -1,12 +1,12 @@
 ################################################################################
-# Copyright (C) 2014-2019 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
+# Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
 #                  copied verbatim in the file "LICENSE"                       #
 ################################################################################
 
-set(target FairDataMatch)
+set(target DataMatch)
 
 set(sources
   FairMCDataCrawler.cxx
@@ -25,6 +25,8 @@ fair_change_extensions_if_exists(.cxx .h FILES "${sources}" OUTVAR headers)
 
 add_library(${target} SHARED ${sources} ${headers})
 fairroot_library_settings(${target})
+# Keep old filesystem name
+set_target_properties(${target} PROPERTIES OUTPUT_NAME FairDataMatch)
 
 target_include_directories(${target} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
@@ -42,7 +44,7 @@ target_link_libraries(${target} PUBLIC
 
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
-  LINKDEF FairMCMatchLinkDef.h
+  LINKDEF LinkDef.h
   EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 

--- a/datamatch/LinkDef.h
+++ b/datamatch/LinkDef.h
@@ -1,8 +1,8 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
- *              This software is distributed under the terms of the             * 
- *              GNU Lesser General Public Licence (LGPL) version 3,             *  
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
 #ifdef __CINT__
@@ -10,6 +10,7 @@
 #pragma link off all globals;
 #pragma link off all classes;
 #pragma link off all functions;
+// clang-format off
 
 #pragma link C++ class FairMCMatch+;
 #pragma link C++ class FairMCMatchCreatorTask+;
@@ -22,5 +23,5 @@
 #pragma link C++ class FairMCResult+;
 #pragma link C++ class FairMCDataCrawler+;
 
+// clang-format on
 #endif
-

--- a/datamatch/README.dox
+++ b/datamatch/README.dox
@@ -14,6 +14,6 @@ This functionality is performed with the help of `FairLink`s, where
 for every created data object a list of `FairLink`s is created, pointing to
 all of the data used to create that very data object, with the pointers to the event number, data's array and data's position in that array. With this information it is possible to compare the reconstructed data with the simulated one.
 
-The CMake target name for this library is `FairRoot::FairDataMatch`.
+The CMake target name for this library is `FairRoot::DataMatch`.
 
  */

--- a/eventdisplay/CMakeLists.txt
+++ b/eventdisplay/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (C) 2014-2019 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
+# Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
@@ -58,7 +58,7 @@ target_include_directories(${target} PUBLIC
 )
 
 target_link_libraries(${target} PUBLIC
-  FairRoot::FairTools
+  FairRoot::Tools
   FairRoot::Base # FairRootManager, FairRunAna, FairTSBufferFunctional, FairTimeStamp, FairEventManager
 
   ROOT::Core

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (C) 2014-2019 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
+# Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
@@ -22,7 +22,7 @@ if(Geant3_FOUND)
     add_subdirectory(common/gconfig)
   endif()
 
-  if(TARGET FairFastSim AND TARGET Boost::program_options)
+  if(TARGET FairRoot::FastSim AND TARGET Boost::program_options)
     add_subdirectory(simulation/Tutorial1)
   endif()
   if(TARGET FairRoot::EventDisplay AND TARGET FairRoot::BaseMQ)

--- a/examples/MQ/Lmd/CMakeLists.txt
+++ b/examples/MQ/Lmd/CMakeLists.txt
@@ -31,7 +31,7 @@ target_include_directories(${target} PUBLIC
 target_link_libraries(${target} PUBLIC
   FairRoot::Base # FairRunIdGenerator
   FairRoot::BaseMQ # Serialization policies
-  FairRoot::FairTools # FairLogger
+  FairRoot::Tools # FairLogger
   FairRoot::ExMbs
   FairRoot::FairMQ
 

--- a/examples/MQ/histogramServer/CMakeLists.txt
+++ b/examples/MQ/histogramServer/CMakeLists.txt
@@ -32,7 +32,7 @@ target_include_directories(${target} PUBLIC
 target_link_libraries(${target} PUBLIC
   FairRoot::Base # FairRunIdGenerator
   FairRoot::BaseMQ # Serialization policies
-  FairRoot::FairTools # FairLogger
+  FairRoot::Tools # FairLogger
   FairRoot::ParBase
   FairRoot::FairMQ
 

--- a/examples/MQ/parameters/CMakeLists.txt
+++ b/examples/MQ/parameters/CMakeLists.txt
@@ -35,7 +35,7 @@ target_include_directories(${target} PUBLIC
 target_link_libraries(${target} PUBLIC
   FairRoot::Base # FairRunIdGenerator
   FairRoot::BaseMQ # Serialization policies
-  FairRoot::FairTools # FairLogger
+  FairRoot::Tools # FairLogger
   FairRoot::ParBase
   FairRoot::FairMQ
 

--- a/examples/MQ/pixelAlternative/src/CMakeLists.txt
+++ b/examples/MQ/pixelAlternative/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (C) 2014-2019 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
+# Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
@@ -41,7 +41,7 @@ target_include_directories(${target} PUBLIC
 
 target_link_libraries(${target} PUBLIC
   FairRoot::Base # FairRunIdGenerator
-  FairRoot::FairTools # FairLogger
+  FairRoot::Tools # FairLogger
   FairRoot::ParBase
   FairRoot::BaseMQ # Serialization policies
   FairRoot::ExPixel

--- a/examples/MQ/pixelDetector/run/CMakeLists.txt
+++ b/examples/MQ/pixelDetector/run/CMakeLists.txt
@@ -105,7 +105,7 @@ add_executable(pixel-sim runMQSim.cxx)
 target_link_libraries(pixel-sim PRIVATE
   ${exe_dependencies}
   FairRoot::Base # FairModule, FairPrimaryGenerator
-  FairRoot::Gen # FairBoxGenerator
+  FairRoot::Generators # FairBoxGenerator
   FairRoot::ParBase # FairParAsciiFileIo
   FairRoot::ExPassive # FairCave
 

--- a/examples/MQ/pixelDetector/src/CMakeLists.txt
+++ b/examples/MQ/pixelDetector/src/CMakeLists.txt
@@ -71,7 +71,7 @@ target_link_libraries(${target} PUBLIC
   FairRoot::Base # FairRunIdGenerator
   FairRoot::BaseMQ # Serialization policies
   FairRoot::Tools # FairLogger
-  FairRoot::Gen # FairBoxGenerator
+  FairRoot::Generators # FairBoxGenerator
   FairRoot::GeoBase
   FairRoot::ParBase # FairParGenericSet
   FairRoot::ExMCStack

--- a/examples/MQ/pixelDetector/src/CMakeLists.txt
+++ b/examples/MQ/pixelDetector/src/CMakeLists.txt
@@ -70,7 +70,7 @@ target_include_directories(${target} PUBLIC
 target_link_libraries(${target} PUBLIC
   FairRoot::Base # FairRunIdGenerator
   FairRoot::BaseMQ # Serialization policies
-  FairRoot::FairTools # FairLogger
+  FairRoot::Tools # FairLogger
   FairRoot::Gen # FairBoxGenerator
   FairRoot::GeoBase
   FairRoot::ParBase # FairParGenericSet

--- a/examples/MQ/pixelSimSplit/run/CMakeLists.txt
+++ b/examples/MQ/pixelSimSplit/run/CMakeLists.txt
@@ -52,7 +52,7 @@ add_executable(pixel-sim-gen runMQGen.cxx)
 target_link_libraries(pixel-sim-gen PRIVATE
   ${exe_dependencies}
   FairRoot::Base # FairModule, FairPrimaryGenerator
-  FairRoot::Gen # FairBoxGenerator
+  FairRoot::Generators # FairBoxGenerator
 
   ROOT::Core # TSystem
   ROOT::MathCore # TRandom

--- a/examples/MQ/pixelSimSplit/src/CMakeLists.txt
+++ b/examples/MQ/pixelSimSplit/src/CMakeLists.txt
@@ -42,7 +42,7 @@ target_include_directories(${target} PUBLIC
 target_link_libraries(${target} PUBLIC
   FairRoot::Base # FairRunIdGenerator
   FairRoot::BaseMQ # Serialization policies
-  FairRoot::FairTools # FairLogger
+  FairRoot::Tools # FairLogger
   FairRoot::ParBase
   FairRoot::ExMCStack
   FairRoot::ExPixel

--- a/examples/MQ/serialization/CMakeLists.txt
+++ b/examples/MQ/serialization/CMakeLists.txt
@@ -35,7 +35,7 @@ target_include_directories(${target} PUBLIC
 target_link_libraries(${target} PUBLIC
   FairRoot::Base # FairRunIdGenerator
   FairRoot::BaseMQ # Serialization policies
-  FairRoot::FairTools # FairLogger
+  FairRoot::Tools # FairLogger
   FairRoot::ParBase
   FairRoot::FairMQ
 

--- a/examples/advanced/MbsTutorial/CMakeLists.txt
+++ b/examples/advanced/MbsTutorial/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (C) 2014-2019 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
+# Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
@@ -32,7 +32,7 @@ target_include_directories(${target} PUBLIC
 
 target_link_libraries(${target} PUBLIC
   FairRoot::Online
-  FairRoot::FairTools # FairLogger
+  FairRoot::Tools # FairLogger
 
   ROOT::Core
 )

--- a/examples/advanced/Tutorial3/CMakeLists.txt
+++ b/examples/advanced/Tutorial3/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (C) 2014-2019 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
+# Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
@@ -118,7 +118,7 @@ target_include_directories(${target} PUBLIC
 target_link_libraries(${target} PUBLIC
   FairRoot::Base # FairRunIdGenerator
   FairRoot::BaseMQ # Serialization policies
-  FairRoot::FairTools # FairLogger
+  FairRoot::Tools # FairLogger
   FairRoot::GeoBase # FairGeoSet
   FairRoot::ExMCStack
   FairRoot::ParBase # FairRuntimeDb, FairContFact, FairParamList

--- a/examples/advanced/propagator/src/CMakeLists.txt
+++ b/examples/advanced/propagator/src/CMakeLists.txt
@@ -1,5 +1,5 @@
  ################################################################################
- #    Copyright (C) 2019 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    #
+ # Copyright (C) 2019-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
  #                                                                              #
  #              This software is distributed under the terms of the             #
  #              GNU Lesser General Public Licence (LGPL) version 3,             #
@@ -49,7 +49,7 @@ target_link_libraries(${target} PUBLIC
   FairRoot::GeoBase # FairGeoSet
   FairRoot::ExMCStack
   FairRoot::ParBase # FairRuntimeDb, FairContFact, FairParamList
-  FairRoot::TrkBase # FairPropagator
+  FairRoot::TrackBase # FairPropagator
   FairRoot::EventDisplay
 
   ROOT::Eve

--- a/examples/advanced/propagator/src/CMakeLists.txt
+++ b/examples/advanced/propagator/src/CMakeLists.txt
@@ -45,7 +45,7 @@ target_include_directories(${target} PUBLIC
 target_link_libraries(${target} PUBLIC
   FairRoot::Base # FairRunIdGenerator
   FairRoot::BaseMQ # Serialization policies
-  FairRoot::FairTools # FairLogger
+  FairRoot::Tools # FairLogger
   FairRoot::GeoBase # FairGeoSet
   FairRoot::ExMCStack
   FairRoot::ParBase # FairRuntimeDb, FairContFact, FairParamList

--- a/examples/common/eventdisplay/CMakeLists.txt
+++ b/examples/common/eventdisplay/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (C) 2014-2020 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
+# Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
@@ -33,7 +33,7 @@ target_link_libraries(${target} PUBLIC
   FairRoot::ParBase
   FairRoot::EventDisplay
   FairRoot::ExMCStack
-  FairRoot::TrkBase
+  FairRoot::TrackBase
 
   ROOT::Core
   ROOT::Eve

--- a/examples/common/gconfig/CMakeLists.txt
+++ b/examples/common/gconfig/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (C) 2014-2019 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
+# Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
@@ -29,7 +29,7 @@ target_include_directories(${target} PUBLIC
 
 target_link_libraries(${target} PUBLIC
   FairRoot::Base # FairRunIdGenerator
-  FairRoot::FairTools # FairLogger
+  FairRoot::Tools # FairLogger
   FairRoot::MCConfigurator # FairYamlVMCConfig
   FairRoot::ExMCStack # FairStack
 

--- a/examples/common/mcstack/CMakeLists.txt
+++ b/examples/common/mcstack/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (C) 2014-2019 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
+# Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
@@ -33,7 +33,7 @@ target_include_directories(${target} PUBLIC
 
 target_link_libraries(${target} PUBLIC
   FairRoot::Base # FairRunIdGenerator
-  FairRoot::FairTools # FairLogger
+  FairRoot::Tools # FairLogger
 
   ROOT::Core
   ROOT::Physics # TLorentzVector, TVector3

--- a/examples/simulation/Tutorial1/src/CMakeLists.txt
+++ b/examples/simulation/Tutorial1/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (C) 2014-2019 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
+# Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
@@ -35,7 +35,7 @@ target_include_directories(${target} PUBLIC
 
 target_link_libraries(${target} PUBLIC
   FairRoot::Base # FairRunIdGenerator
-  FairRoot::FairTools # FairLogger
+  FairRoot::Tools # FairLogger
   FairRoot::FairFastSim
   FairRoot::ParBase
   FairRoot::ExPassive

--- a/examples/simulation/Tutorial1/src/CMakeLists.txt
+++ b/examples/simulation/Tutorial1/src/CMakeLists.txt
@@ -40,7 +40,7 @@ target_link_libraries(${target} PUBLIC
   FairRoot::ParBase
   FairRoot::ExPassive
   FairRoot::ExMCStack
-  FairRoot::Gen
+  FairRoot::Generators
 
   Boost::program_options
 

--- a/examples/simulation/Tutorial1/src/CMakeLists.txt
+++ b/examples/simulation/Tutorial1/src/CMakeLists.txt
@@ -36,7 +36,7 @@ target_include_directories(${target} PUBLIC
 target_link_libraries(${target} PUBLIC
   FairRoot::Base # FairRunIdGenerator
   FairRoot::Tools # FairLogger
-  FairRoot::FairFastSim
+  FairRoot::FastSim
   FairRoot::ParBase
   FairRoot::ExPassive
   FairRoot::ExMCStack

--- a/examples/simulation/Tutorial2/src/CMakeLists.txt
+++ b/examples/simulation/Tutorial2/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (C) 2014-2019 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
+# Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
@@ -35,7 +35,7 @@ target_include_directories(${target} PUBLIC
 
 target_link_libraries(${target} PUBLIC
   FairRoot::Base # FairRunIdGenerator
-  FairRoot::FairTools # FairLogger
+  FairRoot::Tools # FairLogger
   FairRoot::GeoBase # FairContFact
   FairRoot::ExMCStack
   FairRoot::ParBase # FairContFact

--- a/examples/simulation/Tutorial4/src/CMakeLists.txt
+++ b/examples/simulation/Tutorial4/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (C) 2014-2019 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
+# Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
@@ -54,7 +54,7 @@ target_include_directories(${target} PUBLIC
 
 target_link_libraries(${target} PUBLIC
   FairRoot::Base # FairRunIdGenerator
-  FairRoot::FairTools # FairLogger
+  FairRoot::Tools # FairLogger
   FairRoot::ExMCStack
   FairRoot::GeoBase
   FairRoot::ParBase

--- a/examples/simulation/Tutorial4/src/CMakeLists.txt
+++ b/examples/simulation/Tutorial4/src/CMakeLists.txt
@@ -58,7 +58,7 @@ target_link_libraries(${target} PUBLIC
   FairRoot::ExMCStack
   FairRoot::GeoBase
   FairRoot::ParBase
-  FairRoot::Gen
+  FairRoot::Generators
   $<$<BOOL:${ROOT_HAS_OPENGL}>:FairRoot::EventDisplay>
 
   ROOT::Core

--- a/examples/simulation/rutherford/src/CMakeLists.txt
+++ b/examples/simulation/rutherford/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (C) 2014-2019 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
+# Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
@@ -32,7 +32,7 @@ target_include_directories(${target} PUBLIC
 
 target_link_libraries(${target} PUBLIC
   FairRoot::Base # FairRunIdGenerator
-  FairRoot::FairTools # FairLogger
+  FairRoot::Tools # FairLogger
   FairRoot::ExMCStack
   FairRoot::GeoBase
   FairRoot::ParBase

--- a/fairtools/CMakeLists.txt
+++ b/fairtools/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (C) 2014-2019 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
+# Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
@@ -12,7 +12,7 @@ if(Geant3_FOUND AND Geant4VMC_FOUND AND yaml-cpp_FOUND)
   add_subdirectory(MCConfigurator)
 endif()
 
-set(target FairTools)
+set(target Tools)
 
 set(sources
   FairLogger.cxx
@@ -24,6 +24,8 @@ fair_change_extensions_if_exists(.cxx .h FILES "${sources}" OUTVAR headers)
 
 add_library(${target} SHARED ${sources} ${headers})
 fairroot_library_settings(${target})
+# Keep old filesystem name
+set_target_properties(${target} PROPERTIES OUTPUT_NAME FairTools)
 
 target_include_directories(${target} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
@@ -46,7 +48,7 @@ target_link_libraries(${target} PUBLIC
 
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
-  LINKDEF FairToolsLinkDef.h
+  LINKDEF LinkDef.h
   EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 

--- a/fairtools/LinkDef.h
+++ b/fairtools/LinkDef.h
@@ -1,20 +1,20 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
- *              This software is distributed under the terms of the             * 
- *              GNU Lesser General Public Licence (LGPL) version 3,             *  
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
-// $Id: LoggerLinkDef.h,v 1.4 2006/09/15 12:43:35 turany Exp $
-
 #ifdef __CINT__
 
 #pragma link off all globals;
 #pragma link off all classes;
 #pragma link off all functions;
+// clang-format off
 
 #pragma link C++ class FairLogger+;
 #pragma link C++ class FairMonitor+;
 #pragma link C++ class FairSystemInfo;
 
+// clang-format on
 #endif

--- a/fairtools/MCConfigurator/CMakeLists.txt
+++ b/fairtools/MCConfigurator/CMakeLists.txt
@@ -28,7 +28,7 @@ target_include_directories(${target} PUBLIC
 target_link_libraries(${target} PUBLIC
   FairRoot::Tools
   FairRoot::Base # FairGenericVMCConfig
-  FairRoot::FairFastSim # FairFastSimRunConfiguration
+  FairRoot::FastSim # FairFastSimRunConfiguration
 
   geant321
   geant4vmc

--- a/fairtools/MCConfigurator/CMakeLists.txt
+++ b/fairtools/MCConfigurator/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (C) 2014-2019 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
+# Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
@@ -26,7 +26,7 @@ target_include_directories(${target} PUBLIC
 )
 
 target_link_libraries(${target} PUBLIC
-  FairRoot::FairTools
+  FairRoot::Tools
   FairRoot::Base # FairGenericVMCConfig
   FairRoot::FairFastSim # FairFastSimRunConfiguration
 

--- a/fairtools/MCStepLogger/CMakeLists.txt
+++ b/fairtools/MCStepLogger/CMakeLists.txt
@@ -1,7 +1,14 @@
+################################################################################
+#    Copyright (C) 2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    #
+#                                                                              #
+#              This software is distributed under the terms of the             #
+#              GNU Lesser General Public Licence (LGPL) version 3,             #
+#                  copied verbatim in the file "LICENSE"                       #
+################################################################################
 # @author Sandro Wenzel
 # @brief  cmake setup for module Utilities/MCStepLogger
 
-set(target FairMCStepLogger)
+set(target MCStepLogger)
 
 set(sources
   MCStepInterceptor.cxx
@@ -10,6 +17,8 @@ set(sources
 
 add_library(${target} SHARED ${sources})
 fairroot_library_settings(${target})
+# Keep old filesystem name
+set_target_properties(${target} PROPERTIES OUTPUT_NAME FairMCStepLogger)
 
 target_include_directories(${target} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/fairtools/README.dox
+++ b/fairtools/README.dox
@@ -1,7 +1,7 @@
 /**
-\defgroup fairtools FairTools
+\defgroup fairtools Tools
 
-# FairTools
+# Tools
 
 ## FairLogger
 
@@ -18,6 +18,6 @@ We recommend using fair::Logger directly. Upgrade notes:
 - Replace `Debug4(...)` style functions with `LOG(debug4) << content;` calls.
 - Replace `FairLogger::IsLogNeeded(<severity>)` with `fair::Logger::Logging(<severity>)`.
 
-The CMake target name for this library is `FairRoot::FairTools`.
+The CMake target name for this library is `FairRoot::Tools`.
 
  */

--- a/geane/CMakeLists.txt
+++ b/geane/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (C) 2014-2019 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
+# Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
@@ -28,7 +28,7 @@ target_include_directories(${target} PUBLIC
 
 target_link_libraries(${target} PUBLIC
   FairRoot::Base # FairField, FairTask, FairPropagator
-  FairRoot::TrkBase # FairTrackPar
+  FairRoot::TrackBase # FairTrackPar
 
   geant321
 

--- a/generators/CMakeLists.txt
+++ b/generators/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (C) 2014-2019 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
+# Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
@@ -35,7 +35,7 @@ target_include_directories(${target} PUBLIC
 
 target_link_libraries(${target} PUBLIC
   FairRoot::Base # FairPrimaryGenerator, FairGenerator, FairIon, FairParticle, FairRunSim
-  FairRoot::FairTools
+  FairRoot::Tools
 
   ROOT::Core
   ROOT::EG

--- a/generators/CMakeLists.txt
+++ b/generators/CMakeLists.txt
@@ -6,7 +6,7 @@
 #                  copied verbatim in the file "LICENSE"                       #
 ################################################################################
 
-set(target Gen)
+set(target Generators)
 
 set(sources
   FairAsciiGenerator.cxx
@@ -24,6 +24,8 @@ fair_change_extensions_if_exists(.cxx .h FILES "${sources}" OUTVAR headers)
 
 add_library(${target} SHARED ${sources} ${headers})
 fairroot_library_settings(${target})
+# Keep old filesystem name
+set_target_properties(${target} PROPERTIES OUTPUT_NAME Gen)
 
 target_include_directories(${target} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
@@ -46,7 +48,7 @@ target_link_libraries(${target} PUBLIC
 
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
-  LINKDEF GenLinkDef.h
+  LINKDEF LinkDef.h
   EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 

--- a/generators/LinkDef.h
+++ b/generators/LinkDef.h
@@ -1,17 +1,16 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
- *              This software is distributed under the terms of the             * 
- *              GNU Lesser General Public Licence (LGPL) version 3,             *  
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
-// $Id: GenLinkDef.h,v 1.2 2006/09/15 16:53:34 friese Exp $
-
 #ifdef __CINT__
 
 #pragma link off all globals;
 #pragma link off all classes;
 #pragma link off all functions;
+// clang-format off
 
 #pragma link C++ class  FairAsciiGenerator+;
 #pragma link C++ class  FairIonGenerator+;
@@ -23,4 +22,5 @@
 #pragma link C++ class  FairYPtGenerator+;
 #pragma link C++ class  FairBaseMCGenerator+;
 
+// clang-format on
 #endif

--- a/generators/README.dox
+++ b/generators/README.dox
@@ -1,5 +1,5 @@
 /**
-\defgroup generators Generators (Gen)
+\defgroup generators Generators
 
 generators
 ========
@@ -20,6 +20,6 @@ The following generators are part of FairRoot:
 * FairPlutoReactionGenerator inserts an inline PReaction and thus connects Pluto with the FairPrimaryGenerator.
 * FairShieldGenerator is similar to the FairAsciiGenerator. It uses the ASCII output of the SHIELD code as input for simulation. The format of the event header is: event nr., number of particles, beam momentum, impact parameter; followed by a line for each particle of the format: PID; A; Z; px; py; pz. The PID must be given as for Geant3. For ions, it is 1000. The total momentum is required, not momentum per nucleon.
 
-The CMake target name for this library is `FairRoot::Gen`.
+The CMake target name for this library is `FairRoot::Generators`.
 
  */

--- a/geobase/CMakeLists.txt
+++ b/geobase/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (C) 2014-2019 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
+# Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
@@ -57,7 +57,7 @@ target_include_directories(${target} PUBLIC
 )
 
 target_link_libraries(${target} PUBLIC
-  FairRoot::FairTools
+  FairRoot::Tools
 
   ROOT::Core
   ROOT::MathCore

--- a/online/CMakeLists.txt
+++ b/online/CMakeLists.txt
@@ -39,7 +39,7 @@ target_include_directories(${target} PUBLIC
 )
 
 target_link_libraries(${target} PUBLIC
-  FairRoot::FairTools
+  FairRoot::Tools
   FairRoot::Base
   FairRoot::ParBase
   $<$<BOOL:${BUILD_MBS}>:FairRoot::MbsAPI>

--- a/parbase/CMakeLists.txt
+++ b/parbase/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (C) 2014-2019 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
+# Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
@@ -39,7 +39,7 @@ target_include_directories(${target} PUBLIC
 )
 
 target_link_libraries(${target} PUBLIC
-  FairRoot::FairTools
+  FairRoot::Tools
 
   ROOT::Core
   ROOT::RIO

--- a/parmq/CMakeLists.txt
+++ b/parmq/CMakeLists.txt
@@ -29,7 +29,7 @@ target_link_libraries(${target} PUBLIC
   FairRoot::Base # FairRunIdGenerator
   FairRoot::BaseMQ # Serialization policies
   FairRoot::ParBase # FairRuntimeDb, ...
-  FairRoot::FairTools # FairLogger
+  FairRoot::Tools # FairLogger
   FairRoot::FairMQ
 
   ROOT::Core

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (C) 2014-2019 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
+# Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
@@ -7,7 +7,7 @@
 ################################################################################
 
 set(dependencies
-  FairRoot::FairTools
+  FairRoot::Tools
   GTest::GTest
   GTest::Main
 )

--- a/trackbase/CMakeLists.txt
+++ b/trackbase/CMakeLists.txt
@@ -1,12 +1,12 @@
 ################################################################################
-# Copyright (C) 2014-2019 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
+# Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
 #                  copied verbatim in the file "LICENSE"                       #
 ################################################################################
 
-set(target TrkBase)
+set(target TrackBase)
 
 set(sources
   FairGeaneUtil.cxx
@@ -22,6 +22,8 @@ fair_change_extensions_if_exists(.cxx .h FILES "${sources}" OUTVAR headers)
 
 add_library(${target} SHARED ${sources} ${headers})
 fairroot_library_settings(${target})
+# Keep old filesystem name
+set_target_properties(${target} PROPERTIES OUTPUT_NAME TrkBase)
 
 target_include_directories(${target} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
@@ -43,7 +45,7 @@ target_link_libraries(${target} PUBLIC
 
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
-  LINKDEF TrackBaseLinkDef.h
+  LINKDEF LinkDef.h
   EXTRA_INCLUDE_DIRS ${CMAKE_INSTALL_FULL_INCLUDEDIR}
 )
 

--- a/trackbase/CMakeLists.txt
+++ b/trackbase/CMakeLists.txt
@@ -34,7 +34,7 @@ target_include_directories(${target} PUBLIC
 )
 
 target_link_libraries(${target} PUBLIC
-  FairRoot::FairTools
+  FairRoot::Tools
   FairRoot::Base # FairRunAna, FairField
 
   ROOT::Core

--- a/trackbase/LinkDef.h
+++ b/trackbase/LinkDef.h
@@ -1,8 +1,8 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
- *              This software is distributed under the terms of the             * 
- *              GNU Lesser General Public Licence (LGPL) version 3,             *  
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
 #ifdef __CINT__
@@ -10,7 +10,7 @@
 #pragma link off all globals;
 #pragma link off all classes;
 #pragma link off all functions;
-
+// clang-format off
 
 #pragma link C++ class  FairTrackPar+;
 #pragma link C++ class  FairTrackParP+;
@@ -20,6 +20,5 @@
 #pragma link C++ class FairPropagator+;
 #pragma link C++ class FairRKPropagator+;
 
-
+// clang-format on
 #endif
-

--- a/trackbase/README.dox
+++ b/trackbase/README.dox
@@ -1,5 +1,5 @@
 /**
-\defgroup trackbase trackbase (TrkBase)
+\defgroup trackbase TrackBase
 
 trackbase
 ========
@@ -10,6 +10,6 @@ Track parameter containers.
   - `FairTrackParP` - parabolic track representation
   - `FairTrackParH` - helix track representation
 
-The CMake target name for this library is `FairRoot::TrkBase`.
+The CMake target name for this library is `FairRoot::TrackBase`.
 
  */


### PR DESCRIPTION
The directory is named trackbase (with "ac"), while the target was named TrkBase. Rename the target to TrackBase.

Keep the old filesystem name for 19.0 to allow a little bit easier migration. The filesystem name will change in 19.2.

Start documenting targets and naming changes in the CHANGELOG.

NOTE: If this is approved, alike changes for other libraries will follow.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
