### PR TITLE
chore: Drop TMemberInspector declaration

### DIFF
--- a/examples/advanced/Tutorial3/digitization/FairTestDetectorDigiTask.h
+++ b/examples/advanced/Tutorial3/digitization/FairTestDetectorDigiTask.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -13,8 +13,7 @@
 #include "FairTask.h"    // for FairTask, InitStatus
 class TBuffer;
 class TClass;
-class TClonesArray;  // lines 15-15
-class TMemberInspector;
+class TClonesArray;
 
 class FairTestDetectorDigiTask : public FairTask
 {

--- a/examples/common/eventdisplay/FairEveMCTracks.h
+++ b/examples/common/eventdisplay/FairEveMCTracks.h
@@ -29,7 +29,6 @@ class TBuffer;
 class TClass;
 class TClonesArray;
 class TDatabasePDG;
-class TMemberInspector;
 
 class FairEveMCTracks : public FairEveTracks
 {

--- a/examples/common/eventdisplay/FairEveMCTracksEditor.h
+++ b/examples/common/eventdisplay/FairEveMCTracksEditor.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2020 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2020-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -28,9 +28,7 @@ class FairEveMinMaxCut;  // lines 26-26
 class TBuffer;
 class TClass;
 class TGWindow;
-class TMemberInspector;
 class TObject;
-
 
 class FairEveMCTracksEditor : public TGedFrame
 {

--- a/examples/common/eventdisplay/FairMCTracksDraw.h
+++ b/examples/common/eventdisplay/FairMCTracksDraw.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2020 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2020-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -23,8 +23,7 @@ class FairEventManager;  // lines 22-22
 class FairMCTrack;  // lines 23-23
 class TBuffer;
 class TClass;
-class TEveTrackList;  // lines 24-24
-class TMemberInspector;
+class TEveTrackList;
 
 class FairMCTracksDraw : public FairTask
 {

--- a/examples/simulation/rutherford/src/FairRutherfordGeoPar.h
+++ b/examples/simulation/rutherford/src/FairRutherfordGeoPar.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -14,9 +14,7 @@
 class FairParamList;  // lines 16-16
 class TBuffer;
 class TClass;
-class TMemberInspector;
-class TObjArray;  // lines 15-15
-
+class TObjArray;   // lines 15-15
 
 class FairRutherfordGeoPar : public FairParGenericSet
 {

--- a/examples/simulation/rutherford/src/FairRutherfordPoint.h
+++ b/examples/simulation/rutherford/src/FairRutherfordPoint.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -14,8 +14,6 @@
 #include "FairMCPoint.h"  // for FairMCPoint
 class TBuffer;
 class TClass;
-class TMemberInspector;
-
 
 class FairRutherfordPoint : public FairMCPoint
 {

--- a/fairroot/eventdisplay/FairEventManagerEditor.h
+++ b/fairroot/eventdisplay/FairEventManagerEditor.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -23,8 +23,7 @@ class TClass;
 class TGComboBox;  // lines 22-22
 class TGLabel;  // lines 27-27
 class TGNumberEntry;  // lines 28-28
-class TGWindow;  // lines 29-29
-class TMemberInspector;
+class TGWindow;
 class TObject;  // lines 30-30
 
 class FairEventManagerEditor : public TGedFrame

--- a/fairroot/eventdisplay/gui/FairEveCut.h
+++ b/fairroot/eventdisplay/gui/FairEveCut.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2020 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2020-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -24,8 +24,7 @@ class TBuffer;
 class TClass;
 class TGCompositeFrame;
 class TGNumberEntry;  // lines 25-25
-class TGedFrame;  // lines 24-24
-class TMemberInspector;
+class TGedFrame;
 
 /**
  * base class for graphics cuts

--- a/fairroot/eventdisplay/gui/FairEveTransparencyControl.h
+++ b/fairroot/eventdisplay/gui/FairEveTransparencyControl.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2020 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2020-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -15,8 +15,7 @@
 class TBuffer;
 class TClass;
 class TGCheckButton;
-class TGNumberEntry;  // lines 16-16
-class TMemberInspector;
+class TGNumberEntry;
 
 class FairEveTransparencyControl : public TGHorizontalFrame
 {

--- a/fairroot/eventdisplay/tracks/FairEveGeoTracks.h
+++ b/fairroot/eventdisplay/tracks/FairEveGeoTracks.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2020 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2020-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -26,7 +26,6 @@ class TBuffer;
 class TClass;
 class TClonesArray;
 class TGeoTrack;   // lines 22-22
-class TMemberInspector;
 class TBranch;
 
 /**

--- a/fairroot/eventdisplay/tracks/FairEveGeoTracksEditor.h
+++ b/fairroot/eventdisplay/tracks/FairEveGeoTracksEditor.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2020 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2020-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -29,14 +29,11 @@ class FairEveMinMaxCut;  // lines 27-27
 class TBuffer;
 class TClass;
 class TGWindow;
-class TMemberInspector;
 class TObject;
-
 
 /**
  * editor of TGeoTracks in event display
  */
-
 class FairEveGeoTracksEditor : public TGedFrame
 {
     std::unique_ptr<FairEveMinMaxCut> fPtCut;

--- a/fairroot/eventdisplay/tracks/FairEveRecoTrack.h
+++ b/fairroot/eventdisplay/tracks/FairEveRecoTrack.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2020 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2020-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -25,8 +25,7 @@ class TBuffer;
 class TClass;
 class TEvePointSet;  // lines 23-23
 class TEveTrackPropagator;  // lines 24-24
-class TGeoTrack;  // lines 25-25
-class TMemberInspector;
+class TGeoTrack;
 class TParticle;  // lines 26-26
 
 class FairEveRecoTrack : public TEveCompound

--- a/fairroot/eventdisplay/tracks/FairEveRecoTrackList.h
+++ b/fairroot/eventdisplay/tracks/FairEveRecoTrackList.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2020 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2020-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -24,7 +24,6 @@
 class TBuffer;
 class TClass;
 class TEveTrackPropagator;
-class TMemberInspector;
 
 class FairEveRecoTrackList : public TEveTrackList
 {

--- a/fairroot/eventdisplay/tracks/FairEveTrack.h
+++ b/fairroot/eventdisplay/tracks/FairEveTrack.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2020 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2020-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -23,9 +23,7 @@
 class TBuffer;
 class TClass;
 class TEveTrackPropagator;
-class TMemberInspector;
 class TParticle;
-
 
 class FairEveTrack : public TEveTrack
 {

--- a/fairroot/eventdisplay/tracks/FairGeoTracksDraw.h
+++ b/fairroot/eventdisplay/tracks/FairGeoTracksDraw.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2020 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2020-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -23,7 +23,6 @@ class FairEveGeoTracks;  // lines 21-21
 class FairEventManager;  // lines 22-22
 class TBuffer;
 class TClass;
-class TMemberInspector;
 
 /**
  * task that draws the TGeoTracks

--- a/fairroot/trackbase/FairGeaneUtil.h
+++ b/fairroot/trackbase/FairGeaneUtil.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -13,7 +13,6 @@
 #include <TVector3.h>    // for TVector3
 class TBuffer;
 class TClass;
-class TMemberInspector;
 
 class FairGeaneUtil : public TObject
 {

--- a/fairroot/trackbase/FairPropagator.h
+++ b/fairroot/trackbase/FairPropagator.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -26,7 +26,6 @@ class FairTrackParH;  // lines 23-23
 class FairTrackParP;  // lines 24-24
 class TBuffer;
 class TClass;
-class TMemberInspector;
 
 struct PCAOutputStruct
 {

--- a/fairroot/trackbase/FairRKPropagator.h
+++ b/fairroot/trackbase/FairRKPropagator.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -24,7 +24,6 @@ class FairTrackParH;
 class FairTrackParP;   // lines 21-21
 class TBuffer;
 class TClass;
-class TMemberInspector;
 
 enum PropagationFlag
 {

--- a/fairroot/trackbase/FairTrackPar.h
+++ b/fairroot/trackbase/FairTrackPar.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -13,7 +13,6 @@
 #include <TVector3.h>    // for TVector3
 class TBuffer;
 class TClass;
-class TMemberInspector;
 
 class FairTrackPar : public TObject
 {

--- a/fairroot/trackbase/FairTrackParH.h
+++ b/fairroot/trackbase/FairTrackParH.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -24,8 +24,6 @@
 class FairTrackParP;  // lines 25-25
 class TBuffer;
 class TClass;
-class TMemberInspector;
-
 
 class FairTrackParH : public FairTrackPar
 {

--- a/fairroot/trackbase/FairTrackParP.h
+++ b/fairroot/trackbase/FairTrackParP.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -24,12 +24,9 @@
 class FairTrackParH;  // lines 25-25
 class TBuffer;
 class TClass;
-class TMemberInspector;
-
 
 class FairTrackParP : public FairTrackPar
 {
-
   public:
     /** Constructor **/
     FairTrackParP();

--- a/templates/project_root_containers/CTestCustom.cmake
+++ b/templates/project_root_containers/CTestCustom.cmake
@@ -1,5 +1,5 @@
  ################################################################################
- #    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    #
+ # Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
  #                                                                              #
  #              This software is distributed under the terms of the             # 
  #              GNU Lesser General Public Licence (LGPL) version 3,             #  
@@ -81,7 +81,6 @@ set(CTEST_CUSTOM_WARNING_EXCEPTION
         "/include/TMap.h:"
         "/include/TMatrixT.h:"
         "/include/TMatrixTSym.h:"
-        "/include/TMemberInspector.h:"
         "/include/TObjArray.h:"
         "/include/TRefArray.h:"
         "/include/TString.h:"

--- a/templates/project_stl_containers/CTestCustom.cmake
+++ b/templates/project_stl_containers/CTestCustom.cmake
@@ -1,5 +1,5 @@
  ################################################################################
- #    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    #
+ # Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
  #                                                                              #
  #              This software is distributed under the terms of the             # 
  #              GNU Lesser General Public Licence (LGPL) version 3,             #  
@@ -81,7 +81,6 @@ set(CTEST_CUSTOM_WARNING_EXCEPTION
         "/include/TMap.h:"
         "/include/TMatrixT.h:"
         "/include/TMatrixTSym.h:"
-        "/include/TMemberInspector.h:"
         "/include/TObjArray.h:"
         "/include/TRefArray.h:"
         "/include/TString.h:"


### PR DESCRIPTION
No code in FairRoot needs a TMemberInspector directly. If anything from ROOT needs it, then that include should declare it.

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
