### PR TITLE
FRM: Cleanup of fListFodler, fMap

### DIFF
--- a/base/steer/FairRootManager.cxx
+++ b/base/steer/FairRootManager.cxx
@@ -78,7 +78,6 @@ FairRootManager* FairRootManager::Instance()
 
 FairRootManager::FairRootManager()
     : TObject()
-    , fOldEntryNr(-1)
     , fOutFolder(0)
     , fCurrentTime(0)
     , fBranchSeqId(0)
@@ -1028,5 +1027,3 @@ TTree* FairRootManager::GetOutTree()
     auto rootFileSink = static_cast<FairRootFileSink*>(sink);
     return rootFileSink->GetOutTree();
 }
-
-ClassImp(FairRootManager);

--- a/base/steer/FairRootManager.cxx
+++ b/base/steer/FairRootManager.cxx
@@ -81,7 +81,6 @@ FairRootManager::FairRootManager()
     , fOldEntryNr(-1)
     , fOutFolder(0)
     , fCurrentTime(0)
-    , fMap()
     , fBranchSeqId(0)
     , fBranchNameList(new TList())
     , fMCTrackBranchId(-1)
@@ -784,12 +783,10 @@ TObject* FairRootManager::ActivateBranch(const char* BrName)
 void FairRootManager::AddMemoryBranch(const char* fName, TObject* pObj)
 {
     /**branch will be available ionly in Memory, will not be written to disk */
-    map<TString, TObject*>::iterator p;
     TString BrName = fName;
-    p = fMap.find(BrName);
-    if (p != fMap.end()) {
-    } else {
-        fMap.insert(pair<TString, TObject*>(BrName, pObj));
+    auto p = fMap.find(BrName);
+    if (p == fMap.end()) {
+        fMap.emplace(std::move(BrName), pObj);
     }
 }
 
@@ -840,18 +837,16 @@ void FairRootManager::CreatePerMap()
     }
 }
 
-TObject* FairRootManager::GetMemoryBranch(const char* fName)
+TObject* FairRootManager::GetMemoryBranch(const char* fName) const
 {
-
     // return fMap[BrName];
-    TString BrName = fName;
-    map<TString, TObject*>::iterator p;
-    p = fMap.find(BrName);
+    const TString BrName = fName;
+    auto p = fMap.find(BrName);
 
     if (p != fMap.end()) {
         return p->second;
     } else {
-        return 0;
+        return nullptr;
     }
 }
 

--- a/base/steer/FairRootManager.h
+++ b/base/steer/FairRootManager.h
@@ -327,7 +327,7 @@ class FairRootManager : public TObject
     Int_t CheckBranchSt(const char* BrName);
     /**Create the Map for the branch persistency status  */
     void CreatePerMap();
-    TObject* GetMemoryBranch(const char*);
+    TObject* GetMemoryBranch(const char*) const;
     //   void                GetRunIdInfo(TString fileName, TString inputLevel);
 
     FairWriteoutBuffer* GetWriteoutBuffer(TString branchName);

--- a/base/steer/FairRootManager.h
+++ b/base/steer/FairRootManager.h
@@ -400,10 +400,8 @@ class FairRootManager : public TObject
     TRefArray fListOfNonTimebasedBranches{};   //!
 
     /**private Members for multi-threading */
-    // global static data members
-    static Int_t fgCounter;   // The counter of instances
     // data members
-    Int_t fId;   // This manager ID
+    Int_t fId{0};   //! This manager ID
 
     ClassDefOverride(FairRootManager, 14);
 };

--- a/base/steer/FairRootManager.h
+++ b/base/steer/FairRootManager.h
@@ -336,7 +336,7 @@ class FairRootManager : public TObject
     void EmitMemoryBranchWrongTypeWarning(const char* brname, const char* typen1, const char* typen2) const;
 
     /**private Members*/
-    Int_t fOldEntryNr;
+
     /**folder structure of output*/
     TFolder* fOutFolder;
     /** current time in ns*/

--- a/base/steer/FairRootManager.h
+++ b/base/steer/FairRootManager.h
@@ -295,10 +295,14 @@ class FairRootManager : public TObject
     };
 
     /**private methods*/
+
     /**ctor*/
     FairRootManager();
     FairRootManager(const FairRootManager&);
     FairRootManager& operator=(const FairRootManager&);
+
+    TObject* ListFolderSearch(const char* brname) const;
+
     /**  Set the branch address for a given branch name and return
         a TObject pointer, the user have to cast this pointer to the right type.*/
     TObject* ActivateBranch(const char* BrName);
@@ -379,7 +383,7 @@ class FairRootManager : public TObject
     Bool_t fFillLastData;   //!
     Int_t fEntryNr;         //!
 
-    TObjArray* fListFolder;   //!
+    TObjArray* fListFolder{nullptr};   //!
 
     FairSource* fSource;
 


### PR DESCRIPTION
* Improve fListFolder Handling
* fMap Cleanup
* Drop fOldEntryNr, ClassImp
* Use std::atomic for fId

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
