### PR TITLE
fix(examples): Memory Leak of FairRunSim

### DIFF
--- a/examples/MQ/pixelDetector/src/devices/FairMQSimDevice.cxx
+++ b/examples/MQ/pixelDetector/src/devices/FairMQSimDevice.cxx
@@ -17,7 +17,6 @@
 #include "FairModule.h"
 #include "FairParSet.h"
 #include "FairPrimaryGenerator.h"
-#include "FairRunSim.h"
 #include "FairRuntimeDb.h"
 
 #include <TCollection.h>
@@ -31,7 +30,6 @@ FairMQSimDevice::FairMQSimDevice()
     , fSimDeviceId(0)
     , fUpdateChannelName("updateChannel")
     , fRunInitialized(false)
-    , fRunSim(nullptr)
     , fNofEvents(1)
     , fTransportName("TGeant3")
     , fMaterialsFile("")
@@ -46,7 +44,7 @@ FairMQSimDevice::FairMQSimDevice()
 
 void FairMQSimDevice::InitTask()
 {
-    fRunSim = new FairRunSim();
+    fRunSim = std::make_unique<FairRunSim>();
 
     SetupRunSink(*fRunSim);
 
@@ -78,6 +76,11 @@ void FairMQSimDevice::InitTask()
     for (int idet = 0; idet < fDetectorArray->GetEntries(); idet++) {
         fRunSim->AddModule((FairModule*)(fDetectorArray->At(idet)));
     }
+}
+
+void FairMQSimDevice::ResetTask()
+{
+    fRunSim.reset();
 }
 
 void FairMQSimDevice::InitializeRun()

--- a/examples/MQ/pixelDetector/src/devices/FairMQSimDevice.h
+++ b/examples/MQ/pixelDetector/src/devices/FairMQSimDevice.h
@@ -17,6 +17,7 @@
 #define FAIRMQSIMDEVICE_H_
 
 #include "FairMQRunDevice.h"
+#include "FairRunSim.h"
 
 #include <Rtypes.h>
 #include <TString.h>
@@ -24,7 +25,6 @@
 #include <memory>
 #include <string>
 
-class FairRunSim;
 class FairField;
 class FairParIo;
 class FairPrimaryGenerator;
@@ -59,6 +59,7 @@ class FairMQSimDevice : public FairMQRunDevice
 
   protected:
     void InitTask() override;
+    void ResetTask() override;
     void PreRun() override;
     void PostRun() override {}
     bool ConditionalRun() override;
@@ -69,7 +70,7 @@ class FairMQSimDevice : public FairMQRunDevice
 
     bool fRunInitialized;   // false, set to true after initialization in the run stage (!)
 
-    FairRunSim* fRunSim;
+    std::unique_ptr<FairRunSim> fRunSim;
     // ------ FairRunSim settings ------
     int64_t fNofEvents;
     std::string fTransportName;

--- a/examples/MQ/pixelSimSplit/src/devices/FairMQTransportDevice.cxx
+++ b/examples/MQ/pixelSimSplit/src/devices/FairMQTransportDevice.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *
@@ -19,7 +19,6 @@
 #include "FairMCSplitEventHeader.h"
 #include "FairModule.h"
 #include "FairParSet.h"
-#include "FairRunSim.h"
 #include "FairRuntimeDb.h"
 #include "FairTask.h"
 #include "RootSerializer.h"
@@ -46,7 +45,6 @@ FairMQTransportDevice::FairMQTransportDevice()
     , fVMC(nullptr)
     , fStack(nullptr)
     , fMCApplication(nullptr)
-    , fRunSim(nullptr)
     , fNofEvents(1)
     , fTransportName("TGeant3")
     , fMaterialsFile("")
@@ -67,7 +65,7 @@ void FairMQTransportDevice::Init()
 
 void FairMQTransportDevice::InitTask()
 {
-    fRunSim = new FairRunSim();
+    fRunSim = std::make_unique<FairRunSim>();
 
     fMCSplitEventHeader = new FairMCSplitEventHeader(fRunId, 0, 0, 0);
     fRunSim->SetMCEventHeader(fMCSplitEventHeader);
@@ -137,9 +135,13 @@ void FairMQTransportDevice::InitTask()
     }
 }
 
+void FairMQTransportDevice::ResetTask()
+{
+    fRunSim.reset();
+}
+
 void FairMQTransportDevice::InitializeRun()
 {
-
     // -----   Negotiate the run number   -------------------------------------
     // -----      via the fUpdateChannelName   --------------------------------
     // -----      ask the fParamMQServer   ------------------------------------

--- a/examples/MQ/pixelSimSplit/src/devices/FairMQTransportDevice.h
+++ b/examples/MQ/pixelSimSplit/src/devices/FairMQTransportDevice.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2017-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *
@@ -17,6 +17,7 @@
 #define FAIRMQTRANSPORTDEVICE_H_
 
 #include "FairMQRunDevice.h"
+#include "FairRunSim.h"
 
 #include <Rtypes.h>
 #include <TString.h>
@@ -25,7 +26,6 @@
 #include <string>
 
 class FairMCSplitEventHeader;
-class FairRunSim;
 class FairField;
 class FairParIo;
 class TObjArray;
@@ -65,6 +65,7 @@ class FairMQTransportDevice : public FairMQRunDevice
     //  bool TransportData(fair::mq::MessagePtr&, int);
     void Init() override;
     void InitTask() override;
+    void ResetTask() override;
     void PreRun() override;
     void PostRun() override;
     bool ConditionalRun() override;
@@ -81,7 +82,7 @@ class FairMQTransportDevice : public FairMQRunDevice
     TVirtualMC* fVMC;
     FairGenericStack* fStack;
     FairMCApplication* fMCApplication;
-    FairRunSim* fRunSim;
+    std::unique_ptr<FairRunSim> fRunSim;
     // ------ FairRunSim settings ------
     int64_t fNofEvents;
     std::string fTransportName;

--- a/examples/advanced/Tutorial3/macro/run_sim_sep.C
+++ b/examples/advanced/Tutorial3/macro/run_sim_sep.C
@@ -30,49 +30,49 @@ void run_sim_sep(Int_t fileId, Int_t nEvents = 1000, TString mcEngine = "TGeant3
     gSystem->Setenv("CONFIG_DIR", tut_configdir.Data());
 
     // create Instance of Run Manager class
-    FairRunSim *fRun = new FairRunSim();
+    FairRunSim run{};
 
     // set the MC version used
     // ------------------------
 
-    fRun->SetName(mcEngine);
+    run.SetName(mcEngine);
 
     TString outfile = Form("data/testrun_%s_f%d.root", mcEngine.Data(), fileId);
     TString outparam = Form("data/testpar_%s_f%d.root", mcEngine.Data(), fileId);
 
-    fRun->SetSink(new FairRootFileSink(outfile));
+    run.SetSink(new FairRootFileSink(outfile));
 
     // -----   Magnetic field   -------------------------------------------
     // Constant Field
     FairConstField *fMagField = new FairConstField();
     fMagField->SetField(0., 10., 0.);                        // values are in kG
     fMagField->SetFieldRegion(-50, 50, -50, 50, 350, 450);   // values are in cm (xmin,xmax,ymin,ymax,zmin,zmax)
-    fRun->SetField(fMagField);
+    run.SetField(fMagField);
     // --------------------------------------------------------------------
 
     // Set Material file Name
     //-----------------------
-    fRun->SetMaterials("media.geo");
+    run.SetMaterials("media.geo");
 
     // Create and add detectors
     //-------------------------
     FairModule *Cave = new FairCave("CAVE");
     Cave->SetGeometryFileName("cave.geo");
-    fRun->AddModule(Cave);
+    run.AddModule(Cave);
 
     FairModule *Magnet = new FairMagnet("MAGNET");
     Magnet->SetGeometryFileName("magnet.geo");
-    fRun->AddModule(Magnet);
+    run.AddModule(Magnet);
 
     FairDetector *Torino = new FairTestDetector("TORINO", kTRUE);
     Torino->SetGeometryFileName("torino.geo");
-    fRun->AddModule(Torino);
+    run.AddModule(Torino);
 
     // Create and Set Event Generator
     //-------------------------------
 
     FairPrimaryGenerator *primGen = new FairPrimaryGenerator();
-    fRun->SetGenerator(primGen);
+    run.SetGenerator(primGen);
 
     // Box Generator
     FairBoxGenerator *boxGen = new FairBoxGenerator(13, 10);   // 13 = muon; 1 = multipl.
@@ -84,9 +84,9 @@ void run_sim_sep(Int_t fileId, Int_t nEvents = 1000, TString mcEngine = "TGeant3
     // boxGen->SetXYZ(0., 0.37, 0.);
     primGen->AddGenerator(boxGen);
 
-    fRun->SetStoreTraj(kTRUE);
+    run.SetStoreTraj(kTRUE);
 
-    fRun->Init();
+    run.Init();
 
     // -Trajectories Visualization (TGeoManager Only )
     // -----------------------------------------------
@@ -104,7 +104,7 @@ void run_sim_sep(Int_t fileId, Int_t nEvents = 1000, TString mcEngine = "TGeant3
     // Fill the Parameter containers for this run
     //-------------------------------------------
 
-    FairRuntimeDb *rtdb = fRun->GetRuntimeDb();
+    FairRuntimeDb* rtdb = run.GetRuntimeDb();
     Bool_t kParameterMerged = kTRUE;
     FairParRootFileIo *output = new FairParRootFileIo(kParameterMerged);
     output->open(outparam);
@@ -117,9 +117,9 @@ void run_sim_sep(Int_t fileId, Int_t nEvents = 1000, TString mcEngine = "TGeant3
     // -----------------
 
     //  Int_t nEvents = 1;
-    fRun->Run(nEvents);
+    run.Run(nEvents);
 
-    fRun->CreateGeometryFile("data/geofile_full.root");
+    run.CreateGeometryFile("data/geofile_full.root");
 
     // -----   Finish   -------------------------------------------------------
 

--- a/examples/advanced/propagator/macros/runMC.C
+++ b/examples/advanced/propagator/macros/runMC.C
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2019-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2019-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -55,32 +55,32 @@ int runMC(Int_t nEvents = 1000, TString mcEngine = "TGeant4", Bool_t isMT = fals
     // ------------------------------------------------------------------------
 
     // -----   Create simulation run   ----------------------------------------
-    FairRunSim* run = new FairRunSim();
-    run->SetName(mcEngine);   // Transport engine
-    //  run->SetSimulationConfig(new FairVMCConfig());
-    run->SetIsMT(isMT);                            // Multi-threading mode (Geant4 only)
-    run->SetSink(std::make_unique<FairRootFileSink>(outFile));
-    FairRuntimeDb* rtdb = run->GetRuntimeDb();
+    FairRunSim run{};
+    run.SetName(mcEngine);   // Transport engine
+    //  run.SetSimulationConfig(new FairVMCConfig());
+    run.SetIsMT(isMT);   // Multi-threading mode (Geant4 only)
+    run.SetSink(std::make_unique<FairRootFileSink>(outFile));
+    FairRuntimeDb* rtdb = run.GetRuntimeDb();
     // ------------------------------------------------------------------------
 
     // -----   Create media   -------------------------------------------------
-    run->SetMaterials("media.geo");   // Materials
+    run.SetMaterials("media.geo");   // Materials
     // ------------------------------------------------------------------------
 
     // -----   Create geometry   ----------------------------------------------
 
     FairModule* cave = new FairCave("CAVE");
     cave->SetGeometryFileName("cave_vacuum.geo");
-    run->AddModule(cave);
+    run.AddModule(cave);
 
     FairTutPropDet* det = new FairTutPropDet("TutPropDetector", kTRUE);
     det->SetGeometryFileName("tutProp.geo");
-    run->AddModule(det);
+    run.AddModule(det);
 
     FairTutPropDet* det2 = new FairTutPropDet("TutPropDetector2", kTRUE);
     det2->SetGeometryFileName("tutProp2.geo");
     det2->SetPointsArrayName("FairTutPropPoint2");
-    run->AddModule(det2);
+    run.AddModule(det2);
     // ------------------------------------------------------------------------
 
     // -----   Create PrimaryGenerator   --------------------------------------
@@ -99,13 +99,13 @@ int runMC(Int_t nEvents = 1000, TString mcEngine = "TGeant4", Bool_t isMT = fals
     FairConstField* fMagField = new FairConstField();
     fMagField->SetField(0., 0., 20.);                             // values are in kG
     fMagField->SetFieldRegion(-150, 150, -150, 150, -250, 250);   // values are in cm (xmin,xmax,ymin,ymax,zmin,zmax)
-    run->SetField(fMagField);
+    run.SetField(fMagField);
 
-    run->SetGenerator(primGen);
+    run.SetGenerator(primGen);
     // ------------------------------------------------------------------------
-    run->SetStoreTraj(kTRUE);
+    run.SetStoreTraj(kTRUE);
     // -----   Initialize simulation run   ------------------------------------
-    run->Init();
+    run.Init();
     // ------------------------------------------------------------------------
     FairTrajFilter* trajFilter = FairTrajFilter::Instance();
     trajFilter->SetStepSizeCut(0.01);   // 1 cm
@@ -126,8 +126,8 @@ int runMC(Int_t nEvents = 1000, TString mcEngine = "TGeant4", Bool_t isMT = fals
     // ------------------------------------------------------------------------
 
     // -----   Start run   ----------------------------------------------------
-    run->Run(nEvents);
-    run->CreateGeometryFile(geoFile);
+    run.Run(nEvents);
+    run.CreateGeometryFile(geoFile);
     // ------------------------------------------------------------------------
 
     // -----   Finish   -------------------------------------------------------

--- a/examples/advanced/propagator/macros/runMM.C
+++ b/examples/advanced/propagator/macros/runMM.C
@@ -47,32 +47,32 @@ int runMM(Int_t nEvents = 1000, TString mcEngine = "TGeant4", Bool_t isMT = fals
     // ------------------------------------------------------------------------
 
     // -----   Create simulation run   ----------------------------------------
-    FairRunSim* run = new FairRunSim();
-    run->SetName(mcEngine);   // Transport engine
-    //  run->SetSimulationConfig(new FairVMCConfig());
-    run->SetIsMT(isMT);                            // Multi-threading mode (Geant4 only)
-    run->SetSink(new FairRootFileSink(outFile));   // Output file
-    FairRuntimeDb* rtdb = run->GetRuntimeDb();
+    FairRunSim run{};
+    run.SetName(mcEngine);   // Transport engine
+    //  run.SetSimulationConfig(new FairVMCConfig());
+    run.SetIsMT(isMT);                            // Multi-threading mode (Geant4 only)
+    run.SetSink(new FairRootFileSink(outFile));   // Output file
+    FairRuntimeDb* rtdb = run.GetRuntimeDb();
     // ------------------------------------------------------------------------
 
     // -----   Create media   -------------------------------------------------
-    run->SetMaterials("media.geo");   // Materials
+    run.SetMaterials("media.geo");   // Materials
     // ------------------------------------------------------------------------
 
     // -----   Create geometry   ----------------------------------------------
 
     FairModule* cave = new FairCave("CAVE");
     cave->SetGeometryFileName("cave_vacuum.geo");
-    run->AddModule(cave);
+    run.AddModule(cave);
 
     FairTutPropDet* det = new FairTutPropDet("TutPropDetector", kTRUE);
     det->SetGeometryFileName("tutProp.geo");
-    run->AddModule(det);
+    run.AddModule(det);
 
     FairTutPropDet* det2 = new FairTutPropDet("TutPropDetector", kTRUE);
     det2->SetGeometryFileName("tutProp2.geo");
     det2->SetPointsArrayName("FairTutPropPoint2");
-    run->AddModule(det2);
+    run.AddModule(det2);
     // ------------------------------------------------------------------------
 
     // -----   Create PrimaryGenerator   --------------------------------------
@@ -99,13 +99,13 @@ int runMM(Int_t nEvents = 1000, TString mcEngine = "TGeant4", Bool_t isMT = fals
     FairConstField* fMagField = new FairConstField();
     fMagField->SetField(0., 0., 20.);                             // values are in kG
     fMagField->SetFieldRegion(-150, 150, -150, 150, -250, 250);   // values are in cm (xmin,xmax,ymin,ymax,zmin,zmax)
-    run->SetField(fMagField);
+    run.SetField(fMagField);
 
-    run->SetGenerator(primGen);
+    run.SetGenerator(primGen);
     // ------------------------------------------------------------------------
 
     // -----   Initialize simulation run   ------------------------------------
-    run->Init();
+    run.Init();
     // ------------------------------------------------------------------------
 
     // -----   Runtime database   ---------------------------------------------
@@ -119,8 +119,8 @@ int runMM(Int_t nEvents = 1000, TString mcEngine = "TGeant4", Bool_t isMT = fals
     // ------------------------------------------------------------------------
 
     // -----   Start run   ----------------------------------------------------
-    run->Run(nEvents);
-    run->CreateGeometryFile(geoFile);
+    run.Run(nEvents);
+    run.CreateGeometryFile(geoFile);
     // ------------------------------------------------------------------------
 
     // -----   Finish   -------------------------------------------------------

--- a/examples/simulation/Tutorial1/macros/run_tutorial1_fastsim.C
+++ b/examples/simulation/Tutorial1/macros/run_tutorial1_fastsim.C
@@ -64,32 +64,32 @@ void run_tutorial1_fastsim(Int_t nEvents = 10, TString mcEngine = "TGeant3", Boo
     // ------------------------------------------------------------------------
 
     // -----   Create simulation run   ----------------------------------------
-    FairRunSim* run = new FairRunSim();
-    run->SetName(mcEngine);                        // Transport engine
-    run->SetIsMT(isMT);                            // Multi-threading mode (Geant4 only)
-    run->SetSink(new FairRootFileSink(outFile));   // Output file
-    FairRuntimeDb* rtdb = run->GetRuntimeDb();
+    FairRunSim run{};
+    run.SetName(mcEngine);                        // Transport engine
+    run.SetIsMT(isMT);                            // Multi-threading mode (Geant4 only)
+    run.SetSink(new FairRootFileSink(outFile));   // Output file
+    FairRuntimeDb* rtdb = run.GetRuntimeDb();
     // ------------------------------------------------------------------------
 
     // -----   Create media   -------------------------------------------------
-    run->SetMaterials("media.geo");   // Materials
+    run.SetMaterials("media.geo");   // Materials
     // ------------------------------------------------------------------------
 
     // -----   Create geometry   ----------------------------------------------
 
     FairModule* cave = new FairCave("CAVE");
     cave->SetGeometryFileName("cave_vacuum.geo");
-    run->AddModule(cave);
+    run.AddModule(cave);
 
     FairDetector* fastsim = new FairFastSimExample("FastSim");
-    run->AddModule(fastsim);
+    run.AddModule(fastsim);
 
     FairDetector* fastsim2 = new FairFastSimExample2("FastSim2");
-    run->AddModule(fastsim2);
+    run.AddModule(fastsim2);
 
     FairDetector* tutdet = new FairTutorialDet1("TUTDET", kTRUE);
     tutdet->SetGeometryFileName("double_sector.geo");
-    run->AddModule(tutdet);
+    run.AddModule(tutdet);
     // ------------------------------------------------------------------------
 
     // -----   Create PrimaryGenerator   --------------------------------------
@@ -103,7 +103,7 @@ void run_tutorial1_fastsim(Int_t nEvents = 10, TString mcEngine = "TGeant3", Boo
 
     primGen->AddGenerator(boxGen);
 
-    run->SetGenerator(primGen);
+    run.SetGenerator(primGen);
     // ------------------------------------------------------------------------
 
     // -----   Initialize simulation run   ------------------------------------
@@ -111,11 +111,11 @@ void run_tutorial1_fastsim(Int_t nEvents = 10, TString mcEngine = "TGeant3", Boo
     TRandom3 random(randomSeed);
     gRandom = &random;
 
-    run->SetStoreTraj(kTRUE);
+    run.SetStoreTraj(kTRUE);
 
     gLogger->SetLogScreenLevel("info");
 
-    run->Init();
+    run.Init();
     // ------------------------------------------------------------------------
 
     // -----   Runtime database   ---------------------------------------------
@@ -129,8 +129,8 @@ void run_tutorial1_fastsim(Int_t nEvents = 10, TString mcEngine = "TGeant3", Boo
     // ------------------------------------------------------------------------
 
     // -----   Start run   ----------------------------------------------------
-    run->Run(nEvents);
-    run->CreateGeometryFile(geoFile);
+    run.Run(nEvents);
+    run.CreateGeometryFile(geoFile);
     // ------------------------------------------------------------------------
 
     // -----   Finish   -------------------------------------------------------

--- a/examples/simulation/Tutorial1/macros/run_tutorial1_mesh.C
+++ b/examples/simulation/Tutorial1/macros/run_tutorial1_mesh.C
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -63,25 +63,25 @@ void run_tutorial1_mesh(Int_t nEvents = 10, TString mcEngine = "TGeant3")
     // ------------------------------------------------------------------------
 
     // -----   Create simulation run   ----------------------------------------
-    FairRunSim* run = new FairRunSim();
-    run->SetName(mcEngine);                        // Transport engine
-    run->SetSink(std::make_unique<FairRootFileSink>(outFile));
-    FairRuntimeDb* rtdb = run->GetRuntimeDb();
+    FairRunSim run{};
+    run.SetName(mcEngine);   // Transport engine
+    run.SetSink(std::make_unique<FairRootFileSink>(outFile));
+    FairRuntimeDb* rtdb = run.GetRuntimeDb();
     // ------------------------------------------------------------------------
 
     // -----   Create media   -------------------------------------------------
-    run->SetMaterials("media.geo");   // Materials
+    run.SetMaterials("media.geo");   // Materials
     // ------------------------------------------------------------------------
 
     // -----   Create geometry   ----------------------------------------------
 
     FairModule* cave = new FairCave("CAVE");
     cave->SetGeometryFileName("cave_vacuum.geo");
-    run->AddModule(cave);
+    run.AddModule(cave);
 
     FairDetector* tutdet = new FairTutorialDet1("TUTDET", kTRUE);
     tutdet->SetGeometryFileName("double_sector.geo");
-    run->AddModule(tutdet);
+    run.AddModule(tutdet);
     // ------------------------------------------------------------------------
 
     // -----   Create PrimaryGenerator   --------------------------------------
@@ -96,12 +96,12 @@ void run_tutorial1_mesh(Int_t nEvents = 10, TString mcEngine = "TGeant3")
 
     primGen->AddGenerator(boxGen);
 
-    run->SetGenerator(primGen);
+    run.SetGenerator(primGen);
     // ------------------------------------------------------------------------
 
-    run->SetStoreTraj(kFALSE);   // to store particle trajectories
+    run.SetStoreTraj(kFALSE);   // to store particle trajectories
 
-    run->SetRadGridRegister(kTRUE);   // activate RadGridManager
+    run.SetRadGridRegister(kTRUE);   // activate RadGridManager
 
     // define two example meshs for dosimetry
     FairMesh* aMesh1 = new FairMesh("test1");
@@ -117,12 +117,12 @@ void run_tutorial1_mesh(Int_t nEvents = 10, TString mcEngine = "TGeant3")
     aMesh1->print();
     aMesh2->print();
 
-    run->AddMesh(aMesh1);
-    run->AddMesh(aMesh2);
+    run.AddMesh(aMesh1);
+    run.AddMesh(aMesh2);
 
     // -----   Initialize simulation run   ------------------------------------
-    run->Init();
-    run->GetMCApplication()->GetRadGridMan()->SetOutputFileName("radGridResults.root");
+    run.Init();
+    run.GetMCApplication()->GetRadGridMan()->SetOutputFileName("radGridResults.root");
     // ------------------------------------------------------------------------
 
     // -----   Runtime database   ---------------------------------------------
@@ -136,7 +136,7 @@ void run_tutorial1_mesh(Int_t nEvents = 10, TString mcEngine = "TGeant3")
     // ------------------------------------------------------------------------
 
     // -----   Start run   ----------------------------------------------------
-    run->Run(nEvents);
+    run.Run(nEvents);
     // ------------------------------------------------------------------------
 
     // -----   Finish   -------------------------------------------------------

--- a/examples/simulation/Tutorial1/macros/run_tutorial1_pythia6.C
+++ b/examples/simulation/Tutorial1/macros/run_tutorial1_pythia6.C
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -67,27 +67,27 @@ void run_tutorial1_pythia6(Int_t nEvents = 10, TString mcEngine = "TGeant3")
     // ------------------------------------------------------------------------
 
     // -----   Create simulation run   ----------------------------------------
-    FairRunSim* run = new FairRunSim();
-    run->SetName(mcEngine);                        // Transport engine
-    run->SetSink(std::make_unique<FairRootFileSink>(outFile));
-    run->SetPythiaDecayer(pythia6Config);          // Define Pythia6 as decayer
+    FairRunSim run{};
+    run.SetName(mcEngine);   // Transport engine
+    run.SetSink(std::make_unique<FairRootFileSink>(outFile));
+    run.SetPythiaDecayer(pythia6Config);   // Define Pythia6 as decayer
 
-    FairRuntimeDb* rtdb = run->GetRuntimeDb();
+    FairRuntimeDb* rtdb = run.GetRuntimeDb();
     // ------------------------------------------------------------------------
 
     // -----   Create media   -------------------------------------------------
-    run->SetMaterials("media.geo");   // Materials
+    run.SetMaterials("media.geo");   // Materials
     // ------------------------------------------------------------------------
 
     // -----   Create geometry   ----------------------------------------------
 
     FairModule* cave = new FairCave("CAVE");
     cave->SetGeometryFileName("cave_vacuum.geo");
-    run->AddModule(cave);
+    run.AddModule(cave);
 
     FairDetector* tutdet = new FairTutorialDet1("TUTDET", kTRUE);
     tutdet->SetGeometryFileName("double_sector.geo");
-    run->AddModule(tutdet);
+    run.AddModule(tutdet);
     // ------------------------------------------------------------------------
 
     // -----   Create PrimaryGenerator   --------------------------------------
@@ -101,11 +101,11 @@ void run_tutorial1_pythia6(Int_t nEvents = 10, TString mcEngine = "TGeant3")
 
     primGen->AddGenerator(boxGen);
 
-    run->SetGenerator(primGen);
+    run.SetGenerator(primGen);
     // ------------------------------------------------------------------------
 
     // -----   Initialize simulation run   ------------------------------------
-    run->Init();
+    run.Init();
     // ------------------------------------------------------------------------
 
     // -----   Runtime database   ---------------------------------------------
@@ -119,8 +119,8 @@ void run_tutorial1_pythia6(Int_t nEvents = 10, TString mcEngine = "TGeant3")
     // ------------------------------------------------------------------------
 
     // -----   Start run   ----------------------------------------------------
-    run->Run(nEvents);
-    run->CreateGeometryFile(geoFile);
+    run.Run(nEvents);
+    run.CreateGeometryFile(geoFile);
     // ------------------------------------------------------------------------
 
     // -----   Finish   -------------------------------------------------------

--- a/examples/simulation/Tutorial1/macros/run_tutorial1_pythia8.C
+++ b/examples/simulation/Tutorial1/macros/run_tutorial1_pythia8.C
@@ -67,27 +67,27 @@ void run_tutorial1_pythia8(Int_t nEvents = 10, TString mcEngine = "TGeant3")
     // ------------------------------------------------------------------------
 
     // -----   Create simulation run   ----------------------------------------
-    FairRunSim* run = new FairRunSim();
-    run->SetName(mcEngine);                        // Transport engine
-    run->SetSink(std::make_unique<FairRootFileSink>(outFile));
-    run->SetPythiaDecayer(pythia8Config);          // Define Pythia8 as decayer
+    FairRunSim run{};
+    run.SetName(mcEngine);   // Transport engine
+    run.SetSink(std::make_unique<FairRootFileSink>(outFile));
+    run.SetPythiaDecayer(pythia8Config);   // Define Pythia8 as decayer
 
-    FairRuntimeDb* rtdb = run->GetRuntimeDb();
+    FairRuntimeDb* rtdb = run.GetRuntimeDb();
     // ------------------------------------------------------------------------
 
     // -----   Create media   -------------------------------------------------
-    run->SetMaterials("media.geo");   // Materials
+    run.SetMaterials("media.geo");   // Materials
     // ------------------------------------------------------------------------
 
     // -----   Create geometry   ----------------------------------------------
 
     FairModule* cave = new FairCave("CAVE");
     cave->SetGeometryFileName("cave_vacuum.geo");
-    run->AddModule(cave);
+    run.AddModule(cave);
 
     FairDetector* tutdet = new FairTutorialDet1("TUTDET", kTRUE);
     tutdet->SetGeometryFileName("double_sector.geo");
-    run->AddModule(tutdet);
+    run.AddModule(tutdet);
     // ------------------------------------------------------------------------
 
     // -----   Create PrimaryGenerator   --------------------------------------
@@ -101,11 +101,11 @@ void run_tutorial1_pythia8(Int_t nEvents = 10, TString mcEngine = "TGeant3")
 
     primGen->AddGenerator(boxGen);
 
-    run->SetGenerator(primGen);
+    run.SetGenerator(primGen);
     // ------------------------------------------------------------------------
 
     // -----   Initialize simulation run   ------------------------------------
-    run->Init();
+    run.Init();
     // ------------------------------------------------------------------------
 
     // -----   Runtime database   ---------------------------------------------
@@ -119,8 +119,8 @@ void run_tutorial1_pythia8(Int_t nEvents = 10, TString mcEngine = "TGeant3")
     // ------------------------------------------------------------------------
 
     // -----   Start run   ----------------------------------------------------
-    run->Run(nEvents);
-    run->CreateGeometryFile(geoFile);
+    run.Run(nEvents);
+    run.CreateGeometryFile(geoFile);
     // ------------------------------------------------------------------------
 
     // -----   Finish   -------------------------------------------------------

--- a/examples/simulation/Tutorial1/macros/run_tutorial1_urqmd.C
+++ b/examples/simulation/Tutorial1/macros/run_tutorial1_urqmd.C
@@ -53,25 +53,25 @@ void run_tutorial1_urqmd(Int_t nEvents = 2, TString mcEngine = "TGeant3")
     // ------------------------------------------------------------------------
 
     // -----   Create simulation run   ----------------------------------------
-    FairRunSim* run = new FairRunSim();
-    run->SetName(mcEngine);                        // Transport engine
-    run->SetSink(std::make_unique<FairRootFileSink>(outFile));
-    FairRuntimeDb* rtdb = run->GetRuntimeDb();
+    FairRunSim run{};
+    run.SetName(mcEngine);   // Transport engine
+    run.SetSink(std::make_unique<FairRootFileSink>(outFile));
+    FairRuntimeDb* rtdb = run.GetRuntimeDb();
     // ------------------------------------------------------------------------
 
     // -----   Create media   -------------------------------------------------
-    run->SetMaterials("media.geo");   // Materials
+    run.SetMaterials("media.geo");   // Materials
     // ------------------------------------------------------------------------
 
     // -----   Create geometry   ----------------------------------------------
 
     FairModule* cave = new FairCave("CAVE");
     cave->SetGeometryFileName("cave_vacuum.geo");
-    run->AddModule(cave);
+    run.AddModule(cave);
 
     FairDetector* tutdet = new FairTutorialDet1("TUTDET", kTRUE);
     tutdet->SetGeometryFileName("double_sector.geo");
-    run->AddModule(tutdet);
+    run.AddModule(tutdet);
     // ------------------------------------------------------------------------
 
     // -----   Create PrimaryGenerator   --------------------------------------
@@ -80,11 +80,11 @@ void run_tutorial1_urqmd(Int_t nEvents = 2, TString mcEngine = "TGeant3")
     FairUrqmdGenerator* urqmdGen = new FairUrqmdGenerator(inFile.Data(), Urqmd_Conversion_table.Data());
     primGen->AddGenerator(urqmdGen);
 
-    run->SetGenerator(primGen);
+    run.SetGenerator(primGen);
     // ------------------------------------------------------------------------
 
     // -----   Initialize simulation run   ------------------------------------
-    run->Init();
+    run.Init();
     // ------------------------------------------------------------------------
 
     // -----   Runtime database   ---------------------------------------------
@@ -98,8 +98,8 @@ void run_tutorial1_urqmd(Int_t nEvents = 2, TString mcEngine = "TGeant3")
     // ------------------------------------------------------------------------
 
     // -----   Start run   ----------------------------------------------------
-    run->Run(nEvents);
-    run->CreateGeometryFile(geoFile);
+    run.Run(nEvents);
+    run.CreateGeometryFile(geoFile);
     // ------------------------------------------------------------------------
 
     // -----   Finish   -------------------------------------------------------

--- a/examples/simulation/Tutorial4/macros/run_tutorial4.C
+++ b/examples/simulation/Tutorial4/macros/run_tutorial4.C
@@ -73,27 +73,27 @@ void run_tutorial4(Int_t nEvents = 10, TString mcEngine = "TGeant3", Bool_t doAl
     //  gLogger->SetLogScreenLevel("INFO");
 
     // -----   Create simulation run   ----------------------------------------
-    FairRunSim* run = new FairRunSim();
-    run->SetName(mcEngine);                        // Transport engine
-    run->SetIsMT(isMT);                            // Multi-threading mode (Geant4 only)
-    run->SetSink(std::make_unique<FairRootFileSink>(outFile));
-    FairRuntimeDb* rtdb = run->GetRuntimeDb();
+    FairRunSim run{};
+    run.SetName(mcEngine);   // Transport engine
+    run.SetIsMT(isMT);       // Multi-threading mode (Geant4 only)
+    run.SetSink(std::make_unique<FairRootFileSink>(outFile));
+    FairRuntimeDb* rtdb = run.GetRuntimeDb();
     // ------------------------------------------------------------------------
 
     // -----   Create media   -------------------------------------------------
-    run->SetMaterials("media.geo");   // Materials
+    run.SetMaterials("media.geo");   // Materials
     // ------------------------------------------------------------------------
 
     // -----   Create geometry   ----------------------------------------------
     FairModule* cave = new FairCave("CAVE");
     cave->SetGeometryFileName("cave_vacuum.geo");
-    run->AddModule(cave);
+    run.AddModule(cave);
 
     FairTutorialDet4* tutdet = new FairTutorialDet4("TUTDET", kTRUE);
     tutdet->SetGeometryFileName("tutorial4.root");
     tutdet->SetModifyGeometry(doAlign);
 
-    run->AddModule(tutdet);
+    run.AddModule(tutdet);
     // ------------------------------------------------------------------------
 
     // -----   Create PrimaryGenerator   --------------------------------------
@@ -111,10 +111,10 @@ void run_tutorial4(Int_t nEvents = 10, TString mcEngine = "TGeant3", Bool_t doAl
 
     primGen->AddGenerator(boxGen);
 
-    run->SetGenerator(primGen);
+    run.SetGenerator(primGen);
 
     // -----  Store information about particle trajectories  ------------------
-    run->SetStoreTraj(kTRUE);
+    run.SetStoreTraj(kTRUE);
 
     // -----   Runtime database   ---------------------------------------------
 
@@ -128,7 +128,7 @@ void run_tutorial4(Int_t nEvents = 10, TString mcEngine = "TGeant3", Bool_t doAl
     // ------------------------------------------------------------------------
 
     // -----   Initialize simulation run   ------------------------------------
-    run->Init();
+    run.Init();
 
     // -Trajectories Visualization (TGeoManager Only )
     // -----------------------------------------------
@@ -146,15 +146,13 @@ void run_tutorial4(Int_t nEvents = 10, TString mcEngine = "TGeant3", Bool_t doAl
     // ------------------------------------------------------------------------
 
     // -----   Start run   ----------------------------------------------------
-    // run->CreateGeometryFile(geoFile); //misaligned geometry
-    run->Run(nEvents);
-    // run->CreateGeometryFile(geoFile); // original geometry
+    // run.CreateGeometryFile(geoFile); //misaligned geometry
+    run.Run(nEvents);
+    // run.CreateGeometryFile(geoFile); // original geometry
     // ------------------------------------------------------------------------
 
     rtdb->saveOutput();
     rtdb->print();
-
-    delete run;
 
     // -----   Finish   -------------------------------------------------------
 

--- a/examples/simulation/Tutorial4/macros/run_tutorial4_createGeometryFile.C
+++ b/examples/simulation/Tutorial4/macros/run_tutorial4_createGeometryFile.C
@@ -66,26 +66,26 @@ void run_tutorial4_createGeometryFile(Int_t nEvents = 1, TString mcEngine = "TGe
     //  gLogger->SetLogScreenLevel("INFO");
 
     // -----   Create simulation run   ----------------------------------------
-    FairRunSim* run = new FairRunSim();
-    run->SetName(mcEngine);                        // Transport engine
-    run->SetIsMT(isMT);                            // Multi-threading mode (Geant4 only)
-    run->SetSink(new FairRootFileSink(outFile));   // Output file
-    FairRuntimeDb* rtdb = run->GetRuntimeDb();
+    FairRunSim run{};
+    run.SetName(mcEngine);                        // Transport engine
+    run.SetIsMT(isMT);                            // Multi-threading mode (Geant4 only)
+    run.SetSink(new FairRootFileSink(outFile));   // Output file
+    FairRuntimeDb* rtdb = run.GetRuntimeDb();
     // ------------------------------------------------------------------------
 
     // -----   Create media   -------------------------------------------------
-    run->SetMaterials("media.geo");   // Materials
+    run.SetMaterials("media.geo");   // Materials
     // ------------------------------------------------------------------------
 
     // -----   Create geometry   ----------------------------------------------
     FairModule* cave = new FairCave("CAVE");
     cave->SetGeometryFileName("cave_vacuum.geo");
-    run->AddModule(cave);
+    run.AddModule(cave);
 
     FairTutorialDet4* tutdet = new FairTutorialDet4("TUTDET", kTRUE);
     tutdet->SetGeometryFileName("tutorial4.root");
 
-    run->AddModule(tutdet);
+    run.AddModule(tutdet);
     // ------------------------------------------------------------------------
 
     // -----   Create PrimaryGenerator   --------------------------------------
@@ -103,7 +103,7 @@ void run_tutorial4_createGeometryFile(Int_t nEvents = 1, TString mcEngine = "TGe
 
     primGen->AddGenerator(boxGen);
 
-    run->SetGenerator(primGen);
+    run.SetGenerator(primGen);
     // ------------------------------------------------------------------------
 
     // -----   Runtime database   ---------------------------------------------
@@ -117,19 +117,17 @@ void run_tutorial4_createGeometryFile(Int_t nEvents = 1, TString mcEngine = "TGe
     rtdb->setOutput(parOut);
     // ------------------------------------------------------------------------
 
-    run->Init();
+    run.Init();
 
     // ------------------------------------------------------------------------
 
     // -----   Start run   ----------------------------------------------------
-    run->Run(nEvents);
-    run->CreateGeometryFile(geoFile);
+    run.Run(nEvents);
+    run.CreateGeometryFile(geoFile);
     // ------------------------------------------------------------------------
 
     rtdb->saveOutput();
     rtdb->print();
-
-    delete run;
 
     // -----   Finish   -------------------------------------------------------
 

--- a/examples/simulation/Tutorial4/macros/run_tutorial4_createMatrices.C
+++ b/examples/simulation/Tutorial4/macros/run_tutorial4_createMatrices.C
@@ -63,26 +63,26 @@ void run_tutorial4_createMatrices(Int_t nEvents = 10, TString mcEngine = "TGeant
     //  gLogger->SetLogScreenLevel("INFO");
 
     // -----   Create simulation run   ----------------------------------------
-    FairRunSim* run = new FairRunSim();
-    run->SetName(mcEngine);                        // Transport engine
-    run->SetIsMT(isMT);                            // Multi-threading mode (Geant4 only)
-    run->SetSink(new FairRootFileSink(outFile));   // Output file
-    FairRuntimeDb* rtdb = run->GetRuntimeDb();
+    FairRunSim run{};
+    run.SetName(mcEngine);                        // Transport engine
+    run.SetIsMT(isMT);                            // Multi-threading mode (Geant4 only)
+    run.SetSink(new FairRootFileSink(outFile));   // Output file
+    FairRuntimeDb* rtdb = run.GetRuntimeDb();
     // ------------------------------------------------------------------------
 
     // -----   Create media   -------------------------------------------------
-    run->SetMaterials("media.geo");   // Materials
+    run.SetMaterials("media.geo");   // Materials
     // ------------------------------------------------------------------------
 
     // -----   Create geometry   ----------------------------------------------
     FairModule* cave = new FairCave("CAVE");
     cave->SetGeometryFileName("cave_vacuum.geo");
-    run->AddModule(cave);
+    run.AddModule(cave);
 
     FairTutorialDet4* tutdet = new FairTutorialDet4("TUTDET", kTRUE);
     tutdet->SetGeometryFileName("tutorial4.root");
 
-    run->AddModule(tutdet);
+    run.AddModule(tutdet);
     // ------------------------------------------------------------------------
 
     // -----   Create PrimaryGenerator   --------------------------------------
@@ -100,11 +100,11 @@ void run_tutorial4_createMatrices(Int_t nEvents = 10, TString mcEngine = "TGeant
 
     primGen->AddGenerator(boxGen);
 
-    run->SetGenerator(primGen);
+    run.SetGenerator(primGen);
     // ------------------------------------------------------------------------
 
     // -----   Initialize simulation run   ------------------------------------
-    run->SetStoreTraj(kTRUE);
+    run.SetStoreTraj(kTRUE);
 
     // -----   Runtime database   ---------------------------------------------
 
@@ -117,7 +117,7 @@ void run_tutorial4_createMatrices(Int_t nEvents = 10, TString mcEngine = "TGeant
     rtdb->setOutput(parOut);
     // ------------------------------------------------------------------------
 
-    run->Init();
+    run.Init();
 
     // sadly, the align parameters are only available AFTER we called fRun->Init()
 

--- a/examples/simulation/rutherford/macros/run_rad.C
+++ b/examples/simulation/rutherford/macros/run_rad.C
@@ -58,38 +58,38 @@ void run_rad(Int_t nEvents = 100, TString mcEngine = "TGeant4")
     logger->SetLogVerbosityLevel("HIGH");
 
     // -----   Create simulation run   ----------------------------------------
-    FairRunSim* run = new FairRunSim();
-    run->SetName(mcEngine);                        // Transport engine
-    run->SetSink(std::make_unique<FairRootFileSink>(outFile));
-    FairRuntimeDb* rtdb = run->GetRuntimeDb();
+    FairRunSim run{};
+    run.SetName(mcEngine);   // Transport engine
+    run.SetSink(std::make_unique<FairRootFileSink>(outFile));
+    FairRuntimeDb* rtdb = run.GetRuntimeDb();
     // ------------------------------------------------------------------------
 
     // -----   Create media   -------------------------------------------------
-    run->SetMaterials("media.geo");   // Materials
+    run.SetMaterials("media.geo");   // Materials
     // ------------------------------------------------------------------------
 
     //----Start the radiation length manager ----------------------------------
 
-    run->SetRadLenRegister(kTRUE);
+    run.SetRadLenRegister(kTRUE);
 
     // -----   Create geometry   ----------------------------------------------
 
     FairModule* cave = new FairCave("CAVE");
     cave->SetGeometryFileName("cave_vacuum.geo");
-    run->AddModule(cave);
+    run.AddModule(cave);
 
     FairModule* target = new FairTarget("Target");
     target->SetGeometryFileName("target_rutherford.geo");
-    run->AddModule(target);
+    run.AddModule(target);
 
     FairDetector* rutherford = new FairRutherford("RutherfordDetector", kFALSE);
     rutherford->SetGeometryFileName("rutherford.geo");
-    run->AddModule(rutherford);
+    run.AddModule(rutherford);
     // ------------------------------------------------------------------------
 
     // -----   Create PrimaryGenerator   --------------------------------------
     FairPrimaryGenerator* primGen = new FairPrimaryGenerator();
-    run->SetGenerator(primGen);
+    run.SetGenerator(primGen);
 
     FairBoxGenerator* boxGen1 = new FairBoxGenerator(0, 1);
     boxGen1->SetPRange(.005, .005);
@@ -100,10 +100,10 @@ void run_rad(Int_t nEvents = 100, TString mcEngine = "TGeant4")
 
     // ------------------------------------------------------------------------
 
-    run->SetStoreTraj(kTRUE);
+    run.SetStoreTraj(kTRUE);
 
     // -----   Run initialisation   -------------------------------------------
-    run->Init();
+    run.Init();
     // ------------------------------------------------------------------------
 
     // Set cuts for storing the trajectories.
@@ -131,9 +131,9 @@ void run_rad(Int_t nEvents = 100, TString mcEngine = "TGeant4")
     // ------------------------------------------------------------------------
 
     // -----   Start run   ----------------------------------------------------
-    run->Run(nEvents);
+    run.Run(nEvents);
     // ------------------------------------------------------------------------
-    run->CreateGeometryFile(geoFile);
+    run.CreateGeometryFile(geoFile);
 
     // -----   Finish   -------------------------------------------------------
 

--- a/examples/simulation/rutherford/macros/run_rutherford.C
+++ b/examples/simulation/rutherford/macros/run_rutherford.C
@@ -63,36 +63,36 @@ void run_rutherford(Int_t nEvents = 10, TString mcEngine = "TGeant4", Bool_t isM
     logger->SetLogVerbosityLevel("HIGH");
 
     // -----   Create simulation run   ----------------------------------------
-    FairRunSim* run = new FairRunSim();
-    run->SetName(mcEngine);                        // Transport engine
-    run->SetIsMT(isMT);                            // Multi-threading mode (Geant4 only)
-    run->SetSink(std::make_unique<FairRootFileSink>(outFile));
-    FairRuntimeDb* rtdb = run->GetRuntimeDb();
+    FairRunSim run{};
+    run.SetName(mcEngine);   // Transport engine
+    run.SetIsMT(isMT);       // Multi-threading mode (Geant4 only)
+    run.SetSink(std::make_unique<FairRootFileSink>(outFile));
+    FairRuntimeDb* rtdb = run.GetRuntimeDb();
     // ------------------------------------------------------------------------
 
-    run->SetGenerateRunInfo(kFALSE);
+    run.SetGenerateRunInfo(kFALSE);
     // -----   Create media   -------------------------------------------------
-    run->SetMaterials("media.geo");   // Materials
+    run.SetMaterials("media.geo");   // Materials
     // ------------------------------------------------------------------------
 
     // -----   Create geometry   ----------------------------------------------
 
     FairModule* cave = new FairCave("CAVE");
     cave->SetGeometryFileName("cave_vacuum.geo");
-    run->AddModule(cave);
+    run.AddModule(cave);
 
     FairModule* target = new FairTarget("Target");
     target->SetGeometryFileName("target_rutherford.geo");
-    run->AddModule(target);
+    run.AddModule(target);
 
     FairDetector* rutherford = new FairRutherford("RutherfordDetector", kTRUE);
     rutherford->SetGeometryFileName("rutherford.geo");
-    run->AddModule(rutherford);
+    run.AddModule(rutherford);
     // ------------------------------------------------------------------------
 
     // -----   Create PrimaryGenerator   --------------------------------------
     FairPrimaryGenerator* primGen = new FairPrimaryGenerator();
-    run->SetGenerator(primGen);
+    run.SetGenerator(primGen);
 
     // Ion Generator
 
@@ -119,10 +119,10 @@ void run_rutherford(Int_t nEvents = 10, TString mcEngine = "TGeant4", Bool_t isM
     primGen->AddGenerator(ypt);
     // ------------------------------------------------------------------------
 
-    run->SetStoreTraj(kTRUE);
+    run.SetStoreTraj(kTRUE);
 
     // -----   Run initialisation   -------------------------------------------
-    run->Init();
+    run.Init();
     // ------------------------------------------------------------------------
 
     // Set cuts for storing the trajectories.
@@ -150,9 +150,9 @@ void run_rutherford(Int_t nEvents = 10, TString mcEngine = "TGeant4", Bool_t isM
     // ------------------------------------------------------------------------
 
     // -----   Start run   ----------------------------------------------------
-    run->Run(nEvents);
+    run.Run(nEvents);
     // ------------------------------------------------------------------------
-    run->CreateGeometryFile(geoFile);
+    run.CreateGeometryFile(geoFile);
 
     // -----   Finish   -------------------------------------------------------
 


### PR DESCRIPTION
Use value semantics to not leak the FairRunSim in some examples.

And use unique_ptr in some others.

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
