### PR TITLE
chore: Fefactor FairRuntimeDb::activateParIo

### DIFF
--- a/fairroot/parbase/FairParAsciiFileIo.cxx
+++ b/fairroot/parbase/FairParAsciiFileIo.cxx
@@ -20,7 +20,7 @@
 #include "FairParAsciiFileIo.h"
 
 #include "FairDetParIo.h"   // for FairDetParIo
-#include "FairLogger.h"
+#include "FairGenericParAsciiFileIo.h"
 #include "FairRuntimeDb.h"   // for FairRuntimeDb
 
 #include <TCollection.h>   // for TIter
@@ -28,8 +28,9 @@
 #include <TObjString.h>    // for TObjString
 #include <TString.h>       // for TString, operator<<
 #include <TSystem.h>       // for TSystem, gSystem
-#include <iostream>        // for cout, cerr
-#include <string.h>        // for strcmp
+#include <cstring>         // for strcmp
+#include <fairlogger/Logger.h>
+#include <iostream>
 
 using std::cerr;
 using std::cout;
@@ -46,6 +47,15 @@ FairParAsciiFileIo::~FairParAsciiFileIo()
 {
     // default destructor closes an open file and deletes list of I/Os
     close();
+}
+
+void FairParAsciiFileIo::ActivateSelf()
+{
+    if (getDetParIo("FairGenericParIo")) {
+        return;
+    }
+    auto pn = new FairGenericParAsciiFileIo(getFile());
+    setDetParIo(pn);
 }
 
 Bool_t FairParAsciiFileIo::open(const Text_t* fname, const Text_t* status)
@@ -69,6 +79,7 @@ Bool_t FairParAsciiFileIo::open(const Text_t* fname, const Text_t* status)
     filebuf* buf = file->rdbuf();
     if (file && (buf->is_open() == 1)) {
         filename = fname;
+        ActivateSelf();
         FairRuntimeDb::instance()->activateParIo(this);
         return kTRUE;
     }

--- a/fairroot/parbase/FairParAsciiFileIo.h
+++ b/fairroot/parbase/FairParAsciiFileIo.h
@@ -81,6 +81,7 @@ class FairParAsciiFileIo : public FairParIo
   private:
     FairParAsciiFileIo(const FairParAsciiFileIo&);
     FairParAsciiFileIo& operator=(const FairParAsciiFileIo&);
+    void ActivateSelf();
 
     ClassDefOverride(FairParAsciiFileIo, 0);   // Parameter I/O from ASCII files
 };

--- a/fairroot/parbase/FairParRootFileIo.cxx
+++ b/fairroot/parbase/FairParRootFileIo.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -25,6 +25,7 @@
 #include "FairParRootFileIo.h"
 
 #include "FairDetParIo.h"    // for FairDetParIo
+#include "FairGenericParRootFileIo.h"
 #include "FairRtdbRun.h"     // for FairRtdbRun
 #include "FairRuntimeDb.h"   // for FairRuntimeDb
 
@@ -115,6 +116,15 @@ FairParRootFileIo::~FairParRootFileIo()
     close();
 }
 
+void FairParRootFileIo::ActivateSelf()
+{
+    if (getDetParIo("FairGenericParIo")) {
+        return;
+    }
+    auto pn = new FairGenericParRootFileIo(getParRootFile());
+    setDetParIo(pn);
+}
+
 Bool_t FairParRootFileIo::open(const Text_t* fname, Option_t* option, const Text_t* ftitle, Int_t compress)
 {
     // It opens a ROOT file (default option "READ"). An open file will be closed.
@@ -141,6 +151,7 @@ Bool_t FairParRootFileIo::open(const Text_t* fname, Option_t* option, const Text
 
     if (file && file->IsOpen()) {
         filename = fname;
+        ActivateSelf();
         FairRuntimeDb::instance()->activateParIo(this);
         return kTRUE;
     }
@@ -234,6 +245,7 @@ Bool_t FairParRootFileIo::open(TFile* f)
     file = new FairParRootFile(f);
     if (file && file->IsOpen()) {
         filename = file->GetName();
+        ActivateSelf();
         FairRuntimeDb::instance()->activateParIo(this);
         return kTRUE;
     }

--- a/fairroot/parbase/FairParRootFileIo.h
+++ b/fairroot/parbase/FairParRootFileIo.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -26,7 +26,7 @@ class FairParRootFile : public TNamed
     FairRtdbRun* run;   //! pointer to current run in ROOT file
     FairParRootFile(const Text_t* fname, Option_t* option = "READ", const Text_t* ftitle = "", Int_t compress = 1);
     FairParRootFile(TFile* f);
-    ~FairParRootFile();
+    ~FairParRootFile() override;
     FairRtdbRun* getRun() { return run; }
     void readVersions(FairRtdbRun*);
 
@@ -81,7 +81,7 @@ class FairParRootFileIo : public FairParIo
   public:
     FairParRootFileIo();
     FairParRootFileIo(Bool_t merged);
-    ~FairParRootFileIo();
+    ~FairParRootFileIo() override;
     Bool_t open(const Text_t* fname, Option_t* option = "READ", const Text_t* ftitle = "", Int_t compress = 1);
     Bool_t open(const TList* fnamelist, Option_t* option = "READ", const Text_t* ftitle = "", Int_t compress = 1);
     static void MergeFiles(TFile* newParFile, const TList* fnamelist);
@@ -115,6 +115,7 @@ class FairParRootFileIo : public FairParIo
   private:
     FairParRootFileIo(const FairParRootFileIo&);
     FairParRootFileIo& operator=(const FairParRootFileIo&);
+    void ActivateSelf();
 
     ClassDefOverride(FairParRootFileIo, 0);   // Parameter I/O from ROOT files
 };

--- a/fairroot/parbase/FairRuntimeDb.cxx
+++ b/fairroot/parbase/FairRuntimeDb.cxx
@@ -42,11 +42,7 @@
 /////////////////////////////////////////////////////////////
 #include "FairRuntimeDb.h"
 
-#include "FairContFact.h"            // for FairContFact
-#include "FairDetParAsciiFileIo.h"   // for FairDetParAsciiFileIo
-#include "FairDetParRootFileIo.h"    // for FairDetParRootFileIo
-#include "FairGenericParAsciiFileIo.h"   // for FairGenericParAsciiFileIo
-#include "FairGenericParRootFileIo.h"    // for FairGenericParRootFileIo
+#include "FairContFact.h"         // for FairContFact
 #include "FairLogger.h"           // for FairLogger, MESSAGE_ORIGIN
 #include "FairParAsciiFileIo.h"   // for FairParAsciiFileIo
 #include "FairParIo.h"            // for FairParIo
@@ -61,8 +57,6 @@
 #include <cstring>         // for strcmp, strlen
 #include <iomanip>         // for setw, operator<<
 #include <iostream>        // for operator<<, basic_ostream, etc
-
-class FairDetParIo;
 
 using std::cout;
 using std::endl;
@@ -816,24 +810,6 @@ void FairRuntimeDb::closeOutput()
 void FairRuntimeDb::activateParIo(FairParIo* io)
 {
     // activates the detector I/O
-    const char* ioName = io->IsA()->GetName();
-    FairDetParIo* po = io->getDetParIo("FairGenericParIo");
-    if (!po) {
-        if (strcmp(ioName, "FairParRootFileIo") == 0) {
-            FairDetParRootFileIo* pn =
-                new FairGenericParRootFileIo((static_cast<FairParRootFileIo*>(io))->getParRootFile());
-            io->setDetParIo(pn);
-        } else if (strcmp(ioName, "FairParAsciiFileIo") == 0) {
-            FairDetParAsciiFileIo* pn =
-                new FairGenericParAsciiFileIo((static_cast<FairParAsciiFileIo*>(io))->getFile());
-            io->setDetParIo(pn);
-        }
-        // else if(strcmp(ioName,"FairParTSQLIo") == 0) {
-        //  std::cout << "\n\n\n\t TSQL versie is called en nu de rest \n\n";
-        //  FairDetParTSQLIo* pn = new FairGenericParTSQLIo();
-        //  io->setDetParIo(pn);
-        //}
-    }
     TIter next(&contFactories);
     FairContFact* fact;
     while ((fact = static_cast<FairContFact*>(next()))) {


### PR DESCRIPTION
FairParAsciiFileIo and FairParRootFileIo call
FairRuntimeDb::activateParIo (from their open functions). activateParIo then does some things very specific to those both classes.

Instead perform those actions directly in the classes before calling activateParIo.

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
