### PR TITLE
clang-format: Acknowledge enum style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,6 +4,7 @@ BasedOnStyle: Mozilla
 
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: Empty
+AllowShortEnumsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Inline
 AllowShortIfStatementsOnASingleLine: Never
 AllowShortLambdasOnASingleLine: All
@@ -18,6 +19,7 @@ BreakBeforeBinaryOperators: NonAssignment
 BreakBeforeBraces: Custom
 BraceWrapping:
   AfterClass: true
+  AfterEnum: true
   AfterFunction: true
   AfterStruct: true
   SplitEmptyFunction: false

--- a/fairroot/base/sim/FairMCApplication.h
+++ b/fairroot/base/sim/FairMCApplication.h
@@ -47,7 +47,12 @@ class TRefArray;
 class TTask;
 class TVirtualMC;
 
-enum class FairMCApplicationState { kUnknownState, kConstructGeometry, kInitGeometry };
+enum class FairMCApplicationState
+{
+    kUnknownState,
+    kConstructGeometry,
+    kInitGeometry
+};
 
 /**
  * The Main Application ( Interface to MonteCarlo application )


### PR DESCRIPTION
Nearly all enums have their content items on individual lines and the opening brace on its own line too.  The current clang-format settings (especially for short enums) did not match this.

Update them to be in line with the current usage.

Reformat the one case that did not match the new rules.

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
