### PR TITLE
fix: Handle Sink/Source ownership more properly

### DIFF
--- a/fairroot/base/steer/FairRootManager.cxx
+++ b/fairroot/base/steer/FairRootManager.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -84,10 +84,8 @@ FairRootManager::FairRootManager()
     , fBrPerMap()
     , fFillLastData(kFALSE)
     , fEntryNr(0)
-    , fSource(0)
     , fSignalChainList()
     , fEventHeader(new FairEventHeader())
-    , fSink(nullptr)
     , fUseFairLinks(kFALSE)
     , fFinishRun(kFALSE)
 {
@@ -105,10 +103,6 @@ FairRootManager::~FairRootManager()
 
     delete fEventHeader;
     delete fSourceChain;
-    if (fSink)
-        delete fSink;
-    if (fSource)
-        delete fSource;
 
     // Global cleanup
 
@@ -388,6 +382,7 @@ void FairRootManager::WriteFolder()
         fSink->WriteObject(fTimeBasedBranchNameList, "TimeBasedBranchList", TObject::kSingleKey);
     }
 }
+
 Bool_t FairRootManager::SpecifyRunId()
 {
     if (!fSource) {
@@ -892,7 +887,7 @@ std::string FairRootManager::GetNameFromFile(const char* namekind)
 {
     std::string default_name = "";
 
-    if (strcmp(namekind, "treename=") && strcmp(namekind, "foldername=")) {
+    if ((strcmp(namekind, "treename=") != 0) && (strcmp(namekind, "foldername=") != 0)) {
         LOG(fatal) << "FairRootManager, requested " << namekind << ", while only treename= and foldername= available.";
         return default_name;
     }


### PR DESCRIPTION
Waiting for:
- [x] #1442

FairRootManager and FairRun both used to `delete` fSink and fSource. In specific situations (FairRootManager getting destructed before FairRun) this leads to a double delete!

Deprecate the old FairRootManager::Set{Source,Sink} APIs that take something like an owning pointer.  Introduce new Set{Sink,Source}NonOwning internal APIs.

See: https://github.com/FairRootGroup/FairRoot/issues/1418 (see "Double deleting of file source in FairRootManager and FairRun")

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Deprecated `SetSource` and `SetSink` methods now use modern smart pointers for better memory management.
  - Introduced deprecation warnings for `SetOutputFile` and `SetOutputFileName` methods.

- **Improvements**
  - Enhanced memory management by replacing raw pointers with `std::unique_ptr`.
  - Updated to the latest copyright year.

- **Code Maintenance**
  - Removed outdated and commented-out code.
  - Improved code clarity by adjusting `#include` directives and adding necessary using statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->