### PR TITLE
Remove `virtual` from `FairRun::SetSource()`

### DIFF
--- a/fairroot/base/steer/FairRun.h
+++ b/fairroot/base/steer/FairRun.h
@@ -197,7 +197,7 @@ class FairRun : public TNamed
      *
      * Takes an owning pointer!
      */
-    virtual void SetSource(FairSource* tempSource);
+    void SetSource(FairSource* tempSource);
     /** Return non-owning pointer to source **/
     FairSource* GetSource() { return fSource.get(); }
     FairRootManager& GetRootManager() { return *fRootManager; }

--- a/fairroot/base/steer/FairRunAnaProof.cxx
+++ b/fairroot/base/steer/FairRunAnaProof.cxx
@@ -85,6 +85,11 @@ void FairRunAnaProof::Init()
         // input chain. Do a check if the added files are of the same type
         // as the the input file. Same type means check if they contain the
         // same branch.
+        // FairRunAnaProof should accept only FairFileSource
+        fProofFileSource = dynamic_cast<FairFileSource*>(GetSource());
+        if (!fProofFileSource) {
+            LOG(error) << "FairRunAnaProof. Only FairFileSource is accepted as source";
+        }
     }
     // Load Geometry from user file
 
@@ -254,16 +259,6 @@ void FairRunAnaProof::InitContainers()
             LOG(error) << "FairRunAnaProof::Init: fRtdb->initContainers failed";
         }
     }
-}
-
-void FairRunAnaProof::SetSource(FairSource* tempSource)
-{
-    // FairRunAnaProof should accept only FairFileSource
-    if (strncmp(tempSource->GetName(), "FairFileSource", 14) != 0) {
-        LOG(warn) << "FairRunAnaProof. Seems you are trying to set different source than FairFileSource";
-    }
-    FairRunAna::SetSource(tempSource);
-    fProofFileSource = static_cast<FairFileSource*>(tempSource);
 }
 
 void FairRunAnaProof::Run(Int_t Ev_start, Int_t Ev_end)

--- a/fairroot/base/steer/FairRunAnaProof.h
+++ b/fairroot/base/steer/FairRunAnaProof.h
@@ -58,8 +58,6 @@ class FairRunAnaProof : public FairRunAna
     /** Set PROOF output status, possibilities: "copy","merge"*/
     void SetProofOutputStatus(TString outStat) { fProofOutputStatus = outStat; }
 
-    void SetSource(FairSource* tempSource) override;
-
   protected:
     static FairRunAnaProof* fRAPInstance;
 


### PR DESCRIPTION
It was made `virtual` only to override it in `FairRunAnaProof`. Removed this function from `FairRunAnaProof` and moved the contents of the function to `Init` on the main thread.

It addresses a comment from PR #1423 .

---

Checklist:

* [x] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
