### PR TITLE
[18.6] FairRun: Remove fTask from Browsables

### DIFF
--- a/base/steer/FairRun.cxx
+++ b/base/steer/FairRun.cxx
@@ -29,6 +29,7 @@
 #endif
 #include <TList.h>     // for TList
 #include <TObject.h>   // for TObject
+#include <TROOT.h>     // fot gROOT
 #include <cassert>     // for... well, assert
 
 TMCThreadLocal FairRun* FairRun::fRunInstance = 0;
@@ -85,7 +86,11 @@ FairRun::FairRun(Bool_t isMaster)
 FairRun::~FairRun()
 {
     LOG(debug) << "Enter Destructor of FairRun";
-    delete fTask;   // There is another tasklist in MCApplication,
+    if (fTask) {
+        // FairRunAna added it, but let's remove it here, because we own it
+        gROOT->GetListOfBrowsables()->Remove(fTask);
+        delete fTask;   // There is another tasklist in MCApplication,
+    }
     // but this should be independent
     delete fRtdb;   // who is responsible for the RuntimeDataBase
     delete fEvtHeader;


### PR DESCRIPTION
FairRunAna might add fTask to ROOT's "ListOfBrowsables". FairRun deallocates it during its desctructor.
So let's remove it from the list there as well.

(cherry picked from commit f9f1648108e58ca998cd0b8a0d67601440934ad0)

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
