### PR TITLE
chore: Do not call clear in ctor/dtor

### DIFF
--- a/examples/MQ/parameters/FairMQExParamsParOne.cxx
+++ b/examples/MQ/parameters/FairMQExParamsParOne.cxx
@@ -9,7 +9,6 @@
 
 #include "FairParamList.h"   // for FairParamList
 
-#include <TGenericClassInfo.h>   // for TGenericClassInfo
 #include <TString.h>             // for TString
 #include <fairlogger/Logger.h>   // for LOG, Logger
 
@@ -20,17 +19,9 @@ FairMQExParamsParOne::FairMQExParamsParOne(const char* name, const char* title, 
     detName = "TutorialDet";
 }
 
-FairMQExParamsParOne::~FairMQExParamsParOne() { clear(); }
-
-void FairMQExParamsParOne::clear()
-{
-    status = kFALSE;
-    resetInputVersions();
-}
-
 void FairMQExParamsParOne::print()
 {
-    LOG(info) << "Print";
+    FairParGenericSet::print();
     LOG(info) << "fParameterValue: " << fParameterValue;
 }
 

--- a/examples/MQ/parameters/FairMQExParamsParOne.h
+++ b/examples/MQ/parameters/FairMQExParamsParOne.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -8,14 +8,7 @@
 #ifndef FAIRMQEXPARAMSPARONE_H_
 #define FAIRMQEXPARAMSPARONE_H_
 
-#include <Rtypes.h>             // for THashConsistencyHolder, ClassDef
-#include <RtypesCore.h>         // for Int_t, Bool_t
-#include "FairParGenericSet.h"  // for FairParGenericSet
-class FairParamList;  // lines 15-15
-class TBuffer;
-class TClass;
-class TMemberInspector;
-
+#include "FairParGenericSet.h"
 
 class FairMQExParamsParOne : public FairParGenericSet
 {
@@ -26,12 +19,9 @@ class FairMQExParamsParOne : public FairParGenericSet
                          const char* context = "Default");
 
     /** Destructor **/
-    ~FairMQExParamsParOne() override;
+    ~FairMQExParamsParOne() override = default;
 
     void print() override;
-
-    /** Reset all parameters **/
-    void clear() override;
 
     void putParams(FairParamList* list) override;
     Bool_t getParams(FairParamList* list) override;

--- a/examples/MQ/pixelDetector/src/PixelDigiPar.cxx
+++ b/examples/MQ/pixelDetector/src/PixelDigiPar.cxx
@@ -33,12 +33,7 @@ PixelDigiPar::PixelDigiPar(const char* name, const char* title, const char* cont
     , fChargeConvMethod(0)
     , fPixelSorterCellWidth(0.)
     , fPixelSorterNumberOfCells(0)
-{
-    clear();
-}
-
-// -----   Destructor   ----------------------------------------------------
-PixelDigiPar::~PixelDigiPar(void) {}
+{}
 
 void PixelDigiPar::putParams(FairParamList* list)
 {

--- a/examples/MQ/pixelDetector/src/PixelDigiPar.h
+++ b/examples/MQ/pixelDetector/src/PixelDigiPar.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -27,8 +27,7 @@ class PixelDigiPar : public FairParGenericSet
     PixelDigiPar(const char* name = "PixelDigiParameters",
                  const char* title = "Pixel digi parameters",
                  const char* context = "TestDefaultContext");
-    ~PixelDigiPar() override;
-    void clear() override {}
+    ~PixelDigiPar() override = default;
     void putParams(FairParamList* list) override;
     Bool_t getParams(FairParamList* list) override;
 

--- a/examples/MQ/pixelDetector/src/PixelDigiWriteToBinFile.cxx
+++ b/examples/MQ/pixelDetector/src/PixelDigiWriteToBinFile.cxx
@@ -14,15 +14,12 @@
 
 #include "PixelDigiWriteToBinFile.h"
 
-// Includes from base
-#include "FairLogger.h"
-#include "FairRootManager.h"
-
-// Includes from ROOT
 #include "PixelDigi.h"
 
-#include <TClonesArray.h>
-#include <TString.h>
+// Includes from base
+#include "FairRootManager.h"
+
+#include <fairlogger/Logger.h>
 
 PixelDigiWriteToBinFile::PixelDigiWriteToBinFile()
     : PixelDigiWriteToBinFile("Pixel DigiWriter", 0)
@@ -42,17 +39,10 @@ PixelDigiWriteToBinFile::PixelDigiWriteToBinFile(const char* name, Int_t iVerbos
     , fRunId(0)
     , fMCEntryNo(0)
     , fPartNo(0)
-
-{
-    Reset();
-}
-
-PixelDigiWriteToBinFile::~PixelDigiWriteToBinFile() { Reset(); }
+{}
 
 void PixelDigiWriteToBinFile::Exec(Option_t* /*opt*/)
 {
-    Reset();
-
     Int_t nofDigis = fDigis->GetEntriesFast();
 
     Int_t digisPerFile[12] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
@@ -103,7 +93,6 @@ void PixelDigiWriteToBinFile::Exec(Option_t* /*opt*/)
 
 InitStatus PixelDigiWriteToBinFile::Init()
 {
-
     // Get input array
     FairRootManager* ioman = FairRootManager::Instance();
 

--- a/examples/MQ/pixelDetector/src/PixelDigiWriteToBinFile.h
+++ b/examples/MQ/pixelDetector/src/PixelDigiWriteToBinFile.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -18,10 +18,8 @@
 #include "FairTask.h"
 
 #include <Rtypes.h>
+#include <TClonesArray.h>
 #include <TString.h>
-
-class TClonesArray;
-
 #include <fstream>
 
 class PixelDigiWriteToBinFile : public FairTask
@@ -37,7 +35,7 @@ class PixelDigiWriteToBinFile : public FairTask
     PixelDigiWriteToBinFile(const char* name, Int_t iVerbose);
 
     /** Destructor **/
-    ~PixelDigiWriteToBinFile() override;
+    ~PixelDigiWriteToBinFile() override = default;
 
     /** Execution **/
     void Exec(Option_t* opt) override;
@@ -64,9 +62,6 @@ class PixelDigiWriteToBinFile : public FairTask
 
     /** Reinitialisation **/
     InitStatus ReInit() override;
-
-    /** Reset eventwise counters **/
-    void Reset() {}
 
     /** Finish at the end of each event **/
     void Finish() override;

--- a/examples/MQ/pixelDetector/src/PixelFitTracks.cxx
+++ b/examples/MQ/pixelDetector/src/PixelFitTracks.cxx
@@ -14,7 +14,6 @@
 
 #include "PixelFitTracks.h"
 
-#include "FairLogger.h"
 #include "FairRootManager.h"
 #include "FairRun.h"
 #include "FairRuntimeDb.h"
@@ -22,9 +21,8 @@
 #include "PixelHit.h"
 #include "PixelTrack.h"
 
-#include <TClonesArray.h>
-#include <TList.h>
 #include <TMath.h>
+#include <fairlogger/Logger.h>
 
 PixelFitTracks::PixelFitTracks()
     : PixelFitTracks("Pixel Track Fitter", 0)
@@ -46,13 +44,10 @@ PixelFitTracks::PixelFitTracks(const char* name, Int_t iVerbose)
     , fTNofTracks(0)
     , fNFitTracks(0)
     , fTNofFitTracks(0)
-{
-    Reset();
-}
+{}
 
 PixelFitTracks::~PixelFitTracks()
 {
-    Reset();
     delete fDigiPar;
     if (fFitTracks) {
         fFitTracks->Delete();
@@ -62,7 +57,9 @@ PixelFitTracks::~PixelFitTracks()
 
 void PixelFitTracks::Exec(Option_t* /*opt*/)
 {
-    Reset();
+    fNFitTracks = 0;
+    if (fFitTracks)
+        fFitTracks->Clear();
 
     fNHits = fHits->GetEntriesFast();
     fNTracks = fTracks->GetEntriesFast();
@@ -175,8 +172,6 @@ void PixelFitTracks::GetParList(TList* tempList)
 {
     fDigiPar = new PixelDigiPar("PixelDigiParameters");
     tempList->Add(fDigiPar);
-
-    return;
 }
 
 void PixelFitTracks::InitMQ(TList* tempList)
@@ -186,7 +181,6 @@ void PixelFitTracks::InitMQ(TList* tempList)
 
     fFitTracks = new TClonesArray("PixelTrack", 10000);
     fFitTracks->SetName("PixelFitTracks");
-    return;
 }
 
 void PixelFitTracks::ExecMQ(TList* inputList, TList* outputList)
@@ -199,7 +193,6 @@ void PixelFitTracks::ExecMQ(TList* inputList, TList* outputList)
     fTracks = (TClonesArray*)inputList->FindObject("PixelTracks");
     outputList->Add(fFitTracks);
     Exec("");
-    return;
 }
 
 InitStatus PixelFitTracks::Init()
@@ -221,15 +214,6 @@ InitStatus PixelFitTracks::Init()
     ioman->Register("PixelFitTracks", "Pixel", fFitTracks, kTRUE);
 
     return kSUCCESS;
-}
-
-InitStatus PixelFitTracks::ReInit() { return kSUCCESS; }
-
-void PixelFitTracks::Reset()
-{
-    fNFitTracks = fNTracks = fNHits = 0;
-    if (fFitTracks)
-        fFitTracks->Clear();
 }
 
 void PixelFitTracks::Finish()

--- a/examples/MQ/pixelDetector/src/PixelFitTracks.h
+++ b/examples/MQ/pixelDetector/src/PixelFitTracks.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -18,10 +18,10 @@
 #include "FairTask.h"
 
 #include <Rtypes.h>
+#include <TClonesArray.h>
+#include <TList.h>
 
-class TClonesArray;
 class PixelDigiPar;
-class TList;
 
 class PixelFitTracks : public FairTask
 {
@@ -75,12 +75,6 @@ class PixelFitTracks : public FairTask
 
     /** Intialisation **/
     InitStatus Init() override;
-
-    /** Reinitialisation **/
-    InitStatus ReInit() override;
-
-    /** Reset eventwise counters **/
-    void Reset();
 
     /** Finish at the end of each event **/
     void Finish() override;

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2DigiPar.cxx
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2DigiPar.cxx
@@ -25,14 +25,6 @@ FairTutorialDet2DigiPar::FairTutorialDet2DigiPar(const char* name, const char* t
     detName = "TutorialDet";
 }
 
-FairTutorialDet2DigiPar::~FairTutorialDet2DigiPar() { clear(); }
-
-void FairTutorialDet2DigiPar::clear()
-{
-    status = kFALSE;
-    resetInputVersions();
-}
-
 void FairTutorialDet2DigiPar::printparams()
 {
     LOG(info) << "Print";

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2DigiPar.h
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2DigiPar.h
@@ -32,12 +32,9 @@ class FairTutorialDet2DigiPar : public FairParGenericSet
     FairTutorialDet2DigiPar(const FairTutorialDet2DigiPar&) = delete;
     FairTutorialDet2DigiPar& operator=(const FairTutorialDet2DigiPar&) = delete;
     /** Destructor **/
-    ~FairTutorialDet2DigiPar() override;
+    ~FairTutorialDet2DigiPar() override = default;
 
     virtual void printparams();
-
-    /** Reset all parameters **/
-    void clear() override;
 
     void putParams(FairParamList*) override;
     Bool_t getParams(FairParamList*) override;

--- a/fairroot/geobase/FairGeoNode.cxx
+++ b/fairroot/geobase/FairGeoNode.cxx
@@ -44,10 +44,7 @@ FairGeoNode::FairGeoNode()
     , labTransform(nullptr)
     , fDaughterList(new TObjArray(5))
     , fTruncName("")
-{
-    // Constructor
-    clear();
-}
+{}
 
 FairGeoNode::FairGeoNode(FairGeoNode& r)
     : FairGeoVolume(r)

--- a/fairroot/parbase/FairParSet.cxx
+++ b/fairroot/parbase/FairParSet.cxx
@@ -115,6 +115,12 @@ void FairParSet::print()
     }
 }
 
+void FairParSet::clear()
+{
+    status = kFALSE;
+    resetInputVersions();
+}
+
 void FairParSet::resetInputVersions()
 {
     // resets the input versions if the container is not static

--- a/fairroot/parbase/FairParSet.h
+++ b/fairroot/parbase/FairParSet.h
@@ -39,7 +39,7 @@ class FairParSet : public TObject
     virtual Bool_t init(FairParIo*) { return kFALSE; }
     virtual Int_t write();
     virtual Int_t write(FairParIo*) { return kFALSE; }
-    virtual void clear() {}
+    virtual void clear();
     virtual void print();
 
     const char* getDetectorName() { return detName.Data(); }


### PR DESCRIPTION
A ctor should set up all members in a proper way.  No need to call a clear method to reset member variables to the same value again. (Or an empty clear method.)

A dtor only needs to release resources. Member variables do not need to be reset to any values.

Member variables of base classes should be handled in the methods of base classes.

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
