### PR TITLE
fix bugprone-macro-parentheses

### DIFF
--- a/fairroot/fairmq/FairMQ.h
+++ b/fairroot/fairmq/FairMQ.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2022-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -14,7 +14,8 @@
 #undef FAIRMQ_VERSION_DEC   // bugged
 #endif
 #if defined FAIRMQ_VERSION_MAJOR && defined FAIRMQ_VERSION_MINOR && defined FAIRMQ_VERSION_PATCH
-#define FAIRMQ_VERSION_DEC (FAIRMQ_VERSION_MAJOR * 100000) + (FAIRMQ_VERSION_MINOR * 1000) + (FAIRMQ_VERSION_PATCH * 10)
+#define FAIRMQ_VERSION_DEC                                                                                             \
+    ((FAIRMQ_VERSION_MAJOR * 100000) + (FAIRMQ_VERSION_MINOR * 1000) + (FAIRMQ_VERSION_PATCH * 10))
 #else
 #define FAIRMQ_VERSION_DEC 9999999
 #endif

--- a/fairroot/fairmq/FairRunFairMQDevice.h
+++ b/fairroot/fairmq/FairRunFairMQDevice.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2022-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -14,7 +14,8 @@
 #undef FAIRMQ_VERSION_DEC   // bugged
 #endif
 #if defined FAIRMQ_VERSION_MAJOR && defined FAIRMQ_VERSION_MINOR && defined FAIRMQ_VERSION_PATCH
-#define FAIRMQ_VERSION_DEC (FAIRMQ_VERSION_MAJOR * 100000) + (FAIRMQ_VERSION_MINOR * 1000) + (FAIRMQ_VERSION_PATCH * 10)
+#define FAIRMQ_VERSION_DEC                                                                                             \
+    ((FAIRMQ_VERSION_MAJOR * 100000) + (FAIRMQ_VERSION_MINOR * 1000) + (FAIRMQ_VERSION_PATCH * 10))
 #else
 #define FAIRMQ_VERSION_DEC 9999999
 #endif

--- a/fairtools/MCStepLogger/MCStepInterceptor.cxx
+++ b/fairtools/MCStepLogger/MCStepInterceptor.cxx
@@ -28,6 +28,7 @@
 //  @since  2018-10-22
 //  @brief  Modified for FairRoot
 
+// NOLINTBEGIN(bugprone-macro-parentheses) false positive
 // (re)declare symbols to be able to hook into them
 #define DECLARE_INTERCEPT_SYMBOLS(APP)                                                                                 \
     class APP                                                                                                          \
@@ -37,6 +38,7 @@
         void FinishEvent();                                                                                            \
         void FinishRun();                                                                                              \
     };
+// NOLINTEND(bugprone-macro-parentheses)
 
 DECLARE_INTERCEPT_SYMBOLS(FairMCApplication)
 


### PR DESCRIPTION
```cpp
#define  A  3 + 7
const int b = 10*A;
```

b is 37, Not what you usualy want.

So put parentheses around things.

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
