### PR TITLE
Add `MergeFiles` to `FairParAsciiFileIo`

### DIFF
--- a/parbase/FairParAsciiFileIo.cxx
+++ b/parbase/FairParAsciiFileIo.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -95,6 +95,14 @@ Bool_t FairParAsciiFileIo::open(const TList* fnamelist, const Text_t* status)
     Int_t pid = gSystem->GetPid();
     outFileName += pid;
     outFileName += ".par";
+
+    MergeFiles(outFileName, fnamelist);
+
+    return open(outFileName, status);
+}
+
+void FairParAsciiFileIo::MergeFiles(const char* fname, const TList* fnamelist)
+{
     TString catCommand = "cat ";
     TObjString* string;
     TListIter myIter(fnamelist);
@@ -105,18 +113,13 @@ Bool_t FairParAsciiFileIo::open(const TList* fnamelist, const Text_t* status)
         gSystem->ExpandPathName(strParPath);
         if (gSystem->AccessPathName(strParPath))
             LOG(fatal) << "Parameter file " << strParPath << " does not exist.";
-        //    cout <<  string->GetString() <<endl;
         catCommand += string->GetString();
         catCommand += " ";
     }
     catCommand += "> ";
-    catCommand += outFileName;
-
-    //  cout <<"CAT: "<<catCommand.Data()<<endl;
+    catCommand += fname;
 
     gSystem->Exec(catCommand);
-
-    return open(outFileName, status);
 }
 
 void FairParAsciiFileIo::close()

--- a/parbase/FairParAsciiFileIo.h
+++ b/parbase/FairParAsciiFileIo.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -23,19 +23,42 @@ class FairParAsciiFileIo : public FairParIo
   public:
     FairParAsciiFileIo();
 
-    // default destructor closes an open file and deletes list of I/Os
-    ~FairParAsciiFileIo();
+    /**
+     * default destructor closes an open file and deletes list of I/Os
+     */
+    ~FairParAsciiFileIo() override;
 
-    // opens file
-    // if a file is already open, this file will be closed
-    // activates detector I/Os
+    /**
+     * \brief Opens file
+     *
+     * If a file is already open, this file will be closed,
+     * activates detector I/Os.
+     * \param fname name of the parameter file
+     * \param status reading with "in" or writing with "out"
+     */
     Bool_t open(const Text_t* fname, const Text_t* status = "in");
 
-    // concatenate files whose names are stored in the TList
-    // TList holds list od TObjStrings
-    // create file all.par in local working directory
-    // calls open to open the generated file all.par
+    /**
+     * \brief Opens TList of files
+     *
+     * Concatenates files whose names are stored in the TList,
+     * TList holds list of TObjStrings.
+     * Calls MergeFiles with all_$pid.par in local working directory,
+     * calls open to open the generated file all_$pid.par.
+     * \param fnamelist TList of file names to be merged
+     * \param status reading with "in" or writing with "out"
+     */
     Bool_t open(const TList* fnamelist, const Text_t* status = "in");
+
+    /**
+     * \brief Merges files
+     *
+     * \param fname the merged file name, f.e. "all.par"
+     * \param fnamelist TList of file names to be merged
+     *
+     * Users should call standard open (f.e. open("all.par")) after calling this function.
+     */
+    static void MergeFiles(const char* fname, const TList* fnamelist);
 
     // closes file
     void close() override;


### PR DESCRIPTION
Enables the users to choose the name of the merged file. Analogue to `FairParRootFileIo::MergeFiles()`.

Triggered by issue #1314.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
