### PR TITLE
Check the return value `source->InitUnpackers`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ file an issue, so that we can see how to handle this.
   in `FairRunOnline`. Stop run if `false` returned.
 
 
-## 18.8 (UNRELEASED) - 2022-11-XX
+## 18.8.0 - 2022-12-16
 
 ### Breaking Changes
 * Move online related code into the new Online library

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,13 @@ file an issue, so that we can see how to handle this.
 * https://github.com/R3BRootGroup/R3BRoot/pull/413
 
 
+## 18.8.1 (UNRELEASED) - 2023-01-XX
+
+### Bug fixes
+* Check the return value of `source->InitUnpackers()`/`source->ReinitUnpackers()`
+  in `FairRunOnline`. Stop run if `false` returned.
+
+
 ## 18.8 (UNRELEASED) - 2022-11-XX
 
 ### Breaking Changes
@@ -111,7 +118,6 @@ file an issue, so that we can see how to handle this.
   ```
   There is also a convenience header `<FairBoostSerializationSupport.h>` which includes all
   class-based support headers currently offered.
-
 
 ### Deprecations
 

--- a/online/steer/FairRunOnline.cxx
+++ b/online/steer/FairRunOnline.cxx
@@ -43,7 +43,10 @@ using std::endl;
 
 FairRunOnline* FairRunOnline::fgRinstance = nullptr;
 
-FairRunOnline* FairRunOnline::Instance() { return fgRinstance; }
+FairRunOnline* FairRunOnline::Instance()
+{
+    return fgRinstance;
+}
 
 FairRunOnline::FairRunOnline()
     : FairRun()
@@ -96,7 +99,10 @@ FairRunOnline::~FairRunOnline()
 
 Bool_t gIsInterrupted;
 
-void handler_ctrlc(int) { gIsInterrupted = kTRUE; }
+void handler_ctrlc(int)
+{
+    gIsInterrupted = kTRUE;
+}
 
 void FairRunOnline::Init()
 {
@@ -189,7 +195,10 @@ void FairRunOnline::Init()
     fRootManager->Register("EventHeader.", "Event", fEvtHeader, (nullptr != GetSink()));
     fEvtHeader->SetRunId(fRunId);
 
-    GetSource()->InitUnpackers();
+    if (!GetSource()->InitUnpackers()) {
+        LOG(fatal) << "FairRunOnline->Init() InitUnpackers() failed!";
+        return;
+    }
 
     // Now call the User initialize for Tasks
     fTask->InitTask();
@@ -250,7 +259,10 @@ Int_t FairRunOnline::EventLoop()
         LOG(info) << "FairRunOnline::EventLoop() Call Reinit due to changed RunID (from " << fRunId << " to " << tmpId;
         fRunId = tmpId;
         Reinit(fRunId);
-        GetSource()->ReInitUnpackers();
+        if (!GetSource()->ReInitUnpackers()) {
+            LOG(fatal) << "FairRunOnline->EventLoop() ReInitUnpackers() failed!";
+            return 1;
+        }
         fTask->ReInitTask();
     }
 


### PR DESCRIPTION
Return values of the calls to `source->InitUnpackers()` and `source->ReinitUnpackers()` in `FairRunOnline` are now checked. Should the value be `false`,
the fatal message will be printed.

Addresses issue #1301.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
