### PR TITLE
fix: Handle FairRuntimeDb::initContainer failures

### DIFF
--- a/fairroot/base/sim/FairMCApplication.cxx
+++ b/fairroot/base/sim/FairMCApplication.cxx
@@ -1218,7 +1218,9 @@ void FairMCApplication::SetParTask()
         module->SetParContainers();
     }
     FairRuntimeDb* fRTdb = fRun->GetRuntimeDb();
-    fRTdb->initContainers(fRun->GetRunId());
+    if (!fRTdb->initContainers(fRun->GetRunId())) {
+        LOG(error) << "FairMCApplication::SetParTask: rtdb->initContainers failed";
+    }
 }
 //_____________________________________________________________________________
 void FairMCApplication::InitTasks()

--- a/fairroot/base/steer/FairRunAna.cxx
+++ b/fairroot/base/steer/FairRunAna.cxx
@@ -127,7 +127,6 @@ void FairRunAna::SetGeomFile(const char* GeoFileName)
 
 void FairRunAna::Init()
 {
-
     if (fIsInitialized) {
         LOG(fatal) << "Error Init is already called before!";
         exit(-1);
@@ -217,11 +216,10 @@ void FairRunAna::Init()
 
         // Init the containers in Tasks
         LOG(info) << "--- Initialize with RunId  --- " << fRunId;
-        fRtdb->initContainers(fRunId);
+        if (!fRtdb->initContainers(fRunId)) {
+            LOG(error) << "FairRunAna::Init: fRtdb->initContainers failed";
+        }
         fTask->SetParTask();
-
-        // fRtdb->initContainers( fRunId );
-
     } else {   // end----- if(fMixedInput)
         LOG(info) << "Initializing without input file or Mixed input";
         FairEventHeader* evt = GetEventHeader();
@@ -231,7 +229,9 @@ void FairRunAna::Init()
         fRtdb->addRun(fRunId);
         evt->SetRunId(fRunId);
         fTask->SetParTask();
-        fRtdb->initContainers(fRunId);
+        if (!fRtdb->initContainers(fRunId)) {
+            LOG(error) << "FairRunAna::Init: fRtdb->initContainers failed";
+        }
     }
 
     FairFieldFactory* fieldfact = FairFieldFactory::Instance();
@@ -239,7 +239,9 @@ void FairRunAna::Init()
         fieldfact->SetParm();
     }
 
-    fRtdb->initContainers(fRunId);
+    if (!fRtdb->initContainers(fRunId)) {
+        LOG(error) << "FairRunAna::Init: fRtdb->initContainers failed";
+    }
     fFileHeader->SetRunId(fRunId);
 
     // create a field
@@ -614,7 +616,9 @@ void FairRunAna::TerminateRun()
 void FairRunAna::Reinit(UInt_t runId)
 {
     // reinit procedure
-    fRtdb->initContainers(runId);
+    if (!fRtdb->initContainers(runId)) {
+        LOG(error) << "FairRunAna::Reinit: fRtdb->initContainers failed";
+    }
 }
 //_____________________________________________________________________________
 

--- a/fairroot/base/steer/FairRunAnaProof.cxx
+++ b/fairroot/base/steer/FairRunAnaProof.cxx
@@ -183,11 +183,10 @@ void FairRunAnaProof::Init()
 
         // Init the containers in Tasks
         LOG(info) << "--- Initialize with RunId  --- " << fRunId;
-        fRtdb->initContainers(fRunId);
+        if (!fRtdb->initContainers(fRunId)) {
+            LOG(error) << "FairRunAnaProof::Init: fRtdb->initContainers failed";
+        }
         fTask->SetParTask();
-
-        // fRtdb->initContainers( fRunId );
-
     } else {   // end----- if(fMixedInput)
         LOG(info) << "Initializing without input file or Mixed input";
         FairEventHeader* evt = GetEventHeader();
@@ -197,14 +196,18 @@ void FairRunAnaProof::Init()
         fRtdb->addRun(fRunId);
         evt->SetRunId(fRunId);
         fTask->SetParTask();
-        fRtdb->initContainers(fRunId);
+        if (!fRtdb->initContainers(fRunId)) {
+            LOG(error) << "FairRunAnaProof::Init: fRtdb->initContainers failed";
+        }
     }
     FairFieldFactory* fieldfact = FairFieldFactory::Instance();
     if (fieldfact) {
         fieldfact->SetParm();
     }
 
-    fRtdb->initContainers(fRunId);
+    if (!fRtdb->initContainers(fRunId)) {
+        LOG(error) << "FairRunAnaProof::Init: fRtdb->initContainers failed";
+    }
     fFileHeader->SetRunId(fRunId);
 
     // create a field
@@ -248,7 +251,9 @@ void FairRunAnaProof::InitContainers()
 
         // Init the containers in Tasks
         LOG(info) << "--- Initialize with RunId  --- " << fRunId;
-        fRtdb->initContainers(fRunId);
+        if (!fRtdb->initContainers(fRunId)) {
+            LOG(error) << "FairRunAnaProof::Init: fRtdb->initContainers failed";
+        }
     }
 }
 

--- a/fairroot/online/steer/FairRunOnline.cxx
+++ b/fairroot/online/steer/FairRunOnline.cxx
@@ -183,7 +183,9 @@ void FairRunOnline::Init()
 
     GetSource()->SetParUnpackers();
     fTask->SetParTask();
-    fRtdb->initContainers(fRunId);
+    if (!fRtdb->initContainers(fRunId)) {
+        LOG(error) << "FairRunOnline::Init: fRtdb->initContainers failed";
+    }
 
     // --- Get event header from Run
     if (!fEvtHeader) {
@@ -349,7 +351,9 @@ void FairRunOnline::RegisterHttpCommand(TString name, TString command)
 void FairRunOnline::Reinit(UInt_t runId)
 {
     // reinit procedure
-    fRtdb->initContainers(runId);
+    if (!fRtdb->initContainers(runId)) {
+        LOG(error) << "FairRunOnline::Reinit: fRtdb->initContainers failed";
+    }
 }
 
 void FairRunOnline::SetContainerStatic(Bool_t tempBool)

--- a/fairroot/parbase/FairRuntimeDb.cxx
+++ b/fairroot/parbase/FairRuntimeDb.cxx
@@ -454,7 +454,7 @@ Bool_t FairRuntimeDb::writeContainer(FairParSet* cont, FairRtdbRun* run, FairRtd
     return kTRUE;
 }
 
-Bool_t FairRuntimeDb::initContainers(UInt_t runId, Int_t refId, const Text_t* fileName)
+bool FairRuntimeDb::initContainers(UInt_t runId, Int_t refId, const char* fileName)
 {
     // loops over the list of containers and calls the init() function of each
     // container if it is not static

--- a/fairroot/parbase/FairRuntimeDb.h
+++ b/fairroot/parbase/FairRuntimeDb.h
@@ -67,7 +67,7 @@ class FairRuntimeDb : public TObject
     FairParSet* findContainer(const char*);
     void removeContainer(const char*);
     void removeAllContainers();
-    Bool_t initContainers(UInt_t runId, Int_t refId = -1, const Text_t* fileName = "");
+    [[nodiscard]] bool initContainers(UInt_t runId, Int_t refId = -1, const char* fileName = "");
     void setContainersStatic(Bool_t f = kTRUE);
     Bool_t writeContainers(void);
     Bool_t writeContainer(FairParSet*, FairRtdbRun*, FairRtdbRun* refRun = 0);

--- a/fairroot/parmq/ParameterMQServer.cxx
+++ b/fairroot/parmq/ParameterMQServer.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -134,7 +134,10 @@ bool ParameterMQServer::ProcessRequest(fair::mq::MessagePtr& req, int /*index*/)
         parameterName = newParameterName;
         par = static_cast<FairParGenericSet*>(fRtdb->getContainer(parameterName.c_str()));
     }
-    fRtdb->initContainers(runId);
+    if (!fRtdb->initContainers(runId)) {
+        LOG(error) << "ParameterMQServer::ProcessRequest: fRtdb->initContainers failed";
+        return false;
+    }
 
     LOG(info) << "Sending following parameter to the client:";
     if (par) {
@@ -192,7 +195,10 @@ bool ParameterMQServer::ProcessUpdate(fair::mq::MessagePtr& update, int /*index*
                 parDescr.erase(0, parDescr.find("RUNID") + 5);
             }
         }
-        fRtdb->initContainers(runId);
+        if (!fRtdb->initContainers(runId)) {
+            LOG(error) << "ParameterMQServer::ProcessRequest: fRtdb->initContainers failed";
+            return false;
+        }
 
         newPar->setChanged(true);   // trigger writing to file
         newPar->setStatic(true);    // to get rid of error


### PR DESCRIPTION
FairRuntimeDb::initContainer can sometimes fail and will return `false` in that case. This was not handled very well in our code.

Add a `[[nodiscard]]` so that the return value can not be ignored without a warning.

Fix all callers, so that they at least emit an error log entry.

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
