### PR TITLE
Add FairRun::GetEvtHeaderRunId and use it

### DIFF
--- a/base/event/FairEventHeader.cxx
+++ b/base/event/FairEventHeader.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -13,15 +13,6 @@
 #include "FairEventHeader.h"
 
 #include "FairRootManager.h"
-
-FairEventHeader::FairEventHeader()
-    : fRunId(0)
-    , fEventTime(-1.)
-    , fInputFileId(0)
-    , fMCEntryNo(0)
-{}
-
-FairEventHeader::~FairEventHeader() {}
 
 void FairEventHeader::Register(Bool_t Persistence)
 {

--- a/base/event/FairEventHeader.h
+++ b/base/event/FairEventHeader.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -25,19 +25,24 @@ class FairEventHeader : public TNamed
 {
   public:
     /** Default constructor */
-    FairEventHeader();
+    FairEventHeader() = default;
+
+    /**
+     * Destructor
+     */
+    ~FairEventHeader() override = default;
 
     /** Get the run ID for this run*/
-    UInt_t GetRunId() { return fRunId; }
+    UInt_t GetRunId() const { return fRunId; }
 
     /** Get the MC time for this event*/
-    Double_t GetEventTime() { return fEventTime; }
+    Double_t GetEventTime() const { return fEventTime; }
 
     /** Get the MC input file Id for this event*/
-    Int_t GetInputFileId() { return fInputFileId; }
+    Int_t GetInputFileId() const { return fInputFileId; }
 
     /**The entry number in the original MC chain */
-    Int_t GetMCEntryNumber() { return fMCEntryNo; }
+    Int_t GetMCEntryNumber() const { return fMCEntryNo; }
 
     /** Set the run ID for this run
      * @param runid : unique run id
@@ -55,23 +60,19 @@ class FairEventHeader : public TNamed
     /**The entry number in the original MC chain */
     void SetMCEntryNumber(Int_t id) { fMCEntryNo = id; }
 
-    /**
-     * Destructor
-     */
-    virtual ~FairEventHeader();
     virtual void Register(Bool_t Persistance = kTRUE);
 
   protected:
     /** Run Id */
-    UInt_t fRunId;
+    UInt_t fRunId{0};
     /** Event Time **/
-    Double_t fEventTime;
+    Double_t fEventTime{-1.};
     /** Input file identifier, the file description is in the File header*/
-    Int_t fInputFileId;
+    Int_t fInputFileId{0};
     /**MC entry number from input chain*/
-    Int_t fMCEntryNo;
+    Int_t fMCEntryNo{0};
 
-    ClassDef(FairEventHeader, 3);
+    ClassDefOverride(FairEventHeader, 3);
 };
 
 #endif

--- a/base/steer/FairRun.cxx
+++ b/base/steer/FairRun.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -12,7 +12,6 @@
 
 #include "FairRun.h"
 
-#include "FairEventHeader.h"    // for FairEventHeader
 #include "FairFileHeader.h"     // for FairFileHeader
 #include "FairLinkManager.h"    // for FairLinkManager
 #include "FairLogger.h"         // for FairLogger, MESSAGE_ORIGIN

--- a/base/steer/FairRun.h
+++ b/base/steer/FairRun.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -9,6 +9,7 @@
 #define FAIRRUN_H
 
 #include "FairAlignmentHandler.h"
+#include "FairEventHeader.h"
 #include "FairSink.h"
 #include "FairSource.h"
 
@@ -251,6 +252,11 @@ class FairRun : public TNamed
         if (fSource)
             fSource->FillEventHeader(fEvtHeader);
     }
+
+    /**
+     * Get the RunId of the Event Header
+     */
+    UInt_t GetEvtHeaderRunId() const { return fEvtHeader->GetRunId(); }
 
     ClassDefOverride(FairRun, 5);
 };

--- a/base/steer/FairRunAna.cxx
+++ b/base/steer/FairRunAna.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -210,7 +210,7 @@ void FairRunAna::Init()
 
         FillEventHeader();
 
-        fRunId = fEvtHeader->GetRunId();
+        fRunId = GetEvtHeaderRunId();
 
         // Copy the Event Header Info to Output
         fEvtHeader->Register(fStoreEventHeader);
@@ -281,7 +281,6 @@ void FairRunAna::Run(Int_t Ev_start, Int_t Ev_end)
     if (fTimeStamps) {
         RunTSBuffers();
     } else {
-        UInt_t tmpId = 0;
         //  if (fInputFile==0) {
         if (!fInFileIsOpen) {
             DummyRun(Ev_start, Ev_end);
@@ -344,7 +343,7 @@ void FairRunAna::Run(Int_t Ev_start, Int_t Ev_end)
 
             FillEventHeader();
 
-            tmpId = fEvtHeader->GetRunId();
+            auto const tmpId = GetEvtHeaderRunId();
             if (tmpId != fRunId) {
                 fRunId = tmpId;
                 if (!fStatic) {
@@ -483,9 +482,8 @@ void FairRunAna::RunMQ(Long64_t entry)
    This methode is only needed and used with ZeroMQ
    it read a certain event and call the task exec, but no output is written
    */
-    UInt_t tmpId = 0;
     fRootManager->ReadEvent(entry);
-    tmpId = fEvtHeader->GetRunId();
+    auto const tmpId = GetEvtHeaderRunId();
     if (tmpId != fRunId) {
         fRunId = tmpId;
         if (!fStatic) {
@@ -502,9 +500,8 @@ void FairRunAna::RunMQ(Long64_t entry)
 //_____________________________________________________________________________
 void FairRunAna::Run(Long64_t entry)
 {
-    UInt_t tmpId = 0;
     fRootManager->ReadEvent(entry);
-    tmpId = fEvtHeader->GetRunId();
+    auto const tmpId = GetEvtHeaderRunId();
     if (tmpId != fRunId) {
         fRunId = tmpId;
         if (!fStatic) {

--- a/base/steer/FairRunAnaProof.cxx
+++ b/base/steer/FairRunAnaProof.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -176,7 +176,7 @@ void FairRunAnaProof::Init()
 
         FillEventHeader();
 
-        fRunId = fEvtHeader->GetRunId();
+        fRunId = GetEvtHeaderRunId();
 
         // Copy the Event Header Info to Output
         fEvtHeader->Register(kTRUE);
@@ -247,7 +247,7 @@ void FairRunAnaProof::InitContainers()
 
         FillEventHeader();
 
-        fRunId = fEvtHeader->GetRunId();
+        fRunId = GetEvtHeaderRunId();
 
         // Copy the Event Header Info to Output
         fEvtHeader->Register();
@@ -284,12 +284,11 @@ void FairRunAnaProof::RunOneEvent(Long64_t entry)
     if (fTimeStamps) {
         RunTSBuffers();
     } else {
-        UInt_t tmpId = 0;
         fRootManager->ReadEvent(entry);
 
         FillEventHeader();
 
-        tmpId = fEvtHeader->GetRunId();
+        auto const tmpId = GetEvtHeaderRunId();
         if (tmpId != fRunId) {
             fRunId = tmpId;
             if (!fStatic) {

--- a/online/steer/FairRunOnline.cxx
+++ b/online/steer/FairRunOnline.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -130,7 +130,7 @@ void FairRunOnline::Init()
 
     if (0 == fRunId)   // Run ID was not set in run manager
     {
-        if (0 == fEvtHeader->GetRunId())   // Run ID was not set in source
+        if (0 == GetEvtHeaderRunId())   // Run ID was not set in source
         {
             // Generate unique Run ID
             FairRunIdGenerator genid;
@@ -138,7 +138,7 @@ void FairRunOnline::Init()
             GetSource()->SetRunId(fRunId);
         } else {
             // Use Run ID from source
-            fRunId = fEvtHeader->GetRunId();
+            fRunId = GetEvtHeaderRunId();
         }
     } else {
         // Run ID was set in the run manager - propagate to source
@@ -202,7 +202,6 @@ void FairRunOnline::Init()
 
 void FairRunOnline::InitContainers()
 {
-
     fRtdb = GetRuntimeDb();
     FairBaseParSet* par = static_cast<FairBaseParSet*>(fRtdb->getContainer("FairBaseParSet"));
     LOG(info) << "FairRunOnline::InitContainers: par = " << par;
@@ -212,7 +211,7 @@ void FairRunOnline::InitContainers()
     if (par) {
         fEvtHeader = static_cast<FairEventHeader*>(fRootManager->GetObject("EventHeader."));
 
-        fRunId = fEvtHeader->GetRunId();
+        fRunId = GetEvtHeaderRunId();
 
         // Copy the Event Header Info to Output
         fEvtHeader->Register();
@@ -244,7 +243,7 @@ Int_t FairRunOnline::EventLoop()
     signal(SIGINT, handler_ctrlc);
 
     FillEventHeader();
-    auto const tmpId = fEvtHeader->GetRunId();
+    auto const tmpId = GetEvtHeaderRunId();
 
     if (tmpId != fRunId) {
         LOG(info) << "FairRunOnline::EventLoop() Call Reinit due to changed RunID (from " << fRunId << " to " << tmpId;


### PR DESCRIPTION
Classes derived from FairRun often call GetRunId() on fEvtHeader. So let's have a shortcut.