### PR TITLE
Allow running without sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ In the MT mode of Geant4 the folder names changed from 'folderName_1' and 'folde
 ### Bug fixes
 * Check the return value of `source->InitUnpackers()`/`source->ReinitUnpackers()`
   in `FairRunOnline`. Stop run if `false` returned.
+* Remove sink from Tutorial3/MQ/sampler.cxx.
 
 ### Other Notable Changes
 * Allow running without output sink. In this case even persistent branches would not be stored anywhere.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to FairRoot will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+## 18.8.1 (UNRELEASED) - 2023-01-XX
+
+### Breaking Changes
+* The output folder name changed from 'folderName_0' to 'folderName'.
+In the MT mode of Geant4 the folder names changed from 'folderName_1' and 'folderName_2' to 'folderName'.
+
+### Bug fixes
+* Check the return value of `source->InitUnpackers()`/`source->ReinitUnpackers()`
+  in `FairRunOnline`. Stop run if `false` returned.
+
+### Other Notable Changes
+* Allow running without output sink. In this case even persistent branches would not be stored anywhere.
+
 ## 18.8.0 - 2022-12-16
 
 ### Breaking Changes

--- a/base/steer/FairRootManager.cxx
+++ b/base/steer/FairRootManager.cxx
@@ -179,8 +179,10 @@ Bool_t FairRootManager::InitSink()
 {
     if (fSink) {
         fSink->InitSink();
+        return true;
     }
-    return kTRUE;
+    LOG(info) << "The output sink is not set. No branches will be stored.";
+    return false;
 }
 
 template<typename T>
@@ -204,7 +206,7 @@ void FairRootManager::RegisterImpl(const char* name, const char* folderName, T* 
         if (fSink) {
             fSink->RegisterImpl(name, folderName, obj);
         } else {
-            LOG(fatal) << "The sink does not exist to store persistent branches.";
+            LOG(warning) << "The sink does not exist to store persistent branches (" << name << ").";
         }
     }
     AddMemoryBranch(name, obj);

--- a/base/steer/FairRunAna.cxx
+++ b/base/steer/FairRunAna.cxx
@@ -213,7 +213,7 @@ void FairRunAna::Init()
         fRunId = GetEvtHeaderRunId();
 
         // Copy the Event Header Info to Output
-        fEvtHeader->Register(fStoreEventHeader);
+        fEvtHeader->Register(GetSink() ? fStoreEventHeader : false);
 
         // Init the containers in Tasks
         LOG(info) << "--- Initialize with RunId  --- " << fRunId;
@@ -225,7 +225,7 @@ void FairRunAna::Init()
     } else {   // end----- if(fMixedInput)
         LOG(info) << "Initializing without input file or Mixed input";
         FairEventHeader* evt = GetEventHeader();
-        evt->Register(fStoreEventHeader);
+        evt->Register(GetSink() ? fStoreEventHeader : false);
         FairRunIdGenerator genid;
         fRunId = genid.generateId();
         fRtdb->addRun(fRunId);
@@ -269,7 +269,6 @@ void FairRunAna::Init()
     // create the output tree after tasks initialisation
     fRootManager->WriteFolder();
     fRootManager->WriteFileHeader(fFileHeader);
-
 }
 //_____________________________________________________________________________
 

--- a/base/steer/FairRunAnaProof.cxx
+++ b/base/steer/FairRunAnaProof.cxx
@@ -179,10 +179,7 @@ void FairRunAnaProof::Init()
         fRunId = GetEvtHeaderRunId();
 
         // Copy the Event Header Info to Output
-        fEvtHeader->Register(kTRUE);
-
-        // Copy the Event Header Info to Output
-        fEvtHeader->Register();
+        fEvtHeader->Register(GetSink() ? fStoreEventHeader : false);
 
         // Init the containers in Tasks
 
@@ -196,7 +193,7 @@ void FairRunAnaProof::Init()
     } else {
         LOG(info) << "Initializing without input file or Mixed input";
         FairEventHeader* evt = GetEventHeader();
-        evt->Register();
+        evt->Register(GetSink() ? fStoreEventHeader : false);
         FairRunIdGenerator genid;
         fRunId = genid.generateId();
         fRtdb->addRun(fRunId);

--- a/basemq/devices/FairMQSampler.h
+++ b/basemq/devices/FairMQSampler.h
@@ -19,7 +19,6 @@
 #include "FairMQ.h"   // for fair::mq::Device, fair::mq::MessagePtr
 #include "FairMQSamplerTask.h"
 #include "FairParRootFileIo.h"
-#include "FairRootFileSink.h"
 #include "FairRunAna.h"
 #include "FairRuntimeDb.h"
 
@@ -97,10 +96,6 @@ class FairMQSampler : public fair::mq::Device
         }
 
         fFairRunAna->SetSource(source);
-
-        TString output = fInputFile;
-        output.Append(".out.root");
-        fFairRunAna->SetSink(std::make_unique<FairRootFileSink>(output.Data()));
 
         fFairRunAna->AddTask(fSamplerTask);
 


### PR DESCRIPTION
Replaced `LOG(fatal)` with `LOG(warning)` in `FairRootManager::RegisterImpl()`.
Note that in this mode also persistent branches would not be stored anywhere.
Without sink, `FairRootManager::InitSink()` returns `false`.

---

Checklist:

[x] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
