### PR TITLE
ci: Check codemeta version field being correct

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,9 +90,16 @@ include(FairRootSummary)
 include(FairMacros)
 include(WriteConfigFile)
 include(CheckCompiler)
+include(FairRootCodemeta)
 
 if(FairCMakeModules_VERSION VERSION_GREATER_EQUAL 1.0.0)
   fair_get_git_version()
+endif()
+get_codemeta_version()
+if (PROJECT_CODEMETA_VERSION
+    AND NOT "${PROJECT_CODEMETA_VERSION}" STREQUAL "${PROJECT_VERSION}")
+  message(AUTHOR_WARNING "Project Version (${PROJECT_VERSION}) and "
+          "CodeMeta Version (${PROJECT_CODEMETA_VERSION}) do not match!")
 endif()
 
 set(LIBRARY_OUTPUT_PATH "${CMAKE_BINARY_DIR}/lib")

--- a/FairRoot_build_test.cmake
+++ b/FairRoot_build_test.cmake
@@ -30,6 +30,7 @@ ctest_start(Continuous)
 get_filename_component(test_install_prefix "${CTEST_BINARY_DIRECTORY}/install"
                        ABSOLUTE)
 list(APPEND options
+  "-Werror=dev"
   "-DDISABLE_COLOR=ON"
   "-DCMAKE_INSTALL_PREFIX:PATH=${test_install_prefix}"
 )

--- a/cmake/private/FairRootCodemeta.cmake
+++ b/cmake/private/FairRootCodemeta.cmake
@@ -1,0 +1,24 @@
+################################################################################
+#    Copyright (C) 2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    #
+#                                                                              #
+#              This software is distributed under the terms of the             #
+#              GNU Lesser General Public Licence (LGPL) version 3,             #
+#                  copied verbatim in the file "LICENSE"                       #
+################################################################################
+
+function(get_codemeta_version)
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.19)
+    file(READ "${CMAKE_SOURCE_DIR}/codemeta.json" codemeta_content)
+    string(JSON codemeta_version ERROR_VARIABLE json_error
+           GET "${codemeta_content}" "softwareVersion")
+    if(NOT "${json_error}" STREQUAL "NOTFOUND")
+      string(JSON codemeta_version ERROR_VARIABLE json_error
+             GET "${codemeta_content}" "version")
+    endif()
+    if(NOT "${json_error}" STREQUAL "NOTFOUND")
+      return()
+    endif()
+    string(REGEX REPLACE "^v" "" codemeta_version "${codemeta_version}")
+    set(PROJECT_CODEMETA_VERSION "${codemeta_version}" PARENT_SCOPE)
+  endif()
+endfunction()


### PR DESCRIPTION
* Let CI fail on CMake developer warnings
* Let CI throw a developer warning, if the versions in CMake and codemeta.json do not match.

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
