### PR TITLE
chore(FairRun*): Refactor RunId Changes

### DIFF
--- a/fairroot/base/steer/FairRunAna.h
+++ b/fairroot/base/steer/FairRunAna.h
@@ -130,6 +130,11 @@ class FairRunAna : public FairRun
     /** Flag for Event Header Persistency */
     Bool_t fStoreEventHeader;   //!
 
+    /**
+     * \brief Internal facade: Handle RunID changes
+     */
+    void CheckRunIdChanged();
+
     ClassDefOverride(FairRunAna, 6);
 };
 

--- a/fairroot/base/steer/FairRunAnaProof.cxx
+++ b/fairroot/base/steer/FairRunAnaProof.cxx
@@ -284,15 +284,8 @@ void FairRunAnaProof::RunOneEvent(Long64_t entry)
         fRootManager->ReadEvent(entry);
 
         FillEventHeader();
+        CheckRunIdChanged();
 
-        auto const tmpId = GetEvtHeaderRunId();
-        if (tmpId != fRunId) {
-            fRunId = tmpId;
-            if (!fStatic) {
-                Reinit(fRunId);
-                fTask->ReInitTask();
-            }
-        }
         fRootManager->StoreWriteoutBufferData(fRootManager->GetEventTime());
 
         fTask->ExecuteTask("");

--- a/fairroot/online/steer/FairRunOnline.h
+++ b/fairroot/online/steer/FairRunOnline.h
@@ -88,6 +88,12 @@ class FairRunOnline : public FairRun
     /** Main Event loop **/
     Int_t EventLoop();
 
+    /**
+     * \brief Internal facade: Handle RunID changes
+     * \return false on error
+     */
+    bool CheckRunIdChanged();
+
   protected:
     /** This variable became true after Init is called*/
     Bool_t fIsInitialized;


### PR DESCRIPTION
Introduce a CheckRunIdChanged in FairRunAna and FairRunOnline that handles RunId changes.

Fix FairRunAna::RunEventReco: It always used runid for the "new current runid".  Now it just uses CheckRunIdChanged as well.

Inspired by #1396

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
