### PR TITLE
Drop Empty/Useless SetParContainers()

### DIFF
--- a/base/event/FairEventBuilderManager.cxx
+++ b/base/event/FairEventBuilderManager.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -32,7 +32,6 @@
 
 #include "FairRecoEventHeader.h"
 #include "FairRootManager.h"
-#include "FairRunAna.h"
 
 #include <TMath.h>
 #include <iostream>
@@ -131,20 +130,6 @@ void FairEventBuilderManager::AddEventBuilder(FairEventBuilder* eventBuilder)
     fPossibleEvents.push_back(tcArray);
     //  if (fVerbose)
     cout << "*** FairEventBuilderManager. Registered " << eventBuilder->GetName() << endl;
-}
-
-void FairEventBuilderManager::SetParContainers()
-{
-    // Get run and runtime database
-    FairRunAna* run = FairRunAna::Instance();
-    if (!run) {
-        Fatal("SetParContainers", "No analysis run");
-    } else {
-        FairRuntimeDb* db = run->GetRuntimeDb();
-        if (!db) {
-            Fatal("SetParContainers", "No runtime database");
-        }
-    }
 }
 
 InitStatus FairEventBuilderManager::Init()

--- a/base/event/FairEventBuilderManager.h
+++ b/base/event/FairEventBuilderManager.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -71,9 +71,6 @@ class FairEventBuilderManager : public FairTask
     virtual void CreateAndFillEvent(FairRecoEventHeader* recoEvent);
 
   private:
-    /** Get parameter containers **/
-    virtual void SetParContainers();
-
     /** Intialisation **/
     virtual InitStatus Init();
 

--- a/base/event/FairPrintFairLinks.cxx
+++ b/base/event/FairPrintFairLinks.cxx
@@ -88,13 +88,6 @@ void FairPrintFairLinks::PrintBranchNameList(TList* branches)
     LOG(info) << "\n";
 }
 
-void FairPrintFairLinks::SetParContainers()
-{
-    // Get Base Container
-    // FairRun* ana = FairRun::Instance();
-    // FairRuntimeDb* rtdb=ana->GetRuntimeDb();
-}
-
 void FairPrintFairLinks::Exec(Option_t*)
 {
     LOG(info) << "\n--------------------- Event " << FairRootManager::Instance()->GetEntryNr() << " at "

--- a/base/event/FairPrintFairLinks.h
+++ b/base/event/FairPrintFairLinks.h
@@ -29,9 +29,6 @@ class FairPrintFairLinks : public FairTask
     /** Destructor **/
     virtual ~FairPrintFairLinks();
 
-    /** Virtual method Init **/
-    virtual void SetParContainers();
-
     virtual void AddBranchName(const TString& name) { fSelectedBranches->AddLast(new TObjString(name.Data())); }
 
     virtual void PrintBranchNameList(TList* branches);

--- a/base/steer/FairRingSorterTask.h
+++ b/base/steer/FairRingSorterTask.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -93,8 +93,6 @@ class FairRingSorterTask : public FairTask
     void Exec(Option_t* opt) override;
     void FinishEvent() override;
     void FinishTask() override;
-
-    void SetParContainers() override {}
 
     void SetPersistance(Bool_t p = kTRUE) { fPersistance = p; };
     Bool_t GetPersistance() { return fPersistance; };

--- a/datamatch/FairMCMatchCreatorTask.cxx
+++ b/datamatch/FairMCMatchCreatorTask.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -86,8 +86,6 @@ InitStatus FairMCMatchCreatorTask::InitBranches()
     }
     return kSUCCESS;
 }
-
-void FairMCMatchCreatorTask::SetParContainers() {}
 
 void FairMCMatchCreatorTask::Exec(Option_t* /*opt*/)
 {

--- a/datamatch/FairMCMatchCreatorTask.h
+++ b/datamatch/FairMCMatchCreatorTask.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -41,8 +41,6 @@ class FairMCMatchCreatorTask : public FairTask
     /** Destructor **/
     virtual ~FairMCMatchCreatorTask();
 
-    /** Virtual method Init **/
-    virtual void SetParContainers();
     void SetPersistance(Bool_t pers) { fPersistance = pers; }
     Bool_t GetPersistance() { return fPersistance; }
 

--- a/datamatch/FairMCMatchLoaderTask.cxx
+++ b/datamatch/FairMCMatchLoaderTask.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -100,8 +100,6 @@ InitStatus FairMCMatchLoaderTask::Init()
 
     return kSUCCESS;
 }
-
-void FairMCMatchLoaderTask::SetParContainers() {}
 
 void FairMCMatchLoaderTask::Exec(Option_t* /*opt*/)
 {

--- a/datamatch/FairMCMatchLoaderTask.h
+++ b/datamatch/FairMCMatchLoaderTask.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -40,7 +40,6 @@ class FairMCMatchLoaderTask : public FairTask
     virtual ~FairMCMatchLoaderTask();
 
     /** Virtual method Init **/
-    virtual void SetParContainers();
     virtual InitStatus Init();
 
     /** Virtual method Exec **/

--- a/datamatch/FairMCMatchSelectorTask.cxx
+++ b/datamatch/FairMCMatchSelectorTask.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -78,9 +78,6 @@ InitStatus FairMCMatchSelectorTask::Init()
 
     return kSUCCESS;
 }
-
-// -------------------------------------------------------------------------
-void FairMCMatchSelectorTask::SetParContainers() {}
 
 // -----   Public method Exec   --------------------------------------------
 void FairMCMatchSelectorTask::Exec(Option_t* /*opt*/)

--- a/datamatch/FairMCMatchSelectorTask.h
+++ b/datamatch/FairMCMatchSelectorTask.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -46,7 +46,6 @@ class FairMCMatchSelectorTask : public FairTask
     virtual ~FairMCMatchSelectorTask();
 
     /** Virtual method Init **/
-    virtual void SetParContainers();
     virtual InitStatus Init();
 
     /** Virtual method Exec **/

--- a/eventdisplay/FairBoxSetDraw.cxx
+++ b/eventdisplay/FairBoxSetDraw.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -129,8 +129,6 @@ void FairBoxSetDraw::SetTimeWindowMinus(Double_t val) { fTimeWindowMinus = val; 
 void FairBoxSetDraw::SetTimeWindowPlus(Double_t val) { fTimeWindowPlus = val; }
 
 FairBoxSetDraw::~FairBoxSetDraw() {}
-
-void FairBoxSetDraw::SetParContainers() {}
 
 /** Action after each event**/
 void FairBoxSetDraw::Finish() {}

--- a/eventdisplay/FairBoxSetDraw.h
+++ b/eventdisplay/FairBoxSetDraw.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -86,7 +86,6 @@ class FairBoxSetDraw : public FairTask
 
   protected:
     Int_t fVerbose;   //  Verbosity level
-    virtual void SetParContainers();
     virtual InitStatus Init();
     /** Action after each event**/
     virtual void Finish();

--- a/eventdisplay/FairPointSetDraw.cxx
+++ b/eventdisplay/FairPointSetDraw.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -118,8 +118,6 @@ void FairPointSetDraw::Exec(Option_t* /*option*/)
 // TObject* FairPointSetDraw::GetValue(TObject* /*obj*/, Int_t i) { return new TNamed(Form("Point %d", i), ""); }
 
 FairPointSetDraw::~FairPointSetDraw() { delete (fDataSource); }
-
-void FairPointSetDraw::SetParContainers() {}
 
 /** Action after each event**/
 void FairPointSetDraw::Finish() {}

--- a/eventdisplay/FairPointSetDraw.h
+++ b/eventdisplay/FairPointSetDraw.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -72,7 +72,6 @@ class FairPointSetDraw : public FairTask
     //    virtual TObject* GetValue(TObject* obj, Int_t i);
 
     Int_t fVerbose;   //  Verbosity level
-    virtual void SetParContainers();
     virtual InitStatus Init();
     /** Action after each event**/
     virtual void Finish();

--- a/examples/MQ/pixelAlternative/src/PixelAltDigiWriteToRootVector.cxx
+++ b/examples/MQ/pixelAlternative/src/PixelAltDigiWriteToRootVector.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -99,8 +99,6 @@ void PixelAltDigiWriteToRootVector::Exec(Option_t* /*opt*/)
     }
     fMCEntryNo++;
 }
-
-void PixelAltDigiWriteToRootVector::SetParContainers() {}
 
 InitStatus PixelAltDigiWriteToRootVector::Init()
 {

--- a/examples/MQ/pixelAlternative/src/PixelAltDigiWriteToRootVector.h
+++ b/examples/MQ/pixelAlternative/src/PixelAltDigiWriteToRootVector.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -58,9 +58,6 @@ class PixelAltDigiWriteToRootVector : public FairTask
 
     TString fOutputFileName;
     Int_t fNofOutputFiles;
-
-    /** Get parameter containers **/
-    virtual void SetParContainers();
 
     Int_t fDivideLevel;
 

--- a/examples/MQ/pixelDetector/src/PixelDigiWriteToBinFile.h
+++ b/examples/MQ/pixelDetector/src/PixelDigiWriteToBinFile.h
@@ -53,9 +53,6 @@ class PixelDigiWriteToBinFile : public FairTask
     Int_t fNofOutputFiles;
     std::ofstream fOutputFiles[12];   // no more than 12 output files....
 
-    /** Get parameter containers **/
-    void SetParContainers() override {}
-
     Int_t fDivideLevel;
 
     Int_t fRunId;

--- a/examples/MQ/pixelDetector/src/PixelDigiWriteToFile.h
+++ b/examples/MQ/pixelDetector/src/PixelDigiWriteToFile.h
@@ -52,9 +52,6 @@ class PixelDigiWriteToFile : public FairTask
     Int_t fNofOutputFiles;
     std::ofstream fOutputFiles[12];   // no more than 12 output files....
 
-    /** Get parameter containers **/
-    void SetParContainers() override {}
-
     Int_t fDivideLevel;
 
     Int_t fRunId;

--- a/examples/advanced/Tutorial3/digitization/FairTestDetectorHitProducerSmearing.cxx
+++ b/examples/advanced/Tutorial3/digitization/FairTestDetectorHitProducerSmearing.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -29,19 +29,6 @@ FairTestDetectorHitProducerSmearing::~FairTestDetectorHitProducerSmearing()
     LOG(debug) << "Destructor of FairTestDetectorHitProducerSmearing";
     fHitsArray->Delete();
     delete fHitsArray;
-}
-
-void FairTestDetectorHitProducerSmearing::SetParContainers()
-{
-    LOG(debug) << "SetParContainers of FairTestDetectorHitProducerSmearing";
-    // Load all necessary parameter containers from the runtime data base
-    /*
-    FairRunAna* ana = FairRunAna::Instance();
-    FairRuntimeDb* rtdb=ana->GetRuntimeDb();
-
-    <FairTestDetectorHitProducerSmearingDataMember> = (<ClassPointer>*)
-      (rtdb->getContainer("<ContainerName>"));
-    */
 }
 
 InitStatus FairTestDetectorHitProducerSmearing::Init()

--- a/examples/advanced/Tutorial3/digitization/FairTestDetectorHitProducerSmearing.h
+++ b/examples/advanced/Tutorial3/digitization/FairTestDetectorHitProducerSmearing.h
@@ -32,9 +32,6 @@ class FairTestDetectorHitProducerSmearing : public FairTask
     /** Executed for each event. **/
     void Exec(Option_t* opt) override;
 
-    /** Load the parameter container from the runtime database **/
-    void SetParContainers() override;
-
     /** Finish task called at the end of the run **/
     void Finish() override;
 

--- a/examples/simulation/Tutorial4/src/reco/FairTutorialDet4MilleWriter.cxx
+++ b/examples/simulation/Tutorial4/src/reco/FairTutorialDet4MilleWriter.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -31,19 +31,6 @@ FairTutorialDet4MilleWriter::FairTutorialDet4MilleWriter()
 FairTutorialDet4MilleWriter::~FairTutorialDet4MilleWriter()
 {
     LOG(debug) << "Destructor of FairTutorialDet4MilleWriter";
-}
-
-void FairTutorialDet4MilleWriter::SetParContainers()
-{
-    LOG(debug) << "SetParContainers of FairTutorialDet4MilleWriter";
-    // Load all necessary parameter containers from the runtime data base
-    /*
-  FairRunAna* ana = FairRunAna::Instance();
-  FairRuntimeDb* rtdb=ana->GetRuntimeDb();
-
-  <FairTutorialDet4MilleWriterDataMember> = (<ClassPointer>*)
-    (rtdb->getContainer("<ContainerName>"));
-  */
 }
 
 InitStatus FairTutorialDet4MilleWriter::Init()

--- a/examples/simulation/Tutorial4/src/reco/FairTutorialDet4MilleWriter.h
+++ b/examples/simulation/Tutorial4/src/reco/FairTutorialDet4MilleWriter.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -36,9 +36,6 @@ class FairTutorialDet4MilleWriter : public FairTask
 
     /** Executed for each event. **/
     virtual void Exec(Option_t* opt);
-
-    /** Load the parameter container from the runtime database **/
-    virtual void SetParContainers();
 
     /** Finish task called at the end of the run **/
     virtual void Finish();

--- a/examples/simulation/Tutorial4/src/reco/FairTutorialDet4StraightLineFitter.cxx
+++ b/examples/simulation/Tutorial4/src/reco/FairTutorialDet4StraightLineFitter.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -34,19 +34,6 @@ FairTutorialDet4StraightLineFitter::~FairTutorialDet4StraightLineFitter()
         fTracks->Delete();
         delete fTracks;
     }
-}
-
-void FairTutorialDet4StraightLineFitter::SetParContainers()
-{
-    LOG(debug) << "SetParContainers of FairTutorialDet4StraightLineFitter";
-    // Load all necessary parameter containers from the runtime data base
-    /*
-  FairRunAna* ana = FairRunAna::Instance();
-  FairRuntimeDb* rtdb=ana->GetRuntimeDb();
-
-  <FairTutorialDet4StraightLineFitterDataMember> = (<ClassPointer>*)
-    (rtdb->getContainer("<ContainerName>"));
-  */
 }
 
 InitStatus FairTutorialDet4StraightLineFitter::Init()

--- a/examples/simulation/Tutorial4/src/reco/FairTutorialDet4StraightLineFitter.h
+++ b/examples/simulation/Tutorial4/src/reco/FairTutorialDet4StraightLineFitter.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -34,9 +34,6 @@ class FairTutorialDet4StraightLineFitter : public FairTask
 
     /** Executed for each event. **/
     virtual void Exec(Option_t* opt);
-
-    /** Load the parameter container from the runtime database **/
-    virtual void SetParContainers();
 
     /** Finish task called at the end of the run **/
     virtual void Finish();


### PR DESCRIPTION
Many classes derive from FairTask and override
SetParContainers with either an empty method, or one that effectively does nothing useful.

FairTask::SetParContainer() exists, does nothing and thus is a good default/fallback.

So remove all those empty/useless methods.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
