### PR TITLE
Start to enable two bugprone-* checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,6 +2,8 @@
 HeaderFilterRegex: '.*'
 # disable clang-analyzer-core.UndefinedBinaryOperatorResult
 #   ROOT throws lots of them in their headers
+# Bugprone:
+#   These could cause actual bugs.
 # enable cppcoreguidelines-virtual-class-destructor
 #   Avoid undefined behaviour
 # enable google-build-using-namespace
@@ -10,6 +12,8 @@ HeaderFilterRegex: '.*'
 #   readability-simplify-boolean-expr
 Checks: >-
   -clang-analyzer-core.UndefinedBinaryOperatorResult,
+  bugprone-copy-constructor-init,
+  bugprone-sizeof-expression,
   cppcoreguidelines-virtual-class-destructor,
   modernize-make-unique,
   google-build-using-namespace,

--- a/examples/MQ/pixelDetector/src/FairOnlineSink.cxx
+++ b/examples/MQ/pixelDetector/src/FairOnlineSink.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *
@@ -18,16 +18,6 @@
 #include "FairRootManager.h"
 
 #include <fairlogger/Logger.h>
-
-FairOnlineSink::FairOnlineSink()
-    : FairSink()
-    , fMQRunDevice(nullptr)
-{}
-
-FairOnlineSink::FairOnlineSink(const FairOnlineSink&)
-    : FairSink()
-    , fMQRunDevice(nullptr)
-{}
 
 //_____________________________________________________________________________
 void FairOnlineSink::RegisterImpl(const char*, const char*, void*) { return; }
@@ -67,8 +57,7 @@ void FairOnlineSink::Fill()
 FairSink* FairOnlineSink::CloneSink()
 {
     FairRootManager* tempMan = FairRootManager::Instance();
-    FairOnlineSink* newSink = new FairOnlineSink(*this);
-    newSink->SetMQRunDevice(this->GetMQRunDevice());
+    auto newSink = new FairOnlineSink(*this);
     LOG(info) << "[" << tempMan->GetInstanceId() << "] FairOnlineSink::CloneSink() setting MQRunDevice to "
               << this->GetMQRunDevice();
 

--- a/examples/MQ/pixelDetector/src/FairOnlineSink.h
+++ b/examples/MQ/pixelDetector/src/FairOnlineSink.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2017-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *
@@ -24,14 +24,13 @@
 
 class FairEventHeader;
 class FairMQRunDevice;
-class TObject;
-class TTree;
 
 class FairOnlineSink : public FairSink
 {
   public:
-    FairOnlineSink();
+    FairOnlineSink() = default;
     ~FairOnlineSink() override = default;
+    FairOnlineSink& operator=(const FairOnlineSink&) = delete;
 
     Bool_t InitSink() override { return kTRUE; }
     void Close() override {}
@@ -70,13 +69,13 @@ class FairOnlineSink : public FairSink
     T GetPersistentBranchAny(const char* name) const;
 
   private:
-    FairMQRunDevice* fMQRunDevice;
+    FairMQRunDevice* fMQRunDevice{nullptr};
 
     // private helper function to emit a warning
     void EmitPersistentBranchWrongTypeWarning(const char* brname, const char* typen1, const char* typen2) const;
 
-    FairOnlineSink(const FairOnlineSink&);
-    FairOnlineSink& operator=(const FairOnlineSink&);
+    /// internal helper function for CloneSink()
+    FairOnlineSink(const FairOnlineSink&) = default;
 };
 
 // try to retrieve an object address from the registered branches/names

--- a/examples/MQ/serialization/2-multipart/SerializerExample2.h
+++ b/examples/MQ/serialization/2-multipart/SerializerExample2.h
@@ -32,7 +32,7 @@ struct SerializerEx2
 {
     void Serialize(fair::mq::Message& msg, Ex2Header* header)
     {
-        msg.Rebuild(header, sizeof(header), [](void* ptr, void* /*hint*/) { delete static_cast<Ex2Header*>(ptr); });
+        msg.Rebuild(header, sizeof(*header), [](void* ptr, void* /*hint*/) { delete static_cast<Ex2Header*>(ptr); });
     }
 
     void Deserialize(fair::mq::Message& msg, Ex2Header*& header) { header = static_cast<Ex2Header*>(msg.GetData()); }


### PR DESCRIPTION
Enable two `bugprone-*` checks in clang-tidy.

Fix the issues found and improve related code:

* Fix sizeof in Serializer

* Improve/Fix the Constructors of FairOnlineSink and utilize the improved copy constructor.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
