### PR TITLE
fix multiple leaks in FairMCApplication

### DIFF
--- a/fairroot/base/sim/FairMCApplication.h
+++ b/fairroot/base/sim/FairMCApplication.h
@@ -18,6 +18,7 @@
 
 #include <Rtypes.h>                  // for Int_t, Bool_t, Double_t, etc
 #include <TLorentzVector.h>          // for TLorentzVector
+#include <TRefArray.h>               //
 #include <TString.h>                 // for TString
 #include <TVirtualMC.h>              // for TVirtualMC
 #include <TVirtualMCApplication.h>   // for TVirtualMCApplication
@@ -41,11 +42,7 @@ class FairTrajFilter;
 class FairVolume;
 class FairRunSim;
 class TChain;
-class TIterator;
-class TObjArray;
-class TRefArray;
 class TTask;
-class TVirtualMC;
 
 enum class FairMCApplicationState
 {
@@ -260,7 +257,7 @@ class FairMCApplication : public TVirtualMCApplication
      */
     const FairMCApplication* fParent{nullptr};   //!
     /**List of active detector */
-    TRefArray* fActiveDetectors;
+    TRefArray fActiveDetectors;
     /**List of FairTask*/
     FairTask* fFairTaskList;   //!
     /**Module list in simulation*/
@@ -278,9 +275,9 @@ class FairMCApplication : public TVirtualMCApplication
     /**MC Engine 1= Geant3, 2 = Geant4*/
     Int_t fMcVersion;   // mc Version
     /** Track visualization manager */
-    FairTrajFilter* fTrajFilter;   //!
+    std::unique_ptr<FairTrajFilter> fTrajFilter;   //!
     /**Flag for accepted tracks for visualization*/
-    Bool_t fTrajAccepted;   //!
+    bool fTrajAccepted{false};   //!
     /**Flag for using user decay*/
     Bool_t fUserDecay;
     /**User decay config macro*/
@@ -294,14 +291,14 @@ class FairMCApplication : public TVirtualMCApplication
     std::map<Int_t, Int_t> fModVolMap;   //!
     TLorentzVector fTrkPos;              //!
     /** Flag for Radiation length register mode  */
-    Bool_t fRadLength;   //!
+    bool fRadLength{false};   //!
 
     /**Radiation length Manager*/
-    FairRadLenManager* fRadLenMan;   //!
+    std::unique_ptr<FairRadLenManager> fRadLenMan;   //!
     /** Flag for Radiation map register mode  */
-    Bool_t fRadMap;   //!
+    bool fRadMap{false};   //!
     /**Radiation Map Manager*/
-    FairRadMapManager* fRadMapMan;   //!
+    std::unique_ptr<FairRadMapManager> fRadMapMan;   //!
     /**Radiation map Grid Manager*/
     std::unique_ptr<FairRadGridManager> fRadGridMan{};   //!
 

--- a/fairroot/base/steer/FairRunSim.cxx
+++ b/fairroot/base/steer/FairRunSim.cxx
@@ -28,7 +28,6 @@
 #include "FairRunIdGenerator.h"     // for FairRunIdGenerator
 #include "FairRuntimeDb.h"          // for FairRuntimeDb
 #include "FairTask.h"               // for FairTask
-#include "FairTrajFilter.h"         // for FairTrajFilter
 
 #include <TCollection.h>   // for TIter
 #include <TGeoManager.h>   // for gGeoManager
@@ -54,7 +53,6 @@ FairRunSim::FairRunSim(Bool_t isMaster)
     , fParticles(new TObjArray())
     , ListOfModules(new TObjArray())
     , MatFname("")
-    , fStoreTraj(kFALSE)
     , fPythiaDecayer(kFALSE)
     , fPythiaDecayerConfig("")
     , fUserDecay(kFALSE)
@@ -177,7 +175,7 @@ void FairRunSim::Init()
     /** Add Tasks to simulation if any*/
     fApp->AddTask(fTask);
     /** This call will create the container if it does not exist*/
-    FairBaseParSet* par = dynamic_cast<FairBaseParSet*>(fRtdb->getContainer("FairBaseParSet"));
+    auto par = dynamic_cast<FairBaseParSet*>(fRtdb->getContainer("FairBaseParSet"));
     if (par) {
         par->SetDetList(GetListOfModules());
         par->SetGen(GetPrimaryGenerator());
@@ -185,7 +183,7 @@ void FairRunSim::Init()
     }
 
     /** This call will create the container if it does not exist*/
-    FairGeoParSet* geopar = dynamic_cast<FairGeoParSet*>(fRtdb->getContainer("FairGeoParSet"));
+    auto geopar = dynamic_cast<FairGeoParSet*>(fRtdb->getContainer("FairGeoParSet"));
     if (geopar) {
         geopar->SetGeometry(gGeoManager);
     }
@@ -207,7 +205,6 @@ void FairRunSim::Init()
     // on/off visualisation
     if (fStoreTraj) {
         LOG(info) << "Create visualisation manager ";
-        new FairTrajFilter();
     }
     if (fRadLength) {
         fApp->SetRadiationLengthReg(fRadLength);

--- a/fairroot/base/steer/FairRunSim.h
+++ b/fairroot/base/steer/FairRunSim.h
@@ -241,7 +241,7 @@ class FairRunSim : public FairRun
     TObjArray* fParticles;                          //!                         /** Array of user defined particles*/
     TObjArray* ListOfModules;                       //!                       /** Array of used modules */
     TString MatFname;                               //!                           /** Material file name */
-    Bool_t fStoreTraj;                              //!                       /** Trajectory store flags */
+    bool fStoreTraj{false};                         //!< Trajectory store flags
     TString fLoaderName{"TGeo"};                    //!< Geometry Model (TGeo or G3)
     Bool_t fPythiaDecayer;                          //!                    /** flag for using Pythia decayer*/
     TString fPythiaDecayerConfig;                   //!               /** Macro for Pythia decay configuration*/


### PR DESCRIPTION
Turned multiple member variables from raw pointers to unique_ptrs so that the allocated objects get destructed at destruction of FMCA.

Allocation of FairTrajFilter also moved from FairRunSim to FMCA and that way avoids the ::Instance methods.

Also turned one member variable into a valued member to simplify some code.

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
