### PR TITLE
Fix root GetSeed

### DIFF
--- a/examples/simulation/Tutorial2/macros/CMakeLists.txt
+++ b/examples/simulation/Tutorial2/macros/CMakeLists.txt
@@ -12,21 +12,30 @@ GENERATE_ROOT_TEST_SCRIPT(${CMAKE_CURRENT_SOURCE_DIR}/read_digis.C)
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_CURRENT_SOURCE_DIR}/run_background.C)
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_CURRENT_SOURCE_DIR}/run_signal.C)
 GENERATE_ROOT_TEST_SCRIPT(${CMAKE_CURRENT_SOURCE_DIR}/run_tutorial2.C)
+GENERATE_ROOT_TEST_SCRIPT(${CMAKE_CURRENT_SOURCE_DIR}/compare_seed_value.C)
 
 set(maxTestTime 60)
 
 add_test(NAME ex_sim_tutorial2
-         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_tutorial2.sh)
+         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_tutorial2.sh  10 \"TGeant4\" true 333)
 set_tests_properties(ex_sim_tutorial2 PROPERTIES
   TIMEOUT ${maxTestTime}
   PASS_REGULAR_EXPRESSION "Macro finished successfully"
   FIXTURES_SETUP fixtures.ex_sim_tutorial2_sim
 )
 
+add_test(NAME ex_compare_seed_value
+         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/compare_seed_value.sh \"tutorial2_pions.params_p2.000_t0_n10.root\" 333)
+set_tests_properties(ex_compare_seed_value PROPERTIES
+  TIMEOUT ${maxTestTime}
+  FIXTURES_REQUIRED fixtures.ex_sim_tutorial2_sim
+  FIXTURES_SETUP fixtures.ex_compare_seed_value
+)
+
 add_test(NAME ex_sim_tutorial2_create_digis
          COMMAND ${CMAKE_CURRENT_BINARY_DIR}/create_digis.sh)
 set_tests_properties(ex_sim_tutorial2_create_digis PROPERTIES
-  FIXTURES_REQUIRED fixtures.ex_sim_tutorial2_sim
+  FIXTURES_REQUIRED fixtures.ex_compare_seed_value
   TIMEOUT ${maxTestTime}
   PASS_REGULAR_EXPRESSION "Macro finished successfully"
   FIXTURES_SETUP fixtures.ex_sim_tutorial2_digi

--- a/examples/simulation/Tutorial2/macros/CMakeLists.txt
+++ b/examples/simulation/Tutorial2/macros/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (C) 2014-2019 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
+# Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
@@ -22,23 +22,25 @@ set_tests_properties(ex_sim_tutorial2 PROPERTIES
   TIMEOUT ${maxTestTime}
   PASS_REGULAR_EXPRESSION "Macro finished successfully"
   FIXTURES_SETUP fixtures.ex_sim_tutorial2_sim
+  RESOURCE_LOCK ex_sim_tutorial2_paramFile
 )
 
-add_test(NAME ex_compare_seed_value
+add_test(NAME ex_sim_tutorial2_compare_seed_value
          COMMAND ${CMAKE_CURRENT_BINARY_DIR}/compare_seed_value.sh \"tutorial2_pions.params_p2.000_t0_n10.root\" 333)
-set_tests_properties(ex_compare_seed_value PROPERTIES
+set_tests_properties(ex_sim_tutorial2_compare_seed_value PROPERTIES
   TIMEOUT ${maxTestTime}
   FIXTURES_REQUIRED fixtures.ex_sim_tutorial2_sim
-  FIXTURES_SETUP fixtures.ex_compare_seed_value
+  RESOURCE_LOCK ex_sim_tutorial2_paramFile
 )
 
 add_test(NAME ex_sim_tutorial2_create_digis
          COMMAND ${CMAKE_CURRENT_BINARY_DIR}/create_digis.sh)
 set_tests_properties(ex_sim_tutorial2_create_digis PROPERTIES
-  FIXTURES_REQUIRED fixtures.ex_compare_seed_value
+  FIXTURES_REQUIRED fixtures.ex_sim_tutorial2_sim
   TIMEOUT ${maxTestTime}
   PASS_REGULAR_EXPRESSION "Macro finished successfully"
   FIXTURES_SETUP fixtures.ex_sim_tutorial2_digi
+  RESOURCE_LOCK ex_sim_tutorial2_paramFile
 )
 
 add_test(NAME ex_sim_tutorial2_read_digis

--- a/examples/simulation/Tutorial2/macros/compare_seed_value.C
+++ b/examples/simulation/Tutorial2/macros/compare_seed_value.C
@@ -1,0 +1,20 @@
+int compare_seed_value(TString filename, UInt_t initial_seed) {
+
+  // Open parameter file and get the stored random seed from the
+  // FairBaseParSet parameter container
+  // Compare the random seed with the expected one set during the
+  // transport run
+
+  std::unique_ptr<TFile> myFile( TFile::Open(filename) );
+  std::unique_ptr<FairBaseParSet> par(myFile->Get<FairBaseParSet>("FairBaseParSet"));
+  UInt_t seed = par->GetRndSeed();
+
+  if ( seed == initial_seed ) {
+    return 0;
+  }
+  else {
+    std::cout << "Expected seed value  : " << initial_seed << std::endl;
+    std::cout << "Seed value from file : " << seed << std::endl;
+    return 1;
+  }
+}

--- a/examples/simulation/Tutorial2/macros/compare_seed_value.C
+++ b/examples/simulation/Tutorial2/macros/compare_seed_value.C
@@ -1,20 +1,47 @@
-int compare_seed_value(TString filename, UInt_t initial_seed) {
+/********************************************************************************
+ *    Copyright (C) 2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include "FairBaseParSet.h"
 
-  // Open parameter file and get the stored random seed from the
-  // FairBaseParSet parameter container
-  // Compare the random seed with the expected one set during the
-  // transport run
+#include <RtypesCore.h>
+#include <TFile.h>
+#include <TString.h>
+#include <iostream>
+#include <memory>
+#endif
 
-  std::unique_ptr<TFile> myFile( TFile::Open(filename) );
-  std::unique_ptr<FairBaseParSet> par(myFile->Get<FairBaseParSet>("FairBaseParSet"));
-  UInt_t seed = par->GetRndSeed();
+int compare_seed_value(TString filename, UInt_t initial_seed)
+{
 
-  if ( seed == initial_seed ) {
-    return 0;
-  }
-  else {
-    std::cout << "Expected seed value  : " << initial_seed << std::endl;
-    std::cout << "Seed value from file : " << seed << std::endl;
-    return 1;
-  }
+    // Open parameter file and get the stored random seed from the
+    // FairBaseParSet parameter container
+    // Compare the random seed with the expected one set during the
+    // transport run
+
+    std::unique_ptr<TFile> myFile(TFile::Open(filename));
+    if (!myFile || myFile->IsZombie()) {
+        std::cerr << "Error opening file " << filename << std::endl;
+        return 1;
+    }
+
+    std::unique_ptr<FairBaseParSet> par(myFile->Get<FairBaseParSet>("FairBaseParSet"));
+    if (!par) {
+        std::cerr << "Did not find FairBaseParSet in input file" << std::endl;
+        return 1;
+    }
+
+    UInt_t seed = par->GetRndSeed();
+
+    if (seed == initial_seed) {
+        return 0;
+    } else {
+        std::cout << "Expected seed value  : " << initial_seed << std::endl;
+        std::cout << "Seed value from file : " << seed << std::endl;
+        return 1;
+    }
 }

--- a/examples/simulation/Tutorial2/macros/create_digis.C
+++ b/examples/simulation/Tutorial2/macros/create_digis.C
@@ -1,15 +1,29 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
 
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include "FairFileSource.h"
+#include "FairParAsciiFileIo.h"
+#include "FairParRootFileIo.h"
+#include "FairRootFileSink.h"
+#include "FairRunAna.h"
+#include "FairRuntimeDb.h"
+#include "FairSystemInfo.h"
+#include "FairTutorialDet2CustomTask.h"
+#include "FairTutorialDet2DigiPar.h"
+#include "FairTutorialDet2Digitizer.h"
+
 #include <TStopwatch.h>
 #include <TString.h>
+#include <TSystem.h>
 #include <iostream>
 #include <memory>
+#endif
 
 using std::cout;
 using std::endl;

--- a/examples/simulation/Tutorial2/macros/create_digis_mixed.C
+++ b/examples/simulation/Tutorial2/macros/create_digis_mixed.C
@@ -1,7 +1,29 @@
+/********************************************************************************
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include "FairMixedSource.h"
+#include "FairParAsciiFileIo.h"
+#include "FairParRootFileIo.h"
+#include "FairRootFileSink.h"
+#include "FairRunAna.h"
+#include "FairRuntimeDb.h"
+#include "FairSystemInfo.h"
+#include "FairTutorialDet2CustomTask.h"
+#include "FairTutorialDet2DigiPar.h"
+#include "FairTutorialDet2Digitizer.h"
+
 #include <TStopwatch.h>
 #include <TString.h>
+#include <TSystem.h>
 #include <iostream>
 #include <memory>
+#endif
 
 using std::cout;
 using std::endl;

--- a/examples/simulation/Tutorial2/macros/read_digis.C
+++ b/examples/simulation/Tutorial2/macros/read_digis.C
@@ -1,15 +1,29 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
 
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include "FairBaseParSet.h"
+#include "FairFileSource.h"
+#include "FairParAsciiFileIo.h"
+#include "FairParRootFileIo.h"
+#include "FairRootFileSink.h"
+#include "FairRunAna.h"
+#include "FairRuntimeDb.h"
+#include "FairSystemInfo.h"
+#include "FairTutorialDet2CustomTask.h"
+#include "FairTutorialDet2DigiPar.h"
+#include "FairTutorialDet2Digitizer.h"
+
 #include <TStopwatch.h>
 #include <TString.h>
 #include <iostream>
 #include <memory>
+#endif
 
 using std::cout;
 using std::endl;

--- a/examples/simulation/Tutorial2/macros/run_background.C
+++ b/examples/simulation/Tutorial2/macros/run_background.C
@@ -1,7 +1,34 @@
+/********************************************************************************
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include "FairBoxGenerator.h"
+#include "FairCave.h"
+#include "FairDetector.h"
+#include "FairModule.h"
+#include "FairParRootFileIo.h"
+#include "FairPrimaryGenerator.h"
+#include "FairRootFileSink.h"
+#include "FairRunSim.h"
+#include "FairRuntimeDb.h"
+#include "FairSystemInfo.h"
+#include "FairTutorialDet2.h"
+
+#include <RtypesCore.h>
 #include <TStopwatch.h>
 #include <TString.h>
 #include <TSystem.h>
+#include <iostream>
 #include <memory>
+#endif
+
+using std::cout;
+using std::endl;
 
 void run_background(Int_t nEvents = 130)
 {
@@ -53,7 +80,7 @@ void run_background(Int_t nEvents = 130)
 
     // -----   Create simulation run   ----------------------------------------
     auto run = std::make_unique<FairRunSim>();
-    run->SetName("TGeant4");                       // Transport engine
+    run->SetName("TGeant4");   // Transport engine
     run->SetSink(std::make_unique<FairRootFileSink>(outFile));
     FairRuntimeDb* rtdb = run->GetRuntimeDb();
     // ------------------------------------------------------------------------

--- a/examples/simulation/Tutorial2/macros/run_signal.C
+++ b/examples/simulation/Tutorial2/macros/run_signal.C
@@ -1,7 +1,33 @@
+/********************************************************************************
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include "FairBoxGenerator.h"
+#include "FairCave.h"
+#include "FairDetector.h"
+#include "FairModule.h"
+#include "FairParRootFileIo.h"
+#include "FairPrimaryGenerator.h"
+#include "FairRootFileSink.h"
+#include "FairRunSim.h"
+#include "FairRuntimeDb.h"
+#include "FairSystemInfo.h"
+#include "FairTutorialDet2.h"
+
+#include <RtypesCore.h>
 #include <TStopwatch.h>
 #include <TString.h>
 #include <TSystem.h>
 #include <memory>
+#endif
+
+using std::cout;
+using std::endl;
 
 void run_signal(Int_t fileNr, Int_t nEvents = 10)
 {
@@ -55,7 +81,7 @@ void run_signal(Int_t fileNr, Int_t nEvents = 10)
 
     // -----   Create simulation run   ----------------------------------------
     auto run = std::make_unique<FairRunSim>();
-    run->SetName("TGeant4");                       // Transport engine
+    run->SetName("TGeant4");   // Transport engine
     run->SetSink(std::make_unique<FairRootFileSink>(outFile));
     FairRuntimeDb* rtdb = run->GetRuntimeDb();
     // ------------------------------------------------------------------------

--- a/examples/simulation/Tutorial2/macros/run_tutorial2.C
+++ b/examples/simulation/Tutorial2/macros/run_tutorial2.C
@@ -1,19 +1,33 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
 
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include "FairBoxGenerator.h"
+#include "FairCave.h"
+#include "FairDetector.h"
+#include "FairModule.h"
+#include "FairParRootFileIo.h"
+#include "FairPrimaryGenerator.h"
+#include "FairRootFileSink.h"
+#include "FairRunSim.h"
+#include "FairRuntimeDb.h"
+#include "FairSystemInfo.h"
+#include "FairTutorialDet2.h"
+
+#include <RtypesCore.h>
 #include <TRandom.h>
 #include <TStopwatch.h>
 #include <TString.h>
 #include <TSystem.h>
 #include <memory>
+#endif
 
-void run_tutorial2(Int_t nEvents = 10, TString mcEngine = "TGeant4",
-                   Bool_t isMT = true, UInt_t initial_seed=98989)
+void run_tutorial2(Int_t nEvents = 10, TString mcEngine = "TGeant4", Bool_t isMT = true, UInt_t initial_seed = 98989)
 {
     TString dir = getenv("VMCWORKDIR");
 
@@ -66,8 +80,8 @@ void run_tutorial2(Int_t nEvents = 10, TString mcEngine = "TGeant4",
 
     // -----   Create simulation run   ----------------------------------------
     auto run = std::make_unique<FairRunSim>();
-    run->SetName(mcEngine);                        // Transport engine
-    run->SetIsMT(isMT);                            // Multi-threading mode (Geant4 only)
+    run->SetName(mcEngine);   // Transport engine
+    run->SetIsMT(isMT);       // Multi-threading mode (Geant4 only)
     run->SetSink(std::make_unique<FairRootFileSink>(outFile));
     FairRuntimeDb* rtdb = run->GetRuntimeDb();
     // ------------------------------------------------------------------------
@@ -118,30 +132,30 @@ void run_tutorial2(Int_t nEvents = 10, TString mcEngine = "TGeant4",
 
     // -----   Finish   -------------------------------------------------------
 
-    cout << endl << endl;
+    std::cout << std::endl << std::endl;
 
     // Extract the maximal used memory an add is as Dart measurement
     // This line is filtered by CTest and the value send to CDash
     FairSystemInfo sysInfo;
     Float_t maxMemory = sysInfo.GetMaxMemory();
-    cout << "<DartMeasurement name=\"MaxMemory\" type=\"numeric/double\">";
-    cout << maxMemory;
-    cout << "</DartMeasurement>" << endl;
+    std::cout << "<DartMeasurement name=\"MaxMemory\" type=\"numeric/double\">";
+    std::cout << maxMemory;
+    std::cout << "</DartMeasurement>" << std::endl;
 
     timer.Stop();
     Double_t rtime = timer.RealTime();
     Double_t ctime = timer.CpuTime();
 
     Float_t cpuUsage = ctime / rtime;
-    cout << "<DartMeasurement name=\"CpuLoad\" type=\"numeric/double\">";
-    cout << cpuUsage;
-    cout << "</DartMeasurement>" << endl;
+    std::cout << "<DartMeasurement name=\"CpuLoad\" type=\"numeric/double\">";
+    std::cout << cpuUsage;
+    std::cout << "</DartMeasurement>" << std::endl;
 
-    cout << endl << endl;
-    cout << "Output file is " << outFile << endl;
-    cout << "Parameter file is " << parFile << endl;
-    cout << "Real time " << rtime << " s, CPU time " << ctime << "s" << endl << endl;
-    cout << "Macro finished successfully." << endl;
+    std::cout << std::endl << std::endl;
+    std::cout << "Output file is " << outFile << std::endl;
+    std::cout << "Parameter file is " << parFile << std::endl;
+    std::cout << "Real time " << rtime << " s, CPU time " << ctime << "s" << std::endl << std::endl;
+    std::cout << "Macro finished successfully." << std::endl;
 
     // ------------------------------------------------------------------------
 }

--- a/examples/simulation/Tutorial2/macros/run_tutorial2.C
+++ b/examples/simulation/Tutorial2/macros/run_tutorial2.C
@@ -12,7 +12,8 @@
 #include <TSystem.h>
 #include <memory>
 
-void run_tutorial2(Int_t nEvents = 10, TString mcEngine = "TGeant4", Bool_t isMT = true)
+void run_tutorial2(Int_t nEvents = 10, TString mcEngine = "TGeant4",
+                   Bool_t isMT = true, UInt_t initial_seed=98989)
 {
     TString dir = getenv("VMCWORKDIR");
 
@@ -49,7 +50,7 @@ void run_tutorial2(Int_t nEvents = 10, TString mcEngine = "TGeant4", Bool_t isMT
                            nEvents);
 
     // Set the random seed
-    gRandom->SetSeed(98989);
+    gRandom->SetSeed(initial_seed);
 
     // In general, the following parts need not be touched
     // ========================================================================

--- a/fairroot/base/steer/FairRunSim.cxx
+++ b/fairroot/base/steer/FairRunSim.cxx
@@ -231,7 +231,7 @@ void FairRunSim::Init()
     }
     if (par) {
         par->SetContListStr(ContList);
-        par->SetRndSeed(gRandom->GetSeed());
+        par->SetRndSeed(gRandom->TRandom::GetSeed());
         par->setChanged();
         par->setInputVersion(fRunId, 1);
     }

--- a/templates/project_root_containers/MyProjGenerators/Pythia8Generator.h
+++ b/templates/project_root_containers/MyProjGenerators/Pythia8Generator.h
@@ -27,7 +27,7 @@ class FairPrimaryGenerator;
 class PyTr1Rng : public RndmEngine
 {
   public:
-    PyTr1Rng() { rng = new TRandom1(gRandom->GetSeed()); };
+    PyTr1Rng() { rng = new TRandom1(gRandom->TRandom::GetSeed()); };
     virtual ~PyTr1Rng(){};
 
     Double_t flat() { return rng->Rndm(); };
@@ -39,7 +39,7 @@ class PyTr1Rng : public RndmEngine
 class PyTr3Rng : public RndmEngine
 {
   public:
-    PyTr3Rng() { rng = new TRandom3(gRandom->GetSeed()); };
+    PyTr3Rng() { rng = new TRandom3(gRandom->TRandom::GetSeed()); };
     virtual ~PyTr3Rng(){};
 
     Double_t flat() { return rng->Rndm(); };

--- a/templates/project_stl_containers/MyProjGenerators/Pythia8Generator.h
+++ b/templates/project_stl_containers/MyProjGenerators/Pythia8Generator.h
@@ -27,7 +27,7 @@ class FairPrimaryGenerator;
 class PyTr1Rng : public RndmEngine
 {
   public:
-    PyTr1Rng() { rng = new TRandom1(gRandom->GetSeed()); };
+    PyTr1Rng() { rng = new TRandom1(gRandom->TRandom::GetSeed()); };
     virtual ~PyTr1Rng(){};
 
     Double_t flat() { return rng->Rndm(); };
@@ -39,7 +39,7 @@ class PyTr1Rng : public RndmEngine
 class PyTr3Rng : public RndmEngine
 {
   public:
-    PyTr3Rng() { rng = new TRandom3(gRandom->GetSeed()); };
+    PyTr3Rng() { rng = new TRandom3(gRandom->TRandom::GetSeed()); };
     virtual ~PyTr3Rng(){};
 
     Double_t flat() { return rng->Rndm(); };


### PR DESCRIPTION
This PR brings first a test which checks if the set seed value is properly stored in FairBasParSet container during the simulation. Due to a breaking change in ROOT 6.24 the return value of the function TRandom3::GetSeed() doesn't return the seed value but a fixed value of 624. The newly added test should fail for FairSoft versions apr22 and nov22.
The PR will be updated with the proper fix for the problem in a second step.


---

Checklist:

* [x ] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
