### PR TITLE
chore: Drop useless `return;`

### DIFF
--- a/examples/MQ/pixelAlternative/src/PixelAltFindHits.cxx
+++ b/examples/MQ/pixelAlternative/src/PixelAltFindHits.cxx
@@ -188,7 +188,10 @@ void PixelAltFindHits::GetParList(TList* tempList)
 void PixelAltFindHits::InitMQ(TList* tempList)
 {
     LOG(info) << "********************************************** PixelAltFindHits::InitMQ()";
-    fDigiPar = (PixelDigiPar*)tempList->FindObject("PixelDigiParameters");
+    fDigiPar = dynamic_cast<PixelDigiPar*>(tempList->FindObject("PixelDigiParameters"));
+    if (!fDigiPar) {
+        throw std::runtime_error("no PixelDigiParameters");
+    }
 
     fFeCols = fDigiPar->GetFECols();
     fFeRows = fDigiPar->GetFERows();
@@ -211,7 +214,13 @@ void PixelAltFindHits::ExecMQ(TList* inputList, TList* outputList)
     //  << "," << outputList->GetName() << "), Event " << fTNofEvents; LOG(info) <<
     //  "********************************************** PixelAltFindHits::ExecMQ(), Event " << fTNofEvents; LOG(info) <<
     //  "h" << FairLogger::flush;
-    fDigis = (TClonesArray*)inputList->FindObject("PixelDigis");
+    fDigis = dynamic_cast<TClonesArray*>(inputList->FindObject("PixelDigis"));
+    if (!fDigis) {
+        throw std::runtime_error("no PixelDigis");
+    }
+    if (!fDigis->GetClass()->InheritsFrom(PixelDigi::Class())) {
+        throw std::runtime_error("wrong type in PixelDigis TCA");
+    }
     outputList->Add(fHits);
     Exec("");
 }

--- a/examples/MQ/pixelAlternative/src/PixelAltFindHits.cxx
+++ b/examples/MQ/pixelAlternative/src/PixelAltFindHits.cxx
@@ -183,8 +183,6 @@ void PixelAltFindHits::GetParList(TList* tempList)
 {
     fDigiPar = new PixelDigiPar("PixelDigiParameters");
     tempList->Add(fDigiPar);
-
-    return;
 }
 
 void PixelAltFindHits::InitMQ(TList* tempList)
@@ -205,8 +203,6 @@ void PixelAltFindHits::InitMQ(TList* tempList)
     LOG(info) << ">> fPitchY      = " << fPitchY;
 
     fHits = new TClonesArray("PixelHit", 10000);
-
-    return;
 }
 
 void PixelAltFindHits::ExecMQ(TList* inputList, TList* outputList)
@@ -218,7 +214,6 @@ void PixelAltFindHits::ExecMQ(TList* inputList, TList* outputList)
     fDigis = (TClonesArray*)inputList->FindObject("PixelDigis");
     outputList->Add(fHits);
     Exec("");
-    return;
 }
 
 void PixelAltFindHits::ExecMQ(PixelPayload::Digi* digiPalVector,
@@ -241,7 +236,6 @@ void PixelAltFindHits::ExecMQ(PixelPayload::Digi* digiPalVector,
         hitPalVector[idigi].fDetectorID = digiPalVector[idigi].fDetectorID;
         nofHits++;
     }
-    return;
 }
 
 InitStatus PixelAltFindHits::Init()

--- a/examples/MQ/pixelDetector/src/FairOnlineSink.cxx
+++ b/examples/MQ/pixelDetector/src/FairOnlineSink.cxx
@@ -20,7 +20,7 @@
 #include <fairlogger/Logger.h>
 
 //_____________________________________________________________________________
-void FairOnlineSink::RegisterImpl(const char*, const char*, void*) { return; }
+void FairOnlineSink::RegisterImpl(const char*, const char*, void*) {}
 
 //_____________________________________________________________________________
 void FairOnlineSink::RegisterAny(const char* brname, const std::type_info& oi, const std::type_info& pi, void* obj)

--- a/examples/MQ/pixelDetector/src/FairOnlineSink.h
+++ b/examples/MQ/pixelDetector/src/FairOnlineSink.h
@@ -40,7 +40,7 @@ class FairOnlineSink : public FairSink
 
     virtual void FillEventHeader(FairEventHeader* /* feh */) {}
 
-    void SetOutTree(TTree* /* fTree */) override { return; }
+    void SetOutTree(TTree* /* fTree */) override {}
 
     void Fill() override;
 

--- a/examples/MQ/pixelDetector/src/PixelDigiBinSource.cxx
+++ b/examples/MQ/pixelDetector/src/PixelDigiBinSource.cxx
@@ -83,7 +83,7 @@ Int_t PixelDigiBinSource::ReadEvent(UInt_t i)
     LOG(debug) << "PixelDigiBinSource::ReadEvent() Begin of (" << fDigis.GetEntries() << ")";
 
     Int_t head[4];   // runId, MCEntryNo, PartNo, NofDigis
-    fInputFile.read((char*)head, sizeof(head));
+    fInputFile.read(reinterpret_cast<char*>(head), sizeof(head));
 
     if (fInputFile.eof()) {
         LOG(info) << "End of file reached!";
@@ -94,7 +94,7 @@ Int_t PixelDigiBinSource::ReadEvent(UInt_t i)
 
     const Int_t constNofData = head[3] * dataSize;
     short int dataCont[constNofData];
-    fInputFile.read((char*)dataCont, sizeof(dataCont));
+    fInputFile.read(reinterpret_cast<char*>(dataCont), sizeof(dataCont));
 
     fRunId = head[0];
     fMCEntryNo = head[1];
@@ -146,7 +146,7 @@ Int_t PixelDigiBinSource::CheckMaxEventNo(Int_t /*EvtEnd*/) { return -1; }
 
 void PixelDigiBinSource::FillEventHeader(FairEventHeader* feh)
 {
-    ((PixelEventHeader*)feh)->SetRunId(fRunId);
-    ((PixelEventHeader*)feh)->SetMCEntryNumber(fMCEntryNo);
-    ((PixelEventHeader*)feh)->SetPartNo(fPartNo);
+    FairSource::FillEventHeader(feh);
+    feh->SetMCEntryNumber(fMCEntryNo);
+    static_cast<PixelEventHeader*>(feh)->SetPartNo(fPartNo);
 }

--- a/examples/MQ/pixelDetector/src/PixelDigiSource.cxx
+++ b/examples/MQ/pixelDetector/src/PixelDigiSource.cxx
@@ -144,7 +144,7 @@ Int_t PixelDigiSource::CheckMaxEventNo(Int_t /*EvtEnd*/) { return -1; }
 
 void PixelDigiSource::FillEventHeader(FairEventHeader* feh)
 {
-    ((PixelEventHeader*)feh)->SetRunId(fRunId);
-    ((PixelEventHeader*)feh)->SetMCEntryNumber(fMCEntryNo);
-    ((PixelEventHeader*)feh)->SetPartNo(fPartNo);
+    FairSource::FillEventHeader(feh);
+    feh->SetMCEntryNumber(fMCEntryNo);
+    static_cast<PixelEventHeader*>(feh)->SetPartNo(fPartNo);
 }

--- a/examples/MQ/pixelDetector/src/PixelDigitize.cxx
+++ b/examples/MQ/pixelDetector/src/PixelDigitize.cxx
@@ -178,8 +178,6 @@ void PixelDigitize::GetParList(TList* tempList)
 {
     fDigiPar = new PixelDigiPar("PixelDigiParameters");
     tempList->Add(fDigiPar);
-
-    return;
 }
 
 void PixelDigitize::InitMQ(TList* tempList)
@@ -200,8 +198,6 @@ void PixelDigitize::InitMQ(TList* tempList)
     LOG(info) << ">> fPitchY      = " << fPitchY;
 
     fDigis = new TClonesArray("PixelDigi", 10000);
-
-    return;
 }
 
 void PixelDigitize::ExecMQ(TList* inputList, TList* outputList)
@@ -212,7 +208,6 @@ void PixelDigitize::ExecMQ(TList* inputList, TList* outputList)
     fPoints = (TClonesArray*)inputList->FindObject("PixelPoint");
     outputList->Add(fDigis);
     Exec("");
-    return;
 }
 
 InitStatus PixelDigitize::Init()

--- a/examples/MQ/pixelDetector/src/PixelDigitize.cxx
+++ b/examples/MQ/pixelDetector/src/PixelDigitize.cxx
@@ -183,7 +183,10 @@ void PixelDigitize::GetParList(TList* tempList)
 void PixelDigitize::InitMQ(TList* tempList)
 {
     LOG(info) << "********************************************** PixelDigitize::InitMQ()";
-    fDigiPar = (PixelDigiPar*)tempList->FindObject("PixelDigiParameters");
+    fDigiPar = dynamic_cast<PixelDigiPar*>(tempList->FindObject("PixelDigiParameters"));
+    if (!fDigiPar) {
+        throw std::runtime_error("no PixelDigiParameters");
+    }
 
     fFeCols = fDigiPar->GetFECols();
     fFeRows = fDigiPar->GetFERows();
@@ -205,7 +208,13 @@ void PixelDigitize::ExecMQ(TList* inputList, TList* outputList)
     //  LOG(info) << "********************************************** PixelDigitize::ExecMQ(" << inputList->GetName() <<
     //  "," << outputList->GetName() << "), Event " << fTNofEvents; LOG(info) <<
     //  "********************************************** PixelDigitize::ExecMQ(), Event " << fTNofEvents;
-    fPoints = (TClonesArray*)inputList->FindObject("PixelPoint");
+    fPoints = dynamic_cast<TClonesArray*>(inputList->FindObject("PixelPoint"));
+    if (!fPoints) {
+        throw std::runtime_error("no PixelPoint");
+    }
+    if (!fPoints->GetClass()->InheritsFrom(PixelPoint::Class())) {
+        throw std::runtime_error("wrong type in PixelPoint TCA");
+    }
     outputList->Add(fDigis);
     Exec("");
 }

--- a/examples/MQ/pixelDetector/src/PixelFindHits.cxx
+++ b/examples/MQ/pixelDetector/src/PixelFindHits.cxx
@@ -146,8 +146,6 @@ void PixelFindHits::GetParList(TList* tempList)
 {
     fDigiPar = new PixelDigiPar("PixelDigiParameters");
     tempList->Add(fDigiPar);
-
-    return;
 }
 
 void PixelFindHits::InitMQ(TList* tempList)
@@ -168,8 +166,6 @@ void PixelFindHits::InitMQ(TList* tempList)
     LOG(info) << ">> fPitchY      = " << fPitchY;
 
     fHits = new TClonesArray("PixelHit", 10000);
-
-    return;
 }
 
 void PixelFindHits::ExecMQ(TList* inputList, TList* outputList)
@@ -181,7 +177,6 @@ void PixelFindHits::ExecMQ(TList* inputList, TList* outputList)
     fDigis = (TClonesArray*)inputList->FindObject("PixelDigis");
     outputList->Add(fHits);
     Exec("");
-    return;
 }
 
 InitStatus PixelFindHits::Init()

--- a/examples/MQ/pixelDetector/src/PixelFindHits.cxx
+++ b/examples/MQ/pixelDetector/src/PixelFindHits.cxx
@@ -151,7 +151,10 @@ void PixelFindHits::GetParList(TList* tempList)
 void PixelFindHits::InitMQ(TList* tempList)
 {
     LOG(info) << "********************************************** PixelFindHits::InitMQ()";
-    fDigiPar = (PixelDigiPar*)tempList->FindObject("PixelDigiParameters");
+    fDigiPar = dynamic_cast<PixelDigiPar*>(tempList->FindObject("PixelDigiParameters"));
+    if (!fDigiPar) {
+        throw std::runtime_error("no PixelDigiParameters");
+    }
 
     fFeCols = fDigiPar->GetFECols();
     fFeRows = fDigiPar->GetFERows();
@@ -174,7 +177,13 @@ void PixelFindHits::ExecMQ(TList* inputList, TList* outputList)
     //  "," << outputList->GetName() << "), Event " << fTNofEvents; LOG(info) <<
     //  "********************************************** PixelFindHits::ExecMQ(), Event " << fTNofEvents; LOG(info) <<
     //  "h" << FairLogger::flush;
-    fDigis = (TClonesArray*)inputList->FindObject("PixelDigis");
+    fDigis = dynamic_cast<TClonesArray*>(inputList->FindObject("PixelDigis"));
+    if (!fDigis) {
+        throw std::runtime_error("no PixelDigis");
+    }
+    if (!fDigis->GetClass()->InheritsFrom(PixelDigi::Class())) {
+        throw std::runtime_error("wrong type in PixelDigis TCA");
+    }
     outputList->Add(fHits);
     Exec("");
 }

--- a/examples/MQ/pixelDetector/src/PixelFindTracks.cxx
+++ b/examples/MQ/pixelDetector/src/PixelFindTracks.cxx
@@ -151,8 +151,6 @@ void PixelFindTracks::GetParList(TList* tempList)
 {
     fDigiPar = new PixelDigiPar("PixelDigiParameters");
     tempList->Add(fDigiPar);
-
-    return;
 }
 
 void PixelFindTracks::InitMQ(TList* tempList)
@@ -162,8 +160,6 @@ void PixelFindTracks::InitMQ(TList* tempList)
 
     fTracks = new TClonesArray("PixelTrack", 10000);
     fhDist2D = new TH2F("fhDist2D", "Distance between hit and expected track", 400, -1., 1., 400, -1., 1.);
-
-    return;
 }
 
 void PixelFindTracks::ExecMQ(TList* inputList, TList* outputList)
@@ -175,7 +171,6 @@ void PixelFindTracks::ExecMQ(TList* inputList, TList* outputList)
     fHits = (TClonesArray*)inputList->FindObject("PixelHits");
     outputList->Add(fTracks);
     Exec("");
-    return;
 }
 
 InitStatus PixelFindTracks::Init()

--- a/examples/MQ/pixelDetector/src/PixelFindTracks.cxx
+++ b/examples/MQ/pixelDetector/src/PixelFindTracks.cxx
@@ -156,7 +156,10 @@ void PixelFindTracks::GetParList(TList* tempList)
 void PixelFindTracks::InitMQ(TList* tempList)
 {
     LOG(info) << "********************************************** PixelFindTracks::InitMQ()";
-    fDigiPar = (PixelDigiPar*)tempList->FindObject("PixelDigiParameters");
+    fDigiPar = dynamic_cast<PixelDigiPar*>(tempList->FindObject("PixelDigiParameters"));
+    if (!fDigiPar) {
+        throw std::runtime_error("no PixelDigiParameters");
+    }
 
     fTracks = new TClonesArray("PixelTrack", 10000);
     fhDist2D = new TH2F("fhDist2D", "Distance between hit and expected track", 400, -1., 1., 400, -1., 1.);
@@ -168,7 +171,13 @@ void PixelFindTracks::ExecMQ(TList* inputList, TList* outputList)
     //  << "," << outputList->GetName() << "), Event " << fTNofEvents; LOG(info) <<
     //  "********************************************** PixelFindTracks::ExecMQ(), Event " << fTNofEvents; LOG(info) <<
     //  "t" << FairLogger::flush;
-    fHits = (TClonesArray*)inputList->FindObject("PixelHits");
+    fHits = dynamic_cast<TClonesArray*>(inputList->FindObject("PixelHits"));
+    if (!fHits) {
+        throw std::runtime_error("no PixelHits");
+    }
+    if (!fHits->GetClass()->InheritsFrom(PixelHit::Class())) {
+        throw std::runtime_error("wrong type in PixelHits TCA");
+    }
     outputList->Add(fTracks);
     Exec("");
 }

--- a/examples/advanced/propagator/src/FairTutPropTr.cxx
+++ b/examples/advanced/propagator/src/FairTutPropTr.cxx
@@ -97,8 +97,8 @@ void FairTutPropTr::InitPropagator()
     fPro->SetDestinationPlane(planePoint, planeVectJ, planeVectK);
 
     fPropagatorSet = true;
-    return;
 }
+
 // -------------------------------------------------------------------------
 
 // -----   Public method Exec   --------------------------------------------

--- a/fairroot/base/event/FairEventBuilderManager.cxx
+++ b/fairroot/base/event/FairEventBuilderManager.cxx
@@ -70,8 +70,6 @@ void FairEventBuilderManager::Exec(Option_t*)
     // - should extract possible events
     // - is implemented by different experiments
     AnalyzeAndExtractEvents(maxEventTimeAllowed);
-
-    return;
 }
 
 Double_t FairEventBuilderManager::FillEventVectors()

--- a/fairroot/base/event/FairMultiLinkedData.cxx
+++ b/fairroot/base/event/FairMultiLinkedData.cxx
@@ -195,7 +195,6 @@ void FairMultiLinkedData::InsertLink(FairLink link)
     } else {
         fLinks.insert(link);
     }
-    return;
 }
 
 void FairMultiLinkedData::InsertHistory(FairLink link)

--- a/fairroot/base/event/FairTrackParam.cxx
+++ b/fairroot/base/event/FairTrackParam.cxx
@@ -187,7 +187,6 @@ void FairTrackParam::SetCovariance(Int_t i, Int_t j, Double_t val)
         index = 10 + j;
     }
     fCovMatrix[index] = val;
-    return;
 }
 
 FairTrackParam& FairTrackParam::operator=(const FairTrackParam& par)

--- a/fairroot/base/sim/FairGenerator.h
+++ b/fairroot/base/sim/FairGenerator.h
@@ -53,7 +53,7 @@ class FairGenerator : public TNamed
     virtual Bool_t Init() { return kTRUE; }
 
     /**Finalize the generator if needed */
-    virtual void Finish() { return; }
+    virtual void Finish() {}
 
     /** Clone this object (used in MT mode only) */
     virtual FairGenerator* CloneGenerator() const;

--- a/fairroot/base/sim/FairRunIdGenerator.cxx
+++ b/fairroot/base/sim/FairRunIdGenerator.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -109,7 +109,6 @@ void FairRunIdGenerator::get_random_bytes(void* buf, int nbytes)
     for (i = 0; i < nbytes; i++) {
         *cp++ = rand() & 0xFF;
     }
-    return;
 }
 
 /*

--- a/fairroot/base/source/FairFileSource.cxx
+++ b/fairroot/base/source/FairFileSource.cxx
@@ -699,8 +699,8 @@ void FairFileSource::ReadBranchEvent(const char* BrName)
         fEventTime = GetEventTime();
         return;
     }
-    return;
 }
+
 void FairFileSource::ReadBranchEvent(const char* BrName, Int_t Entry)
 {
     fCurrentEntryNo = Entry;
@@ -714,7 +714,6 @@ void FairFileSource::ReadBranchEvent(const char* BrName, Int_t Entry)
         fEventTime = GetEventTime();
         return;
     }
-    return;
 }
 
 void FairFileSource::FillEventHeader(FairEventHeader* feh)

--- a/fairroot/base/source/FairMixedSource.cxx
+++ b/fairroot/base/source/FairMixedSource.cxx
@@ -413,7 +413,6 @@ void FairMixedSource::FillEventHeader(FairEventHeader* feh)
     LOG(debug) << "FairMixedSource::FillEventHeader() Event " << fCurrentEntryNo << " at " << feh->GetEventTime()
                << " -> Run id = " << fOutHeader->GetRunId() << " event#" << feh->GetMCEntryNumber() << " from file#"
                << fOutHeader->GetInputFileId();
-    return;
 }
 
 void FairMixedSource::SetSignalFile(TString name, UInt_t identifier)
@@ -741,7 +740,6 @@ void FairMixedSource::ReadBranchEvent(const char* BrName)
         return;
     }
     chain->FindBranch(BrName)->GetEntry(fEvtHeader->GetMCEntryNumber());
-    return;
 }
 
 void FairMixedSource::ReadBranchEvent(const char* BrName, Int_t Entry)
@@ -755,7 +753,6 @@ void FairMixedSource::ReadBranchEvent(const char* BrName, Int_t Entry)
         return;
     }
     chain->FindBranch(BrName)->GetEntry(Entry);
-    return;
 }
 
 void FairMixedSource::UseRunIdFromBG()

--- a/fairroot/base/source/FairSource.h
+++ b/fairroot/base/source/FairSource.h
@@ -46,8 +46,8 @@ class FairSource : public TObject
     /**Check the maximum event number we can run to*/
     virtual Int_t CheckMaxEventNo(Int_t = 0) { return -1; }
     /**Read the tree entry on one branch**/
-    virtual void ReadBranchEvent(const char*) { return; }
-    virtual void ReadBranchEvent(const char*, Int_t) { return; }
+    virtual void ReadBranchEvent(const char*) {}
+    virtual void ReadBranchEvent(const char*, Int_t) {}
     virtual void FillEventHeader(FairEventHeader* feh);
     void SetRunId(Int_t runId) { fRunId = runId; }
     Int_t GetRunId() const { return fRunId; }

--- a/fairroot/base/steer/FairRunAnaProof.cxx
+++ b/fairroot/base/steer/FairRunAnaProof.cxx
@@ -264,7 +264,6 @@ void FairRunAnaProof::InitContainers()
 void FairRunAnaProof::Run(Int_t Ev_start, Int_t Ev_end)
 {
     RunOnProof(Ev_start, Ev_end);
-    return;
 }
 
 void FairRunAnaProof::RunOneEvent(Long64_t entry)

--- a/fairroot/geobase/FairGeoBasicShape.h
+++ b/fairroot/geobase/FairGeoBasicShape.h
@@ -40,7 +40,7 @@ class FairGeoBasicShape : public TNamed
     virtual void printPoints(FairGeoVolume* volu);
     virtual TArrayD* calcVoluParam(FairGeoVolume*) { return 0; }
     virtual void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&);
-    virtual void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&) { return; }
+    virtual void calcVoluPosition(FairGeoVolume*, const FairGeoTransform&, const FairGeoTransform&) {}
     void printParam();
 
   protected:

--- a/fairroot/geobase/FairGeoSet.cxx
+++ b/fairroot/geobase/FairGeoSet.cxx
@@ -152,7 +152,6 @@ void FairGeoSet::readInout(std::fstream& fin)
         do {
             fin.get(c);
         } while (c != '\n');
-    return;
 }
 
 void FairGeoSet::readTransform(std::fstream& fin, FairGeoTransform& tf)


### PR DESCRIPTION
`return;` at the end of a function is quite pointless.

Also fix some C-Style Casts

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
