### PR TITLE
feat: Close Sink/Source in FairRun dtor

### DIFF
--- a/fairroot/base/sink/FairSink.h
+++ b/fairroot/base/sink/FairSink.h
@@ -16,15 +16,14 @@
 #define FAIRSINK_H
 
 #include <Rtypes.h>
+#include <TFolder.h>
+#include <TObject.h>
 #include <TString.h>
+#include <TTree.h>
 #include <map>        // map
 #include <memory>     // unique_ptr
 #include <string>     // string
 #include <typeinfo>   // type_info
-
-class TObject;
-class TFolder;
-class TTree;
 
 enum Sink_Type
 {
@@ -40,6 +39,12 @@ class FairSink
     virtual ~FairSink();
 
     virtual Bool_t InitSink() = 0;
+
+    /**
+     * \note It might be called multiple times, please handle that.
+     * \note It will be called from the dtor of FairRun.
+     *       Don't interact with FairRun here.
+     */
     virtual void Close() = 0;
     virtual void Reset() = 0;
 

--- a/fairroot/base/source/FairSource.h
+++ b/fairroot/base/source/FairSource.h
@@ -35,6 +35,12 @@ class FairSource : public TObject
     virtual Bool_t Init() = 0;
     virtual Int_t ReadEvent(UInt_t = 0) = 0;
     virtual Bool_t SpecifyRunId() = 0;
+
+    /**
+     * \note It might be called multiple times, please handle that.
+     * \note It will be called from the dtor of FairRun.
+     *       Don't interact with FairRun here.
+     */
     virtual void Close() = 0;
     virtual void Reset() = 0;
     virtual Bool_t ActivateObject(TObject**, const char*) { return kFALSE; }

--- a/fairroot/base/steer/FairRun.cxx
+++ b/fairroot/base/steer/FairRun.cxx
@@ -82,6 +82,13 @@ FairRun::~FairRun()
 {
     LOG(debug) << "Enter Destructor of FairRun";
 
+    if (fSource) {
+        fSource->Close();
+    }
+    if (fSink) {
+        fSink->Close();
+    }
+
     // So that FairRootManager does not try to delete these, because we will do that:
     fRootManager->SetSource(nullptr);
     fRootManager->SetSink(nullptr);


### PR DESCRIPTION
If we destruct the sink/source during destruction of a FairRun (via unique_ptr), we could probably call the Close method of the sink and source as well.

The dtor of a sink/source should handle cleaning up anyway. But being nice and closing it could be considered "being good citizens".

See: https://github.com/FairRootGroup/FairRoot/issues/1462

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
