### PR TITLE
Geant4MT: Fix closing sink in MT mode

### DIFF
--- a/fairroot/base/sim/FairMCApplication.cxx
+++ b/fairroot/base/sim/FairMCApplication.cxx
@@ -509,6 +509,10 @@ void FairMCApplication::FinishRunOnWorker()
     LOG(debug) << "FairMCApplication::FinishRunOnWorker: ";
 
     FinishRun();
+
+    // Close the sink on workers so that the execution of main FairRunSim->Run()
+    // finishes with the output files properly closed.
+    fRootManager->CloseSink();
 }
 
 //_____________________________________________________________________________


### PR DESCRIPTION
In the MT mode FairRunSim cannot close the sinks,
only FairMCApplication can.

---

Checklist:

* [x] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
