### PR TITLE
build(Packaging): Setup Dependency-Exporting

### DIFF
--- a/cmake/private/FairRootConfig.cmake.in
+++ b/cmake/private/FairRootConfig.cmake.in
@@ -1,5 +1,5 @@
 ################################################################################
-#    Copyright (C) 2021 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    #
+# Copyright (C) 2021-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
@@ -13,5 +13,9 @@ set(@PROJECT_NAME@_BINDIR "@PACKAGE_CMAKE_INSTALL_FULL_BINDIR@")
 set(@PROJECT_NAME@_CXX_STANDARD "@CMAKE_CXX_STANDARD@")
 
 check_required_components(@PROJECT_NAME@)
+
+# ***** PACKAGE_DEPENDENCIES *****
+@PACKAGE_DEPENDENCIES@
+# ***** PACKAGE_DEPENDENCIES *****
 
 include(@PACKAGE_PACKAGE_INSTALL_DESTINATION@/@PROJECT_NAME@Targets.cmake)

--- a/cmake/private/FairRootPackage.cmake
+++ b/cmake/private/FairRootPackage.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (C) 2021 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH       #
+# Copyright (C) 2021-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
@@ -10,6 +10,13 @@ include(CMakePackageConfigHelpers)
 
 # Configure/Install CMake package
 function(install_cmake_package)
+  if(FairCMakeModules_VERSION VERSION_GREATER_EQUAL 1.0.0)
+    # FairCMakeModules 1.0.0 needed for OPTIONAL_COMPONENTS exporting
+    fair_generate_package_dependencies()
+  else()
+    set(PACKAGE_DEPENDENCIES "# Not supported")
+  endif()
+
   set(PACKAGE_INSTALL_DESTINATION
     ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}-${PROJECT_VERSION})
   if(PROJECT_EXPORT_SET)


### PR DESCRIPTION
On FairCMakeModules 1.0.0 export all the information about needed packages and their (optional) components.

Previous versions of FairCMakeModules can't handle `OPTIONAL_COMPONENTS` properly.  So don't export stuff there.