### PR TITLE
fix: Use TKey::ReadObject<T> instead of ReadObj

### DIFF
--- a/examples/simulation/Tutorial4/macros/run_tutorial4_createParameterFile.C
+++ b/examples/simulation/Tutorial4/macros/run_tutorial4_createParameterFile.C
@@ -1,17 +1,21 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
 
+#include <TCollection.h>
+#include <TGeoManager.h>
+#include <TKey.h>
+#include <TList.h>
+
 // forward declaration
 void writeVectorToFile(std::vector<Double_t>& vec, ofstream* myfile);
 
 void run_tutorial4_createParameterFile()
 {
-
     // Create shift in x, y, z when true
     Bool_t ShiftX = kTRUE;
     Bool_t ShiftY = kTRUE;
@@ -42,14 +46,14 @@ void run_tutorial4_createParameterFile()
 
     TList* l = f->GetListOfKeys();
 
-    TKey* key;
-    TIter next(l);
-
     TGeoManager* geoMan{nullptr};
 
-    while ((key = (TKey*)next())) {
-        if (key->ReadObj()->InheritsFrom("TGeoManager")) {
-            geoMan = static_cast<TGeoManager*>(key->ReadObj());
+    for (auto key : TRangeDynCast<TKey>(l)) {
+        if (!key) {
+            continue;
+        }
+        geoMan = key->ReadObject<TGeoManager>();
+        if (geoMan) {
             break;
         }
     }

--- a/fairroot/base/steer/FairRunAna.h
+++ b/fairroot/base/steer/FairRunAna.h
@@ -142,6 +142,11 @@ class FairRunAna : public FairRun
      */
     void CheckRunIdChanged();
 
+    /**
+     * \brief Internal helper: Search for TGeoManager in fInputGeoFile
+     */
+    void SearchForTGeoManagerInGeoFile();
+
     ClassDefOverride(FairRunAna, 6);
 };
 

--- a/fairroot/base/steer/FairRunAnaProof.cxx
+++ b/fairroot/base/steer/FairRunAnaProof.cxx
@@ -94,17 +94,7 @@ void FairRunAnaProof::Init()
     // Load Geometry from user file
 
     if (fLoadGeo) {
-        if (fInputGeoFile != 0) {   // First check if the user has a separate Geo file!
-            TIter next(fInputGeoFile->GetListOfKeys());
-            TKey* key;
-            while ((key = static_cast<TKey*>(next()))) {
-                if (strcmp(key->GetClassName(), "TGeoManager") != 0) {
-                    continue;
-                }
-                gGeoManager = static_cast<TGeoManager*>(key->ReadObj());
-                break;
-            }
-        }
+        SearchForTGeoManagerInGeoFile();
     } else {
         //    FairGeoParSet* geopar=dynamic_cast<FairGeoParSet*>(fRtdb->getContainer("FairGeoParSet"));
         fRtdb->getContainer("FairGeoParSet");
@@ -142,17 +132,7 @@ void FairRunAnaProof::Init()
     } else {   //  if(fInputFile )
         // NO input file but there is a geometry file
         if (fLoadGeo) {
-            if (fInputGeoFile != 0) {   // First check if the user has a separate Geo file!
-                TIter next(fInputGeoFile->GetListOfKeys());
-                TKey* key;
-                while ((key = static_cast<TKey*>(next()))) {
-                    if (strcmp(key->GetClassName(), "TGeoManager") != 0) {
-                        continue;
-                    }
-                    gGeoManager = static_cast<TGeoManager*>(key->ReadObj());
-                    break;
-                }
-            }
+            SearchForTGeoManagerInGeoFile();
         }
     }
     // Init the Chain ptr


### PR DESCRIPTION
`TKey::ReadObj` returns an owning pointer.
Using dynamic_cast and ignoring the "not castable" case can leak memory.

Also one `std::unique_ptr`

See: https://root-forum.cern.ch/t/possible-leak-with-dynamic-cast-and-tkey-readobj/56799
See: https://github.com/root-project/root/pull/13931

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
