### PR TITLE
format: set SpacesBeforeTrailingComments to 1

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -35,7 +35,7 @@ IncludeBlocks: Regroup
 NamespaceIndentation: None
 PointerAlignment: Left
 SortIncludes: true
-SpacesBeforeTrailingComments: 3
+SpacesBeforeTrailingComments: 1
 Standard: c++17
 UseTab: Never
 ...


### PR DESCRIPTION
Set clang-format's `SpacesBeforeTrailingComments` to `1`.

