### PR TITLE
Fix exported target name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
  #                  copied verbatim in the file "LICENSE"                       #
  ################################################################################
 cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
-cmake_policy(VERSION 3.15...3.23)
+cmake_policy(VERSION 3.15...3.27)
 
 set(PROJECT_MIN_CXX_STANDARD 17)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,8 @@
  #              GNU Lesser General Public Licence (LGPL) version 3,             #
  #                  copied verbatim in the file "LICENSE"                       #
  ################################################################################
-cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
-cmake_policy(VERSION 3.15...3.27)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
+cmake_policy(VERSION 3.18...3.27)
 
 set(PROJECT_MIN_CXX_STANDARD 17)
 
@@ -260,12 +260,11 @@ endif()
 # The target name includes the namespace yaml-cpp begining
 # from version 0.8.0. So the new exported target is now
 # yaml-cpp::yaml-cpp.
-if(yaml-cpp_FOUND)
-  if(TARGET yaml-cpp::yaml-cpp)
-    set(YAMLCPPLIB yaml-cpp::yaml-cpp)
-  else()
-    set(YAMLCPPLIB yaml-cpp)
-  endif()
+# To work also with previous versions of yaml-cpp an alias
+# is created and the new target name is used in the project
+if(yaml-cpp_FOUND AND TARGET yaml-cpp AND NOT TARGET yaml-cpp::yaml-cpp)
+  message(VERBOSE "Creating target alias yaml-cpp::yaml-cpp")
+  add_library(yaml-cpp::yaml-cpp ALIAS yaml-cpp)
 endif()
 
 if(BUILD_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,6 +256,17 @@ if(    yaml-cpp_FOUND
     INTERFACE_INCLUDE_DIRECTORIES "${YAML_CPP_INCLUDE_DIR}"
   )
 endif()
+# Workaround to fix a problem with the imported target name
+# The target name includes the namespace yaml-cpp begining
+# from version 0.8.0. So the new exported target is now
+# yaml-cpp::yaml-cpp.
+if(yaml-cpp_FOUND)
+  if(TARGET yaml-cpp::yaml-cpp)
+    set(YAMLCPPLIB yaml-cpp::yaml-cpp)
+  else()
+    set(YAMLCPPLIB yaml-cpp)
+  endif()
+endif()
 
 if(BUILD_TESTING)
   Include(FetchContent)

--- a/fairroot/mcconfigurator/CMakeLists.txt
+++ b/fairroot/mcconfigurator/CMakeLists.txt
@@ -25,7 +25,7 @@ target_include_directories(${target} PUBLIC
 target_link_libraries(${target}
   PUBLIC
   FairRoot::Base # FairGenericVMCConfig
-  yaml-cpp
+  ${YAMLCPPLIB}
 
   PRIVATE
   FairRoot::Tools

--- a/fairroot/mcconfigurator/CMakeLists.txt
+++ b/fairroot/mcconfigurator/CMakeLists.txt
@@ -25,7 +25,7 @@ target_include_directories(${target} PUBLIC
 target_link_libraries(${target}
   PUBLIC
   FairRoot::Base # FairGenericVMCConfig
-  ${YAMLCPPLIB}
+  yaml-cpp::yaml-cpp
 
   PRIVATE
   FairRoot::Tools


### PR DESCRIPTION
With the latest version of yaml-cpp (0.8.0) the name of the exported target has changed from yaml-cpp to yaml-cpp::yaml-cpp which breaks the compilation.
To work around the problem an alias yaml-cpp::yaml-cpp is created in case the exported target name is yaml-cpp.

---

Checklist:

* [ x] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
