### PR TITLE
clang-tidy: readability-simplify-boolean-expr

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,8 +6,11 @@ HeaderFilterRegex: '.*'
 #   Avoid undefined behaviour
 # enable google-build-using-namespace
 #   "using namespace" imports a changing amount of symbols, avoid it
+# improve readability:
+#   readability-simplify-boolean-expr
 Checks: >-
   -clang-analyzer-core.UndefinedBinaryOperatorResult,
   cppcoreguidelines-virtual-class-destructor,
   modernize-make-unique,
-  google-build-using-namespace
+  google-build-using-namespace,
+  readability-simplify-boolean-expr

--- a/FairRoot_doxygen_test.cmake
+++ b/FairRoot_doxygen_test.cmake
@@ -61,6 +61,8 @@ else()
   if (midpart AND IS_DIRECTORY "${WEB_PATH}")
     get_filename_component(parent "${WEB_PATH}/${midpart}" DIRECTORY)
     file(MAKE_DIRECTORY "${parent}")
+    # Just in case, remove the target directory
+    file(REMOVE_RECURSE "${WEB_PATH}/${midpart}")
     # In theory we should "install with component Doxygen".
     # Copying a few thousand files via NFS isn't fun.
     # We run on the same FS anyhow. Let's move.


### PR DESCRIPTION
Now that all warnings from this check have been fixed, enable it.

See-Also: 990d473a532769f0d45414d7be92b57c3b571736

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
