### PR TITLE
fix: Close Sink at end of a Run

### DIFF
--- a/base/sim/FairMCApplication.cxx
+++ b/base/sim/FairMCApplication.cxx
@@ -391,7 +391,6 @@ void FairMCApplication::FinishRun()
 
     if (!fRadGridMan && fRootManager) {
         fRootManager->Write();
-        fRootManager->CloseSink();
     }
 
     if (fEvGen) {
@@ -642,7 +641,6 @@ void FairMCApplication::StopRun()
     FinishRun();
     if (fRootManager) {
         fRootManager->Write();
-        fRootManager->CloseSink();
     }
     LOG(warn) << "StopRun() exiting not safetly oopps !!!@@@!!!";
     exit(0);

--- a/base/sink/FairRootFileSink.cxx
+++ b/base/sink/FairRootFileSink.cxx
@@ -39,11 +39,6 @@ FairRootFileSink::FairRootFileSink(TFile* f, const char* Title)
     : FairSink()
     , fOutputTitle(Title)
     , fRootFile(f)
-    , fOutTree(0)
-    , fListFolder(new TObjArray(16))
-    , fCbmout(0)
-    , fIsInitialized(kFALSE)
-    , fFileHeader(0)
 {
     if ((!fRootFile) || fRootFile->IsZombie()) {
         LOG(fatal) << "Error opening the Input file";
@@ -54,11 +49,6 @@ FairRootFileSink::FairRootFileSink(TFile* f, const char* Title)
 FairRootFileSink::FairRootFileSink(const TString* RootFileName, const char* Title)
     : FairSink()
     , fOutputTitle(Title)
-    , fOutTree(0)
-    , fListFolder(new TObjArray(16))
-    , fCbmout(0)
-    , fIsInitialized(kFALSE)
-    , fFileHeader(0)
 {
     fRootFile.reset(TFile::Open(RootFileName->Data(), "recreate"));
     if ((!fRootFile) || fRootFile->IsZombie()) {
@@ -70,11 +60,6 @@ FairRootFileSink::FairRootFileSink(const TString* RootFileName, const char* Titl
 FairRootFileSink::FairRootFileSink(const TString RootFileName, const char* Title)
     : FairSink()
     , fOutputTitle(Title)
-    , fOutTree(0)
-    , fListFolder(new TObjArray(16))
-    , fCbmout(0)
-    , fIsInitialized(kFALSE)
-    , fFileHeader(0)
 {
     fRootFile.reset(TFile::Open(RootFileName.Data(), "recreate"));
     if ((!fRootFile) || fRootFile->IsZombie()) {
@@ -82,8 +67,6 @@ FairRootFileSink::FairRootFileSink(const TString RootFileName, const char* Title
     }
     LOG(debug) << "FairRootFileSink created------------";
 }
-
-FairRootFileSink::~FairRootFileSink() {}
 
 TFile* FairRootFileSink::OpenRootFile(TString fileName)
 {

--- a/base/sink/FairRootFileSink.h
+++ b/base/sink/FairRootFileSink.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *
@@ -18,17 +18,14 @@
 #include "FairSink.h"
 
 #include <Rtypes.h>
+#include <TBranch.h>
 #include <TFile.h>
 #include <TString.h>
+#include <memory>
 #include <typeinfo>
 
 class FairEventHeader;
 class FairFileHeader;
-class TBranch;
-class TObjArray;
-class TObject;
-class TTree;
-class TFolder;
 
 class FairRootFileSink : public FairSink
 {
@@ -48,7 +45,7 @@ class FairRootFileSink : public FairSink
     virtual void FillEventHeader(FairEventHeader* feh);
 
     virtual TFile* OpenRootFile(TString fileName = "");
-    TFile* GetRootFile() { return fRootFile; }
+    TFile* GetRootFile() { return fRootFile.get(); }
     virtual TString GetFileName() { return (fRootFile ? fRootFile->GetName() : ""); }
 
     virtual void SetOutTree(TTree* fTree) { fOutTree = fTree; }
@@ -73,7 +70,7 @@ class FairRootFileSink : public FairSink
     /** Title of input sink, could be input, background or signal*/
     TString fOutputTitle;
     /** ROOT file */
-    TFile* fRootFile;
+    std::unique_ptr<TFile> fRootFile;
     /** Output Tree  */
     TTree* fOutTree;
     /**  list of folders from all input (and friends) files */

--- a/base/sink/FairRootFileSink.h
+++ b/base/sink/FairRootFileSink.h
@@ -33,38 +33,39 @@ class FairRootFileSink : public FairSink
     FairRootFileSink(TFile* f, const char* Title = "OutputRootFile");
     FairRootFileSink(const TString* RootFileName, const char* Title = "OutputRootFile");
     FairRootFileSink(const TString RootFileName, const char* Title = "OutputRootFile");
-    //  FairRootFileSink(const FairRootFileSink& file);
-    virtual ~FairRootFileSink();
+    FairRootFileSink(const FairRootFileSink&) = delete;
+    FairRootFileSink operator=(const FairRootFileSink&) = delete;
+    ~FairRootFileSink() override = default;
 
-    virtual Bool_t InitSink();
-    virtual void Close();
-    virtual void Reset();
+    Bool_t InitSink() override;
+    void Close() override;
+    void Reset() override;
 
-    virtual Sink_Type GetSinkType() { return kFILESINK; }
+    Sink_Type GetSinkType() override { return kFILESINK; }
 
     virtual void FillEventHeader(FairEventHeader* feh);
 
     virtual TFile* OpenRootFile(TString fileName = "");
     TFile* GetRootFile() { return fRootFile.get(); }
-    virtual TString GetFileName() { return (fRootFile ? fRootFile->GetName() : ""); }
+    TString GetFileName() override { return (fRootFile ? fRootFile->GetName() : ""); }
 
-    virtual void SetOutTree(TTree* fTree) { fOutTree = fTree; }
+    void SetOutTree(TTree* fTree) override { fOutTree = fTree; }
     TTree* GetOutTree() { return fOutTree; }
 
-    virtual void Fill();
+    void Fill() override;
 
-    virtual Int_t Write(const char* name = 0, Int_t option = 0, Int_t bufsize = 0);
+    Int_t Write(const char* name = nullptr, Int_t option = 0, Int_t bufsize = 0) override;
 
-    virtual void RegisterImpl(const char*, const char*, void*);
-    virtual void RegisterAny(const char* brname, const std::type_info& oi, const std::type_info& pi, void* obj);
+    void RegisterImpl(const char*, const char*, void*) override;
+    void RegisterAny(const char* brname, const std::type_info& oi, const std::type_info& pi, void* obj) override;
 
-    virtual void WriteFolder();
-    virtual bool CreatePersistentBranchesAny();
+    void WriteFolder() override;
+    bool CreatePersistentBranchesAny() override;
 
-    virtual void WriteObject(TObject* f, const char*, Int_t option = 0);
-    virtual void WriteGeometry();
+    void WriteObject(TObject* f, const char*, Int_t option = 0) override;
+    void WriteGeometry() override;
 
-    virtual FairSink* CloneSink();
+    FairSink* CloneSink() override;
 
   private:
     /** Title of input sink, could be input, background or signal*/
@@ -72,27 +73,20 @@ class FairRootFileSink : public FairSink
     /** ROOT file */
     std::unique_ptr<TFile> fRootFile;
     /** Output Tree  */
-    TTree* fOutTree;
-    /**  list of folders from all input (and friends) files */
-    TObjArray* fListFolder;   //!
-    /** folder structure of output */
-    TFolder* fCbmout;
+    TTree* fOutTree{nullptr};
     /** Initialization flag, true if initialized */
-    Bool_t fIsInitialized;
-
-    FairRootFileSink(const FairRootFileSink&);
-    FairRootFileSink operator=(const FairRootFileSink&);
+    Bool_t fIsInitialized{kFALSE};
 
     void TruncateBranchNames();
     void TruncateBranchNames(TBranch* b, TString ffn);
     // bool CreatePersistentBranchesAny();
 
     /**File Header*/
-    FairFileHeader* fFileHeader;   //!
+    FairFileHeader* fFileHeader{nullptr};   //!
 
     bool fPersistentBranchesDone{false};   //!
 
-    ClassDef(FairRootFileSink, 1);
+    ClassDefOverride(FairRootFileSink, 1);
 };
 
 #endif /* defined(__FAIRROOT__FairRootFileSink__) */

--- a/base/steer/FairRunSim.cxx
+++ b/base/steer/FairRunSim.cxx
@@ -314,6 +314,9 @@ void FairRunSim::Run(Int_t NEvents, Int_t)
 {
     fApp->RunMC(NEvents);
     fWasMT = fApp->GetIsMT();
+    if (fSink) {
+        fSink->Close();
+    }
 }
 
 void FairRunSim::SetField(FairField* field)


### PR DESCRIPTION
After a FairRunSim::Run the Sink is sometimes still open.

Close it properly.

Also close the ROOT-File if a FairRootFileSink gets destructed.

See: https://cdash.gsi.de/testDetails.php?test=13258151&build=366624

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
