### PR TITLE
Try Compiling Macros to Check them

### DIFF
--- a/examples/simulation/Tutorial2/macros/CMakeLists.txt
+++ b/examples/simulation/Tutorial2/macros/CMakeLists.txt
@@ -6,79 +6,93 @@
 #                  copied verbatim in the file "LICENSE"                       #
 ################################################################################
 
-GENERATE_ROOT_TEST_SCRIPT(${CMAKE_CURRENT_SOURCE_DIR}/create_digis_mixed.C)
-GENERATE_ROOT_TEST_SCRIPT(${CMAKE_CURRENT_SOURCE_DIR}/create_digis.C)
-GENERATE_ROOT_TEST_SCRIPT(${CMAKE_CURRENT_SOURCE_DIR}/read_digis.C)
-GENERATE_ROOT_TEST_SCRIPT(${CMAKE_CURRENT_SOURCE_DIR}/run_background.C)
-GENERATE_ROOT_TEST_SCRIPT(${CMAKE_CURRENT_SOURCE_DIR}/run_signal.C)
-GENERATE_ROOT_TEST_SCRIPT(${CMAKE_CURRENT_SOURCE_DIR}/run_tutorial2.C)
-GENERATE_ROOT_TEST_SCRIPT(${CMAKE_CURRENT_SOURCE_DIR}/compare_seed_value.C)
+set(prefix ex_sim_tutorial2)
+
+set(macrofiles
+        compare_seed_value.C
+        create_digis.C
+        create_digis_mixed.C
+        read_digis.C
+        run_background.C
+        run_signal.C
+        run_tutorial2.C)
+
+foreach(macro IN LISTS macrofiles)
+    GENERATE_ROOT_TEST_SCRIPT(${CMAKE_CURRENT_SOURCE_DIR}/${macro})
+endforeach()
+
+# Try to compile the macros as normal files
+add_library(${prefix}_check_compile OBJECT ${macrofiles})
+target_link_libraries(${prefix}_check_compile PRIVATE
+    FairRoot::ExSimulation2
+    FairRoot::ExPassive
+    FairRoot::Generators)
 
 set(maxTestTime 60)
 
-add_test(NAME ex_sim_tutorial2
+add_test(NAME ${prefix}
          COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_tutorial2.sh  10 \"TGeant4\" true 333)
-set_tests_properties(ex_sim_tutorial2 PROPERTIES
+set_tests_properties(${prefix} PROPERTIES
   TIMEOUT ${maxTestTime}
   PASS_REGULAR_EXPRESSION "Macro finished successfully"
-  FIXTURES_SETUP fixtures.ex_sim_tutorial2_sim
-  RESOURCE_LOCK ex_sim_tutorial2_paramFile
+  FIXTURES_SETUP fixtures.${prefix}_sim
+  RESOURCE_LOCK ${prefix}_paramFile
 )
 
-add_test(NAME ex_sim_tutorial2_compare_seed_value
+add_test(NAME ${prefix}_compare_seed_value
          COMMAND ${CMAKE_CURRENT_BINARY_DIR}/compare_seed_value.sh \"tutorial2_pions.params_p2.000_t0_n10.root\" 333)
-set_tests_properties(ex_sim_tutorial2_compare_seed_value PROPERTIES
+set_tests_properties(${prefix}_compare_seed_value PROPERTIES
   TIMEOUT ${maxTestTime}
-  FIXTURES_REQUIRED fixtures.ex_sim_tutorial2_sim
-  RESOURCE_LOCK ex_sim_tutorial2_paramFile
+  FIXTURES_REQUIRED fixtures.${prefix}_sim
+  RESOURCE_LOCK ${prefix}_paramFile
 )
 
-add_test(NAME ex_sim_tutorial2_create_digis
+add_test(NAME ${prefix}_create_digis
          COMMAND ${CMAKE_CURRENT_BINARY_DIR}/create_digis.sh)
-set_tests_properties(ex_sim_tutorial2_create_digis PROPERTIES
-  FIXTURES_REQUIRED fixtures.ex_sim_tutorial2_sim
+set_tests_properties(${prefix}_create_digis PROPERTIES
+  FIXTURES_REQUIRED fixtures.${prefix}_sim
   TIMEOUT ${maxTestTime}
   PASS_REGULAR_EXPRESSION "Macro finished successfully"
-  FIXTURES_SETUP fixtures.ex_sim_tutorial2_digi
-  RESOURCE_LOCK ex_sim_tutorial2_paramFile
+  FIXTURES_SETUP fixtures.${prefix}_digi
+  RESOURCE_LOCK ${prefix}_paramFile
 )
 
-add_test(NAME ex_sim_tutorial2_read_digis
+add_test(NAME ${prefix}_read_digis
          COMMAND ${CMAKE_CURRENT_BINARY_DIR}/read_digis.sh)
-set_tests_properties(ex_sim_tutorial2_read_digis PROPERTIES
-  FIXTURES_REQUIRED fixtures.ex_sim_tutorial2_digi
+set_tests_properties(${prefix}_read_digis PROPERTIES
+  FIXTURES_REQUIRED fixtures.${prefix}_digi
   TIMEOUT ${maxTestTime}
   PASS_REGULAR_EXPRESSION "Macro finished successfully"
 )
 
-add_test(NAME ex_sim_tutorial2_run_background
+add_test(NAME ${prefix}_run_background
          COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_background.sh)
-set_tests_properties(ex_sim_tutorial2_run_background PROPERTIES
+set_tests_properties(${prefix}_run_background PROPERTIES
   TIMEOUT ${maxTestTime}
   PASS_REGULAR_EXPRESSION "Macro finished successfully"
-  FIXTURES_SETUP fixtures.ex_sim_tutorial2_back
+  FIXTURES_SETUP fixtures.${prefix}_back
 )
 
-add_test(NAME ex_sim_tutorial2_run_signal1
+add_test(NAME ${prefix}_run_signal1
          COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_signal.sh 1 10)
-set_tests_properties(ex_sim_tutorial2_run_signal1 PROPERTIES
+set_tests_properties(${prefix}_run_signal1 PROPERTIES
   TIMEOUT ${maxTestTime}
   PASS_REGULAR_EXPRESSION "Macro finished successfully"
-  FIXTURES_SETUP fixtures.ex_sim_tutorial2_sig1
+  FIXTURES_SETUP fixtures.${prefix}_sig1
 )
 
-add_test(NAME ex_sim_tutorial2_run_signal2
+add_test(NAME ${prefix}_run_signal2
          COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_signal.sh 2 20)
-set_tests_properties(ex_sim_tutorial2_run_signal2 PROPERTIES
+set_tests_properties(${prefix}_run_signal2 PROPERTIES
   TIMEOUT ${maxTestTime}
   PASS_REGULAR_EXPRESSION "Macro finished successfully"
-  FIXTURES_SETUP fixtures.ex_sim_tutorial2_sig2
+  FIXTURES_SETUP fixtures.${prefix}_sig2
 )
 
-add_test(NAME ex_sim_tutorial2_create_digis_mixed
+add_test(NAME ${prefix}_create_digis_mixed
          COMMAND ${CMAKE_CURRENT_BINARY_DIR}/create_digis_mixed.sh)
-set_tests_properties(ex_sim_tutorial2_create_digis_mixed PROPERTIES
-  FIXTURES_REQUIRED "fixtures.ex_sim_tutorial2_back;fixtures.ex_sim_tutorial2_sig1;fixtures.ex_sim_tutorial2_sig2"
+set_tests_properties(${prefix}_create_digis_mixed PROPERTIES
+  FIXTURES_REQUIRED "fixtures.${prefix}_back;fixtures.${prefix}_sig1;fixtures.${prefix}_sig2"
   TIMEOUT ${maxTestTime}
   PASS_REGULAR_EXPRESSION "Macro finished successfully"
 )

--- a/examples/simulation/Tutorial2/macros/create_digis.C
+++ b/examples/simulation/Tutorial2/macros/create_digis.C
@@ -82,7 +82,8 @@ void create_digis()
 
     rtdb->getContainer("FairTutorialDet2DigiPar")->print();
 
-    FairTutorialDet2DigiPar* DigiPar = (FairTutorialDet2DigiPar*)rtdb->getContainer("FairTutorialDet2DigiPar");
+    auto DigiPar = dynamic_cast<FairTutorialDet2DigiPar*>(rtdb->getContainer("FairTutorialDet2DigiPar"));
+    assert(DigiPar);
 
     DigiPar->setChanged();
     DigiPar->setInputVersion(fRun->GetRunId(), 1);

--- a/examples/simulation/Tutorial2/macros/create_digis_mixed.C
+++ b/examples/simulation/Tutorial2/macros/create_digis_mixed.C
@@ -115,7 +115,8 @@ void create_digis_mixed()
 
     rtdb->getContainer("FairTutorialDet2DigiPar")->print();
 
-    FairTutorialDet2DigiPar* DigiPar = (FairTutorialDet2DigiPar*)rtdb->getContainer("FairTutorialDet2DigiPar");
+    auto DigiPar = dynamic_cast<FairTutorialDet2DigiPar*>(rtdb->getContainer("FairTutorialDet2DigiPar"));
+    assert(DigiPar);
 
     DigiPar->setChanged();
     DigiPar->setInputVersion(fRun->GetRunId(), 1);

--- a/examples/simulation/Tutorial2/macros/read_digis.C
+++ b/examples/simulation/Tutorial2/macros/read_digis.C
@@ -94,7 +94,8 @@ void read_digis()
     rtdb->saveOutput();
 
     // -- Print out the random seed from the simulation ----------------------
-    FairBaseParSet* BasePar = (FairBaseParSet*)rtdb->getContainer("FairBaseParSet");
+    auto BasePar = dynamic_cast<FairBaseParSet*>(rtdb->getContainer("FairBaseParSet"));
+    assert(BasePar);
     cout << "RndSeed used in simulation was  " << BasePar->GetRndSeed() << endl;
 
     // -----------------------------------------------------------------------
@@ -102,7 +103,7 @@ void read_digis()
     // Second version to print the parameters
     // which also shows how to change and save them again
 
-    FairTutorialDet2DigiPar* DigiPar = (FairTutorialDet2DigiPar*)rtdb->getContainer("FairTutorialDet2DigiPar");
+    auto DigiPar = static_cast<FairTutorialDet2DigiPar*>(rtdb->getContainer("FairTutorialDet2DigiPar"));
 
     DigiPar->setChanged();
     DigiPar->setInputVersion(fRun->GetRunId(), 1);

--- a/fairroot/base/event/FairTimeStamp.h
+++ b/fairroot/base/event/FairTimeStamp.h
@@ -23,11 +23,17 @@ class FairTimeStamp : public FairMultiLinkedData_Interface
 {
   public:
     /** Default constructor **/
-    FairTimeStamp();
+    FairTimeStamp() = default;
+
     /** Constructor with time **/
-    FairTimeStamp(Double_t time);
+    FairTimeStamp(Double_t time)
+        : fTimeStamp(time)
+    {}
     /** Constructor with time and time error **/
-    FairTimeStamp(Double_t time, Double_t timeerror);
+    FairTimeStamp(Double_t time, Double_t timeerror)
+        : fTimeStamp(time)
+        , fTimeStampError(timeerror)
+    {}
 
     /** Destructor **/
     ~FairTimeStamp() override = default;
@@ -42,12 +48,10 @@ class FairTimeStamp : public FairMultiLinkedData_Interface
         if (this == obj) {
             return 0;
         }
-        FairTimeStamp* tsobj = static_cast<FairTimeStamp*>(const_cast<TObject*>(obj));
+        auto tsobj = static_cast<FairTimeStamp const*>(obj);
         Double_t ts = tsobj->GetTimeStamp();
         Double_t tserror = tsobj->GetTimeStampError();
-        if (fTimeStamp < ts) {
-            return -1;
-        } else if (fTimeStamp == ts && fTimeStampError < tserror) {
+        if ((fTimeStamp < ts) || (fTimeStamp == ts && fTimeStampError < tserror)) {
             return -1;
         } else if (fTimeStamp == ts && fTimeStampError == tserror) {
             return 0;
@@ -73,30 +77,10 @@ class FairTimeStamp : public FairMultiLinkedData_Interface
     virtual bool operator<(const FairTimeStamp* rValue) const { return GetTimeStamp() < rValue->GetTimeStamp(); }
 
   protected:
-    Double_t fTimeStamp;      /** Time of digit or Hit  [ns] */
-    Double_t fTimeStampError; /** Error on time stamp */
+    Double_t fTimeStamp{-1};        //< Time of digit or Hit  [ns]
+    Double_t fTimeStampError{-1};   //< Error on time stamp
 
     ClassDefOverride(FairTimeStamp, 4);
 };
-
-// -----   Default constructor   -------------------------------------------
-inline FairTimeStamp::FairTimeStamp()
-    : FairMultiLinkedData_Interface()
-    , fTimeStamp(-1)
-    , fTimeStampError(-1)
-{}
-
-// -----   Standard constructor   ------------------------------------------
-inline FairTimeStamp::FairTimeStamp(Double_t time)
-    : FairMultiLinkedData_Interface()
-    , fTimeStamp(time)
-    , fTimeStampError(-1)
-{}
-
-inline FairTimeStamp::FairTimeStamp(Double_t time, Double_t timeerror)
-    : FairMultiLinkedData_Interface()
-    , fTimeStamp(time)
-    , fTimeStampError(timeerror)
-{}
 
 #endif   // FAIRTIMESTAMP_H


### PR DESCRIPTION
Many of the newer macros are actually valid C++ files. So let's compile them to get all the warnings and checks from the main compile checks.

Also fix some warnings in `FairTimeStamp.h`

---

Checklist:

* [x] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
