### PR TITLE
Drop useless overriden Initialize()

### DIFF
--- a/base/sim/fastsim/FairFastSimDetector.h
+++ b/base/sim/fastsim/FairFastSimDetector.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -24,8 +24,6 @@ class FairFastSimDetector : public FairDetector
     FairFastSimDetector(const char* name, Int_t DetId = 0);
 
     ~FairFastSimDetector() override;
-
-    void Initialize() override = 0;
 
     Bool_t ProcessHits(FairVolume* vol = 0) override final;
 

--- a/examples/MQ/pixelDetector/src/Pixel.cxx
+++ b/examples/MQ/pixelDetector/src/Pixel.cxx
@@ -73,8 +73,6 @@ Pixel::~Pixel()
     }
 }
 
-void Pixel::Initialize() { FairDetector::Initialize(); }
-
 Bool_t Pixel::ProcessHits(FairVolume* vol)
 {
     /** This method is called from the MC stepping */

--- a/examples/MQ/pixelDetector/src/Pixel.h
+++ b/examples/MQ/pixelDetector/src/Pixel.h
@@ -33,9 +33,6 @@ class Pixel : public FairDetector
     /**       destructor     */
     ~Pixel() override;
 
-    /**      Initialization of the detector is done here    */
-    void Initialize() override;
-
     /**       this method is called for each step during simulation
      *       (see FairMCApplication::Stepping())
      */

--- a/examples/advanced/propagator/src/FairTutPropDet.cxx
+++ b/examples/advanced/propagator/src/FairTutPropDet.cxx
@@ -62,8 +62,6 @@ FairTutPropDet::~FairTutPropDet()
     }
 }
 
-void FairTutPropDet::Initialize() { FairDetector::Initialize(); }
-
 Bool_t FairTutPropDet::ProcessHits(FairVolume* vol)
 {
 

--- a/examples/advanced/propagator/src/FairTutPropDet.h
+++ b/examples/advanced/propagator/src/FairTutPropDet.h
@@ -32,9 +32,6 @@ class FairTutPropDet : public FairDetector
     /**       destructor     */
     ~FairTutPropDet() override;
 
-    /**      Initialization of the detector is done here    */
-    void Initialize() override;
-
     /**       this method is called for each step during simulation
      *       (see FairMCApplication::Stepping())
      */

--- a/examples/simulation/Tutorial1/src/FairFastSimExample.cxx
+++ b/examples/simulation/Tutorial1/src/FairFastSimExample.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -65,8 +65,6 @@ FairFastSimExample::~FairFastSimExample()
         delete fPointsArray;
     }
 }
-
-void FairFastSimExample::Initialize() { FairDetector::Initialize(); }
 
 void FairFastSimExample::FastSimProcessParticle()
 {

--- a/examples/simulation/Tutorial1/src/FairFastSimExample.h
+++ b/examples/simulation/Tutorial1/src/FairFastSimExample.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -29,9 +29,6 @@ class FairFastSimExample : public FairFastSimDetector
 
     /**       destructor     */
     virtual ~FairFastSimExample();
-
-    /**      Initialization of the detector is done here    */
-    virtual void Initialize();
 
     /**       Registers the produced collections in FAIRRootManager.     */
     virtual void Register();

--- a/examples/simulation/Tutorial1/src/FairFastSimExample2.cxx
+++ b/examples/simulation/Tutorial1/src/FairFastSimExample2.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -64,8 +64,6 @@ FairFastSimExample2::~FairFastSimExample2()
         delete fPointsArray;
     }
 }
-
-void FairFastSimExample2::Initialize() { FairDetector::Initialize(); }
 
 void FairFastSimExample2::FastSimProcessParticle()
 {

--- a/examples/simulation/Tutorial1/src/FairFastSimExample2.h
+++ b/examples/simulation/Tutorial1/src/FairFastSimExample2.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -29,9 +29,6 @@ class FairFastSimExample2 : public FairFastSimDetector
 
     /**       destructor     */
     virtual ~FairFastSimExample2();
-
-    /**      Initialization of the detector is done here    */
-    virtual void Initialize();
 
     /**       Registers the produced collections in FAIRRootManager.     */
     virtual void Register();

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2.cxx
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2.cxx
@@ -70,15 +70,6 @@ FairTutorialDet2::~FairTutorialDet2()
     }
 }
 
-void FairTutorialDet2::Initialize()
-{
-    FairDetector::Initialize();
-    /*
-  FairRuntimeDb* rtdb= FairRun::Instance()->GetRuntimeDb();
-  FairTutorialDet2GeoPar* par=(FairTutorialDet2GeoPar*)(rtdb->getContainer("FairTutorialDet2GeoPar"));
-*/
-}
-
 Bool_t FairTutorialDet2::ProcessHits(FairVolume* vol)
 {
     /** This method is called from the MC stepping */

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2.h
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2.h
@@ -36,9 +36,6 @@ class FairTutorialDet2 : public FairDetector
     /**       destructor     */
     virtual ~FairTutorialDet2();
 
-    /**      Initialization of the detector is done here    */
-    virtual void Initialize();
-
     /**       this method is called for each step during simulation
      *       (see FairMCApplication::Stepping())
      */

--- a/examples/simulation/rutherford/src/FairRutherford.cxx
+++ b/examples/simulation/rutherford/src/FairRutherford.cxx
@@ -42,15 +42,6 @@ FairRutherford::~FairRutherford()
     }
 }
 
-void FairRutherford::Initialize()
-{
-    FairDetector::Initialize();
-    /*
-  FairRuntimeDb* rtdb= FairRun::Instance()->GetRuntimeDb();
-  FairRutherfordGeoPar* par=(FairRutherfordGeoPar*)(rtdb->getContainer("FairRutherfordGeoPar"));
-*/
-}
-
 Bool_t FairRutherford::ProcessHits(FairVolume* vol)
 {
     /** This method is called from the MC stepping */

--- a/examples/simulation/rutherford/src/FairRutherford.h
+++ b/examples/simulation/rutherford/src/FairRutherford.h
@@ -35,9 +35,6 @@ class FairRutherford : public FairDetector
     /**       destructor     */
     ~FairRutherford() override;
 
-    /**      Initialization of the detector is done here    */
-    void Initialize() override;
-
     /**       this method is called for each step during simulation
      *       (see FairMCApplication::Stepping())
      */


### PR DESCRIPTION
A few examples override FairDetector::Initialize and just call FairDetector::Initialize(), so effectively do the same as not overriding it at all.

So drop the overriden methods.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
