### PR TITLE
build: Move catch2 setup into third_party/ and use SYSTEM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,23 +267,7 @@ if(yaml-cpp_FOUND AND TARGET yaml-cpp AND NOT TARGET yaml-cpp::yaml-cpp)
   add_library(yaml-cpp::yaml-cpp ALIAS yaml-cpp)
 endif()
 
-if(BUILD_TESTING)
-  Include(FetchContent)
-
-  FetchContent_Declare(
-    Catch2
-    SOURCE_DIR ${CMAKE_SOURCE_DIR}/third_party/Catch2_v3.4.0
-    # GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    # GIT_TAG        v3.4.0
-  )
-
-  FetchContent_MakeAvailable(Catch2)
-
-  # Include `Catch` module for the `catch_discover_tests` command, see
-  # https://github.com/catchorg/Catch2/blob/devel/docs/cmake-integration.md#customization
-  list(PREPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
-  include(Catch)
-endif()
+add_subdirectory(third_party)
 
 # Set some useful variables
 SetBasicVariables()

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -6,6 +6,12 @@
 #                  copied verbatim in the file "LICENSE"                       #
 ################################################################################
 
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.25)
+  set(declare_with_system "SYSTEM")
+else()
+  set(declare_with_system "")
+endif()
+
 if(BUILD_TESTING)
   Include(FetchContent)
 
@@ -14,6 +20,7 @@ if(BUILD_TESTING)
     SOURCE_DIR ${CMAKE_SOURCE_DIR}/third_party/Catch2_v3.4.0
     # GIT_REPOSITORY https://github.com/catchorg/Catch2.git
     # GIT_TAG        v3.4.0
+    ${declare_with_system}
   )
 
   FetchContent_MakeAvailable(Catch2)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,0 +1,26 @@
+################################################################################
+#    Copyright (C) 2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    #
+#                                                                              #
+#              This software is distributed under the terms of the             #
+#              GNU Lesser General Public Licence (LGPL) version 3,             #
+#                  copied verbatim in the file "LICENSE"                       #
+################################################################################
+
+if(BUILD_TESTING)
+  Include(FetchContent)
+
+  FetchContent_Declare(
+    Catch2
+    SOURCE_DIR ${CMAKE_SOURCE_DIR}/third_party/Catch2_v3.4.0
+    # GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+    # GIT_TAG        v3.4.0
+  )
+
+  FetchContent_MakeAvailable(Catch2)
+
+  # Include `Catch` module for the `catch_discover_tests` command, see
+  # https://github.com/catchorg/Catch2/blob/devel/docs/cmake-integration.md#customization
+  list(PREPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
+  set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE)
+  include(Catch)
+endif()


### PR DESCRIPTION
1. Move catch2 setup into third_party/

   Declutter the main CMakeLists.txt a bit.

2. Use FetchContent_Declare(SYSTEM)

   CMake 3.25 allows setting a "SYSTEM" option on FetchContent_Declare. Declare Catch2 using this option (if supported). This way consumers of Catch2 targets will consider catch2 includes as system includes and not show warnings for them.
---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
