### PR TITLE
Move ActivateObjectAnyImpl to FairFileSourceBase

### DIFF
--- a/base/source/FairFileSourceBase.cxx
+++ b/base/source/FairFileSourceBase.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2022-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -9,14 +9,8 @@
 #include "FairFileSourceBase.h"
 
 #include <TObjString.h>
-#include <algorithm>   // for std::for_each
+#include <fairlogger/Logger.h>
 #include <set>
-
-using std::set;
-
-ClassImp(FairFileSourceBase);
-
-FairFileSourceBase::~FairFileSourceBase() {}
 
 Bool_t FairFileSourceBase::CompareBranchList(TFile* fileHandle, TString inputLevel)
 {
@@ -37,13 +31,11 @@ Bool_t FairFileSourceBase::CompareBranchList(TFile* fileHandle, TString inputLev
     // If a branch with the same name is found, this branch is removed from
     // the list. If in the end no branch is left in the list everything is
     // fine.
-    set<TString>::iterator iter1;
     auto list = fileHandle->Get<TList>("BranchList");
     if (list) {
-        TObjString* Obj = 0;
         for (Int_t i = 0; i < list->GetEntries(); i++) {
-            Obj = dynamic_cast<TObjString*>(list->At(i));
-            iter1 = branches.find(Obj->GetString().Data());
+            auto Obj = dynamic_cast<TObjString*>(list->At(i));
+            auto iter1 = branches.find(Obj->GetString());
             if (iter1 != branches.end()) {
                 branches.erase(iter1);
             } else {
@@ -57,12 +49,49 @@ Bool_t FairFileSourceBase::CompareBranchList(TFile* fileHandle, TString inputLev
     // If the size of branches is !=0 after removing all branches also in the
     // reference list, this is also a sign that both branch list are not the
     // same
-    if (branches.size() != 0) {
+    if (!branches.empty()) {
         LOG(info) << "Compare Branch List will return kFALSE. The list has " << branches.size() << " branches:";
-        for (auto branchName : branches)
+        for (auto const& branchName : branches) {
             LOG(info) << "  -> " << branchName;
+        }
         return kFALSE;
     }
 
     return kTRUE;
+}
+
+bool FairFileSourceBase::ActivateObjectAnyImpl(TTree* source,
+                                               void** obj,
+                                               const std::type_info& info,
+                                               const char* brname)
+{
+    if (!source) {
+        return false;
+    }
+    // we check if the types match at all
+    auto br = source->GetBranch(brname);
+    if (!br) {
+        // branch not found in source
+        return false;
+    }
+
+    // look up the TClass and resulting typeid stored in this branch
+    auto cl = TClass::GetClass(br->GetClassName());
+    if (!cl) {
+        // class not found
+        return false;
+    }
+
+    auto storedtype = cl->GetTypeInfo();
+
+    // check consistency of types
+    if (info.hash_code() != storedtype->hash_code()) {
+        LOG(info) << "Trying to read from branch " << brname << " with wrong type " << info.name()
+                  << " (expected: " << storedtype->name() << ")\n";
+        return false;
+    }
+    source->SetBranchStatus(brname, true);
+    // force to use the (void*) interface which is non-checking
+    source->SetBranchAddress(brname, (void*)obj);
+    return true;
 }

--- a/base/source/FairFileSourceBase.h
+++ b/base/source/FairFileSourceBase.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2022-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -12,6 +12,7 @@
 #include "FairSource.h"
 
 #include <TFile.h>
+#include <TTree.h>
 #include <list>
 #include <map>
 
@@ -21,7 +22,7 @@
 class FairFileSourceBase : public FairSource
 {
   public:
-    ~FairFileSourceBase() override;
+    ~FairFileSourceBase() override = default;
     void Reset() override {}
     Source_Type GetSourceType() override { return kFILE; }
     void SetParUnpackers() override {}
@@ -35,6 +36,8 @@ class FairFileSourceBase : public FairSource
         : FairSource(){};
 
     std::map<TString, std::list<TString>> fCheckInputBranches{};   //!
+
+    static bool ActivateObjectAnyImpl(TTree* source, void** obj, const std::type_info& info, const char* brname);
 
     ClassDefOverride(FairFileSourceBase, 0);
 };

--- a/base/source/FairSource.h
+++ b/base/source/FairSource.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -14,9 +14,6 @@
 
 #ifndef FAIRSOURCE_H
 #define FAIRSOURCE_H
-
-#include "FairLogger.h"
-#include "TClass.h"
 
 #include <Rtypes.h>
 #include <TObject.h>
@@ -34,7 +31,7 @@ class FairSource : public TObject
   public:
     FairSource();
     FairSource(const FairSource& source);
-    virtual ~FairSource();
+    ~FairSource() override;
     virtual Bool_t Init() = 0;
     virtual Int_t ReadEvent(UInt_t = 0) = 0;
     virtual Bool_t SpecifyRunId() = 0;
@@ -59,42 +56,7 @@ class FairSource : public TObject
     Int_t fRunId;
 
   public:
-    ClassDef(FairSource, 2);
+    ClassDefOverride(FairSource, 2);
 };
-
-namespace {
-
-template<typename S>
-bool ActivateObjectAnyImpl(S* source, void** obj, const std::type_info& info, const char* brname)
-{
-    // we check if the types match at all
-    auto br = source->GetBranch(brname);
-    if (!br) {
-        // branch not found in source
-        return false;
-    }
-
-    // look up the TClass and resulting typeid stored in this branch
-    auto cl = TClass::GetClass(br->GetClassName());
-    if (!cl) {
-        // class not found
-        return false;
-    }
-
-    auto storedtype = cl->GetTypeInfo();
-
-    // check consistency of types
-    if (info.hash_code() != storedtype->hash_code()) {
-        LOG(info) << "Trying to read from branch " << brname << " with wrong type " << info.name()
-                  << " (expected: " << storedtype->name() << ")\n";
-        return false;
-    }
-    source->SetBranchStatus(brname, 1);
-    // force to use the (void*) interface which is non-checking
-    source->SetBranchAddress(brname, (void*)obj);
-    return true;
-}
-
-}   // namespace
 
 #endif


### PR DESCRIPTION
ActivateObjectAnyImpl is really specific to TTree, TFile and friends.  Move it into FairFileSourceBase and remove the template part.

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
