### PR TITLE
Make member pointer fEvtHeader of FairRun into unique pointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
     in addition.
 * Renamed our `ROOT_GENERATE_DICTIONARY` to `FAIRROOT_GENERATE_DICTIONARY`.
   (It's not used in many places anyway, it seems.)
+* `fEvtHeader` member variable now is a private unique pointer owned by `FairRun`. To access
+  the event header, please use the public member function `GetEventHeader()`.
 * The following files have been deleted. As far as we know they were not used anywhere:
   * basemq/baseMQtools/baseMQtools.h
   * basemq/policies/Sampler/FairMQFileSource.h
@@ -78,6 +80,9 @@ file an issue, so that we can see how to handle this.
 * Deprecated FairEventBuilder and FairEventBuilderManager
   * The functionality, introduced to enable event reconstruction, is not used.
   * It can be enabled with `-DBUILD_EVENT_BUILDER=ON`.
+* Deprecated `FairRun::SetEventHeader(FairEventHeader*)`
+   * Use `FairRun::SetEventHeader(std::unique_ptr<FairEventHeader> EvHeader)`, which 
+     indicates the ownership transferring.
 
 ### Other Notable Changes
 * Consider calling `fairroot_check_root_cxxstd_compatibility()`

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -32,6 +32,7 @@ Shahoyan, Ruben
 Stockmanns, Tobias
 Ustyuzhanin, Andrey
 von Haller, Barthélémy
+Wang, Yanzhao [https://orcid.org/0000-0002-7006-7986]
 Wenzel, Sandro
 Wielanek, Daniel
 Winckler, Nicolas

--- a/fairroot/base/steer/FairRun.h
+++ b/fairroot/base/steer/FairRun.h
@@ -75,7 +75,9 @@ class FairRun : public TNamed
      *       Set the experiment dependent run header
      *       for each run
      */
-    void SetEventHeader(FairEventHeader* EvHeader) { fEvtHeader = EvHeader; }
+    void SetEventHeader(std::unique_ptr<FairEventHeader> EvHeader);
+    [[deprecated("Use SetEventHeader(std::unique_ptr<FairEventHeader>) instead")]] void SetEventHeader(
+        FairEventHeader* EvHeader);
     /**
      * return a pointer to the RuntimeDB
      */
@@ -206,6 +208,8 @@ class FairRun : public TNamed
     FairRun& operator=(const FairRun&) { return *this; }
     /** Number of Tasks added*/
     Int_t fNTasks;
+    /** MC Event Header */
+    std::unique_ptr<FairEventHeader> fEvtHeader;   //!
 
     FairLinkManager fLinkManager{};   //!
 
@@ -228,8 +232,6 @@ class FairRun : public TNamed
     UInt_t fRunId;   //!
     /** true for Anaylsis session*/
     Bool_t fAna;   //!
-    /** MC Event Header */
-    FairEventHeader* fEvtHeader;   //!
     /** File  Header */
     FairFileHeader* fFileHeader;
     /** true if RunInfo file should be written*/

--- a/fairroot/base/steer/FairRunAna.cxx
+++ b/fairroot/base/steer/FairRunAna.cxx
@@ -202,20 +202,16 @@ void FairRunAna::Init()
 
     // Assure that basic info is there for the run
     //  if(par && fInputFile) {
+    auto* evtHeader = GetEventHeader();
     if (par && fInFileIsOpen) {
 
         LOG(info) << "Parameter and input file are available, Assure that basic info is there for the run!";
         fRootManager->SpecifyRunId();
-
-        //    fEvtHeader = GetEventHeader();
-        GetEventHeader();
-
         FillEventHeader();
-
         fRunId = GetEvtHeaderRunId();
 
         // Copy the Event Header Info to Output
-        fEvtHeader->Register(GetSink() ? fStoreEventHeader : false);
+        evtHeader->Register(GetSink() ? fStoreEventHeader : false);
 
         // Init the containers in Tasks
         LOG(info) << "--- Initialize with RunId  --- " << fRunId;
@@ -225,12 +221,11 @@ void FairRunAna::Init()
         fTask->SetParTask();
     } else {   // end----- if(fMixedInput)
         LOG(info) << "Initializing without input file or Mixed input";
-        FairEventHeader* evt = GetEventHeader();
-        evt->Register(GetSink() ? fStoreEventHeader : false);
+        evtHeader->Register(GetSink() ? fStoreEventHeader : false);
         FairRunIdGenerator genid;
         fRunId = genid.generateId();
         fRtdb->addRun(fRunId);
-        evt->SetRunId(fRunId);
+        evtHeader->SetRunId(fRunId);
         fTask->SetParTask();
         if (!fRtdb->initContainers(fRunId)) {
             LOG(error) << "FairRunAna::Init: fRtdb->initContainers failed";

--- a/fairroot/base/steer/FairRunAnaProof.cxx
+++ b/fairroot/base/steer/FairRunAnaProof.cxx
@@ -13,7 +13,6 @@
 #include "FairRunAnaProof.h"
 
 #include "FairBaseParSet.h"
-#include "FairEventHeader.h"
 #include "FairFieldFactory.h"
 #include "FairFileHeader.h"
 #include "FairLogger.h"
@@ -170,19 +169,18 @@ void FairRunAnaProof::Init()
 
     // Assure that basic info is there for the run
 
+    auto* evtHeader = GetEventHeader();
     if (par && fInFileIsOpen) {
 
         LOG(info) << "Parameter and input file are available, Assure that basic info is there for the run!";
         fRootManager->SpecifyRunId();
-
-        GetEventHeader();
 
         FillEventHeader();
 
         fRunId = GetEvtHeaderRunId();
 
         // Copy the Event Header Info to Output
-        fEvtHeader->Register(GetSink() ? fStoreEventHeader : false);
+        evtHeader->Register(GetSink() ? fStoreEventHeader : false);
 
         // Init the containers in Tasks
         LOG(info) << "--- Initialize with RunId  --- " << fRunId;
@@ -192,12 +190,11 @@ void FairRunAnaProof::Init()
         fTask->SetParTask();
     } else {   // end----- if(fMixedInput)
         LOG(info) << "Initializing without input file or Mixed input";
-        FairEventHeader* evt = GetEventHeader();
-        evt->Register(GetSink() ? fStoreEventHeader : false);
+        evtHeader->Register(GetSink() ? fStoreEventHeader : false);
         FairRunIdGenerator genid;
         fRunId = genid.generateId();
         fRtdb->addRun(fRunId);
-        evt->SetRunId(fRunId);
+        evtHeader->SetRunId(fRunId);
         fTask->SetParTask();
         if (!fRtdb->initContainers(fRunId)) {
             LOG(error) << "FairRunAnaProof::Init: fRtdb->initContainers failed";
@@ -238,19 +235,18 @@ void FairRunAnaProof::InitContainers()
     fRtdb = GetRuntimeDb();
     FairBaseParSet* par = dynamic_cast<FairBaseParSet*>(fRtdb->getContainer("FairBaseParSet"));
 
+    auto* evtHeader = GetEventHeader();
     if (par && fInFileIsOpen) {
         fRootManager->SpecifyRunId();
-
-        GetEventHeader();
 
         FillEventHeader();
 
         fRunId = GetEvtHeaderRunId();
 
-        LOG(info) << "RKGOT FEH " << fEvtHeader << " (" << fRunId << ") FROM FRM " << fRootManager << ".";
+        LOG(info) << "RKGOT FEH " << evtHeader << " (" << fRunId << ") FROM FRM " << fRootManager << ".";
 
         // Copy the Event Header Info to Output
-        fEvtHeader->Register(GetSink() ? fStoreEventHeader : false);
+        evtHeader->Register(GetSink() ? fStoreEventHeader : false);
 
         // Init the containers in Tasks
         LOG(info) << "--- Initialize with RunId  --- " << fRunId;

--- a/fairroot/online/steer/FairRunOnline.cxx
+++ b/fairroot/online/steer/FairRunOnline.cxx
@@ -130,10 +130,9 @@ void FairRunOnline::Init()
         fRootManager->ReadEvent(0);
     }
 
-    GetEventHeader();
-
+    // --- Get event header from Run
+    auto* evtHeader = GetEventHeader();
     FillEventHeader();
-
     if (0 == fRunId)   // Run ID was not set in run manager
     {
         if (0 == GetEvtHeaderRunId())   // Run ID was not set in source
@@ -187,14 +186,9 @@ void FairRunOnline::Init()
         LOG(error) << "FairRunOnline::Init: fRtdb->initContainers failed";
     }
 
-    // --- Get event header from Run
-    if (!fEvtHeader) {
-        LOG(fatal) << "FairRunOnline::Init() No event header in run!";
-        return;
-    }
-    LOG(info) << "FairRunOnline::Init() Event header at " << fEvtHeader;
-    fRootManager->Register("EventHeader.", "Event", fEvtHeader, (nullptr != GetSink()));
-    fEvtHeader->SetRunId(fRunId);
+    LOG(info) << "FairRunOnline::Init() Event header at " << evtHeader;
+    fRootManager->Register("EventHeader.", "Event", evtHeader, (nullptr != GetSink()));
+    evtHeader->SetRunId(fRunId);
 
     if (!GetSource()->InitUnpackers()) {
         LOG(fatal) << "FairRunOnline->Init() InitUnpackers() failed!";
@@ -222,6 +216,7 @@ Int_t FairRunOnline::EventLoop()
 
     fRootManager->StoreWriteoutBufferData(fRootManager->GetEventTime());
     fTask->ExecuteTask("");
+    // TODO: Fill the event header again? Is this necessary?
     FillEventHeader();
     Fill();
     fRootManager->DeleteOldWriteoutBufferData();


### PR DESCRIPTION
Encapsulate member pointer FairEventHeader from FairRun inside `std::unique_ptr`. This specifies the ownership of the event header and prevents it from being deleted multiple times.

Fixes #1242

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
