### PR TITLE
fix: First set of TFile::Get Related leaks

### DIFF
--- a/examples/MQ/serialization/sampler.cxx
+++ b/examples/MQ/serialization/sampler.cxx
@@ -33,17 +33,14 @@ namespace bpo = boost::program_options;
 
 struct Sampler : fair::mq::Device
 {
-    Sampler()
-        : fInput(nullptr)
-        , fTree(nullptr)
-    {}
+    Sampler() = default;
 
     void Init() override
     {
         fFileName = fConfig->GetValue<std::string>("input-file");
         fInputFile.reset(TFile::Open(fFileName.c_str(), "READ"));
         if (fInputFile) {
-            fTree = fInputFile->Get<TTree>("cbmsim");
+            fTree.reset(fInputFile->Get<TTree>("cbmsim"));
             if (fTree) {
                 fTree->SetBranchAddress("MyDigi", &fInput);
             } else {
@@ -116,10 +113,10 @@ struct Sampler : fair::mq::Device
         return hits;
     }
 
-    TClonesArray* fInput;
-    TTree* fTree;
+    TClonesArray* fInput{nullptr};
     std::string fFileName;
     std::unique_ptr<TFile> fInputFile;
+    std::unique_ptr<TTree> fTree;
 };
 
 void addCustomOptions(bpo::options_description& options)

--- a/examples/advanced/propagator/macros/runPull.C
+++ b/examples/advanced/propagator/macros/runPull.C
@@ -1,10 +1,29 @@
 /********************************************************************************
- *    Copyright (C) 2019 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2019-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
+
+#if !defined(__CLING__) || defined(__ROOTCLING__)
+#include "FairTrackParP.h"
+#endif
+
+#include <TCanvas.h>
+#include <TClonesArray.h>
+#include <TF1.h>
+#include <TFile.h>
+#include <TH1F.h>
+#include <TROOT.h>
+#include <TStyle.h>
+#include <TTree.h>
+#include <iostream>
+#include <memory>
+
+using std::cout;
+using std::endl;
+
 int runPull(std::string propName = "rk", bool drawHist = false)
 {
     if (propName != "geane" && propName != "rk") {
@@ -15,11 +34,10 @@ int runPull(std::string propName = "rk", bool drawHist = false)
     gROOT->Reset();
     gStyle->SetOptFit(1);
 
-    TFile* f = new TFile(Form("prop.%s.cal.root", propName.c_str()));
-    TTree* simtree = (TTree*)f->Get("cbmsim");
+    std::unique_ptr<TFile> f{TFile::Open(Form("prop.%s.cal.root", propName.c_str()))};
+    std::unique_ptr<TTree> simtree{f->Get<TTree>("cbmsim")};
 
     TClonesArray* fTrackParProp = new TClonesArray("FairTrackParP");
-    TClonesArray* fTrackParIni = new TClonesArray("FairTrackParP");
     TClonesArray* fTrackParFinal = new TClonesArray("FairTrackParP");
 
     Double_t maxDist = 0.1;

--- a/fairroot/base/source/FairFileSourceBase.cxx
+++ b/fairroot/base/source/FairFileSourceBase.cxx
@@ -10,8 +10,10 @@
 
 #include "FairRootManager.h"
 
+#include <TCollection.h>
 #include <TObjString.h>
 #include <fairlogger/Logger.h>
+#include <memory>
 #include <set>
 
 FairFileSourceBase::~FairFileSourceBase()
@@ -38,10 +40,12 @@ Bool_t FairFileSourceBase::CompareBranchList(TFile* fileHandle, TString inputLev
     // If a branch with the same name is found, this branch is removed from
     // the list. If in the end no branch is left in the list everything is
     // fine.
-    auto list = fileHandle->Get<TList>("BranchList");
+    std::unique_ptr<TList> list{fileHandle->Get<TList>("BranchList")};
     if (list) {
-        for (Int_t i = 0; i < list->GetEntries(); i++) {
-            auto Obj = dynamic_cast<TObjString*>(list->At(i));
+        for (auto Obj : TRangeDynCast<TObjString>(list.get())) {
+            if (!Obj) {
+                continue;
+            }
             auto iter1 = branches.find(Obj->GetString());
             if (iter1 != branches.end()) {
                 branches.erase(iter1);

--- a/fairroot/base/steer/FairRootManager.h
+++ b/fairroot/base/steer/FairRootManager.h
@@ -87,7 +87,7 @@ class FairRootManager : public TObject
     Int_t GetMCTrackBranchId() const { return fMCTrackBranchId; }
 
     /**Return a TList of TObjString of branch names available in this session*/
-    TList* GetBranchNameList() { return fBranchNameList; }
+    TList* GetBranchNameList() { return &fBranchNameList; }
 
     /**  Get the Object (container) for the given branch name,
          this method can be used to access the data of
@@ -360,7 +360,7 @@ class FairRootManager : public TObject
     /**Branch id for this run */
     Int_t fBranchSeqId;
     /**List of branch names as TObjString*/
-    TList* fBranchNameList;   //!
+    TList fBranchNameList{};   //!
 
     /**The branch ID for the special (required) MCTrack branch**/
     Int_t fMCTrackBranchId;   //!

--- a/fairroot/parbase/FairParRootFileIo.h
+++ b/fairroot/parbase/FairParRootFileIo.h
@@ -14,20 +14,17 @@
 #include <TFile.h>    // for TFile
 #include <TNamed.h>   // for TNamed
 #include <fstream>
-using std::fstream;
+#include <memory>
 
 class FairRtdbRun;
-class TKey;
-class TList;
 
 class FairParRootFile : public TNamed
 {
   public:
-    FairRtdbRun* run;   //! pointer to current run in ROOT file
     FairParRootFile(const Text_t* fname, Option_t* option = "READ", const Text_t* ftitle = "", Int_t compress = 1);
     FairParRootFile(TFile* f);
     ~FairParRootFile() override;
-    FairRtdbRun* getRun() { return run; }
+    FairRtdbRun* getRun() { return run.get(); }
     void readVersions(FairRtdbRun*);
 
     Bool_t IsOpen() { return RootFile && (RootFile->IsOpen()); }
@@ -66,6 +63,8 @@ class FairParRootFile : public TNamed
     TFile* RootFile;
 
   private:
+    std::unique_ptr<FairRtdbRun> run;   //! pointer to current run in ROOT file
+
     FairParRootFile(const FairParRootFile&);
     FairParRootFile& operator=(const FairParRootFile&);
 


### PR DESCRIPTION
It turned out that `TFile::Get<>` returns an owning pointer.  So store this into a unique_ptr as soon as possible, so that the memory is handled correctly.

If one stores a TList in a root file, it is best to mark it as an owning TList (if it is), so that readers do not have to explicitly `->Delete()` the contents of the TList.

This fixes a first set of instances.

See: https://root-forum.cern.ch/t/solved-memory-leak-with-tfile-get/19683/8

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
