### PR TITLE
Disable event builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,9 @@ file an issue, so that we can see how to handle this.
   * Proof was deprecated by ROOT
   * The affected code in FairRoot is disabled by default now
   * It can still be enabled with `-DBUILD_PROOF_SUPPORT=ON`.
+* Deprecated FairEventBuilder and FairEventBuilderManager
+  * The functionality, introduced to enable event reconstruction, is not used.
+  * It can be enabled with `-DBUILD_EVENT_BUILDER=ON`.
 
 ### Other Notable Changes
 * Consider calling `fairroot_check_root_cxxstd_compatibility()`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,7 @@ ENDIF(NOT UNIX)
 option(BUILD_UNITTESTS "Build all unittests and add them as new tests" OFF)
 option(ENABLE_GEANT3_TESTING "Enable tests utilizing Geant3" OFF)
 option(BUILD_PROOF_SUPPORT "Support ROOT::Proof (deprecated)" OFF)
+option(BUILD_EVENT_BUILDER "Build FairEventBuild" ON)
 
 option(BUILD_ONLINE "Build the online library" ON)
 option(BUILD_MBS "Build MBS" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ ENDIF(NOT UNIX)
 option(BUILD_UNITTESTS "Build all unittests and add them as new tests" OFF)
 option(ENABLE_GEANT3_TESTING "Enable tests utilizing Geant3" OFF)
 option(BUILD_PROOF_SUPPORT "Support ROOT::Proof (deprecated)" OFF)
-option(BUILD_EVENT_BUILDER "Build FairEventBuild" ON)
+option(BUILD_EVENT_BUILDER "Build FairEventBuild" OFF)
 
 option(BUILD_ONLINE "Build the online library" ON)
 option(BUILD_MBS "Build MBS" OFF)

--- a/FairRoot_build_test.cmake
+++ b/FairRoot_build_test.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (C) 2021-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
+# Copyright (C) 2021-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
@@ -49,6 +49,9 @@ if ((NOT DEFINED BUILD_MBS) OR BUILD_MBS)
 endif()
 if ((NOT DEFINED BUILD_PROOF_SUPPORT) OR BUILD_PROOF_SUPPORT)
   list(APPEND options "-DBUILD_PROOF_SUPPORT=ON")
+endif()
+if ((NOT DEFINED BUILD_EVENT_BUILDER) OR BUILD_EVENT_BUILDER)
+  list(APPEND options "-DBUILD_EVENT_BUILDER=ON")
 endif()
 if (USE_CLANG_TIDY)
   list(APPEND options "-DCMAKE_CXX_CLANG_TIDY=clang-tidy")

--- a/fairroot/base/CMakeLists.txt
+++ b/fairroot/base/CMakeLists.txt
@@ -9,8 +9,6 @@
 set(target Base)
 
 set(sources
-  event/FairEventBuilder.cxx
-  event/FairEventBuilderManager.cxx
   event/FairEventHeader.cxx
   event/FairFileHeader.cxx
   event/FairFileInfo.cxx
@@ -80,6 +78,13 @@ if(BUILD_PROOF_SUPPORT)
   )
 endif()
 
+if(BUILD_EVENT_BUILDER)
+  list(APPEND sources
+    event/FairEventBuilder.cxx
+    event/FairEventBuilderManager.cxx
+  )
+endif()
+
 fair_change_extensions_if_exists(.cxx .h FILES "${sources}" OUTVAR headers)
 
 add_library(${target} SHARED ${sources} ${headers})
@@ -127,6 +132,10 @@ target_compile_definitions(${target}
 if(BUILD_PROOF_SUPPORT)
   target_link_libraries(${target} PRIVATE ROOT::Proof)
   target_compile_definitions(${target} PRIVATE BUILD_PROOF_SUPPORT)
+endif()
+
+if(BUILD_EVENT_BUILDER)
+  target_compile_definitions(${target} PRIVATE BUILD_EVENT_BUILDER)
 endif()
 
 fairroot_target_root_dictionary(${target}

--- a/fairroot/base/LinkDef.h
+++ b/fairroot/base/LinkDef.h
@@ -16,8 +16,6 @@
 #pragma link C++ class FairGeoParSet;
 #pragma link C++ class FairDetector+;
 //#pragma link C++ class FairDoubleHit+;
-#pragma link C++ class FairEventBuilder+;
-#pragma link C++ class FairEventBuilderManager+;
 #pragma link C++ class FairEventHeader+;
 #pragma link C++ class FairFileHeader+;
 #pragma link C++ class FairGeaneApplication+;
@@ -78,6 +76,10 @@
 #ifdef BUILD_PROOF_SUPPORT
 #pragma link C++ class FairAnaSelector+;
 #pragma link C++ class FairRunAnaProof;
+#endif
+#ifdef BUILD_EVENT_BUILDER
+#pragma link C++ class FairEventBuilder+;
+#pragma link C++ class FairEventBuilderManager+;
 #endif
 
 #endif

--- a/fairroot/base/LinkDef.h
+++ b/fairroot/base/LinkDef.h
@@ -1,5 +1,5 @@
 /*************************************************************************************
- *    Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ *    Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
  *                                                                                   *
  *                 This software is distributed under the terms of the               *
  *                 GNU Lesser General Public Licence (LGPL) version 3,               *

--- a/fairroot/base/steer/FairRunAna.h
+++ b/fairroot/base/steer/FairRunAna.h
@@ -42,7 +42,8 @@ class FairRunAna : public FairRun
     /**Run for the given single entry*/
     void Run(Long64_t entry);
     /**Run event reconstruction from event number NStart to event number NStop */
-    void RunEventReco(Int_t NStart, Int_t NStop);
+    /** \deprecated Deprecated along with FairEventBuilder. */
+    [[deprecated("Deprecated along with FairEventBuilder.")]] void RunEventReco(Int_t NStart, Int_t NStop);
     /**Run over all TSBuffers until the data is processed*/
     void RunTSBuffers();
     /** the dummy run does not check the evt header or the parameters!! */


### PR DESCRIPTION
Introduced `BUILD_EVENT_BUILDER` flag, that allows 
disabling build of `FairEventBuilder` and `FairEventBuilderManager` classes.
Set it to `OFF`.

Consequence of discussion in PR #1406.

---

Checklist:

* [x] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
