### PR TITLE
Fix license header

### DIFF
--- a/examples/simulation/Tutorial2/macros/read_digis.C
+++ b/examples/simulation/Tutorial2/macros/read_digis.C
@@ -1,3 +1,4 @@
+/********************************************************************************
  * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *


### PR DESCRIPTION
Fix license header which was corrupted by one of the previous commits.
The 4 previous commits brought in the proper handling of TRandom::GetSeed() which was implemented with #1412.
Unfortunately these commits were pushed accidentely directly to the main repository instead of my fork.
Please review also the commits

f111598f7cb9cb29d9812ea0d45d63366c58feec
b4c42d35d0d3aa647a263c99b6b5fa599cb3d83a
b40931eb2c26ec311408328aee662a16d2a846a5
36584050e395169ff65af7ccba0a4847104142a9 

such that they can be either be accepted or removed as early as possible by another commit which reverts the changes.

---

Checklist:

* [ ] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
