### PR TITLE
fix: Correct Deprecation Version

### DIFF
--- a/base/steer/FairRootManager.h
+++ b/base/steer/FairRootManager.h
@@ -183,7 +183,7 @@ class FairRootManager : public TObject
     /** Replace the time based branch name list*/
     void SetTimeBasedBranchNameList(TList* list);
 
-    /** \deprecated Deprecated in v19, will be removed in v20. */
+    /** \deprecated Deprecated in v18.8, will be removed in v20. */
     [[deprecated]] void FillEventHeader(FairEventHeader* feh)
     {
         if (fSource)


### PR DESCRIPTION
FairRootManager::FillEventHeader already deprecated in v18.8.

Thanks @fuhlig1 for noticing!

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
