### PR TITLE
chore: Pass FairOnlineSink to SendBranches in Pixel

### DIFF
--- a/examples/MQ/pixelDetector/src/FairOnlineSink.cxx
+++ b/examples/MQ/pixelDetector/src/FairOnlineSink.cxx
@@ -49,8 +49,9 @@ void FairOnlineSink::Fill()
     /// Fill the Root tree.
     LOG(debug) << "[" << FairRootManager::Instance()->GetInstanceId() << "] called FairOnlineSink::Fill()!!!!";
 
-    if (fMQRunDevice)
-        fMQRunDevice->SendBranches();
+    if (fMQRunDevice) {
+        fMQRunDevice->SendBranches(*this);
+    }
 }
 
 //_____________________________________________________________________________

--- a/examples/MQ/pixelDetector/src/devices/FairMQRunDevice.h
+++ b/examples/MQ/pixelDetector/src/devices/FairMQRunDevice.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2017-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *
@@ -32,7 +32,7 @@ class FairMQRunDevice : public fair::mq::Device
     FairMQRunDevice& operator=(const FairMQRunDevice&) = delete;
     ~FairMQRunDevice() override;
 
-    virtual void SendBranches();
+    virtual void SendBranches(FairOnlineSink& sink);
 
     void SetSink(std::unique_ptr<FairOnlineSink> sink);
 

--- a/examples/MQ/pixelDetector/src/devices/FairMQSimDevice.cxx
+++ b/examples/MQ/pixelDetector/src/devices/FairMQSimDevice.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *
@@ -161,10 +161,10 @@ void FairMQSimDevice::UpdateParameterServer()
     printf("FairMQSimDevice::UpdateParameterServer() finished\n");
 }
 
-void FairMQSimDevice::SendBranches()
+void FairMQSimDevice::SendBranches(FairOnlineSink& sink)
 {
     if (NewStatePending()) {
         fRunSim->StopMCRun();
     }
-    FairMQRunDevice::SendBranches();
+    FairMQRunDevice::SendBranches(sink);
 }

--- a/examples/MQ/pixelDetector/src/devices/FairMQSimDevice.h
+++ b/examples/MQ/pixelDetector/src/devices/FairMQSimDevice.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2017-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *
@@ -55,7 +55,7 @@ class FairMQSimDevice : public FairMQRunDevice
 
     void InitializeRun();
 
-    void SendBranches() override;
+    void SendBranches(FairOnlineSink& sink) override;
 
   protected:
     void InitTask() override;


### PR DESCRIPTION
We know the FairOnlineSink when calling SendBranches. So just pass it in instead of asking FairRootManager.

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
