### PR TITLE
Fix FindROOT.cmake to work with v6.30.00

### DIFF
--- a/cmake/modules/FindROOT.cmake
+++ b/cmake/modules/FindROOT.cmake
@@ -76,9 +76,9 @@ If(ROOT_CONFIG_EXECUTABLE)
 
   # extract major, minor, and patch versions from
   # the version string given by root-config
-  String(REGEX REPLACE "^([0-9]+)\\.[0-9][0-9]+\\/[0-9][0-9]+.*" "\\1" ROOT_VERSION_MAJOR "${ROOT_VERSION_STRING}")
-  String(REGEX REPLACE "^[0-9]+\\.([0-9][0-9])+\\/[0-9][0-9]+.*" "\\1" ROOT_VERSION_MINOR "${ROOT_VERSION_STRING}")
-  String(REGEX REPLACE "^[0-9]+\\.[0-9][0-9]+\\/([0-9][0-9]+).*" "\\1" ROOT_VERSION_PATCH "${ROOT_VERSION_STRING}")
+  String(REGEX REPLACE "^([0-9]+)\\.[0-9][0-9]+[\\/.][0-9][0-9]+.*" "\\1" ROOT_VERSION_MAJOR "${ROOT_VERSION_STRING}")
+  String(REGEX REPLACE "^[0-9]+\\.([0-9][0-9])+[\\/.][0-9][0-9]+.*" "\\1" ROOT_VERSION_MINOR "${ROOT_VERSION_STRING}")
+  String(REGEX REPLACE "^[0-9]+\\.[0-9][0-9]+[\\/.]([0-9][0-9]+).*" "\\1" ROOT_VERSION_PATCH "${ROOT_VERSION_STRING}")
 
   if(NOT ROOT_FIND_VERSION_MAJOR)
     set(ROOT_FIND_VERSION_MAJOR 0)


### PR DESCRIPTION
Apparently ROOT changed the version string.