### PR TITLE
chore: Improve closing on FairLmdSource

### DIFF
--- a/fairroot/online/source/FairLmdSource.h
+++ b/fairroot/online/source/FairLmdSource.h
@@ -65,6 +65,9 @@ class FairLmdSource : public FairMbsSource
 
     FairLmdSource& operator=(const FairLmdSource&);
 
+  private:
+    void CloseLmd();
+
     ClassDefOverride(FairLmdSource, 0);
 };
 


### PR DESCRIPTION
`Close` is a virtual method. It's getting called internally in a scenario where only FairLmdSource specific resources should be closed.

Also the desctructor did not close.

This was triggered by a comment here: https://github.com/FairRootGroup/FairRoot/pull/1464#pullrequestreview-1738378541

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
