### PR TITLE
fix leaks in FairRun and FairTutorialDet4StraightLineFitter 

### DIFF
--- a/examples/simulation/Tutorial4/src/reco/FairTutorialDet4StraightLineFitter.h
+++ b/examples/simulation/Tutorial4/src/reco/FairTutorialDet4StraightLineFitter.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -11,8 +11,7 @@
 #include "FairTask.h"   // for InitStatus, FairTask
 
 #include <Rtypes.h>   // for ClassDef
-
-class TClonesArray;
+#include <TClonesArray.h>
 
 class FairTutorialDet4StraightLineFitter : public FairTask
 {
@@ -24,28 +23,22 @@ class FairTutorialDet4StraightLineFitter : public FairTask
     //  FairTutorialDet4StraightLineFitter(Int_t verbose);
 
     /** Destructor **/
-    ~FairTutorialDet4StraightLineFitter();
+    ~FairTutorialDet4StraightLineFitter() override = default;
 
     /** Initiliazation of task at the beginning of a run **/
-    virtual InitStatus Init();
-
-    /** ReInitiliazation of task when the runID changes **/
-    virtual InitStatus ReInit();
+    InitStatus Init() override;
 
     /** Executed for each event. **/
-    virtual void Exec(Option_t* opt);
-
-    /** Finish task called at the end of the run **/
-    virtual void Finish();
+    void Exec(Option_t* opt) override;
 
     void SetVersion(Int_t val) { fVersion = val; }
 
   private:
     /** Input array from previous already existing data level **/
-    TClonesArray* fHits;
+    TClonesArray const* fHits{nullptr};
 
     /** Output array to  new data level**/
-    TClonesArray* fTracks;
+    TClonesArray fTracks;
 
     Int_t fVersion;
 
@@ -54,7 +47,7 @@ class FairTutorialDet4StraightLineFitter : public FairTask
     FairTutorialDet4StraightLineFitter(const FairTutorialDet4StraightLineFitter&);
     FairTutorialDet4StraightLineFitter operator=(const FairTutorialDet4StraightLineFitter&);
 
-    ClassDef(FairTutorialDet4StraightLineFitter, 1);
+    ClassDefOverride(FairTutorialDet4StraightLineFitter, 1);
 };
 
 #endif

--- a/fairroot/base/steer/FairLinkManager.cxx
+++ b/fairroot/base/steer/FairLinkManager.cxx
@@ -1,3 +1,10 @@
+/********************************************************************************
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
 // -------------------------------------------------------------------------
 // -----                   FairLinkManager source file                 -----
 // -----            Created 05/06/14  by T.Stockmanns                  -----

--- a/fairroot/base/steer/FairLinkManager.h
+++ b/fairroot/base/steer/FairLinkManager.h
@@ -1,3 +1,10 @@
+/********************************************************************************
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
 #ifndef FAIR_LINK_MANAGER_H
 #define FAIR_LINK_MANAGER_H
 

--- a/fairroot/base/steer/FairRun.cxx
+++ b/fairroot/base/steer/FairRun.cxx
@@ -13,7 +13,6 @@
 #include "FairRun.h"
 
 #include "FairFileHeader.h"     // for FairFileHeader
-#include "FairLinkManager.h"    // for FairLinkManager
 #include "FairLogger.h"         // for FairLogger, MESSAGE_ORIGIN
 #include "FairRootFileSink.h"   // only temporary, should be removed after the move to FairSink is finished
 #include "FairRootManager.h"    // for FairRootManager
@@ -77,8 +76,6 @@ FairRun::FairRun(Bool_t isMaster)
 #endif
 
     fRootManager = FairRootManager::Instance();
-
-    new FairLinkManager();
 }
 
 FairRun::~FairRun()

--- a/fairroot/base/steer/FairRun.h
+++ b/fairroot/base/steer/FairRun.h
@@ -10,6 +10,7 @@
 
 #include "FairAlignmentHandler.h"
 #include "FairEventHeader.h"
+#include "FairLinkManager.h"
 #include "FairSink.h"
 #include "FairSource.h"
 
@@ -208,6 +209,8 @@ class FairRun : public TNamed
     FairRun& operator=(const FairRun&) { return *this; }
     /** Number of Tasks added*/
     Int_t fNTasks;
+
+    FairLinkManager fLinkManager{};   //!
 
   protected:
     /** static pointer to this run*/


### PR DESCRIPTION
* FairRun's constructor used to allocate a FairLinkManager, but the destructor did not deallocate it.

  Switch it over to a valued member so that default behaviour allocates and deallocates it.

* Replace multiple heap allocated objects by either value members of the class or just local stack variables.

  Introduce more `override`.

  And drop empty ReInit and Finish methods that override the original methods that are also doing the same.

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
