### PR TITLE
FairModule: move member variable initialization to the header file

### DIFF
--- a/fairroot/base/sim/FairModule.cxx
+++ b/fairroot/base/sim/FairModule.cxx
@@ -53,11 +53,6 @@
 
 class FairGeoMedium;
 
-thread_local TArrayI* FairModule::volNumber = 0;
-thread_local Int_t FairModule::fNbOfVolumes = 0;
-thread_local FairVolumeList* FairModule::vList = 0;
-thread_local TRefArray* FairModule::svList = 0;
-
 void FairModule::ConstructGeometry()
 {
     LOG(warn)
@@ -74,16 +69,7 @@ FairModule::~FairModule() {}
 
 FairModule::FairModule(const char* Name, const char* title, Bool_t Active)
     : TNamed(Name, title)
-    , fMotherVolumeName("")
-    , fgeoVer("Not defined")
-    , fgeoName("Not defined")
-    , fModId(-1)
     , fActive(Active)
-    , fNbOfSensitiveVol(0)
-    , fVerboseLevel(0)
-    , flGeoPar(nullptr)
-    , fGeoSaved(kFALSE)
-    , fMC(nullptr)
 {
     if (!svList) {
         svList = new TRefArray();
@@ -102,9 +88,7 @@ FairModule::FairModule(const FairModule& rhs)
     , fActive(rhs.fActive)
     , fNbOfSensitiveVol(rhs.fNbOfSensitiveVol)
     , fVerboseLevel(rhs.fVerboseLevel)
-    , flGeoPar(nullptr)
     , fGeoSaved(rhs.fGeoSaved)
-    , fMC(nullptr)
 {
     if (!svList) {
         svList = new TRefArray();
@@ -135,16 +119,6 @@ FairModule::FairModule(const FairModule& rhs)
 
 FairModule::FairModule()
     : TNamed()
-    , fMotherVolumeName("")
-    , fgeoVer("Not defined")
-    , fgeoName("Not defined")
-    , fModId(-1)
-    , fActive(kFALSE)
-    , fNbOfSensitiveVol(0)
-    , fVerboseLevel(0)
-    , flGeoPar(nullptr)
-    , fGeoSaved(kFALSE)
-    , fMC(nullptr)
 {}
 
 FairModule& FairModule::operator=(const FairModule& rhs)

--- a/fairroot/base/sim/FairModule.h
+++ b/fairroot/base/sim/FairModule.h
@@ -137,14 +137,14 @@ class FairModule : public TNamed
     TList* GetListOfGeoPar() { return flGeoPar; }
 
     /**list of volumes in a simulation session*/
-    static thread_local FairVolumeList* vList;   //!
+    static thread_local inline FairVolumeList* vList{0};   //!
     /**total number of volumes in a simulaion session*/
-    static thread_local Int_t fNbOfVolumes;   //!
+    static thread_local inline Int_t fNbOfVolumes{0};   //!
     /**list of all sensitive volumes in  a simulaion session*/
-    static thread_local TRefArray* svList;   //!
+    static thread_local inline TRefArray* svList{0};   //!
 
-    static thread_local TArrayI* volNumber;   //!
-    TString fMotherVolumeName;                //!
+    static thread_local inline TArrayI* volNumber{0};   //!
+    TString fMotherVolumeName{""};                      //!
     FairVolume* getFairVolume(FairGeoNode* fNode);
     void AddSensitiveVolume(TGeoVolume* v);
 
@@ -160,15 +160,15 @@ class FairModule : public TNamed
   protected:
     FairModule(const FairModule&);
     FairModule& operator=(const FairModule&);
-    TString fgeoVer;
-    TString fgeoName;
-    Int_t fModId;
-    Bool_t fActive;
-    Int_t fNbOfSensitiveVol;   //!
-    Int_t fVerboseLevel;
-    TList* flGeoPar;    //!  list of Detector Geometry parameters
-    Bool_t fGeoSaved;   //! flag for initialisation
-    TVirtualMC* fMC;    //! cahed pointer to MC (available only after initialization)
+    TString fgeoVer{"Not defined"};
+    TString fgeoName{"Not defined"};
+    Int_t fModId{-1};
+    Bool_t fActive{kFALSE};
+    Int_t fNbOfSensitiveVol{0};   //!
+    Int_t fVerboseLevel{0};
+    TList* flGeoPar{nullptr};   //!  list of Detector Geometry parameters
+    Bool_t fGeoSaved{kFALSE};   //! flag for initialisation
+    TVirtualMC* fMC{nullptr};   //! cahed pointer to MC (available only after initialization)
 
     ClassDefOverride(FairModule, 4);
 };


### PR DESCRIPTION
Static thread_local member variables initialization in the source file does not work within pyROOT.
Moved all member initialization to the header file.

---

Checklist:

* [x] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
