### PR TITLE
Remove unused FairRunOnline::InitContainers() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ file an issue, so that we can see how to handle this.
 * Check the return value of `source->InitUnpackers()`/`source->ReinitUnpackers()`
   in `FairRunOnline`. Stop run if `false` returned.
 * Remove sink from Tutorial3/MQ/sampler.cxx.
+* Fixed broken `StaticContainer` functionality (do not `ReInit`ialize when `RunId` changes) in `FairRunOnline`.
 
 ### Other Notable Changes
 * Allow running without output sink. In this case even persistent branches would not be stored anywhere.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,9 @@ file an issue, so that we can see how to handle this.
 
 ### Breaking Changes
 * The output folder name changed from 'folderName_0' to 'folderName'.
-In the MT mode of Geant4 the folder names changed from 'folderName_1' and 'folderName_2' to 'folderName'.
+  In the MT mode of Geant4 the folder names changed from 'folderName_1' and 'folderName_2' to 'folderName'.
+* Removed the FairRunOnline::InitContainers() function.
+  It has not been used in FairRoot. Tested with R3BRoot.
 
 ### Bug fixes
 * Check the return value of `source->InitUnpackers()`/`source->ReinitUnpackers()`

--- a/fairroot/online/steer/FairRunOnline.cxx
+++ b/fairroot/online/steer/FairRunOnline.cxx
@@ -215,16 +215,20 @@ Int_t FairRunOnline::EventLoop()
 
     FillEventHeader();
     auto const tmpId = GetEvtHeaderRunId();
-
     if (tmpId != fRunId) {
-        LOG(info) << "FairRunOnline::EventLoop() Call Reinit due to changed RunID (from " << fRunId << " to " << tmpId;
+        LOG(info) << "FairRunOnline::EventLoop() Detected changed RunID from " << fRunId << " to " << tmpId;
         fRunId = tmpId;
-        Reinit(fRunId);
-        if (!GetSource()->ReInitUnpackers()) {
-            LOG(fatal) << "FairRunOnline->EventLoop() ReInitUnpackers() failed!";
-            return 1;
+        if (!fStatic) {
+            LOG(info) << "FairRunOnline::EventLoop() Call Reinit.";
+            Reinit(fRunId);
+            if (!GetSource()->ReInitUnpackers()) {
+                LOG(fatal) << "FairRunOnline->EventLoop() ReInitUnpackers() failed!";
+                return 1;
+            }
+            fTask->ReInitTask();
+        } else {
+            LOG(info) << "FairRunOnline::EventLoop() ReInit not called because initialisation is static.";
         }
-        fTask->ReInitTask();
     }
 
     fRootManager->StoreWriteoutBufferData(fRootManager->GetEventTime());

--- a/fairroot/online/steer/FairRunOnline.cxx
+++ b/fairroot/online/steer/FairRunOnline.cxx
@@ -185,13 +185,12 @@ void FairRunOnline::Init()
     fTask->SetParTask();
     fRtdb->initContainers(fRunId);
 
-    //  InitContainers();
     // --- Get event header from Run
     if (!fEvtHeader) {
-        LOG(fatal) << "FairRunOnline::InitContainers:No event header in run!";
+        LOG(fatal) << "FairRunOnline::Init() No event header in run!";
         return;
     }
-    LOG(info) << "FairRunOnline::InitContainers: event header at " << fEvtHeader;
+    LOG(info) << "FairRunOnline::Init() Event header at " << fEvtHeader;
     fRootManager->Register("EventHeader.", "Event", fEvtHeader, (nullptr != GetSink()));
     fEvtHeader->SetRunId(fRunId);
 
@@ -207,43 +206,6 @@ void FairRunOnline::Init()
     fRootManager->InitSink();
     fRootManager->WriteFolder();
     fRootManager->WriteFileHeader(fFileHeader);
-}
-
-void FairRunOnline::InitContainers()
-{
-    fRtdb = GetRuntimeDb();
-    FairBaseParSet* par = static_cast<FairBaseParSet*>(fRtdb->getContainer("FairBaseParSet"));
-    LOG(info) << "FairRunOnline::InitContainers: par = " << par;
-    if (nullptr == par)
-        LOG(warn) << "FairRunOnline::InitContainers: no  'FairBaseParSet' container !";
-
-    if (par) {
-        fEvtHeader = static_cast<FairEventHeader*>(fRootManager->GetObject("EventHeader."));
-
-        fRunId = GetEvtHeaderRunId();
-
-        // Copy the Event Header Info to Output
-        fEvtHeader->Register();
-
-        // Init the containers in Tasks
-        fRtdb->initContainers(fRunId);
-        fTask->ReInitTask();
-        //    fTask->SetParTask();
-        fRtdb->initContainers(fRunId);
-        //     if (gGeoManager==0) {
-        //       par->GetGeometry();
-        //     }
-    } else {
-        // --- Get event header from Run
-        //      fEvtHeader = dynamic_cast<FairEventHeader*> (FairRunOnline::Instance()->GetEventHeade
-        GetEventHeader();
-        if (!fEvtHeader) {
-            LOG(fatal) << "FairRunOnline::InitContainers:No event header in run!";
-            return;
-        }
-        LOG(info) << "FairRunOnline::InitContainers: event header at " << fEvtHeader;
-        fRootManager->Register("EventHeader.", "Event", fEvtHeader, kTRUE);
-    }
 }
 
 Int_t FairRunOnline::EventLoop()

--- a/fairroot/online/steer/FairRunOnline.h
+++ b/fairroot/online/steer/FairRunOnline.h
@@ -55,8 +55,6 @@ class FairRunOnline : public FairRun
      *  is not checked anymore after initialization
      */
 
-    /** Init containers executed on PROOF, which is part of Init when running locally*/
-    void InitContainers();
     void SetContainerStatic(Bool_t tempBool = kTRUE);
     Bool_t GetContainerStatic() { return fStatic; };
 


### PR DESCRIPTION
The function is not being invoked, and was not used.

Addresses issue #1346.

---

Checklist:

* [x] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
