### PR TITLE
Add streamer for the `FairEventHeader`

### DIFF
--- a/base/FairLinkDef.h
+++ b/base/FairLinkDef.h
@@ -18,7 +18,7 @@
 //#pragma link C++ class FairDoubleHit+;
 #pragma link C++ class FairEventBuilder+;
 #pragma link C++ class FairEventBuilderManager+;
-#pragma link C++ class FairEventHeader;
+#pragma link C++ class FairEventHeader+;
 #pragma link C++ class FairFileHeader+;
 #pragma link C++ class FairGeaneApplication+;
 #pragma link C++ class FairGenerator+;


### PR DESCRIPTION
Added `+` to `FairEventHeader` in `LinkDef`.
Without `+`, there is no information printed
about `FairEventHeader` in the tree->Print() output.

Addresses issue #1306.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
