### PR TITLE
[18.8 backport] build: Use FairRoot:: targets in templates

### DIFF
--- a/templates/project_root_containers/MyProjData/CMakeLists.txt
+++ b/templates/project_root_containers/MyProjData/CMakeLists.txt
@@ -24,6 +24,12 @@ MyProjMCTrack.cxx
 Set(HEADERS )
 Set(LINKDEF MCStackLinkDef.h)
 Set(LIBRARY_NAME MyProjData)
-Set(DEPENDENCIES Base FairLogger::FairLogger ${VMCLIB} ROOT::EG ROOT::Physics ROOT::Core)
+Set(DEPENDENCIES
+    FairRoot::Base
+    FairLogger::FairLogger
+    ${VMCLIB}
+    ROOT::EG
+    ROOT::Physics
+    ROOT::Core)
 
 GENERATE_LIBRARY()

--- a/templates/project_root_containers/NewDetector/CMakeLists.txt
+++ b/templates/project_root_containers/NewDetector/CMakeLists.txt
@@ -1,5 +1,5 @@
  ################################################################################
- #    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    #
+ # Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
  #                                                                              #
  #              This software is distributed under the terms of the             # 
  #              GNU Lesser General Public Licence (LGPL) version 3,             #  
@@ -40,7 +40,9 @@ Set(LINKDEF NewDetectorLinkDef.h)
 Set(LIBRARY_NAME NewDetector)
 Set(DEPENDENCIES
     MyProjData
-    Base GeoBase ParBase
+    FairRoot::Base
+    FairRoot::GeoBase
+    FairRoot::ParBase
     FairLogger::FairLogger
     ${VMCLIB}
 )

--- a/templates/project_root_containers/field/CMakeLists.txt
+++ b/templates/project_root_containers/field/CMakeLists.txt
@@ -26,7 +26,8 @@ MyFieldPar.cxx
 set(LINKDEF FieldLinkDef.h)
 Set(LIBRARY_NAME Field)
 Set(DEPENDENCIES
-    Base ParBase
+    FairRoot::Base
+    FairRoot::ParBase
     FairLogger::FairLogger
     ROOT::Core
 )

--- a/templates/project_root_containers/passive/CMakeLists.txt
+++ b/templates/project_root_containers/passive/CMakeLists.txt
@@ -28,8 +28,12 @@ MyPassiveContFact.cxx
 Set(HEADERS )
 Set(LINKDEF PassiveLinkDef.h)
 Set(LIBRARY_NAME Passive)
-Set(DEPENDENCIES Base GeoBase ParBase
+Set(DEPENDENCIES
+    FairRoot::Base
+    FairRoot::GeoBase
+    FairRoot::ParBase
     FairLogger::FairLogger
-    ROOT::Geom ROOT::Core)
+    ROOT::Geom
+    ROOT::Core)
 
 GENERATE_LIBRARY()

--- a/templates/project_stl_containers/MyProjData/CMakeLists.txt
+++ b/templates/project_stl_containers/MyProjData/CMakeLists.txt
@@ -24,6 +24,12 @@ MyProjMCTrack.cxx
 Set(HEADERS )
 Set(LINKDEF MCStackLinkDef.h)
 Set(LIBRARY_NAME MyProjData)
-Set(DEPENDENCIES Base FairLogger::FairLogger ${VMCLIB} ROOT::EG ROOT::Physics ROOT::Core)
+Set(DEPENDENCIES
+    FairRoot::Base
+    FairLogger::FairLogger
+    ${VMCLIB}
+    ROOT::EG
+    ROOT::Physics
+    ROOT::Core)
 
 GENERATE_LIBRARY()

--- a/templates/project_stl_containers/NewDetector/CMakeLists.txt
+++ b/templates/project_stl_containers/NewDetector/CMakeLists.txt
@@ -1,5 +1,5 @@
  ################################################################################
- #    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    #
+ # Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
  #                                                                              #
  #              This software is distributed under the terms of the             # 
  #              GNU Lesser General Public Licence (LGPL) version 3,             #  
@@ -40,7 +40,9 @@ Set(LINKDEF NewDetectorLinkDef.h)
 Set(LIBRARY_NAME NewDetector)
 Set(DEPENDENCIES
     MyProjData
-    Base GeoBase ParBase
+    FairRoot::Base
+    FairRoot::GeoBase
+    FairRoot::ParBase
     FairLogger::FairLogger
     ${VMCLIB}
 )

--- a/templates/project_stl_containers/field/CMakeLists.txt
+++ b/templates/project_stl_containers/field/CMakeLists.txt
@@ -26,7 +26,8 @@ MyFieldPar.cxx
 set(LINKDEF FieldLinkDef.h)
 Set(LIBRARY_NAME Field)
 Set(DEPENDENCIES
-    Base ParBase
+    FairRoot::Base
+    FairRoot::ParBase
     FairLogger::FairLogger
     ROOT::Core
 )

--- a/templates/project_stl_containers/passive/CMakeLists.txt
+++ b/templates/project_stl_containers/passive/CMakeLists.txt
@@ -28,8 +28,12 @@ MyPassiveContFact.cxx
 Set(HEADERS )
 Set(LINKDEF PassiveLinkDef.h)
 Set(LIBRARY_NAME Passive)
-Set(DEPENDENCIES Base GeoBase ParBase
+Set(DEPENDENCIES
+    FairRoot::Base
+    FairRoot::GeoBase
+    FairRoot::ParBase
     FairLogger::FairLogger
-    ROOT::Geom ROOT::Core)
+    ROOT::Geom
+    ROOT::Core)
 
 GENERATE_LIBRARY()


### PR DESCRIPTION
Now that we have FairRoot:: targets, use them in the templates.

(cherry picked from commit a4b5cf78ef5d5a8e7adb87b7b9fa90bfd1c4a06a)

See: #1279

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
