### PR TITLE
chore(eventdisplay): Refactor PDG To Color

### DIFF
--- a/examples/advanced/propagator/src/FairEveRecoTracksExample.cxx
+++ b/examples/advanced/propagator/src/FairEveRecoTracksExample.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2020 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2020-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -18,6 +18,7 @@
 
 #include "FairEveRecoTrack.h"
 #include "FairEveTrack.h"
+#include "FairEventManager.h"
 #include "FairField.h"
 #include "FairHit.h"
 #include "FairMCTrack.h"
@@ -194,19 +195,22 @@ void FairEveRecoTracksExample::Repaint()
 
 InitStatus FairEveRecoTracksExample::Init()
 {
-    FairRootManager *mngr = FairRootManager::Instance();
-    fContainerReco = (TClonesArray *)mngr->GetObject("FairTutPropTracks");
+    auto status = FairEveTracks::Init();
+    if (status != kSUCCESS)
+        return status;
+    FairRootManager& mngr = GetEventManager()->GetRootManager();
+    fContainerReco = dynamic_cast<TClonesArray*>(mngr.GetObject("FairTutPropTracks"));
     if (fContainerReco == nullptr) {
         LOG(error) << "Reco traks not found";
         return kFATAL;
     }
-    fHits1 = (TClonesArray *)mngr->GetObject("FairTutPropHits");
-    fHits2 = (TClonesArray *)mngr->GetObject("FairTutPropHits2");
+    fHits1 = dynamic_cast<TClonesArray*>(mngr.GetObject("FairTutPropHits"));
+    fHits2 = dynamic_cast<TClonesArray*>(mngr.GetObject("FairTutPropHits2"));
     if (fHits1 == nullptr || fHits2 == nullptr) {
         LOG(error) << "Hits not found";
         return kFATAL;
     }
-    fContainerSim = (TClonesArray *)mngr->GetObject("MCTrack");
+    fContainerSim = dynamic_cast<TClonesArray*>(mngr.GetObject("MCTrack"));
     if (fContainerSim == nullptr) {
         LOG(warning) << "No branch with MC tracks";
     }
@@ -218,7 +222,7 @@ InitStatus FairEveRecoTracksExample::Init()
     }
     fRK = new FairRKPropagator(field);
     fPDG = TDatabasePDG::Instance();
-    return FairEveTracks::Init();
+    return kSUCCESS;
 }
 
 void FairEveRecoTracksExample::SetDrawMC(Bool_t draw)

--- a/examples/common/eventdisplay/FairEveMCTracks.cxx
+++ b/examples/common/eventdisplay/FairEveMCTracks.cxx
@@ -145,6 +145,9 @@ void FairEveMCTracks::Repaint()
 
 InitStatus FairEveMCTracks::Init()
 {
+    auto status = FairEveTracks::Init();
+    if (status != kSUCCESS)
+        return status;
     FairEventManager* eveManager = GetEventManager();
     FairRootManager* mngr = &(eveManager->GetRootManager());
     fContainer = dynamic_cast<TClonesArray*>(mngr->GetObject("MCTrack"));
@@ -165,7 +168,7 @@ InitStatus FairEveMCTracks::Init()
     }
     fRK = std::make_unique<FairRKPropagator>(field);
     fPDG = TDatabasePDG::Instance();
-    return FairEveTracks::Init();
+    return kSUCCESS;
 }
 
 FairEveMCTracks::~FairEveMCTracks() = default;

--- a/fairroot/eventdisplay/CMakeLists.txt
+++ b/fairroot/eventdisplay/CMakeLists.txt
@@ -39,6 +39,8 @@ set(sources
   tracks/FairEveTracks.cxx
   tracks/FairGeoTracksDraw.cxx
   tracks/FairGeoTrackHandler.cxx
+  xml/FairXMLEveConf.cxx
+  xml/FairXMLPdgColor.cxx
 )
 
 fair_change_extensions_if_exists(.cxx .h FILES "${sources}" OUTVAR headers)
@@ -51,6 +53,7 @@ target_include_directories(${target} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/tracks>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/gui>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/datasource>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/xml>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 

--- a/fairroot/eventdisplay/FairEventManager.cxx
+++ b/fairroot/eventdisplay/FairEventManager.cxx
@@ -39,8 +39,6 @@
 #include <TGeoVolume.h>   // for TGeoVolume
 #include <TVector3.h>
 
-ClassImp(FairEventManager);
-
 FairEventManager* FairEventManager::fgRinstance = nullptr;
 
 FairEventManager* FairEventManager::Instance()
@@ -70,55 +68,6 @@ FairEventManager::FairEventManager()
 {
     fgRinstance = this;
     AddParticlesToPdgDataBase();
-    fPDGToColor[22] = 623;         // photon
-    fPDGToColor[-2112] = 2;        // anti-neutron
-    fPDGToColor[-11] = 3;          // e+
-    fPDGToColor[-3122] = 4;        // anti-lambda
-    fPDGToColor[11] = 5;           // e-
-    fPDGToColor[-3222] = 6;        // Sigma -
-    fPDGToColor[12] = 7;           // e-neutrino
-    fPDGToColor[-3212] = 8;        //  Sigma0
-    fPDGToColor[-13] = 9;          // mu+
-    fPDGToColor[-3112] = 10;       // Sigma+ (PB
-    fPDGToColor[13] = 11;          //  mu-
-    fPDGToColor[-3322] = 12;       //  Xi0
-    fPDGToColor[111] = 13;         // pi0
-    fPDGToColor[-3312] = 14;       //  Xi+
-    fPDGToColor[211] = 15;         // pi+
-    fPDGToColor[-3334] = 16;       //  Omega+ (PB)
-    fPDGToColor[-211] = 17;        // pi-
-    fPDGToColor[-15] = 18;         // tau+
-    fPDGToColor[130] = 19;         // K long
-    fPDGToColor[15] = 20;          //  tau -
-    fPDGToColor[321] = 21;         // K+
-    fPDGToColor[411] = 22;         // D+
-    fPDGToColor[-321] = 23;        // K-
-    fPDGToColor[-411] = 24;        // D-
-    fPDGToColor[2112] = 25;        // n
-    fPDGToColor[421] = 26;         // D0
-    fPDGToColor[2212] = 27;        // p
-    fPDGToColor[-421] = 28;        // D0
-    fPDGToColor[-2212] = 29;       //  anti-proton
-    fPDGToColor[431] = 30;         // Ds+
-    fPDGToColor[310] = 31;         // K short
-    fPDGToColor[-431] = 32;        // anti Ds-
-    fPDGToColor[221] = 33;         // eta
-    fPDGToColor[4122] = 34;        // Lambda_C+
-    fPDGToColor[3122] = 35;        //  Lambda
-    fPDGToColor[24] = 36;          // W+
-    fPDGToColor[3222] = 37;        // Sigma+
-    fPDGToColor[-24] = 38;         //  W-
-    fPDGToColor[3212] = 39;        // Sigma0
-    fPDGToColor[23] = 40;          //  Z
-    fPDGToColor[3112] = 41;        // Sigma -
-    fPDGToColor[3322] = 42;        // Xi0
-    fPDGToColor[3312] = 43;        // Xi-
-    fPDGToColor[3334] = 44;        // Omega- (PB)
-    fPDGToColor[50000050] = 801;   // Cerenkov
-    fPDGToColor[1000010020] = 45;
-    fPDGToColor[1000010030] = 48;
-    fPDGToColor[1000020040] = 50;
-    fPDGToColor[1000020030] = 55;
 }
 
 void FairEventManager::Init(Int_t visopt, Int_t vislvl, Int_t maxvisnds)
@@ -253,14 +202,6 @@ void FairEventManager::Close() {}
 
 void FairEventManager::DisplaySettings() {}
 
-Int_t FairEventManager::Color(int pdg)
-{
-    if (fPDGToColor.find(pdg) != fPDGToColor.end()) {
-        return fPDGToColor[pdg];
-    }
-    return 0;
-}
-
 void FairEventManager::AddParticlesToPdgDataBase(Int_t /*pdg*/)
 {
     // Add particles to the PDG data base
@@ -371,14 +312,14 @@ void FairEventManager::LoadXMLSettings()
                 FairXMLNode *color = colors->GetChild(j);
                 TString pgd_code = color->GetAttrib("pdg")->GetValue();
                 TString color_code = color->GetAttrib("color")->GetValue();
-                fPDGToColor[pgd_code.Atoi()] = StringToColor(color_code);
+                fPDGColor.SetColor(pgd_code.Atoi(), FairXMLPdgColor::StringToColor(color_code));
             }
         }
     }
     gEve->Redraw3D();
 }
 
-void FairEventManager::LoadXMLDetector(TGeoNode *node, FairXMLNode *xml, Int_t depth)
+void FairEventManager::LoadXMLDetector(TGeoNode* node, FairXMLNode* xml, Int_t depth)
 {
     TString name = xml->GetAttrib("name")->GetValue();
     TString node_name = node->GetName();
@@ -388,8 +329,8 @@ void FairEventManager::LoadXMLDetector(TGeoNode *node, FairXMLNode *xml, Int_t d
     TString transparency = xml->GetAttrib("transparency")->GetValue();
     TString color = xml->GetAttrib("color")->GetValue();
     if (!color.EqualTo("")) {
-        node->GetVolume()->SetFillColor(StringToColor(color));
-        node->GetVolume()->SetLineColor(StringToColor(color));
+        node->GetVolume()->SetFillColor(FairXMLPdgColor::StringToColor(color));
+        node->GetVolume()->SetLineColor(FairXMLPdgColor::StringToColor(color));
     }
     if (!transparency.EqualTo("")) {
         node->GetVolume()->SetTransparency((Char_t)(transparency.Atoi()));
@@ -416,63 +357,6 @@ void FairEventManager::LoadXMLDetector(TGeoNode *node, FairXMLNode *xml, Int_t d
                 }
             }
         }
-    }
-}
-
-Int_t FairEventManager::StringToColor(TString color) const
-{
-    if (color.Contains("k")) {
-        Int_t plus_index = color.First('+');
-        Int_t minus_index = color.First('-');
-        Int_t cut = plus_index;
-        if (cut == -1)
-            cut = minus_index;
-        if (cut == -1)
-            cut = color.Length();
-        TString col_name(color(0, cut));
-        Int_t col_val = 0;
-        if (col_name.EqualTo("kWhite")) {
-            col_val = 0;
-        } else if (col_name.EqualTo("kBlack")) {
-            col_val = 1;
-        } else if (col_name.EqualTo("kGray")) {
-            col_val = 920;
-        } else if (col_name.EqualTo("kRed")) {
-            col_val = 632;
-        } else if (col_name.EqualTo("kGreen")) {
-            col_val = 416;
-        } else if (col_name.EqualTo("kBlue")) {
-            col_val = 600;
-        } else if (col_name.EqualTo("kYellow")) {
-            col_val = 400;
-        } else if (col_name.EqualTo("kMagenta")) {
-            col_val = 616;
-        } else if (col_name.EqualTo("kCyan")) {
-            col_val = 432;
-        } else if (col_name.EqualTo("kOrange")) {
-            col_val = 800;
-        } else if (col_name.EqualTo("kSpring")) {
-            col_val = 820;
-        } else if (col_name.EqualTo("kTeal")) {
-            col_val = 840;
-        } else if (col_name.EqualTo("kAzure")) {
-            col_val = 860;
-        } else if (col_name.EqualTo("kViolet")) {
-            col_val = 880;
-        } else if (col_name.EqualTo("kPink")) {
-            col_val = 900;
-        }
-        TString col_num(color(cut + 1, color.Length()));
-        if (col_num.Length() > 0) {
-            if (color.Contains("+")) {
-                col_val += col_num.Atoi();
-            } else {
-                col_val -= col_num.Atoi();
-            }
-        }
-        return col_val;
-    } else {
-        return color.Atoi();
     }
 }
 

--- a/fairroot/eventdisplay/FairEventManager.h
+++ b/fairroot/eventdisplay/FairEventManager.h
@@ -14,6 +14,7 @@
 
 #include "FairEveAnimationControl.h"
 #include "FairRunAna.h"   // for FairRunAna
+#include "FairXMLPdgColor.h"
 
 #include <Rtypes.h>             // for Float_t, Int_t, Bool_t, etc
 #include <TEveEventManager.h>   // for TEveEventManager
@@ -50,7 +51,7 @@ class FairEventManager : public TEveEventManager
     virtual void PrevEvent();              // *MENU*
     virtual void Close();
     virtual void DisplaySettings();   //  *Menu*
-    virtual Int_t Color(Int_t pdg);
+    virtual Int_t Color(Int_t pdg) { return fPDGColor.GetColor(pdg); }
     void AddTask(FairTask* t) { fRunAna->AddTask(t); }
     virtual void Init(Int_t visopt = 1, Int_t vislvl = 3, Int_t maxvisnds = 10000);
     virtual Int_t GetCurrentEvent() { return fEntry; }
@@ -151,7 +152,10 @@ class FairEventManager : public TEveEventManager
     TEveProjectionAxes* GetRhoZAxes() const { return fAxesRho; };
     virtual void LoadXMLSettings();
     void LoadXMLDetector(TGeoNode* node, FairXMLNode* xml, Int_t depth = 0);
-    Int_t StringToColor(TString color) const;
+    [[deprecated("Use FairXMLPdgColor::StringToColor")]] Int_t StringToColor(const TString& color) const
+    {
+        return FairXMLPdgColor::StringToColor(color);
+    }
 
   private:
     FairRunAna* fRunAna;                                //!
@@ -181,8 +185,8 @@ class FairEventManager : public TEveEventManager
     TEveProjectionAxes* fAxesRho{nullptr};              //!
     TEveText* fEventTimeText{nullptr};                  //!
     TEveText* fEventNumberText{nullptr};                //!
+    FairXMLPdgColor fPDGColor{};                        //!
     TString fXMLConfig;
-    std::map<int, int> fPDGToColor;
     void SetTransparencyForLayer(TGeoNode* node, Int_t depth, Char_t transparency);
     static FairEventManager* fgRinstance;   //!
     FairEventManager(const FairEventManager&);

--- a/fairroot/eventdisplay/tracks/FairEveGeoTracks.cxx
+++ b/fairroot/eventdisplay/tracks/FairEveGeoTracks.cxx
@@ -47,6 +47,9 @@ FairEveGeoTracks::FairEveGeoTracks()
 
 InitStatus FairEveGeoTracks::Init()
 {
+    auto status = FairEveTracks::Init();
+    if (status != kSUCCESS)
+        return status;
     FairEventManager* eveManager = GetEventManager();
     auto& mngr = eveManager->GetRootManager();
     fContainer = dynamic_cast<TClonesArray*>(mngr.GetObject("GeoTracks"));
@@ -56,7 +59,7 @@ InitStatus FairEveGeoTracks::Init()
     }
     fBranch = mngr.GetInTree()->GetBranch("GeoTracks");
     FairGetEventTime::Instance().Init();
-    return FairEveTracks::Init();
+    return kSUCCESS;
 }
 
 void FairEveGeoTracks::DrawTrack(Int_t id)
@@ -154,7 +157,7 @@ void FairEveGeoTracks::Repaint()
 {
     bool useGeoTrackHandler = false;
     if (FairRunAna::Instance()->IsTimeStamp() && fBranch != nullptr) {
-        Double_t simTime = FairEventManager::Instance()->GetEvtTime();
+        Double_t simTime = GetEventManager()->GetEvtTime();
         std::pair<int, double> evt = FairGetEventTime::Instance().GetEvent(simTime);
 
         if (evt.first < 0) {
@@ -162,7 +165,7 @@ void FairEveGeoTracks::Repaint()
         } else {
             fBranch->GetEvent(evt.first);
         }
-        if (FairEventManager::Instance()->GetClearHandler()) {
+        if (GetEventManager()->GetClearHandler()) {
             fGeoTrackHandler.Reset();
         }
         if (evt.first > -1)
@@ -176,7 +179,7 @@ void FairEveGeoTracks::Repaint()
         nTracks = fContainer->GetEntriesFast();
     }
     RemoveElements();
-    FairEventManager::Instance()->GetTimeLimits(fTMin, fTMax);
+    GetEventManager()->GetTimeLimits(fTMin, fTMax);
     if (fTMin > fTMax) {   // wrong time limits draw entire tracks
         for (int iTrack = 0; iTrack < nTracks; iTrack++) {
             DrawTrack(iTrack);

--- a/fairroot/eventdisplay/xml/FairXMLEveConf.cxx
+++ b/fairroot/eventdisplay/xml/FairXMLEveConf.cxx
@@ -1,0 +1,74 @@
+/********************************************************************************
+ * Copyright (C) 2020-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+/*
+ * FairXMLEveConf.cxx
+ *
+ *  Created on: 21 paź 2021
+ *      Author: Daniel Wielanek
+ *		E-mail: daniel.wielanek@gmail.com
+ *		Warsaw University of Technology, Faculty of Physics
+ */
+#include "FairXMLEveConf.h"
+
+Int_t FairXMLEveConf::StringToColor(const TString& color)
+{
+    if (color.Contains("k")) {
+        Int_t plus_index = color.First('+');
+        Int_t minus_index = color.First('-');
+        Int_t cut = plus_index;
+        if (cut == -1)
+            cut = minus_index;
+        if (cut == -1)
+            cut = color.Length();
+        TString col_name(color(0, cut));
+        Int_t col_val = 0;
+        if (col_name.EqualTo("kWhite")) {
+            col_val = 0;
+        } else if (col_name.EqualTo("kBlack")) {
+            col_val = 1;
+        } else if (col_name.EqualTo("kGray")) {
+            col_val = 920;
+        } else if (col_name.EqualTo("kRed")) {
+            col_val = 632;
+        } else if (col_name.EqualTo("kGreen")) {
+            col_val = 416;
+        } else if (col_name.EqualTo("kBlue")) {
+            col_val = 600;
+        } else if (col_name.EqualTo("kYellow")) {
+            col_val = 400;
+        } else if (col_name.EqualTo("kMagenta")) {
+            col_val = 616;
+        } else if (col_name.EqualTo("kCyan")) {
+            col_val = 432;
+        } else if (col_name.EqualTo("kOrange")) {
+            col_val = 800;
+        } else if (col_name.EqualTo("kSpring")) {
+            col_val = 820;
+        } else if (col_name.EqualTo("kTeal")) {
+            col_val = 840;
+        } else if (col_name.EqualTo("kAzure")) {
+            col_val = 860;
+        } else if (col_name.EqualTo("kViolet")) {
+            col_val = 880;
+        } else if (col_name.EqualTo("kPink")) {
+            col_val = 900;
+        }
+        TString col_num(color(cut + 1, color.Length()));
+        if (col_num.Length() > 0) {
+            if (color.Contains("+")) {
+                col_val += col_num.Atoi();
+            } else {
+                col_val -= col_num.Atoi();
+            }
+        }
+        return col_val;
+    } else {
+        return color.Atoi();
+    }
+}

--- a/fairroot/eventdisplay/xml/FairXMLEveConf.h
+++ b/fairroot/eventdisplay/xml/FairXMLEveConf.h
@@ -1,0 +1,29 @@
+/********************************************************************************
+ * Copyright (C) 2020-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+/*
+ * FairXMLEveConf.h
+ *
+ *  Created on: 21 paź 2021
+ *      Author: Daniel Wielanek
+ *		E-mail: daniel.wielanek@gmail.com
+ *		Warsaw University of Technology, Faculty of Physics
+ */
+#ifndef FAIRROOT_EVENTDISPLAY_XML_FAIRXMLEVECONF_H_
+#define FAIRROOT_EVENTDISPLAY_XML_FAIRXMLEVECONF_H_
+
+#include <TString.h>
+
+struct FairXMLEveConf
+{
+    FairXMLEveConf() = default;
+    virtual ~FairXMLEveConf() = default;
+    static Int_t StringToColor(const TString& color);
+};
+
+#endif /* FAIRROOT_EVENTDISPLAY_XML_FAIRXMLEVECONF_H_ */

--- a/fairroot/eventdisplay/xml/FairXMLPdgColor.cxx
+++ b/fairroot/eventdisplay/xml/FairXMLPdgColor.cxx
@@ -1,0 +1,102 @@
+/********************************************************************************
+ * Copyright (C) 2020-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+/*
+ * FairXMLPdgColor.cxx
+ *
+ *  Created on: 21 paź 2021
+ *      Author: Daniel Wielanek
+ *		E-mail: daniel.wielanek@gmail.com
+ *		Warsaw University of Technology, Faculty of Physics
+ */
+
+#include "FairXMLPdgColor.h"
+
+#include "FairXMLNode.h"
+
+#include <TString.h>
+
+FairXMLPdgColor::FairXMLPdgColor(FairXMLNode* node)
+{
+    if (!node) {
+        SetDefColor();
+        return;
+    }
+
+    if (!node->GetNChildren()) {
+        SetDefColor();
+        return;
+    }
+
+    for (int i = 0; i < node->GetNChildren(); i++) {
+        FairXMLNode* colors = node->GetChild(i);
+        TString pgd_code = colors->GetAttrib("pdg")->GetValue();
+        TString color_code = colors->GetAttrib("color")->GetValue();
+        fPDGToColor[pgd_code.Atoi()] = StringToColor(color_code);
+    }
+}
+
+Int_t FairXMLPdgColor::GetColor(Int_t pdg) const
+{
+    if (fPDGToColor.find(pdg) != fPDGToColor.end()) {
+        return fPDGToColor.at(pdg);
+    }
+    return 0;
+}
+
+void FairXMLPdgColor::SetDefColor()
+{
+    fPDGToColor[22] = 623;         // photon
+    fPDGToColor[-2112] = 2;        // anti-neutron
+    fPDGToColor[-11] = 3;          // e+
+    fPDGToColor[-3122] = 4;        // anti-lambda
+    fPDGToColor[11] = 5;           // e-
+    fPDGToColor[-3222] = 6;        // Sigma -
+    fPDGToColor[12] = 7;           // e-neutrino
+    fPDGToColor[-3212] = 8;        //  Sigma0
+    fPDGToColor[-13] = 9;          // mu+
+    fPDGToColor[-3112] = 10;       // Sigma+ (PB
+    fPDGToColor[13] = 11;          //  mu-
+    fPDGToColor[-3322] = 12;       //  Xi0
+    fPDGToColor[111] = 13;         // pi0
+    fPDGToColor[-3312] = 14;       //  Xi+
+    fPDGToColor[211] = 15;         // pi+
+    fPDGToColor[-3334] = 16;       //  Omega+ (PB)
+    fPDGToColor[-211] = 17;        // pi-
+    fPDGToColor[-15] = 18;         // tau+
+    fPDGToColor[130] = 19;         // K long
+    fPDGToColor[15] = 20;          //  tau -
+    fPDGToColor[321] = 21;         // K+
+    fPDGToColor[411] = 22;         // D+
+    fPDGToColor[-321] = 23;        // K-
+    fPDGToColor[-411] = 24;        // D-
+    fPDGToColor[2112] = 25;        // n
+    fPDGToColor[421] = 26;         // D0
+    fPDGToColor[2212] = 27;        // p
+    fPDGToColor[-421] = 28;        // D0
+    fPDGToColor[-2212] = 29;       //  anti-proton
+    fPDGToColor[431] = 30;         // Ds+
+    fPDGToColor[310] = 31;         // K short
+    fPDGToColor[-431] = 32;        // anti Ds-
+    fPDGToColor[221] = 33;         // eta
+    fPDGToColor[4122] = 34;        // Lambda_C+
+    fPDGToColor[3122] = 35;        //  Lambda
+    fPDGToColor[24] = 36;          // W+
+    fPDGToColor[3222] = 37;        // Sigma+
+    fPDGToColor[-24] = 38;         //  W-
+    fPDGToColor[3212] = 39;        // Sigma0
+    fPDGToColor[23] = 40;          //  Z
+    fPDGToColor[3112] = 41;        // Sigma -
+    fPDGToColor[3322] = 42;        // Xi0
+    fPDGToColor[3312] = 43;        // Xi-
+    fPDGToColor[3334] = 44;        // Omega- (PB)
+    fPDGToColor[50000050] = 801;   // Cerenkov
+    fPDGToColor[1000010020] = 45;
+    fPDGToColor[1000010030] = 48;
+    fPDGToColor[1000020040] = 50;
+    fPDGToColor[1000020030] = 55;
+}

--- a/fairroot/eventdisplay/xml/FairXMLPdgColor.h
+++ b/fairroot/eventdisplay/xml/FairXMLPdgColor.h
@@ -1,0 +1,37 @@
+/********************************************************************************
+ * Copyright (C) 2020-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+/*
+ * FairXMLPdgColor.h
+ *
+ *  Created on: 21 paź 2021
+ *      Author: Daniel Wielanek
+ *		E-mail: daniel.wielanek@gmail.com
+ *		Warsaw University of Technology, Faculty of Physics
+ */
+#ifndef FAIRROOT_EVENTDISPLAY_XML_FAIRXMLPDGCOLOR_H_
+#define FAIRROOT_EVENTDISPLAY_XML_FAIRXMLPDGCOLOR_H_
+
+#include "FairXMLEveConf.h"
+
+#include <map>
+
+class FairXMLNode;
+
+class FairXMLPdgColor : public FairXMLEveConf
+{
+    std::map<int, int> fPDGToColor;
+    void SetDefColor();
+
+  public:
+    explicit FairXMLPdgColor(FairXMLNode* node = nullptr);
+    ~FairXMLPdgColor() override = default;
+    void SetColor(Int_t pdg, Int_t color) { fPDGToColor[pdg] = color; }
+    Int_t GetColor(Int_t pdg) const;
+};
+
+#endif /* FAIRROOT_EVENTDISPLAY_XML_FAIRXMLPDGCOLOR_H_ */


### PR DESCRIPTION
This is part of a bigger patchset by @DanielWielanek.

Move the color configuration from FairEventManager to a new FairXMLPdgColor.

FairXMLPdgColor can also read config from an xml file, which is not yet used.

Co-Authored: Christian Tacke @ChristianTackeGSI

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
