### PR TITLE
*ContFact: Use AddContainer, drop setAllContainers

### DIFF
--- a/base/sim/FairBaseContFact.cxx
+++ b/base/sim/FairBaseContFact.cxx
@@ -34,11 +34,11 @@ FairBaseContFact::FairBaseContFact()
 
     /** Creates the Container objects with all accepted contexts and adds them to
      *  the list of containers for the base library.*/
-    FairContainer* pTest = new FairContainer("FairBaseParSet", "class for parameter io", "DefaultContext");
-    containers->Add(pTest);
+    auto pTest = new FairContainer("FairBaseParSet", "class for parameter io", "DefaultContext");
+    AddContainer(pTest);
 
-    FairContainer* pGeo = new FairContainer("FairGeoParSet", "class for Geo parameter", "DefaultContext");
-    containers->Add(pGeo);
+    auto pGeo = new FairContainer("FairGeoParSet", "class for Geo parameter", "DefaultContext");
+    AddContainer(pGeo);
 }
 
 FairParSet* FairBaseContFact::createContainer(FairContainer* c)

--- a/base/sim/FairBaseContFact.cxx
+++ b/base/sim/FairBaseContFact.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -31,11 +31,7 @@ FairBaseContFact::FairBaseContFact()
     : FairContFact("FairBaseContFact", "Factory for parameter containers in libSts")
 {
     // Constructor (called when the library is loaded)
-    setAllContainers();
-}
 
-void FairBaseContFact::setAllContainers()
-{
     /** Creates the Container objects with all accepted contexts and adds them to
      *  the list of containers for the base library.*/
     FairContainer* pTest = new FairContainer("FairBaseParSet", "class for parameter io", "DefaultContext");

--- a/base/sim/FairBaseContFact.h
+++ b/base/sim/FairBaseContFact.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -17,9 +17,6 @@ class FairParSet;
 class FairBaseContFact : public FairContFact
 {
     /** Factory for all Base parameter containers */
-  private:
-    void setAllContainers();
-
   public:
     /**default ctor*/
     FairBaseContFact();

--- a/examples/MQ/parameters/FairMQExParamsContFact.cxx
+++ b/examples/MQ/parameters/FairMQExParamsContFact.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -16,11 +16,6 @@ static FairMQExParamsContFact gFairMQExParamsContFact;
 
 FairMQExParamsContFact::FairMQExParamsContFact()
     : FairContFact("FairMQExParamsContFact", "Factory for parameter containers in FairMQ Example 7")
-{
-    setAllContainers();
-}
-
-void FairMQExParamsContFact::setAllContainers()
 {
     FairContainer* container =
         new FairContainer("FairMQExParamsParOne", "FairMQExParamsParOne Parameters", "TestDefaultContext");

--- a/examples/MQ/parameters/FairMQExParamsContFact.cxx
+++ b/examples/MQ/parameters/FairMQExParamsContFact.cxx
@@ -17,9 +17,8 @@ static FairMQExParamsContFact gFairMQExParamsContFact;
 FairMQExParamsContFact::FairMQExParamsContFact()
     : FairContFact("FairMQExParamsContFact", "Factory for parameter containers in FairMQ Example 7")
 {
-    FairContainer* container =
-        new FairContainer("FairMQExParamsParOne", "FairMQExParamsParOne Parameters", "TestDefaultContext");
-    containers->Add(container);
+    auto container = new FairContainer("FairMQExParamsParOne", "FairMQExParamsParOne Parameters", "TestDefaultContext");
+    AddContainer(container);
 }
 
 FairParSet* FairMQExParamsContFact::createContainer(FairContainer* container)

--- a/examples/MQ/parameters/FairMQExParamsContFact.h
+++ b/examples/MQ/parameters/FairMQExParamsContFact.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -15,9 +15,6 @@ class FairParSet;
 
 class FairMQExParamsContFact : public FairContFact
 {
-  private:
-    void setAllContainers();
-
   public:
     FairMQExParamsContFact();
     ~FairMQExParamsContFact() override = default;

--- a/examples/MQ/pixelDetector/src/PixelContFact.cxx
+++ b/examples/MQ/pixelDetector/src/PixelContFact.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -25,11 +25,7 @@ PixelContFact::PixelContFact()
     : FairContFact("PixelContFact", "Factory for parameter containers in libPixel")
 {
     /** Constructor (called when the library is loaded) */
-    setAllContainers();
-}
 
-void PixelContFact::setAllContainers()
-{
     /** Creates the Container objects with all accepted
       contexts and adds them to
       the list of containers for the Pixel library.

--- a/examples/MQ/pixelDetector/src/PixelContFact.cxx
+++ b/examples/MQ/pixelDetector/src/PixelContFact.cxx
@@ -31,11 +31,11 @@ PixelContFact::PixelContFact()
       the list of containers for the Pixel library.
   */
 
-    FairContainer* p = new FairContainer("PixelGeoPar", "Pixel Geometry Parameters", "TestDefaultContext");
-    containers->Add(p);
+    auto p = new FairContainer("PixelGeoPar", "Pixel Geometry Parameters", "TestDefaultContext");
+    AddContainer(p);
 
-    FairContainer* p2 = new FairContainer("PixelDigiParameters", "Pixel digi parameters", "TestDefaultContext");
-    containers->Add(p2);
+    auto p2 = new FairContainer("PixelDigiParameters", "Pixel digi parameters", "TestDefaultContext");
+    AddContainer(p2);
 }
 
 FairParSet* PixelContFact::createContainer(FairContainer* c)

--- a/examples/MQ/pixelDetector/src/PixelContFact.h
+++ b/examples/MQ/pixelDetector/src/PixelContFact.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -14,9 +14,6 @@
 
 class PixelContFact : public FairContFact
 {
-  private:
-    void setAllContainers();
-
   public:
     PixelContFact();
     ~PixelContFact() override = default;

--- a/examples/advanced/Tutorial3/simulation/FairTestDetectorContFact.cxx
+++ b/examples/advanced/Tutorial3/simulation/FairTestDetectorContFact.cxx
@@ -30,13 +30,11 @@ FairTestDetectorContFact::FairTestDetectorContFact()
         the list of containers for the FairTestDetector library.
     */
 
-    FairContainer* p =
-        new FairContainer("FairTestDetectorGeoPar", "FairTestDetector Geometry Parameters", "TestDefaultContext");
+    auto p = new FairContainer("FairTestDetectorGeoPar", "FairTestDetector Geometry Parameters", "TestDefaultContext");
+    AddContainer(p);
 
-    FairContainer* p1 = new FairContainer("FairConstPar", "Constant Field Parameters", "TestDefaultContext");
-
-    containers->Add(p);
-    containers->Add(p1);
+    auto p1 = new FairContainer("FairConstPar", "Constant Field Parameters", "TestDefaultContext");
+    AddContainer(p1);
 }
 
 FairParSet* FairTestDetectorContFact::createContainer(FairContainer* c)

--- a/examples/advanced/Tutorial3/simulation/FairTestDetectorContFact.cxx
+++ b/examples/advanced/Tutorial3/simulation/FairTestDetectorContFact.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -24,11 +24,7 @@ FairTestDetectorContFact::FairTestDetectorContFact()
     : FairContFact("FairTestDetectorContFact", "Factory for parameter containers in libFairTestDetector")
 {
     /** Constructor (called when the library is loaded) */
-    setAllContainers();
-}
 
-void FairTestDetectorContFact::setAllContainers()
-{
     /** Creates the Container objects with all accepted
         contexts and adds them to
         the list of containers for the FairTestDetector library.

--- a/examples/advanced/Tutorial3/simulation/FairTestDetectorContFact.h
+++ b/examples/advanced/Tutorial3/simulation/FairTestDetectorContFact.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -16,9 +16,6 @@ class FairParSet;
 
 class FairTestDetectorContFact : public FairContFact
 {
-  private:
-    void setAllContainers();
-
   public:
     FairTestDetectorContFact();
     ~FairTestDetectorContFact() override = default;

--- a/examples/advanced/propagator/src/FairTutPropContFact.cxx
+++ b/examples/advanced/propagator/src/FairTutPropContFact.cxx
@@ -27,8 +27,8 @@ FairTutPropContFact::FairTutPropContFact()
         the list of containers for the FairTutProp library.
     */
 
-    FairContainer* p = new FairContainer("FairTutPropGeoPar", "FairTutProp Geometry Parameters", "TestDefaultContext");
-    containers->Add(p);
+    auto p = new FairContainer("FairTutPropGeoPar", "FairTutProp Geometry Parameters", "TestDefaultContext");
+    AddContainer(p);
 }
 
 FairParSet* FairTutPropContFact::createContainer(FairContainer* c)

--- a/examples/advanced/propagator/src/FairTutPropContFact.cxx
+++ b/examples/advanced/propagator/src/FairTutPropContFact.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2019-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2019-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -21,11 +21,7 @@ FairTutPropContFact::FairTutPropContFact()
     : FairContFact("FairTutPropContFact", "Factory for parameter containers in libFairTutProp")
 {
     /** Constructor (called when the library is loaded) */
-    setAllContainers();
-}
 
-void FairTutPropContFact::setAllContainers()
-{
     /** Creates the Container objects with all accepted
         contexts and adds them to
         the list of containers for the FairTutProp library.

--- a/examples/advanced/propagator/src/FairTutPropContFact.h
+++ b/examples/advanced/propagator/src/FairTutPropContFact.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2019-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2019-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -15,9 +15,6 @@ class FairParSet;
 
 class FairTutPropContFact : public FairContFact
 {
-  private:
-    void setAllContainers();
-
   public:
     FairTutPropContFact();
     ~FairTutPropContFact() override = default;

--- a/examples/common/passive/FairPassiveContFact.cxx
+++ b/examples/common/passive/FairPassiveContFact.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -33,11 +33,7 @@ FairPassiveContFact::FairPassiveContFact()
     : FairContFact("FairPassiveContFact", "Factory for parameter containers in libPassive")
 {
     // Constructor (called when the library is loaded)
-    setAllContainers();
-}
 
-void FairPassiveContFact::setAllContainers()
-{
     /** Creates the Container objects with all accepted contexts and adds them to
      *  the list of containers for the STS library.*/
 

--- a/examples/common/passive/FairPassiveContFact.cxx
+++ b/examples/common/passive/FairPassiveContFact.cxx
@@ -37,8 +37,8 @@ FairPassiveContFact::FairPassiveContFact()
     /** Creates the Container objects with all accepted contexts and adds them to
      *  the list of containers for the STS library.*/
 
-    FairContainer* p = new FairContainer("FairGeoPassivePar", "Passive Geometry Parameters", "TestDefaultContext");
-    containers->Add(p);
+    auto p = new FairContainer("FairGeoPassivePar", "Passive Geometry Parameters", "TestDefaultContext");
+    AddContainer(p);
 }
 
 FairParSet* FairPassiveContFact::createContainer(FairContainer* c)

--- a/examples/common/passive/FairPassiveContFact.h
+++ b/examples/common/passive/FairPassiveContFact.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -16,9 +16,6 @@ class FairParSet;
 
 class FairPassiveContFact : public FairContFact
 {
-  private:
-    void setAllContainers();
-
   public:
     FairPassiveContFact();
     ~FairPassiveContFact() {}

--- a/examples/simulation/Tutorial1/src/FairTutorialDet1ContFact.cxx
+++ b/examples/simulation/Tutorial1/src/FairTutorialDet1ContFact.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -23,11 +23,7 @@ FairTutorialDet1ContFact::FairTutorialDet1ContFact()
     : FairContFact("FairTutorialDet1ContFact", "Factory for parameter containers in libTutorial1")
 {
     /** Constructor (called when the library is loaded) */
-    setAllContainers();
-}
 
-void FairTutorialDet1ContFact::setAllContainers()
-{
     /** Creates the Container objects with all accepted
       contexts and adds them to
       the list of containers for the Tutorial1 library.

--- a/examples/simulation/Tutorial1/src/FairTutorialDet1ContFact.cxx
+++ b/examples/simulation/Tutorial1/src/FairTutorialDet1ContFact.cxx
@@ -29,9 +29,8 @@ FairTutorialDet1ContFact::FairTutorialDet1ContFact()
       the list of containers for the Tutorial1 library.
   */
 
-    FairContainer* p =
-        new FairContainer("FairTutorialDet1GeoPar", "FairTutorialDet1 Geometry Parameters", "TestDefaultContext");
-    containers->Add(p);
+    auto p = new FairContainer("FairTutorialDet1GeoPar", "FairTutorialDet1 Geometry Parameters", "TestDefaultContext");
+    AddContainer(p);
 }
 
 FairParSet* FairTutorialDet1ContFact::createContainer(FairContainer* c)

--- a/examples/simulation/Tutorial1/src/FairTutorialDet1ContFact.h
+++ b/examples/simulation/Tutorial1/src/FairTutorialDet1ContFact.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -16,9 +16,6 @@ class FairParSet;
 
 class FairTutorialDet1ContFact : public FairContFact
 {
-  private:
-    void setAllContainers();
-
   public:
     FairTutorialDet1ContFact();
     ~FairTutorialDet1ContFact() {}

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2ContFact.cxx
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2ContFact.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -20,11 +20,7 @@ FairTutorialDet2ContFact::FairTutorialDet2ContFact()
     : FairContFact("FairTutorialDet2ContFact", "Factory for parameter containers in libTutorial1")
 {
     /** Constructor (called when the library is loaded) */
-    setAllContainers();
-}
 
-void FairTutorialDet2ContFact::setAllContainers()
-{
     /** Creates the Container objects with all accepted
       contexts and adds them to
       the list of containers for the Tutorial1 library.

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2ContFact.cxx
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2ContFact.cxx
@@ -26,13 +26,11 @@ FairTutorialDet2ContFact::FairTutorialDet2ContFact()
       the list of containers for the Tutorial1 library.
   */
 
-    FairContainer* p1 =
-        new FairContainer("FairTutorialDet2GeoPar", "FairTutorialDet2 Geometry Parameters", "TestDefaultContext");
-    containers->Add(p1);
+    auto p1 = new FairContainer("FairTutorialDet2GeoPar", "FairTutorialDet2 Geometry Parameters", "TestDefaultContext");
+    AddContainer(p1);
 
-    FairContainer* p2 =
-        new FairContainer("FairTutorialDet2DigiPar", "Tutorial Det Digi Parameters", "TestDefaultContext");
-    containers->Add(p2);
+    auto p2 = new FairContainer("FairTutorialDet2DigiPar", "Tutorial Det Digi Parameters", "TestDefaultContext");
+    AddContainer(p2);
 }
 
 FairParSet* FairTutorialDet2ContFact::createContainer(FairContainer* c)

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2ContFact.h
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2ContFact.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -16,9 +16,6 @@ class FairParSet;
 
 class FairTutorialDet2ContFact : public FairContFact
 {
-  private:
-    void setAllContainers();
-
   public:
     FairTutorialDet2ContFact();
     ~FairTutorialDet2ContFact() {}

--- a/examples/simulation/Tutorial4/src/param/FairTutorialDet4ContFact.cxx
+++ b/examples/simulation/Tutorial4/src/param/FairTutorialDet4ContFact.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -24,11 +24,7 @@ FairTutorialDet4ContFact::FairTutorialDet4ContFact()
     : FairContFact("FairTutorialDet4ContFact", "Factory for parameter containers in libTutorial1")
 {
     /** Constructor (called when the library is loaded) */
-    setAllContainers();
-}
 
-void FairTutorialDet4ContFact::setAllContainers()
-{
     /** Creates the Container objects with all accepted
       contexts and adds them to
       the list of containers for the Tutorial1 library.

--- a/examples/simulation/Tutorial4/src/param/FairTutorialDet4ContFact.cxx
+++ b/examples/simulation/Tutorial4/src/param/FairTutorialDet4ContFact.cxx
@@ -30,13 +30,12 @@ FairTutorialDet4ContFact::FairTutorialDet4ContFact()
       the list of containers for the Tutorial1 library.
   */
 
-    FairContainer* p =
-        new FairContainer("FairTutorialDet4GeoPar", "FairTutorialDet4 Geometry Parameters", "TestDefaultContext");
-    containers->Add(p);
+    auto p = new FairContainer("FairTutorialDet4GeoPar", "FairTutorialDet4 Geometry Parameters", "TestDefaultContext");
+    AddContainer(p);
 
-    FairContainer* p1 = new FairContainer(
+    auto p1 = new FairContainer(
         "FairTutorialDet4MissallignPar", "FairTutorialDet4 Missallignment Parameters", "TestDefaultContext");
-    containers->Add(p1);
+    AddContainer(p1);
 }
 
 FairParSet* FairTutorialDet4ContFact::createContainer(FairContainer* c)

--- a/examples/simulation/Tutorial4/src/param/FairTutorialDet4ContFact.h
+++ b/examples/simulation/Tutorial4/src/param/FairTutorialDet4ContFact.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -16,9 +16,6 @@ class FairParSet;
 
 class FairTutorialDet4ContFact : public FairContFact
 {
-  private:
-    void setAllContainers();
-
   public:
     FairTutorialDet4ContFact();
     ~FairTutorialDet4ContFact() {}

--- a/examples/simulation/rutherford/src/FairRutherfordContFact.cxx
+++ b/examples/simulation/rutherford/src/FairRutherfordContFact.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -23,11 +23,7 @@ FairRutherfordContFact::FairRutherfordContFact()
     : FairContFact("FairRutherfordContFact", "Factory for parameter containers in libFairRutherford")
 {
     /** Constructor (called when the library is loaded) */
-    setAllContainers();
-}
 
-void FairRutherfordContFact::setAllContainers()
-{
     /** Creates the Container objects with all accepted
       contexts and adds them to
       the list of containers for the FairRutherford library.

--- a/examples/simulation/rutherford/src/FairRutherfordContFact.cxx
+++ b/examples/simulation/rutherford/src/FairRutherfordContFact.cxx
@@ -30,7 +30,7 @@ FairRutherfordContFact::FairRutherfordContFact()
   */
 
     auto p = new FairContainer("FairRutherfordGeoPar", "FairRutherford Geometry Parameters", "TestDefaultContext");
-    containers->Add(p);
+    AddContainer(p);
 }
 
 FairParSet* FairRutherfordContFact::createContainer(FairContainer* c)

--- a/examples/simulation/rutherford/src/FairRutherfordContFact.h
+++ b/examples/simulation/rutherford/src/FairRutherfordContFact.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -16,9 +16,6 @@ class FairParSet;
 
 class FairRutherfordContFact : public FairContFact
 {
-  private:
-    void setAllContainers();
-
   public:
     FairRutherfordContFact();
     ~FairRutherfordContFact() override {}

--- a/templates/NewDetector_root_containers/NewDetectorContFact.cxx
+++ b/templates/NewDetector_root_containers/NewDetectorContFact.cxx
@@ -25,8 +25,8 @@ NewDetectorContFact::NewDetectorContFact()
       the list of containers for the NewDetector library.
   */
 
-    FairContainer* p = new FairContainer("NewDetectorGeoPar", "NewDetector Geometry Parameters", "TestDefaultContext");
-    containers->Add(p);
+    auto p = new FairContainer("NewDetectorGeoPar", "NewDetector Geometry Parameters", "TestDefaultContext");
+    AddContainer(p);
 }
 
 FairParSet* NewDetectorContFact::createContainer(FairContainer* c)

--- a/templates/NewDetector_root_containers/NewDetectorContFact.cxx
+++ b/templates/NewDetector_root_containers/NewDetectorContFact.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -19,11 +19,7 @@ NewDetectorContFact::NewDetectorContFact()
     : FairContFact("NewDetectorContFact", "Factory for parameter containers in libNewDetector")
 {
     /** Constructor (called when the library is loaded) */
-    setAllContainers();
-}
 
-void NewDetectorContFact::setAllContainers()
-{
     /** Creates the Container objects with all accepted
       contexts and adds them to
       the list of containers for the NewDetector library.

--- a/templates/NewDetector_root_containers/NewDetectorContFact.h
+++ b/templates/NewDetector_root_containers/NewDetectorContFact.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -14,9 +14,6 @@ class FairContainer;
 
 class NewDetectorContFact : public FairContFact
 {
-  private:
-    void setAllContainers();
-
   public:
     NewDetectorContFact();
     ~NewDetectorContFact() {}

--- a/templates/NewDetector_stl_containers/NewDetectorContFact.cxx
+++ b/templates/NewDetector_stl_containers/NewDetectorContFact.cxx
@@ -25,8 +25,8 @@ NewDetectorContFact::NewDetectorContFact()
       the list of containers for the NewDetector library.
   */
 
-    FairContainer* p = new FairContainer("NewDetectorGeoPar", "NewDetector Geometry Parameters", "TestDefaultContext");
-    containers->Add(p);
+    auto p = new FairContainer("NewDetectorGeoPar", "NewDetector Geometry Parameters", "TestDefaultContext");
+    AddContainer(p);
 }
 
 FairParSet* NewDetectorContFact::createContainer(FairContainer* c)

--- a/templates/NewDetector_stl_containers/NewDetectorContFact.cxx
+++ b/templates/NewDetector_stl_containers/NewDetectorContFact.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -19,11 +19,7 @@ NewDetectorContFact::NewDetectorContFact()
     : FairContFact("NewDetectorContFact", "Factory for parameter containers in libNewDetector")
 {
     /** Constructor (called when the library is loaded) */
-    setAllContainers();
-}
 
-void NewDetectorContFact::setAllContainers()
-{
     /** Creates the Container objects with all accepted
       contexts and adds them to
       the list of containers for the NewDetector library.

--- a/templates/NewDetector_stl_containers/NewDetectorContFact.h
+++ b/templates/NewDetector_stl_containers/NewDetectorContFact.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -14,9 +14,6 @@ class FairContainer;
 
 class NewDetectorContFact : public FairContFact
 {
-  private:
-    void setAllContainers();
-
   public:
     NewDetectorContFact();
     ~NewDetectorContFact() {}

--- a/templates/project_root_containers/NewDetector/NewDetectorContFact.cxx
+++ b/templates/project_root_containers/NewDetector/NewDetectorContFact.cxx
@@ -25,8 +25,8 @@ NewDetectorContFact::NewDetectorContFact()
       the list of containers for the NewDetector library.
   */
 
-    FairContainer* p = new FairContainer("NewDetectorGeoPar", "NewDetector Geometry Parameters", "TestDefaultContext");
-    containers->Add(p);
+    auto p = new FairContainer("NewDetectorGeoPar", "NewDetector Geometry Parameters", "TestDefaultContext");
+    AddContainer(p);
 }
 
 FairParSet* NewDetectorContFact::createContainer(FairContainer* c)

--- a/templates/project_root_containers/NewDetector/NewDetectorContFact.cxx
+++ b/templates/project_root_containers/NewDetector/NewDetectorContFact.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -19,11 +19,7 @@ NewDetectorContFact::NewDetectorContFact()
     : FairContFact("NewDetectorContFact", "Factory for parameter containers in libNewDetector")
 {
     /** Constructor (called when the library is loaded) */
-    setAllContainers();
-}
 
-void NewDetectorContFact::setAllContainers()
-{
     /** Creates the Container objects with all accepted
       contexts and adds them to
       the list of containers for the NewDetector library.

--- a/templates/project_root_containers/NewDetector/NewDetectorContFact.h
+++ b/templates/project_root_containers/NewDetector/NewDetectorContFact.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -14,9 +14,6 @@ class FairContainer;
 
 class NewDetectorContFact : public FairContFact
 {
-  private:
-    void setAllContainers();
-
   public:
     NewDetectorContFact();
     ~NewDetectorContFact() {}

--- a/templates/project_root_containers/passive/MyPassiveContFact.cxx
+++ b/templates/project_root_containers/passive/MyPassiveContFact.cxx
@@ -41,8 +41,8 @@ MyPassiveContFact::MyPassiveContFact()
     /** Creates the Container objects with all accepted contexts and adds them to
      *  the list of containers for the STS library.*/
 
-    FairContainer* p = new FairContainer("FairGeoPassivePar", "Passive Geometry Parameters", "TestDefaultContext");
-    containers->Add(p);
+    auto p = new FairContainer("FairGeoPassivePar", "Passive Geometry Parameters", "TestDefaultContext");
+    AddContainer(p);
 }
 
 FairParSet* MyPassiveContFact::createContainer(FairContainer* c)

--- a/templates/project_root_containers/passive/MyPassiveContFact.cxx
+++ b/templates/project_root_containers/passive/MyPassiveContFact.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -37,11 +37,7 @@ MyPassiveContFact::MyPassiveContFact()
     : FairContFact("MyPassiveContFact", "Factory for parameter containers in libPassive")
 {
     // Constructor (called when the library is loaded)
-    setAllContainers();
-}
 
-void MyPassiveContFact::setAllContainers()
-{
     /** Creates the Container objects with all accepted contexts and adds them to
      *  the list of containers for the STS library.*/
 

--- a/templates/project_root_containers/passive/MyPassiveContFact.h
+++ b/templates/project_root_containers/passive/MyPassiveContFact.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -22,9 +22,6 @@ class FairParSet;
 
 class MyPassiveContFact : public FairContFact
 {
-  private:
-    void setAllContainers();
-
   public:
     MyPassiveContFact();
     ~MyPassiveContFact() {}

--- a/templates/project_stl_containers/NewDetector/NewDetectorContFact.cxx
+++ b/templates/project_stl_containers/NewDetector/NewDetectorContFact.cxx
@@ -25,8 +25,8 @@ NewDetectorContFact::NewDetectorContFact()
       the list of containers for the NewDetector library.
   */
 
-    FairContainer* p = new FairContainer("NewDetectorGeoPar", "NewDetector Geometry Parameters", "TestDefaultContext");
-    containers->Add(p);
+    auto p = new FairContainer("NewDetectorGeoPar", "NewDetector Geometry Parameters", "TestDefaultContext");
+    AddContainer(p);
 }
 
 FairParSet* NewDetectorContFact::createContainer(FairContainer* c)

--- a/templates/project_stl_containers/NewDetector/NewDetectorContFact.cxx
+++ b/templates/project_stl_containers/NewDetector/NewDetectorContFact.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -19,11 +19,7 @@ NewDetectorContFact::NewDetectorContFact()
     : FairContFact("NewDetectorContFact", "Factory for parameter containers in libNewDetector")
 {
     /** Constructor (called when the library is loaded) */
-    setAllContainers();
-}
 
-void NewDetectorContFact::setAllContainers()
-{
     /** Creates the Container objects with all accepted
       contexts and adds them to
       the list of containers for the NewDetector library.

--- a/templates/project_stl_containers/NewDetector/NewDetectorContFact.h
+++ b/templates/project_stl_containers/NewDetector/NewDetectorContFact.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -14,9 +14,6 @@ class FairContainer;
 
 class NewDetectorContFact : public FairContFact
 {
-  private:
-    void setAllContainers();
-
   public:
     NewDetectorContFact();
     ~NewDetectorContFact() {}

--- a/templates/project_stl_containers/passive/MyPassiveContFact.cxx
+++ b/templates/project_stl_containers/passive/MyPassiveContFact.cxx
@@ -41,8 +41,8 @@ MyPassiveContFact::MyPassiveContFact()
     /** Creates the Container objects with all accepted contexts and adds them to
      *  the list of containers for the STS library.*/
 
-    FairContainer* p = new FairContainer("FairGeoPassivePar", "Passive Geometry Parameters", "TestDefaultContext");
-    containers->Add(p);
+    auto p = new FairContainer("FairGeoPassivePar", "Passive Geometry Parameters", "TestDefaultContext");
+    AddContainer(p);
 }
 
 FairParSet* MyPassiveContFact::createContainer(FairContainer* c)

--- a/templates/project_stl_containers/passive/MyPassiveContFact.cxx
+++ b/templates/project_stl_containers/passive/MyPassiveContFact.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -37,11 +37,7 @@ MyPassiveContFact::MyPassiveContFact()
     : FairContFact("MyPassiveContFact", "Factory for parameter containers in libPassive")
 {
     // Constructor (called when the library is loaded)
-    setAllContainers();
-}
 
-void MyPassiveContFact::setAllContainers()
-{
     /** Creates the Container objects with all accepted contexts and adds them to
      *  the list of containers for the STS library.*/
 

--- a/templates/project_stl_containers/passive/MyPassiveContFact.h
+++ b/templates/project_stl_containers/passive/MyPassiveContFact.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -22,9 +22,6 @@ class FairParSet;
 
 class MyPassiveContFact : public FairContFact
 {
-  private:
-    void setAllContainers();
-
   public:
     MyPassiveContFact();
     ~MyPassiveContFact() {}


### PR DESCRIPTION


The constructor of nearly all "Container Factories" calls a
private member function called setAllContainers. And it's
the only call. And that member function is called from
nowhere else.

Instead of modifying `containers` directly, use
`AddContainer()`.

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
