### PR TITLE
fix: Do not use std::type_info::hash_code

### DIFF
--- a/base/source/FairFileSourceBase.cxx
+++ b/base/source/FairFileSourceBase.cxx
@@ -85,7 +85,7 @@ bool FairFileSourceBase::ActivateObjectAnyImpl(TTree* source,
     auto storedtype = cl->GetTypeInfo();
 
     // check consistency of types
-    if (info.hash_code() != storedtype->hash_code()) {
+    if (info != *storedtype) {
         LOG(info) << "Trying to read from branch " << brname << " with wrong type " << info.name()
                   << " (expected: " << storedtype->name() << ")\n";
         return false;

--- a/base/steer/FairRootManager.h
+++ b/base/steer/FairRootManager.h
@@ -426,7 +426,7 @@ T FairRootManager::GetMemoryBranchAny(const char* brname) const
     auto iter = fAnyBranchMap.find(brname);
     if (iter != fAnyBranchMap.end()) {
         // verify type consistency
-        if (typeid(P).hash_code() != iter->second->origtypeinfo.hash_code()) {
+        if (typeid(P) != iter->second->origtypeinfo) {
             EmitMemoryBranchWrongTypeWarning(brname, typeid(P).name(), iter->second->origtypeinfo.name());
             return nullptr;
         }

--- a/examples/MQ/pixelDetector/src/FairOnlineSink.h
+++ b/examples/MQ/pixelDetector/src/FairOnlineSink.h
@@ -87,7 +87,7 @@ T FairOnlineSink::GetPersistentBranchAny(const char* brname) const
     auto iter = fPersistentBranchesMap.find(brname);
     if (iter != fPersistentBranchesMap.end()) {
         // verify type consistency
-        if (typeid(P).hash_code() != iter->second->origtypeinfo.hash_code()) {
+        if (typeid(P) != iter->second->origtypeinfo) {
             EmitPersistentBranchWrongTypeWarning(brname, typeid(P).name(), iter->second->origtypeinfo.name());
             return nullptr;
         }


### PR DESCRIPTION
> No other guarantees are given: std::type_info objects referring to
> different types may have the same hash code

This is not good for comparisons.

Use direct comparisons instead.

See: https://en.cppreference.com/w/cpp/types/type_info/hash_code
See: https://en.cppreference.com/w/cpp/types/type_info/operator_cmp

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
