### PR TITLE
document/test default behaviour of maybe_owning_ptr

### DIFF
--- a/fairroot/tools/FairMemory.h
+++ b/fairroot/tools/FairMemory.h
@@ -51,6 +51,11 @@ struct optional_deleter
  * contain a reference (and thus not delete its content
  * on destruction).
  *
+ * The default is an owning pointer, so that it can be used
+ * just like a plain std::unique_ptr. It should be trivial to
+ * switch to a plain one later, if the non-owning part is not
+ * used any longer.
+ *
  * \note Think twice before using this!
  *
  * It's mostly meant for cases, where FairRoot has a public API

--- a/fairroot/tools/tests/maybe_owning.cxx
+++ b/fairroot/tools/tests/maybe_owning.cxx
@@ -54,6 +54,17 @@ TEST_CASE("maybe_owning_ptr")
         REQUIRE(analyzer.destructed == 1);
         REQUIRE(analyzer.was_destructed('A'));
     }
+    SECTION("unique_ptr style initialize and go out of scope")
+    {
+        {
+            MaybeOwning other{item_a.release()};
+            REQUIRE(!item_a);
+            REQUIRE(other);
+            REQUIRE(analyzer.destructed == 0);
+        }
+        REQUIRE(analyzer.destructed == 1);
+        REQUIRE(analyzer.was_destructed('A'));
+    }
     SECTION("Pass ownership and go out of scope")
     {
         {


### PR DESCRIPTION
The default behaviour is not an accidental side effect. So document and test it.

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
