### PR TITLE
Fix memory leak in PixelDigi*Source

### DIFF
--- a/examples/MQ/pixelDetector/src/PixelDigiBinSource.cxx
+++ b/examples/MQ/pixelDetector/src/PixelDigiBinSource.cxx
@@ -15,21 +15,16 @@
 //
 #include "PixelDigiBinSource.h"
 
-#include "FairLogger.h"
 #include "FairRootManager.h"
 #include "PixelDigi.h"
-#include "PixelEventHeader.h"
 
-#include <TClonesArray.h>
-#include <TObject.h>
-#include <TString.h>
 #include <cstring>
+#include <fairlogger/Logger.h>
 #include <string>
 
 PixelDigiBinSource::PixelDigiBinSource(TString inputFileName)
     : FairSource()
-    , fEventHeader(nullptr)
-    , fDigis(nullptr)
+    , fDigis(PixelDigi::Class(), 10000)
     , fNDigis(0)
     , fTNofEvents(0)
     , fTNofDigis(0)
@@ -43,8 +38,6 @@ PixelDigiBinSource::PixelDigiBinSource(TString inputFileName)
     LOG(debug) << "PixelDigiBinSource created------------";
 }
 
-PixelDigiBinSource::~PixelDigiBinSource() {}
-
 Bool_t PixelDigiBinSource::Init()
 {
     // Get input array
@@ -55,12 +48,10 @@ Bool_t PixelDigiBinSource::Init()
         LOG(fatal) << "No FairRootManager";
 
     // Register output array StsDigi
-    fDigis = new TClonesArray("PixelDigi", 10000);
-    ioman->Register("PixelDigis", "Pixel", fDigis, kFALSE);
+    ioman->Register("PixelDigis", "Pixel", &fDigis, kFALSE);
 
-    fEventHeader = new PixelEventHeader();
-    fEventHeader->SetName("EventHeader.");
-    ioman->Register("EventHeader.", "EvtHeader", fEventHeader, kFALSE);
+    fEventHeader.SetName("EventHeader.");
+    ioman->Register("EventHeader.", "EvtHeader", &fEventHeader, kFALSE);
 
     fInputFile.open(fInputFileName.Data(), std::fstream::in | std::fstream::binary);
 
@@ -74,7 +65,7 @@ Bool_t PixelDigiBinSource::Init()
 
 Int_t PixelDigiBinSource::ReadEvent(UInt_t i)
 {
-    fDigis->Clear();
+    fDigis.Clear();
     fNDigis = 0;
 
     if (!fInputFile) {
@@ -89,7 +80,7 @@ Int_t PixelDigiBinSource::ReadEvent(UInt_t i)
     fCurrentEntryNo = i;
 
     std::string buffer;
-    LOG(debug) << "PixelDigiBinSource::ReadEvent() Begin of (" << fDigis->GetEntries() << ")";
+    LOG(debug) << "PixelDigiBinSource::ReadEvent() Begin of (" << fDigis.GetEntries() << ")";
 
     Int_t head[4];   // runId, MCEntryNo, PartNo, NofDigis
     fInputFile.read((char*)head, sizeof(head));
@@ -99,7 +90,7 @@ Int_t PixelDigiBinSource::ReadEvent(UInt_t i)
         return 1;
     }
 
-    Int_t dataSize = 4;   // detId, feId, col, row
+    const int dataSize = 4;   // detId, feId, col, row
 
     const Int_t constNofData = head[3] * dataSize;
     short int dataCont[constNofData];
@@ -108,22 +99,22 @@ Int_t PixelDigiBinSource::ReadEvent(UInt_t i)
     fRunId = head[0];
     fMCEntryNo = head[1];
     fPartNo = head[2];
-    fEventHeader->SetRunId(fRunId);
-    fEventHeader->SetMCEntryNumber(fMCEntryNo);
-    fEventHeader->SetPartNo(fPartNo);
+    fEventHeader.SetRunId(fRunId);
+    fEventHeader.SetMCEntryNumber(fMCEntryNo);
+    fEventHeader.SetPartNo(fPartNo);
 
     for (Int_t idata = 0; idata < head[3]; idata++) {
         LOG(debug) << "    --/" << idata << "/-->    " << dataCont[idata * dataSize + 0] << " / "
                    << dataCont[idata * dataSize + 1] << " / " << dataCont[idata * dataSize + 2] << " / "
                    << dataCont[idata * dataSize + 3] << " / "
                    << " 0.";
-        new ((*fDigis)[fNDigis]) PixelDigi(-1,
-                                           (Int_t)dataCont[idata * dataSize + 0],
-                                           (Int_t)dataCont[idata * dataSize + 1],
-                                           (Int_t)dataCont[idata * dataSize + 2],
-                                           (Int_t)dataCont[idata * dataSize + 3],
-                                           0.,
-                                           0.);
+        new (fDigis[fNDigis]) PixelDigi(-1,
+                                        dataCont[idata * dataSize + 0],
+                                        dataCont[idata * dataSize + 1],
+                                        dataCont[idata * dataSize + 2],
+                                        dataCont[idata * dataSize + 3],
+                                        0.,
+                                        0.);
         fNDigis++;
     }
     LOG(debug) << "PixelDigiBinSource::ReadEvent() End of";
@@ -138,9 +129,9 @@ Int_t PixelDigiBinSource::ReadEvent(UInt_t i)
 Bool_t PixelDigiBinSource::ActivateObject(TObject** obj, const char* BrName)
 {
     if (strcmp(BrName, "PixelDigis") == 0)
-        *obj = (TObject*)fDigis;
+        *obj = &fDigis;
     else if (strcmp(BrName, "EventHeader.") == 0)
-        *obj = (TObject*)fEventHeader;
+        *obj = &fEventHeader;
     else
         return kFALSE;
 

--- a/examples/MQ/pixelDetector/src/PixelDigiBinSource.h
+++ b/examples/MQ/pixelDetector/src/PixelDigiBinSource.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -17,21 +17,18 @@
 #define PIXELDIGIBINSOURCE_H_
 
 #include "FairSource.h"
+#include "PixelEventHeader.h"
 
 #include <Rtypes.h>
+#include <TClonesArray.h>
 #include <TString.h>
 #include <fstream>
-
-class TClonesArray;
-class TObject;
-class PixelEventHeader;
-class FairEventHeader;
 
 class PixelDigiBinSource : public FairSource
 {
   public:
     PixelDigiBinSource(TString inputFileName = "test.dat");
-    ~PixelDigiBinSource() override;
+    ~PixelDigiBinSource() override = default;
 
     Bool_t Init() override;
 
@@ -62,8 +59,8 @@ class PixelDigiBinSource : public FairSource
     Bool_t ActivateObject(TObject** obj, const char* BrName) override;
 
   private:
-    PixelEventHeader* fEventHeader;
-    TClonesArray* fDigis; /** Output array of PixelDigi **/
+    PixelEventHeader fEventHeader{};
+    TClonesArray fDigis; /** Output array of PixelDigi **/
     Int_t fNDigis;
 
     Int_t fTNofEvents;

--- a/examples/MQ/pixelDetector/src/PixelDigiSource.h
+++ b/examples/MQ/pixelDetector/src/PixelDigiSource.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -17,21 +17,18 @@
 #define PIXELDIGISOURCE_H_
 
 #include "FairSource.h"
+#include "PixelEventHeader.h"
 
 #include <Rtypes.h>
+#include <TClonesArray.h>
 #include <TString.h>
 #include <fstream>
-
-class TClonesArray;
-
-class PixelEventHeader;
-class FairEventHeader;
 
 class PixelDigiSource : public FairSource
 {
   public:
     PixelDigiSource(TString inputFileName = "test.dat");
-    ~PixelDigiSource() override;
+    ~PixelDigiSource() override = default;
 
     Bool_t Init() override;
 
@@ -62,8 +59,8 @@ class PixelDigiSource : public FairSource
     Bool_t ActivateObject(TObject** obj, const char* BrName) override;
 
   private:
-    PixelEventHeader* fEventHeader;
-    TClonesArray* fDigis; /** Output array of PixelDigi **/
+    PixelEventHeader fEventHeader{};
+    TClonesArray fDigis; /** Output array of PixelDigi **/
     Int_t fNDigis;
 
     Int_t fTNofEvents;


### PR DESCRIPTION
Use valued members instead of heap objects.

FairRootManager::GetObject uses FairSource::ActivateObject as a backend. Let's start and fix the memory handling there.

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
