### PR TITLE
Replace `FairRunAna::Run(Long64_t)` by `RunSingleEntry(Long64_t)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,8 +81,11 @@ file an issue, so that we can see how to handle this.
   * The functionality, introduced to enable event reconstruction, is not used.
   * It can be enabled with `-DBUILD_EVENT_BUILDER=ON`.
 * Deprecated `FairRun::SetEventHeader(FairEventHeader*)`
-   * Use `FairRun::SetEventHeader(std::unique_ptr<FairEventHeader> EvHeader)`, which 
-     indicates the ownership transferring.
+  * Use `FairRun::SetEventHeader(std::unique_ptr<FairEventHeader> EvHeader)`,
+    which indicates the ownership transferring.
+* Deprecated `FairRunAna::Run(Long64_t entry)`
+  * Functionality unclear due to dubious `Run(int)` and `Run(long)`.
+  * Use `FairRunAna::RunSingleEntry(Long64_t entry)` instead.
 
 ### Other Notable Changes
 * Consider calling `fairroot_check_root_cxxstd_compatibility()`

--- a/fairroot/base/steer/FairRunAna.cxx
+++ b/fairroot/base/steer/FairRunAna.cxx
@@ -475,7 +475,7 @@ void FairRunAna::RunMQ(Long64_t entry)
 //_____________________________________________________________________________
 
 //_____________________________________________________________________________
-void FairRunAna::Run(Long64_t entry)
+void FairRunAna::RunSingleEntry(Long64_t entry)
 {
     fRootManager->ReadEvent(entry);
     CheckRunIdChanged();

--- a/fairroot/base/steer/FairRunAna.h
+++ b/fairroot/base/steer/FairRunAna.h
@@ -35,12 +35,18 @@ class FairRunAna : public FairRun
     FairRunAna();
     /**initialize the run manager*/
     void Init() override;
-    /**Run from event number NStart to event number NStop */
+    /** Run analysis:
+     * for the whole input if NEntry == NStop == 0,
+     * for NEntry entries if NStop == 0,
+     * from NEntry until NStop entry is reached
+     * from NEntry to the end of input, if NStop = -1 */
     void Run(Int_t NStart = 0, Int_t NStop = 0) override;
     /**Run over the whole input file with timpe window delta_t as unit (entry)*/
     void Run(Double_t delta_t);
+    /** \deprecated Replaced by unambiguous RunSingleEntry(entry)*/
+    [[deprecated("Replaced by unambiguous RunSingleEntry(entry)")]] void Run(Long64_t entry) { RunSingleEntry(entry); }
     /**Run for the given single entry*/
-    void Run(Long64_t entry);
+    void RunSingleEntry(Long64_t entry);
     /**Run event reconstruction from event number NStart to event number NStop */
     /** \deprecated Deprecated along with FairEventBuilder. */
     [[deprecated("Deprecated along with FairEventBuilder.")]] void RunEventReco(Int_t NStart, Int_t NStop);

--- a/fairroot/eventdisplay/FairEventManager.cxx
+++ b/fairroot/eventdisplay/FairEventManager.cxx
@@ -179,7 +179,7 @@ void FairEventManager::GotoEvent(Int_t event)
     fEntry = event;
     fTimeMin = 0;
     fTimeMax = DBL_MAX;
-    fRunAna->Run(static_cast<Long64_t>(event));
+    fRunAna->RunSingleEntry(fEntry);
 }
 
 void FairEventManager::NextEvent()
@@ -187,7 +187,7 @@ void FairEventManager::NextEvent()
     fEntry += 1;
     fTimeMin = 0;
     fTimeMax = DBL_MAX;
-    fRunAna->Run(static_cast<Long64_t>(fEntry));
+    fRunAna->RunSingleEntry(fEntry);
 }
 
 void FairEventManager::PrevEvent()
@@ -195,7 +195,7 @@ void FairEventManager::PrevEvent()
     fEntry -= 1;
     fTimeMin = 0;
     fTimeMax = DBL_MAX;
-    fRunAna->Run(static_cast<Long64_t>(fEntry));
+    fRunAna->RunSingleEntry(fEntry);
 }
 
 void FairEventManager::Close() {}


### PR DESCRIPTION
Deprecated `FairRunAna::Run(Long64_t)` and replaced by newly introduced `FairRunAna::RunSingleEntry(Long64_t)`.

Changed description of `FairRunAna::Run(Int_t, Int_t)` to match the actual function behaviour.

Addresses issue #1397.

Describe your proposal.

Mention any issue this PR resolves or is related to.

---

Checklist:

* [x] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
