### PR TITLE
Clean `FairRootManager::GetObject` function

### DIFF
--- a/base/steer/FairRootManager.cxx
+++ b/base/steer/FairRootManager.cxx
@@ -80,7 +80,6 @@ FairRootManager::FairRootManager()
     : TObject()
     , fOldEntryNr(-1)
     , fOutFolder(0)
-    , fRootFolder(0)
     , fCurrentTime(0)
     , fMap()
     , fBranchSeqId(0)
@@ -516,22 +515,7 @@ TObject* FairRootManager::GetObject(const char* BrName)
             LOG(debug2) << "Object " << BrName << " was already activated by another task";
         }
     }
-    /**if the object does not exist then it could be a memory branch */
-    if (!Obj) {
-        LOG(debug2) << "Try to find if the object " << BrName << " is a memory branch";
-        Obj = GetMemoryBranch(BrName);
-        if (Obj) {
-            LOG(debug2) << "Object " << BrName << " is a memory branch";
-        }
-    }
-    /**if the object does not exist then look in the input tree */
-    if (fRootFolder && !Obj) {
-        /** there is an input tree and the object was not in memory */
-        LOG(debug2) << "Object " << BrName
-                    << " is not a memory branch and not yet activated, try the Input Tree (Chain)";
-        Obj = fRootFolder->FindObjectAny(BrName);
-        Obj = ActivateBranch(BrName);
-    }
+    /**Get object from memory or source*/
     if (!Obj) {
         Obj = ActivateBranch(BrName);
     }
@@ -731,7 +715,10 @@ void FairRootManager::SetInChain(TChain* tempChain, Int_t ident)
         fSignalChainList[ident] = tempChain;
 }
 
-Double_t FairRootManager::GetEventTime() { return fCurrentTime; }
+Double_t FairRootManager::GetEventTime()
+{
+    return fCurrentTime;
+}
 
 void FairRootManager::UpdateBranches()
 {
@@ -809,11 +796,6 @@ Int_t FairRootManager::CheckBranchSt(const char* BrName)
         fListFolder = new TObjArray(16);
     }
 
-    // cout <<"FairRootManager::CheckBranchSt  :  " <<fRootFolder << endl;
-    if (fRootFolder) {
-        fListFolder->Add(fRootFolder);
-        Obj1 = fRootFolder->FindObjectAny(BrName);
-    }
     if (fOutFolder && !Obj1) {
         fListFolder->Add(fOutFolder);
         Obj1 = fOutFolder->FindObjectAny(BrName);   // Branch in output folder

--- a/base/steer/FairRootManager.h
+++ b/base/steer/FairRootManager.h
@@ -94,7 +94,8 @@ class FairRootManager : public TObject
          a branch that was created from a different
          analysis task, and not written in the tree yet.
          the user have to cast this pointer to the right type.
-         Return a pointer to the object (collection) saved in the fInChain branch named BrName*/
+         Returns a non-owning pointer to the found object
+         or nullptr if none found*/
     TObject* GetObject(const char* BrName);
 
     /// Initializes and returns a default object for a branch or looks it up when it exists already.
@@ -334,8 +335,6 @@ class FairRootManager : public TObject
     Int_t fOldEntryNr;
     /**folder structure of output*/
     TFolder* fOutFolder;
-    /**folder structure of input*/
-    TFolder* fRootFolder;
     /** current time in ns*/
     Double_t fCurrentTime;
     std::vector<TObject*> fObj2{};   //!


### PR DESCRIPTION
Removed unused `fRootFolder`.
Removed code present anyways in `ActivateBranch`.

---

Checklist:

* [x] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
