### PR TITLE
FMCApp: Do not leak Modules

### DIFF
--- a/base/sim/FairMCApplication.cxx
+++ b/base/sim/FairMCApplication.cxx
@@ -74,7 +74,6 @@ FairMCApplication::FairMCApplication(const char* name, const char* title, TObjAr
     : TVirtualMCApplication(name, title)
     , fActiveDetectors(nullptr)
     , fFairTaskList(nullptr)
-    , fDetectors(nullptr)
     , fModIter(nullptr)
     , fModules(nullptr)
     , fNoSenVolumes(0)
@@ -120,7 +119,6 @@ FairMCApplication::FairMCApplication(const char* name, const char* title, TObjAr
     fModules = ModList;
     fModIter = fModules->MakeIterator();
     // Create and fill a list of active detectors
-    fDetectors = new TRefArray;
     fActiveDetectors = new TRefArray();
     fModIter->Reset();
     FairDetector* detector;
@@ -129,7 +127,6 @@ FairMCApplication::FairMCApplication(const char* name, const char* title, TObjAr
     while ((obj = fModIter->Next())) {
         detector = dynamic_cast<FairDetector*>(obj);
         if (detector) {
-            fDetectors->Add(detector);
             listDetectors.push_back(detector);
             if (detector->IsActive()) {
                 fActiveDetectors->Add(detector);
@@ -153,7 +150,6 @@ FairMCApplication::FairMCApplication(const FairMCApplication& rhs, std::unique_p
     : TVirtualMCApplication(rhs.GetName(), rhs.GetTitle())
     , fActiveDetectors(nullptr)
     , fFairTaskList(nullptr)
-    , fDetectors(nullptr)
     , fModIter(nullptr)
     , fModules(nullptr)
     , fNoSenVolumes(0)
@@ -209,7 +205,6 @@ FairMCApplication::FairMCApplication(const FairMCApplication& rhs, std::unique_p
     }
 
     // Create and fill a list of active detectors
-    fDetectors = new TRefArray;
     fActiveDetectors = new TRefArray();
     fModIter->Reset();
     FairDetector* detector;
@@ -217,7 +212,6 @@ FairMCApplication::FairMCApplication(const FairMCApplication& rhs, std::unique_p
         if (obj->InheritsFrom("FairDetector")) {
             detector = dynamic_cast<FairDetector*>(obj);
             if (detector) {
-                fDetectors->Add(detector);
                 listDetectors.push_back(detector);
                 if (detector->IsActive()) {
                     fActiveDetectors->Add(detector);
@@ -246,7 +240,6 @@ FairMCApplication::FairMCApplication()
     : TVirtualMCApplication()
     , fActiveDetectors(0)
     , fFairTaskList(0)
-    , fDetectors(0)
     , fModIter(0)
     , fModules(0)
     , fNoSenVolumes(0)
@@ -291,7 +284,6 @@ FairMCApplication::~FairMCApplication()
     delete fStack;
     delete fActiveDetectors;   // don't do fActiveDetectors->Delete() here
     // the modules are already deleted in FairRunSim
-    delete fDetectors;
     delete fModIter;
     //  LOG(debug3) << "Leave Destructor of FairMCApplication";
     delete fMC;

--- a/base/sim/FairMCApplication.h
+++ b/base/sim/FairMCApplication.h
@@ -244,8 +244,6 @@ class FairMCApplication : public TVirtualMCApplication
     TRefArray* fActiveDetectors;
     /**List of FairTask*/
     FairTask* fFairTaskList;   //!
-    /**detector list (Passive and Active)*/
-    TRefArray* fDetectors;
     /**Iterator for Module list*/
     TIterator* fModIter;   //!
     /**Module list in simulation*/

--- a/base/sim/FairMCApplication.h
+++ b/base/sim/FairMCApplication.h
@@ -23,11 +23,13 @@
 #include <list>                      // for list
 #include <map>                       // for map, multimap, etc
 #include <memory>                    // for std::unique_ptr
+#include <vector>                    // for std::vector
 
 class FairDetector;
 class FairEventHeader;
 class FairField;
 class FairGenericStack;
+class FairModule;
 class FairMCEventHeader;
 class FairPrimaryGenerator;
 class FairRadLenManager;
@@ -321,6 +323,16 @@ class FairMCApplication : public TVirtualMCApplication
 
     FairRunInfo fRunInfo;   //!
     Bool_t fGeometryIsInitialized;
+
+    /**
+     * List of modules, mirrors fModules
+     */
+    std::vector<FairModule*> fListModules{};   //!
+
+    /**
+     * Owned Modules (inside the worker)
+     */
+    std::vector<std::unique_ptr<FairModule>> fOwnedModules;   //!
 
     /**
      * Clean up the FairRunSim created in CloneForWorker


### PR DESCRIPTION
In the Worker, the `fModules` are cloned.
So they need to be cleaned up afterwards.

Also add `fListModules` as a mirror of fModules to improve
some parts of the code.

Also drop the unsed `fDetectors`.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
