### PR TITLE
clang-tidy: Enable cppcoreguidelines-pro-type-cstyle-cast

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,8 +4,11 @@ HeaderFilterRegex: '.*'
 #   ROOT throws lots of them in their headers
 # Bugprone:
 #   These could cause actual bugs.
-# enable cppcoreguidelines-virtual-class-destructor
+# C++ Core Guidelines
+# * cppcoreguidelines-virtual-class-destructor
 #   Avoid undefined behaviour
+# * cppcoreguidelines-pro-type-cstyle-cast
+#   Avoid C-Style Casts which might be problematic
 # enable google-build-using-namespace
 #   "using namespace" imports a changing amount of symbols, avoid it
 # improve readability:
@@ -18,6 +21,7 @@ Checks: >-
   -bugprone-virtual-near-miss,
   -bugprone-unhandled-self-assignment,
   -bugprone-reserved-identifier,
+  cppcoreguidelines-pro-type-cstyle-cast,
   cppcoreguidelines-virtual-class-destructor,
   modernize-make-unique,
   google-build-using-namespace,

--- a/examples/common/mcstack/FairStack.h
+++ b/examples/common/mcstack/FairStack.h
@@ -45,9 +45,6 @@
 #include <stack>     // for stack
 #include <utility>   // for pair
 
-class TClonesArray;
-class TRefArray;
-
 class FairStack : public FairGenericStack
 {
   public:
@@ -165,7 +162,7 @@ class FairStack : public FairGenericStack
     void FillTrackArray() override;
 
     /** Update the track index in the MCTracks and MCPoints **/
-    void UpdateTrackIndex(TRefArray* detArray = 0) override;
+    void UpdateTrackIndex(TRefArray* detArray = nullptr) override;
 
     /** Resets arrays and stack and deletes particles and tracks **/
     void Reset() override;
@@ -198,24 +195,14 @@ class FairStack : public FairGenericStack
     TParticle* GetParticle(Int_t trackId) const;
     TClonesArray* GetListOfParticles() override { return fParticles; }
 
-    void SetParticleArray(TClonesArray* partArray) override
-    {
-        for (Int_t ipart = 0; ipart < partArray->GetEntries(); ipart++) {
-            ((TParticle*)(partArray->At(ipart)))->SetUniqueID(fNPrimaries);
-            fStack.push((TParticle*)partArray->At(ipart));
-            AddParticle((TParticle*)partArray->At(ipart));
-            fNParticles++;
-            fNPrimaries++;
-        }
-    }
-
     void SetParticleArray(TClonesArray* partArray, Int_t partFrom, Int_t partTo) override
     {
         for (Int_t ipart = partFrom; ipart < partTo; ipart++) {
-            ((TParticle*)(partArray->At(ipart)))->SetUniqueID(fNPrimaries);
-            ((TParticle*)(partArray->At(ipart)))->SetStatusCode(fNPrimaries);
-            fStack.push((TParticle*)partArray->At(ipart));
-            AddParticle((TParticle*)partArray->At(ipart));
+            auto particle = static_cast<TParticle*>(partArray->At(ipart));
+            particle->SetUniqueID(fNPrimaries);
+            particle->SetStatusCode(fNPrimaries);
+            fStack.push(particle);
+            AddParticle(particle);
             fNParticles++;
             fNPrimaries++;
         }
@@ -224,7 +211,7 @@ class FairStack : public FairGenericStack
     /** Clone this object (used in MT mode only) */
     FairGenericStack* CloneStack() const override
     {
-        FairStack* clonedStack = new FairStack();
+        auto clonedStack = new FairStack();
         clonedStack->StoreSecondaries(fStoreSecondaries);
         clonedStack->SetMinPoints(fMinPoints);
         clonedStack->SetEnergyCut(fEnergyCut);

--- a/fairroot/base/sim/FairGenericStack.h
+++ b/fairroot/base/sim/FairGenericStack.h
@@ -96,8 +96,13 @@ class FairGenericStack : public TVirtualMCStack
     /** Register the MCTrack array to the Root Manager  **/
     virtual void Register() {}
 
-    virtual TClonesArray* GetListOfParticles() { return 0; }
-    virtual void SetParticleArray(__attribute__((unused)) TClonesArray* partArray) {}
+    virtual TClonesArray* GetListOfParticles() { return nullptr; }
+    virtual void SetParticleArray(TClonesArray* partArray)
+    {
+        if (partArray) {
+            SetParticleArray(partArray, 0, partArray->GetEntries());
+        }
+    }
     virtual void SetParticleArray(__attribute__((unused)) TClonesArray* partArray,
                                   __attribute__((unused)) Int_t partFrom,
                                   __attribute__((unused)) Int_t partTo)


### PR DESCRIPTION
This will not mark all C Style Casts, but those that could be problematic and should be looked at.

And start to fix them in `FairStack.h`

---

Checklist:

* [x] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
