### PR TITLE
Forward Port: Move FillEventHeader from FRM to FairRun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,8 @@ file an issue, so that we can see how to handle this.
     no other code in FairRoot uses the setters,
     we're not aware of anyone using it.
   * `FairFieldFactory::fCreator` points to `this`.
+  * `FairRootManager::FillEventHeader` is only a wrapper around
+    `FairSource::FillEventHeader`.
 * Many items were already deprecated in prior versions.
   Marked them with proper C++14 deprecation warnings.
   Scheduled them for removal in v20.

--- a/base/steer/FairRootManager.h
+++ b/base/steer/FairRootManager.h
@@ -183,7 +183,8 @@ class FairRootManager : public TObject
     /** Replace the time based branch name list*/
     void SetTimeBasedBranchNameList(TList* list);
 
-    void FillEventHeader(FairEventHeader* feh)
+    /** \deprecated Deprecated in v18.8, will be removed in v20. */
+    [[deprecated]] void FillEventHeader(FairEventHeader* feh)
     {
         if (fSource)
             fSource->FillEventHeader(feh);

--- a/base/steer/FairRun.h
+++ b/base/steer/FairRun.h
@@ -241,6 +241,14 @@ class FairRun : public TNamed
     std::unique_ptr<FairSource> fSource{};   //!
 
     void AlignGeometry() const;
+    /**
+     * Call FillEventHeader on the source
+     */
+    void FillEventHeader()
+    {
+        if (fSource)
+            fSource->FillEventHeader(fEvtHeader);
+    }
 
     ClassDefOverride(FairRun, 5);
 };

--- a/base/steer/FairRunAna.cxx
+++ b/base/steer/FairRunAna.cxx
@@ -208,7 +208,7 @@ void FairRunAna::Init()
         //    fEvtHeader = GetEventHeader();
         GetEventHeader();
 
-        fRootManager->FillEventHeader(fEvtHeader);
+        FillEventHeader();
 
         fRunId = fEvtHeader->GetRunId();
 
@@ -342,7 +342,7 @@ void FairRunAna::Run(Int_t Ev_start, Int_t Ev_end)
                 break;
             }
 
-            fRootManager->FillEventHeader(fEvtHeader);
+            FillEventHeader();
 
             tmpId = fEvtHeader->GetRunId();
             if (tmpId != fRunId) {
@@ -434,7 +434,7 @@ void FairRunAna::RunEventReco(Int_t Ev_start, Int_t Ev_end)
         fRootManager->StoreWriteoutBufferData(fRootManager->GetEventTime());
         fTask->ExecuteTask("");
 
-        fRootManager->FillEventHeader(fEvtHeader);
+        FillEventHeader();
         // Fill();
         fTask->FinishEvent();
 
@@ -460,7 +460,7 @@ void FairRunAna::Run(Double_t delta_t)
 {
     while (fRootManager->ReadNextEvent(delta_t)) {
         fTask->ExecuteTask("");
-        fRootManager->FillEventHeader(fEvtHeader);
+        FillEventHeader();
         Fill();
         fRootManager->DeleteOldWriteoutBufferData();
         fTask->FinishEvent();
@@ -494,7 +494,7 @@ void FairRunAna::RunMQ(Long64_t entry)
         }
     }
     fTask->ExecuteTask("");
-    fRootManager->FillEventHeader(fEvtHeader);
+    FillEventHeader();
     fTask->FinishTask();
 }
 //_____________________________________________________________________________
@@ -513,7 +513,7 @@ void FairRunAna::Run(Long64_t entry)
         }
     }
     fTask->ExecuteTask("");
-    fRootManager->FillEventHeader(fEvtHeader);
+    FillEventHeader();
     fTask->FinishTask();
     Fill();
     fRootManager->DeleteOldWriteoutBufferData();
@@ -535,7 +535,7 @@ void FairRunAna::RunTSBuffers()
             fRootManager->ReadNonTimeBasedEventFromBranches(globalEvent++);
         }
         fTask->ExecuteTask("");
-        fRootManager->FillEventHeader(fEvtHeader);
+        FillEventHeader();
         Fill();
         fRootManager->DeleteOldWriteoutBufferData();
         fTask->FinishEvent();
@@ -564,7 +564,7 @@ void FairRunAna::RunOnLmdFiles(UInt_t NStart, UInt_t NStop)
         }
 
         fTask->ExecuteTask("");
-        fRootManager->FillEventHeader(fEvtHeader);
+        FillEventHeader();
         Fill();
     }
 
@@ -588,11 +588,10 @@ void FairRunAna::RunOnTBData()
 //_____________________________________________________________________________
 void FairRunAna::DummyRun(Int_t Ev_start, Int_t Ev_end)
 {
-
     /** This methode is just for testing, if you are not sure about what you do, don't use it */
     for (int i = Ev_start; i < Ev_end; i++) {
         fTask->ExecuteTask("");
-        fRootManager->FillEventHeader(fEvtHeader);
+        FillEventHeader();
         Fill();
     }
     fTask->FinishTask();

--- a/base/steer/FairRunAnaProof.cxx
+++ b/base/steer/FairRunAnaProof.cxx
@@ -174,7 +174,7 @@ void FairRunAnaProof::Init()
 
         GetEventHeader();
 
-        fRootManager->FillEventHeader(fEvtHeader);
+        FillEventHeader();
 
         fRunId = fEvtHeader->GetRunId();
 
@@ -245,7 +245,7 @@ void FairRunAnaProof::InitContainers()
         if (nullptr == fEvtHeader)
             LOG(fatal) << "Could not read event header.";
 
-        fRootManager->FillEventHeader(fEvtHeader);
+        FillEventHeader();
 
         fRunId = fEvtHeader->GetRunId();
 
@@ -287,7 +287,7 @@ void FairRunAnaProof::RunOneEvent(Long64_t entry)
         UInt_t tmpId = 0;
         fRootManager->ReadEvent(entry);
 
-        fRootManager->FillEventHeader(fEvtHeader);
+        FillEventHeader();
 
         tmpId = fEvtHeader->GetRunId();
         if (tmpId != fRunId) {

--- a/online/steer/FairRunOnline.cxx
+++ b/online/steer/FairRunOnline.cxx
@@ -126,7 +126,7 @@ void FairRunOnline::Init()
 
     GetEventHeader();
 
-    fRootManager->FillEventHeader(fEvtHeader);
+    FillEventHeader();
 
     if (0 == fRunId)   // Run ID was not set in run manager
     {
@@ -243,7 +243,7 @@ Int_t FairRunOnline::EventLoop()
     gSystem->IgnoreInterrupt();
     signal(SIGINT, handler_ctrlc);
 
-    fRootManager->FillEventHeader(fEvtHeader);
+    FillEventHeader();
     auto const tmpId = fEvtHeader->GetRunId();
 
     if (tmpId != fRunId) {
@@ -256,7 +256,7 @@ Int_t FairRunOnline::EventLoop()
 
     fRootManager->StoreWriteoutBufferData(fRootManager->GetEventTime());
     fTask->ExecuteTask("");
-    fRootManager->FillEventHeader(fEvtHeader);
+    FillEventHeader();
     Fill();
     fRootManager->DeleteOldWriteoutBufferData();
     fTask->FinishEvent();


### PR DESCRIPTION
FairRootManager::FillEventHeader is only called from FairRun (and derived classes). So create an appropriate FairRun::FillEventHeader and use it around.

Deprecate FairRootManager::FillEventHeader.

(cherry picked from commit b46784a7ebe819e7780e05f9a1944b9b1dfd8235)

See: #1255

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
