### PR TITLE
Deprecate DataMatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,9 @@ file an issue, so that we can see how to handle this.
 * Many items were already deprecated in prior versions.
   Marked them with proper C++14 deprecation warnings.
   Scheduled them for removal in v20.
+* Deprecated DataMatch library
+  * Contact the developers should you need it.
+  * Scheduled to remove without replacement in a future major release of FairRoot.
 
 ### Other Notable Changes
 * CMake [targets](https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html)

--- a/datamatch/CMakeLists.txt
+++ b/datamatch/CMakeLists.txt
@@ -39,6 +39,10 @@ target_link_libraries(${target} PUBLIC
   ROOT::Core
 )
 
+target_compile_definitions(${target} PRIVATE
+  FAIR_SILENCE_DATAMATCH_DEPRECATION
+)
+
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}
   LINKDEF LinkDef.h

--- a/datamatch/FairMCDataCrawler.h
+++ b/datamatch/FairMCDataCrawler.h
@@ -15,6 +15,10 @@
 #ifndef FAIRMCDATACRAWLER_H_
 #define FAIRMCDATACRAWLER_H_
 
+#ifndef FAIR_SILENCE_DATAMATCH_DEPRECATION
+#warning "FairRoot::DataMatch is deprecated and will be removed in a future major release"
+#endif
+
 #include "FairMultiLinkedData.h"   // for FairMultiLinkedData
 
 #include <Rtypes.h>    // for Int_t, Bool_t, etc

--- a/datamatch/FairMCEntry.h
+++ b/datamatch/FairMCEntry.h
@@ -15,6 +15,10 @@
 #ifndef FAIRMCENTRY_H_
 #define FAIRMCENTRY_H_
 
+#ifndef FAIR_SILENCE_DATAMATCH_DEPRECATION
+#warning "FairRoot::DataMatch is deprecated and will be removed in a future major release"
+#endif
+
 #include "FairLink.h"              // for FairLink
 #include "FairMultiLinkedData.h"   // for FairMultiLinkedData
 

--- a/datamatch/FairMCList.h
+++ b/datamatch/FairMCList.h
@@ -15,6 +15,10 @@
 #ifndef FAIRMCLIST_H_
 #define FAIRMCLIST_H_
 
+#ifndef FAIR_SILENCE_DATAMATCH_DEPRECATION
+#warning "FairRoot::DataMatch is deprecated and will be removed in a future major release"
+#endif
+
 #include <Rtypes.h>    // for Int_t, FairMCList::Class, etc
 #include <TObject.h>   // for TObject
 #include <vector>      // for vector

--- a/datamatch/FairMCMatch.h
+++ b/datamatch/FairMCMatch.h
@@ -15,6 +15,10 @@
 #ifndef FAIRMCMATCH_H_
 #define FAIRMCMATCH_H_
 
+#ifndef FAIR_SILENCE_DATAMATCH_DEPRECATION
+#warning "FairRoot::DataMatch is deprecated and will be removed in a future major release"
+#endif
+
 #include "FairMCEntry.h"           // for FairMCEntry
 #include "FairMCResult.h"          // for FairMCResult
 #include "FairMCStage.h"           // for FairMCStage

--- a/datamatch/FairMCMatchCreatorTask.h
+++ b/datamatch/FairMCMatchCreatorTask.h
@@ -19,6 +19,10 @@
 #ifndef FAIRMCMATCHCREATORTASK_H
 #define FAIRMCMATCHCREATORTASK_H
 
+#ifndef FAIR_SILENCE_DATAMATCH_DEPRECATION
+#warning "FairRoot::DataMatch is deprecated and will be removed in a future major release"
+#endif
+
 #include "FairTask.h"   // for InitStatus, FairTask
 
 #include <Rtypes.h>   // for Bool_t, etc

--- a/datamatch/FairMCMatchLoaderTask.h
+++ b/datamatch/FairMCMatchLoaderTask.h
@@ -19,6 +19,10 @@
 #ifndef FAIRMCMATCHLOADERTASK_H
 #define FAIRMCMATCHLOADERTASK_H
 
+#ifndef FAIR_SILENCE_DATAMATCH_DEPRECATION
+#warning "FairRoot::DataMatch is deprecated and will be removed in a future major release"
+#endif
+
 #include "FairTask.h"   // for FairTask, InitStatus
 
 #include <Rtypes.h>   // for ClassDef

--- a/datamatch/FairMCMatchSelectorTask.h
+++ b/datamatch/FairMCMatchSelectorTask.h
@@ -19,6 +19,10 @@
 #ifndef FAIRMCMATCHSELECTORTASK_H
 #define FAIRMCMATCHSELECTORTASK_H
 
+#ifndef FAIR_SILENCE_DATAMATCH_DEPRECATION
+#warning "FairRoot::DataMatch is deprecated and will be removed in a future major release"
+#endif
+
 #include "FairTask.h"   // for FairTask, InitStatus
 
 #include <Rtypes.h>    // for Int_t, Float_t, etc

--- a/datamatch/FairMCObject.h
+++ b/datamatch/FairMCObject.h
@@ -15,6 +15,10 @@
 #ifndef FAIRMCOBJECT_H_
 #define FAIRMCOBJECT_H_
 
+#ifndef FAIR_SILENCE_DATAMATCH_DEPRECATION
+#warning "FairRoot::DataMatch is deprecated and will be removed in a future major release"
+#endif
+
 #include "FairLink.h"              // for FairLink
 #include "FairMCEntry.h"           // for FairMCEntry
 #include "FairMultiLinkedData.h"   // for FairMultiLinkedData

--- a/datamatch/FairMCResult.h
+++ b/datamatch/FairMCResult.h
@@ -15,6 +15,10 @@
 #ifndef FAIRMCRESULT_H_
 #define FAIRMCRESULT_H_
 
+#ifndef FAIR_SILENCE_DATAMATCH_DEPRECATION
+#warning "FairRoot::DataMatch is deprecated and will be removed in a future major release"
+#endif
+
 #include "FairMCEntry.h"    // for FairMCEntry
 #include "FairMCObject.h"   // for FairMCObject
 

--- a/datamatch/FairMCStage.h
+++ b/datamatch/FairMCStage.h
@@ -15,6 +15,10 @@
 #ifndef FAIRMCSTAGE_H_
 #define FAIRMCSTAGE_H_
 
+#ifndef FAIR_SILENCE_DATAMATCH_DEPRECATION
+#warning "FairRoot::DataMatch is deprecated and will be removed in a future major release"
+#endif
+
 #include "FairMCObject.h"   // for FairMCObject
 
 #include <Rtypes.h>   // for Bool_t, Double_t, etc


### PR DESCRIPTION
By default it will not be built.
Enable it by -DBUILD_DATAMATCH=ON

Addresses issue #1270.

---

Checklist:

[ X ] Rebased against `dev` branch
[ X ] My name is in the resp. CONTRIBUTORS/AUTHORS file
[ X ] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
