### PR TITLE
chore(templates): Drop ClassImp

### DIFF
--- a/templates/NewDetector_root_containers/NewDetector.cxx
+++ b/templates/NewDetector_root_containers/NewDetector.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -256,5 +256,3 @@ Bool_t NewDetector::IsSensitive(const std::string& name)
     }
     return kFALSE;
 }
-
-ClassImp(NewDetector);

--- a/templates/NewDetector_root_containers/NewDetectorContFact.cxx
+++ b/templates/NewDetector_root_containers/NewDetectorContFact.cxx
@@ -11,8 +11,6 @@
 
 #include <iostream>
 
-ClassImp(NewDetectorContFact);
-
 static NewDetectorContFact gNewDetectorContFact;
 
 NewDetectorContFact::NewDetectorContFact()

--- a/templates/NewDetector_root_containers/NewDetectorGeo.cxx
+++ b/templates/NewDetector_root_containers/NewDetectorGeo.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -8,8 +8,6 @@
 #include "NewDetectorGeo.h"
 
 #include "FairGeoNode.h"
-
-ClassImp(NewDetectorGeo);
 
 // -----   Default constructor   -------------------------------------------
 NewDetectorGeo::NewDetectorGeo()

--- a/templates/NewDetector_root_containers/NewDetectorGeoPar.cxx
+++ b/templates/NewDetector_root_containers/NewDetectorGeoPar.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -11,8 +11,6 @@
 
 #include <TObjArray.h>
 #include <iostream>
-
-ClassImp(NewDetectorGeoPar);
 
 NewDetectorGeoPar ::NewDetectorGeoPar(const char* name, const char* title, const char* context)
     : FairParGenericSet(name, title, context)

--- a/templates/NewDetector_root_containers/NewDetectorPoint.cxx
+++ b/templates/NewDetector_root_containers/NewDetectorPoint.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -43,5 +43,3 @@ void NewDetectorPoint::Print(const Option_t* /*opt*/) const
          << endl;
 }
 // -------------------------------------------------------------------------
-
-ClassImp(NewDetectorPoint);

--- a/templates/NewDetector_stl_containers/NewDetector.cxx
+++ b/templates/NewDetector_stl_containers/NewDetector.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -248,5 +248,3 @@ Bool_t NewDetector::IsSensitive(const std::string& name)
     }
     return kFALSE;
 }
-
-ClassImp(NewDetector);

--- a/templates/NewDetector_stl_containers/NewDetectorContFact.cxx
+++ b/templates/NewDetector_stl_containers/NewDetectorContFact.cxx
@@ -11,8 +11,6 @@
 
 #include <iostream>
 
-ClassImp(NewDetectorContFact);
-
 static NewDetectorContFact gNewDetectorContFact;
 
 NewDetectorContFact::NewDetectorContFact()

--- a/templates/NewDetector_stl_containers/NewDetectorGeo.cxx
+++ b/templates/NewDetector_stl_containers/NewDetectorGeo.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -8,8 +8,6 @@
 #include "NewDetectorGeo.h"
 
 #include "FairGeoNode.h"
-
-ClassImp(NewDetectorGeo);
 
 // -----   Default constructor   -------------------------------------------
 NewDetectorGeo::NewDetectorGeo()

--- a/templates/NewDetector_stl_containers/NewDetectorGeoPar.cxx
+++ b/templates/NewDetector_stl_containers/NewDetectorGeoPar.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -11,8 +11,6 @@
 
 #include <TObjArray.h>
 #include <iostream>
-
-ClassImp(NewDetectorGeoPar);
 
 NewDetectorGeoPar ::NewDetectorGeoPar(const char* name, const char* title, const char* context)
     : FairParGenericSet(name, title, context)

--- a/templates/NewDetector_stl_containers/NewDetectorPoint.cxx
+++ b/templates/NewDetector_stl_containers/NewDetectorPoint.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -66,5 +66,3 @@ void NewDetectorPoint::Print(const Option_t* /*opt*/) const
          << endl;
 }
 // -------------------------------------------------------------------------
-
-ClassImp(NewDetectorPoint);

--- a/templates/NewParameterContainer/NewParameterContainer.cxx
+++ b/templates/NewParameterContainer/NewParameterContainer.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -10,8 +10,6 @@
 #include "FairParamList.h"
 
 #include <iostream>
-
-ClassImp(NewParameterContainer);
 
 NewParameterContainer ::NewParameterContainer(const char* name, const char* title, const char* context)
     : FairParGenericSet(name, title, context)

--- a/templates/NewTask/NewTask.cxx
+++ b/templates/NewTask/NewTask.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -73,6 +73,7 @@ InitStatus NewTask::ReInit()
 void NewTask::Exec(Option_t* /*option*/) { LOG(debug) << "Exec of NewTask"; }
 
 // ---- Finish --------------------------------------------------------
-void NewTask::Finish() { LOG(debug) << "Finish of NewTask"; }
-
-ClassImp(NewTask);
+void NewTask::Finish()
+{
+    LOG(debug) << "Finish of NewTask";
+}

--- a/templates/TimeBased/MyRingSorter.cxx
+++ b/templates/TimeBased/MyRingSorter.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -18,6 +18,7 @@
 
 MyRingSorter::~MyRingSorter() {}
 
-FairTimeStamp* MyRingSorter::CreateElement(FairTimeStamp* data) { return new MyDataClass(*(MyDataClass*)data); }
-
-ClassImp(MyRingSorter);
+FairTimeStamp* MyRingSorter::CreateElement(FairTimeStamp* data)
+{
+    return new MyDataClass(*(MyDataClass*)data);
+}

--- a/templates/TimeBased/MySorterTask.cxx
+++ b/templates/TimeBased/MySorterTask.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -38,5 +38,3 @@ FairRingSorter* MySorterTask::InitSorter(Int_t numberOfCells, Double_t widthOfCe
 {
     return new MyRingSorter(numberOfCells, widthOfCells);
 }
-
-ClassImp(MySorterTask);

--- a/templates/TimeBased/MyWriteoutBuffer.cxx
+++ b/templates/TimeBased/MyWriteoutBuffer.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -84,5 +84,3 @@ void MyWriteoutBuffer::EraseDataFromDataMap(FairTimeStamp* data)
         fData_map.erase(fData_map.find(myData));
     }
 }
-
-ClassImp(MyWriteoutBuffer);

--- a/templates/project_root_containers/MyProjData/MyProjMCTrack.cxx
+++ b/templates/project_root_containers/MyProjData/MyProjMCTrack.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -177,5 +177,3 @@ void MyProjMCTrack::SetNPoints(Int_t iDet, Int_t nPoints)
 */
 }
 // -------------------------------------------------------------------------
-
-ClassImp(MyProjMCTrack);

--- a/templates/project_root_containers/MyProjData/MyProjStack.cxx
+++ b/templates/project_root_containers/MyProjData/MyProjStack.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -494,5 +494,3 @@ void MyProjStack::SelectTracks()
     }
 }
 // -------------------------------------------------------------------------
-
-ClassImp(MyProjStack);

--- a/templates/project_root_containers/MyProjGenerators/Pythia6Generator.cxx
+++ b/templates/project_root_containers/MyProjGenerators/Pythia6Generator.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -142,5 +142,3 @@ void Pythia6Generator::CloseInput()
     }
 }
 // ------------------------------------------------------------------------
-
-ClassImp(Pythia6Generator);

--- a/templates/project_root_containers/MyProjGenerators/Pythia8Generator.cxx
+++ b/templates/project_root_containers/MyProjGenerators/Pythia8Generator.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -168,5 +168,3 @@ void Pythia8Generator::GetPythiaInstance(int arg)
     cout << "canDecay " << fPythia.particleData.canDecay(arg) << " " << fPythia.particleData.mayDecay(arg) << endl;
 }
 // -------------------------------------------------------------------------
-
-ClassImp(Pythia8Generator);

--- a/templates/project_root_containers/NewDetector/NewDetector.cxx
+++ b/templates/project_root_containers/NewDetector/NewDetector.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -257,5 +257,3 @@ Bool_t NewDetector::IsSensitive(const std::string& name)
     }
     return kFALSE;
 }
-
-ClassImp(NewDetector);

--- a/templates/project_root_containers/NewDetector/NewDetectorContFact.cxx
+++ b/templates/project_root_containers/NewDetector/NewDetectorContFact.cxx
@@ -11,8 +11,6 @@
 
 #include <iostream>
 
-ClassImp(NewDetectorContFact);
-
 static NewDetectorContFact gNewDetectorContFact;
 
 NewDetectorContFact::NewDetectorContFact()

--- a/templates/project_root_containers/NewDetector/NewDetectorGeo.cxx
+++ b/templates/project_root_containers/NewDetector/NewDetectorGeo.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -8,8 +8,6 @@
 #include "NewDetectorGeo.h"
 
 #include "FairGeoNode.h"
-
-ClassImp(NewDetectorGeo);
 
 // -----   Default constructor   -------------------------------------------
 NewDetectorGeo::NewDetectorGeo()

--- a/templates/project_root_containers/NewDetector/NewDetectorGeoPar.cxx
+++ b/templates/project_root_containers/NewDetector/NewDetectorGeoPar.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -11,8 +11,6 @@
 
 #include <TObjArray.h>
 #include <iostream>
-
-ClassImp(NewDetectorGeoPar);
 
 NewDetectorGeoPar ::NewDetectorGeoPar(const char* name, const char* title, const char* context)
     : FairParGenericSet(name, title, context)

--- a/templates/project_root_containers/NewDetector/NewDetectorPoint.cxx
+++ b/templates/project_root_containers/NewDetector/NewDetectorPoint.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -43,5 +43,3 @@ void NewDetectorPoint::Print(const Option_t* /*opt*/) const
          << endl;
 }
 // -------------------------------------------------------------------------
-
-ClassImp(NewDetectorPoint);

--- a/templates/project_root_containers/field/MyConstField.cxx
+++ b/templates/project_root_containers/field/MyConstField.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -171,5 +171,3 @@ void MyConstField::Print()
     cout << "======================================================" << endl;
 }
 // -------------------------------------------------------------------------
-
-ClassImp(MyConstField);

--- a/templates/project_root_containers/field/MyFieldCreator.cxx
+++ b/templates/project_root_containers/field/MyFieldCreator.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -62,5 +62,3 @@ FairField *MyFieldCreator::createFairField()
     }
     return fMagneticField;
 }
-
-ClassImp(MyFieldCreator);

--- a/templates/project_root_containers/field/MyFieldPar.cxx
+++ b/templates/project_root_containers/field/MyFieldPar.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -192,9 +192,5 @@ void MyFieldPar::SetParameters(FairField* field)
         fMapName = "";
         fPosX = fPosY = fPosZ = fScale = 0.;
     }
-
-    return;
 }
 // -------------------------------------------------------------------------
-
-ClassImp(MyFieldPar);

--- a/templates/project_root_containers/passive/MyCave.cxx
+++ b/templates/project_root_containers/passive/MyCave.cxx
@@ -1,6 +1,5 @@
-
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -25,8 +24,6 @@
 #include <TObjArray.h>   // for TObjArray
 #include <TString.h>     // for TString
 #include <stddef.h>      // for NULL
-
-ClassImp(MyCave);
 
 void MyCave::ConstructGeometry()
 {

--- a/templates/project_root_containers/passive/MyGeoCave.cxx
+++ b/templates/project_root_containers/passive/MyGeoCave.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -29,8 +29,6 @@
 #include <TList.h>    // for TList
 #include <iostream>   // for cout
 #include <string.h>   // for strcmp
-
-ClassImp(MyGeoCave);
 
 MyGeoCave::MyGeoCave()
     : FairGeoSet()

--- a/templates/project_root_containers/passive/MyMagnet.cxx
+++ b/templates/project_root_containers/passive/MyMagnet.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -91,6 +91,7 @@ void MyMagnet::ConstructGeometry()
     top->AddNode(magnet1, 2, m6);
 }
 
-FairModule *MyMagnet::CloneModule() const { return new MyMagnet(*this); }
-
-ClassImp(MyMagnet);
+FairModule* MyMagnet::CloneModule() const
+{
+    return new MyMagnet(*this);
+}

--- a/templates/project_root_containers/passive/MyPassiveContFact.cxx
+++ b/templates/project_root_containers/passive/MyPassiveContFact.cxx
@@ -29,8 +29,6 @@
 
 class FairParSet;
 
-ClassImp(MyPassiveContFact);
-
 static MyPassiveContFact gMyPassiveContFact;
 
 MyPassiveContFact::MyPassiveContFact()

--- a/templates/project_root_containers/passive/MyPipe.cxx
+++ b/templates/project_root_containers/passive/MyPipe.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -74,6 +74,7 @@ void MyPipe::ConstructGeometry()
 }
 // ----------------------------------------------------------------------------
 
-FairModule* MyPipe::CloneModule() const { return new MyPipe(*this); }
-
-ClassImp(MyPipe);
+FairModule* MyPipe::CloneModule() const
+{
+    return new MyPipe(*this);
+}

--- a/templates/project_stl_containers/MyProjData/MyProjMCTrack.cxx
+++ b/templates/project_stl_containers/MyProjData/MyProjMCTrack.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -177,5 +177,3 @@ void MyProjMCTrack::SetNPoints(Int_t iDet, Int_t nPoints)
 */
 }
 // -------------------------------------------------------------------------
-
-ClassImp(MyProjMCTrack);

--- a/templates/project_stl_containers/MyProjData/MyProjStack.cxx
+++ b/templates/project_stl_containers/MyProjData/MyProjStack.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -499,5 +499,3 @@ void MyProjStack::SelectTracks()
     }
 }
 // -------------------------------------------------------------------------
-
-ClassImp(MyProjStack);

--- a/templates/project_stl_containers/MyProjGenerators/Pythia6Generator.cxx
+++ b/templates/project_stl_containers/MyProjGenerators/Pythia6Generator.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -142,5 +142,3 @@ void Pythia6Generator::CloseInput()
     }
 }
 // ------------------------------------------------------------------------
-
-ClassImp(Pythia6Generator);

--- a/templates/project_stl_containers/MyProjGenerators/Pythia8Generator.cxx
+++ b/templates/project_stl_containers/MyProjGenerators/Pythia8Generator.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -168,5 +168,3 @@ void Pythia8Generator::GetPythiaInstance(int arg)
     cout << "canDecay " << fPythia.particleData.canDecay(arg) << " " << fPythia.particleData.mayDecay(arg) << endl;
 }
 // -------------------------------------------------------------------------
-
-ClassImp(Pythia8Generator);

--- a/templates/project_stl_containers/NewDetector/NewDetector.cxx
+++ b/templates/project_stl_containers/NewDetector/NewDetector.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -249,5 +249,3 @@ Bool_t NewDetector::IsSensitive(const std::string& name)
     }
     return kFALSE;
 }
-
-ClassImp(NewDetector);

--- a/templates/project_stl_containers/NewDetector/NewDetectorContFact.cxx
+++ b/templates/project_stl_containers/NewDetector/NewDetectorContFact.cxx
@@ -11,8 +11,6 @@
 
 #include <iostream>
 
-ClassImp(NewDetectorContFact);
-
 static NewDetectorContFact gNewDetectorContFact;
 
 NewDetectorContFact::NewDetectorContFact()

--- a/templates/project_stl_containers/NewDetector/NewDetectorGeo.cxx
+++ b/templates/project_stl_containers/NewDetector/NewDetectorGeo.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -8,8 +8,6 @@
 #include "NewDetectorGeo.h"
 
 #include "FairGeoNode.h"
-
-ClassImp(NewDetectorGeo);
 
 // -----   Default constructor   -------------------------------------------
 NewDetectorGeo::NewDetectorGeo()

--- a/templates/project_stl_containers/NewDetector/NewDetectorGeoPar.cxx
+++ b/templates/project_stl_containers/NewDetector/NewDetectorGeoPar.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -11,8 +11,6 @@
 
 #include <TObjArray.h>
 #include <iostream>
-
-ClassImp(NewDetectorGeoPar);
 
 NewDetectorGeoPar ::NewDetectorGeoPar(const char* name, const char* title, const char* context)
     : FairParGenericSet(name, title, context)

--- a/templates/project_stl_containers/NewDetector/NewDetectorPoint.cxx
+++ b/templates/project_stl_containers/NewDetector/NewDetectorPoint.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -63,5 +63,3 @@ void NewDetectorPoint::Print(const Option_t* /*opt*/) const
          << endl;
 }
 // -------------------------------------------------------------------------
-
-ClassImp(NewDetectorPoint);

--- a/templates/project_stl_containers/field/MyConstField.cxx
+++ b/templates/project_stl_containers/field/MyConstField.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -171,5 +171,3 @@ void MyConstField::Print()
     cout << "======================================================" << endl;
 }
 // -------------------------------------------------------------------------
-
-ClassImp(MyConstField);

--- a/templates/project_stl_containers/field/MyFieldCreator.cxx
+++ b/templates/project_stl_containers/field/MyFieldCreator.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -62,5 +62,3 @@ FairField *MyFieldCreator::createFairField()
     }
     return fMagneticField;
 }
-
-ClassImp(MyFieldCreator);

--- a/templates/project_stl_containers/field/MyFieldPar.cxx
+++ b/templates/project_stl_containers/field/MyFieldPar.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -192,9 +192,5 @@ void MyFieldPar::SetParameters(FairField* field)
         fMapName = "";
         fPosX = fPosY = fPosZ = fScale = 0.;
     }
-
-    return;
 }
 // -------------------------------------------------------------------------
-
-ClassImp(MyFieldPar);

--- a/templates/project_stl_containers/passive/MyCave.cxx
+++ b/templates/project_stl_containers/passive/MyCave.cxx
@@ -1,6 +1,5 @@
-
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -25,8 +24,6 @@
 #include <TObjArray.h>   // for TObjArray
 #include <TString.h>     // for TString
 #include <stddef.h>      // for NULL
-
-ClassImp(MyCave);
 
 void MyCave::ConstructGeometry()
 {

--- a/templates/project_stl_containers/passive/MyGeoCave.cxx
+++ b/templates/project_stl_containers/passive/MyGeoCave.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -29,8 +29,6 @@
 #include <TList.h>    // for TList
 #include <iostream>   // for cout
 #include <string.h>   // for strcmp
-
-ClassImp(MyGeoCave);
 
 MyGeoCave::MyGeoCave()
     : FairGeoSet()

--- a/templates/project_stl_containers/passive/MyMagnet.cxx
+++ b/templates/project_stl_containers/passive/MyMagnet.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -91,6 +91,7 @@ void MyMagnet::ConstructGeometry()
     top->AddNode(magnet1, 2, m6);
 }
 
-FairModule *MyMagnet::CloneModule() const { return new MyMagnet(*this); }
-
-ClassImp(MyMagnet);
+FairModule* MyMagnet::CloneModule() const
+{
+    return new MyMagnet(*this);
+}

--- a/templates/project_stl_containers/passive/MyPassiveContFact.cxx
+++ b/templates/project_stl_containers/passive/MyPassiveContFact.cxx
@@ -29,8 +29,6 @@
 
 class FairParSet;
 
-ClassImp(MyPassiveContFact);
-
 static MyPassiveContFact gMyPassiveContFact;
 
 MyPassiveContFact::MyPassiveContFact()

--- a/templates/project_stl_containers/passive/MyPipe.cxx
+++ b/templates/project_stl_containers/passive/MyPipe.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -74,6 +74,7 @@ void MyPipe::ConstructGeometry()
 }
 // ----------------------------------------------------------------------------
 
-FairModule* MyPipe::CloneModule() const { return new MyPipe(*this); }
-
-ClassImp(MyPipe);
+FairModule* MyPipe::CloneModule() const
+{
+    return new MyPipe(*this);
+}


### PR DESCRIPTION
As we lately learned that ClassImp is not needed…

ROOT 6.28 deprecates `ClassImp`. [1]
In August 2018 there already was a "recommendation is to not use".  [2]

Drop it from templates first, so that we do not promote old style.

[1]: https://root.cern/doc/v628/Rtypes_8h.html#a3f9bf160bbbb44209e95556960836b96
[2]: https://root-forum.cern.ch/t/dev-general-what-is-the-purpose-of-declfilename/30283/3

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
