### PR TITLE
fix(ex_MQ_serialization): InputArguments WARNING

### DIFF
--- a/examples/MQ/serialization/data_generator/RooDataGenerator.h
+++ b/examples/MQ/serialization/data_generator/RooDataGenerator.h
@@ -92,7 +92,7 @@ class MultiVariatePDF
         , fT("t", "t", static_cast<double>(tStart), static_cast<double>(tStart + 1))
         , fTErr("tErr", "tErr", fOpt.fTErr.fMin, fOpt.fTErr.fMax)
         , fMeanT("mu_t", "mean of t-distribution", (static_cast<double>(tStart) + static_cast<double>(tStart + 1)) / 2)
-        , fSigmaT("fSigmaT", "width of t-distribution", 0.1)
+        , fSigmaT("fSigmaT", "width of t-distribution", 0.1, 1e-4, 1000.)
         , fGaussX("fGaussX", "gaussian PDF", fX, RooFit::RooConst(fOpt.fX.fMean), RooFit::RooConst(fOpt.fX.fSigma))
         , fGaussY("fGaussY", "gaussian PDF", fY, RooFit::RooConst(fOpt.fY.fMean), RooFit::RooConst(fOpt.fY.fSigma))
         , fGaussZ("fGaussZ", "gaussian PDF", fZ, RooFit::RooConst(fOpt.fZ.fMean), RooFit::RooConst(fOpt.fZ.fSigma))
@@ -113,7 +113,7 @@ class MultiVariatePDF
     MultiVariatePDF(const MultiVariatePDF&) = delete;
     MultiVariatePDF operator=(const MultiVariatePDF&) = delete;
 
-    ~MultiVariatePDF() {}
+    ~MultiVariatePDF() = default;
 
     RooDataSet* GetGeneratedData(unsigned int n, unsigned int ti)
     {


### PR DESCRIPTION
```
[#0] WARNING:InputArguments -- The parameter 'fSigmaT' with range [-1e+30, 1e+30] of the RooGaussian 'fGaussT' exceeds the safe range of (0, inf). Advise to limit its range.
```

The sigma of a Guassian has to be positive.
So limit the range of the sigma variable to some arbitrary positive values.

See: https://github.com/FairRootGroup/FairRoot/pull/1341#issuecomment-1420771138

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
