### PR TITLE
Revert get out file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
     flexible local code by users.
   * Replace with a local template, `configure_file`, and `execute_process()`
   * In your template consider using `source @FairRoot_BINDIR/FairRootConfig.sh`
-* Drop deprecated `FairRootManager::GetOut{File,Tree}`
-  It has been deprecated since 18.0.0.
 
 ### Deprecations
 
@@ -168,3 +166,5 @@ file an issue, so that we can see how to handle this.
   those tests have a probability > 0 for failing.
   If you want to run them anyways, pass
   `-DENABLE_GEANT3_TESTING=ON` to CMake.
+* Undeprecate `FairRootManager::GetOut{File,Tree}`
+  It has been deprecated since 18.0.0.

--- a/base/steer/FairRootManager.cxx
+++ b/base/steer/FairRootManager.cxx
@@ -1048,7 +1048,6 @@ void FairRootManager::UpdateFileName(TString& fileName)
 
 TFile* FairRootManager::GetOutFile()
 {
-    LOG(warning) << "FairRootManager::GetOutFile() deprecated. Use separate file to store additional data.";
     auto sink = GetSink();
     assert(sink->GetSinkType() == kFILESINK);
     auto rootFileSink = static_cast<FairRootFileSink*>(sink);
@@ -1057,7 +1056,6 @@ TFile* FairRootManager::GetOutFile()
 
 TTree* FairRootManager::GetOutTree()
 {
-    LOG(warning) << "FairRootManager::GetOutTree() deprecated. Use separate file to store additional data.";
     auto sink = GetSink();
     assert(sink->GetSinkType() == kFILESINK);
     auto rootFileSink = static_cast<FairRootFileSink*>(sink);

--- a/base/steer/FairRootManager.cxx
+++ b/base/steer/FairRootManager.cxx
@@ -1046,4 +1046,22 @@ void FairRootManager::UpdateFileName(TString& fileName)
     fileName.Insert(fileName.Index(".root"), tid);
 }
 
+TFile* FairRootManager::GetOutFile()
+{
+    LOG(warning) << "FairRootManager::GetOutFile() deprecated. Use separate file to store additional data.";
+    auto sink = GetSink();
+    assert(sink->GetSinkType() == kFILESINK);
+    auto rootFileSink = static_cast<FairRootFileSink*>(sink);
+    return rootFileSink->GetRootFile();
+}
+
+TTree* FairRootManager::GetOutTree()
+{
+    LOG(warning) << "FairRootManager::GetOutTree() deprecated. Use separate file to store additional data.";
+    auto sink = GetSink();
+    assert(sink->GetSinkType() == kFILESINK);
+    auto rootFileSink = static_cast<FairRootFileSink*>(sink);
+    return rootFileSink->GetOutTree();
+}
+
 ClassImp(FairRootManager);

--- a/base/steer/FairRootManager.h
+++ b/base/steer/FairRootManager.h
@@ -271,6 +271,13 @@ class FairRootManager : public TObject
     Int_t GetInstanceId() const { return fId; }
     void UpdateFileName(TString& fileName);
 
+    // vvvvvvvvvv depracted functions, replaced by FairSink vvvvvvvvvv
+    /** Return a pointer to the output File of type TFile */
+    TFile* GetOutFile();
+    /** Return a pointer to the output tree of type TTree */
+    TTree* GetOutTree();
+    // ^^^^^^^^^^ depracted functions, replaced by FairSink ^^^^^^^^^^
+
     /**Read one event from source to find out which RunId to use*/
     Bool_t SpecifyRunId();
 

--- a/base/steer/FairRootManager.h
+++ b/base/steer/FairRootManager.h
@@ -271,12 +271,10 @@ class FairRootManager : public TObject
     Int_t GetInstanceId() const { return fId; }
     void UpdateFileName(TString& fileName);
 
-    // vvvvvvvvvv depracted functions, replaced by FairSink vvvvvvvvvv
     /** Return a pointer to the output File of type TFile */
     TFile* GetOutFile();
     /** Return a pointer to the output tree of type TTree */
     TTree* GetOutTree();
-    // ^^^^^^^^^^ depracted functions, replaced by FairSink ^^^^^^^^^^
 
     /**Read one event from source to find out which RunId to use*/
     Bool_t SpecifyRunId();


### PR DESCRIPTION
Undeprecated the FairRootManager::GetOut{File,Tree}.
Reverted the FairRootManager::GetOut{File,Tree}
removed by commit 1094179b9fa5fc9bffdc4ff413ea465c227dc2b8.

---

Checklist:

[ X ] Rebased against `dev` branch
[ X ] My name is in the resp. CONTRIBUTORS/AUTHORS file
[ X ] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
