### PR TITLE
Remove calling Close method in FairRootManager/FairRun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
     * `virtual bool operator<(const FairTimeStamp* rValue) const` changed to `bool operator<(const FairTimeStamp& rValue) const`
   * FairModule::svList is gone. This was never intended as a public
     API.
+  * Remove calling `Close()`
+    * `FairSink::Close()` and `FairSource::Close()` are no longer called in FairRoot.
+    * Derived classes from `FairSink` and `FairSource` should close the resources automatically in their destructors.
 
 ### Deprecations
 

--- a/examples/MQ/pixelDetector/src/FairOnlineSink.h
+++ b/examples/MQ/pixelDetector/src/FairOnlineSink.h
@@ -33,7 +33,6 @@ class FairOnlineSink : public FairSink
     FairOnlineSink& operator=(const FairOnlineSink&) = delete;
 
     Bool_t InitSink() override { return kTRUE; }
-    void Close() override {}
     void Reset() override {}
 
     Sink_Type GetSinkType() override { return kONLINESINK; }

--- a/examples/MQ/pixelDetector/src/PixelDigiBinSource.cxx
+++ b/examples/MQ/pixelDetector/src/PixelDigiBinSource.cxx
@@ -106,8 +106,7 @@ Int_t PixelDigiBinSource::ReadEvent(UInt_t i)
     for (Int_t idata = 0; idata < head[3]; idata++) {
         LOG(debug) << "    --/" << idata << "/-->    " << dataCont[idata * dataSize + 0] << " / "
                    << dataCont[idata * dataSize + 1] << " / " << dataCont[idata * dataSize + 2] << " / "
-                   << dataCont[idata * dataSize + 3] << " / "
-                   << " 0.";
+                   << dataCont[idata * dataSize + 3] << " / " << " 0.";
         new (fDigis[fNDigis]) PixelDigi(-1,
                                         dataCont[idata * dataSize + 0],
                                         dataCont[idata * dataSize + 1],
@@ -138,11 +137,12 @@ Bool_t PixelDigiBinSource::ActivateObject(TObject** obj, const char* BrName)
     return kTRUE;
 }
 
-void PixelDigiBinSource::Close() { fInputFile.close(); }
-
 void PixelDigiBinSource::Reset() {}
 
-Int_t PixelDigiBinSource::CheckMaxEventNo(Int_t /*EvtEnd*/) { return -1; }
+Int_t PixelDigiBinSource::CheckMaxEventNo(Int_t /*EvtEnd*/)
+{
+    return -1;
+}
 
 void PixelDigiBinSource::FillEventHeader(FairEventHeader* feh)
 {

--- a/examples/MQ/pixelDetector/src/PixelDigiBinSource.h
+++ b/examples/MQ/pixelDetector/src/PixelDigiBinSource.h
@@ -33,7 +33,6 @@ class PixelDigiBinSource : public FairSource
     Bool_t Init() override;
 
     Int_t ReadEvent(UInt_t i = 0) override;
-    void Close() override;
     void Reset() override;
     Bool_t SpecifyRunId() override
     {
@@ -77,6 +76,9 @@ class PixelDigiBinSource : public FairSource
 
     PixelDigiBinSource(const PixelDigiBinSource&);
     PixelDigiBinSource& operator=(const PixelDigiBinSource&);
+
+    // Private member functions:
+    void Close() override { fInputFile.close(); }
 
     ClassDefOverride(PixelDigiBinSource, 1);
 };

--- a/examples/MQ/pixelDetector/src/PixelDigiSource.cxx
+++ b/examples/MQ/pixelDetector/src/PixelDigiSource.cxx
@@ -136,11 +136,12 @@ Bool_t PixelDigiSource::ActivateObject(TObject** obj, const char* BrName)
     return kTRUE;
 }
 
-void PixelDigiSource::Close() { fInputFile.close(); }
-
 void PixelDigiSource::Reset() {}
 
-Int_t PixelDigiSource::CheckMaxEventNo(Int_t /*EvtEnd*/) { return -1; }
+Int_t PixelDigiSource::CheckMaxEventNo(Int_t /*EvtEnd*/)
+{
+    return -1;
+}
 
 void PixelDigiSource::FillEventHeader(FairEventHeader* feh)
 {

--- a/examples/MQ/pixelDetector/src/PixelDigiSource.h
+++ b/examples/MQ/pixelDetector/src/PixelDigiSource.h
@@ -33,7 +33,6 @@ class PixelDigiSource : public FairSource
     Bool_t Init() override;
 
     Int_t ReadEvent(UInt_t i = 0) override;
-    void Close() override;
     void Reset() override;
     Bool_t SpecifyRunId() override
     {
@@ -77,6 +76,8 @@ class PixelDigiSource : public FairSource
 
     PixelDigiSource(const PixelDigiSource&);
     PixelDigiSource& operator=(const PixelDigiSource&);
+
+    void Close() override { fInputFile.close(); }
 
     ClassDefOverride(PixelDigiSource, 1);
 };

--- a/fairroot/base/sim/FairMCApplication.cxx
+++ b/fairroot/base/sim/FairMCApplication.cxx
@@ -478,10 +478,6 @@ void FairMCApplication::FinishRunOnWorker()
     LOG(debug) << "FairMCApplication::FinishRunOnWorker: ";
 
     FinishRun();
-
-    // Close the sink on workers so that the execution of main FairRunSim->Run()
-    // finishes with the output files properly closed.
-    fRootManager->CloseSink();
 }
 
 //_____________________________________________________________________________

--- a/fairroot/base/sink/FairRootFileSink.cxx
+++ b/fairroot/base/sink/FairRootFileSink.cxx
@@ -202,7 +202,7 @@ void FairRootFileSink::TruncateBranchNames(TBranch* b, TString ffn)
 
 void FairRootFileSink::Close()
 {
-    if (fRootFile) {
+    if (fRootFile != nullptr) {
         fRootFile->Close();
     }
 }
@@ -251,7 +251,8 @@ void FairRootFileSink::WriteFolder()
     }
 }
 
-namespace impl {
+namespace impl
+{
 // a helper function to demangle a type_name
 inline std::string demangle(const char* name)
 {

--- a/fairroot/base/sink/FairRootFileSink.h
+++ b/fairroot/base/sink/FairRootFileSink.h
@@ -38,7 +38,6 @@ class FairRootFileSink : public FairSink
     ~FairRootFileSink() override = default;
 
     Bool_t InitSink() override;
-    void Close() override;
     void Reset() override;
 
     Sink_Type GetSinkType() override { return kFILESINK; }
@@ -66,6 +65,7 @@ class FairRootFileSink : public FairSink
     void WriteGeometry() override;
 
     FairSink* CloneSink() override;
+    void Close() override;
 
   private:
     /** Title of input sink, could be input, background or signal*/

--- a/fairroot/base/sink/FairSink.h
+++ b/fairroot/base/sink/FairSink.h
@@ -40,7 +40,7 @@ class FairSink
     virtual ~FairSink();
 
     virtual Bool_t InitSink() = 0;
-    virtual void Close() = 0;
+    virtual void Close() {}
     virtual void Reset() = 0;
 
     virtual Sink_Type GetSinkType() = 0;

--- a/fairroot/base/source/FairFileSource.cxx
+++ b/fairroot/base/source/FairFileSource.cxx
@@ -144,8 +144,6 @@ FairFileSource::FairFileSource(const TString RootFileName, const char* Title, UI
     LOG(debug) << "FairFileSource created------------";
 }
 
-FairFileSource::~FairFileSource() = default;
-
 Bool_t FairFileSource::Init()
 {
     if (IsInitialized) {
@@ -303,11 +301,15 @@ Bool_t FairFileSource::SpecifyRunId()
     return fInChain->GetEntry(0) != 0;
 }
 
-void FairFileSource::Close() { CloseInFile(); }
+void FairFileSource::AddFriend(TString fName)
+{
+    fFriendFileList.push_back(fName);
+}
 
-void FairFileSource::AddFriend(TString fName) { fFriendFileList.push_back(fName); }
-
-void FairFileSource::AddFile(TString FileName) { fInputChainList.push_back(FileName); }
+void FairFileSource::AddFile(TString FileName)
+{
+    fInputChainList.push_back(FileName);
+}
 
 void FairFileSource::AddFriendsToChain()
 {

--- a/fairroot/base/source/FairFileSource.h
+++ b/fairroot/base/source/FairFileSource.h
@@ -40,11 +40,10 @@ class FairFileSource : public FairFileSourceBase
     FairFileSource(const TString* RootFileName, const char* Title = "InputRootFile", UInt_t identifier = 0);
     FairFileSource(const TString RootFileName, const char* Title = "InputRootFile", UInt_t identifier = 0);
     // FairFileSource(const FairFileSource& file);
-    ~FairFileSource() override;
+    ~FairFileSource() override = default;
 
     Bool_t Init() override;
     Int_t ReadEvent(UInt_t i = 0) override;
-    void Close() override;
 
     /**Check the maximum event number we can run to*/
     Int_t CheckMaxEventNo(Int_t EvtEnd = 0) override;
@@ -65,9 +64,9 @@ class FairFileSource : public FairFileSourceBase
     void CreateNewFriendChain(TString inputFile, TString inputLevel);
     TTree* GetInTree() { return fInChain->GetTree(); }
     TChain* GetInChain() { return fInChain; }
-    void CloseInFile()
+    [[deprecated("Use Close() function")]] void CloseInFile()
     {
-        if (fRootFile) {
+        if (fRootFile != nullptr) {
             fRootFile->Close();
         }
     }

--- a/fairroot/base/source/FairFileSourceBase.h
+++ b/fairroot/base/source/FairFileSourceBase.h
@@ -54,6 +54,14 @@ class FairFileSourceBase : public FairSource
     /** list of folders from all input (and friends) files*/
     TObjArray fListFolder{16};   //!
 
+    // private virtual methods:
+    void Close() override
+    {
+        if (fRootFile != nullptr) {
+            fRootFile->Close();
+        }
+    }
+
     ClassDefOverride(FairFileSourceBase, 0);
 };
 

--- a/fairroot/base/source/FairMixedSource.cxx
+++ b/fairroot/base/source/FairMixedSource.cxx
@@ -183,8 +183,6 @@ FairMixedSource::FairMixedSource(const TString RootFileName, const Int_t signalI
     // }
 }
 
-FairMixedSource::~FairMixedSource() = default;
-
 Bool_t FairMixedSource::Init()
 {
     fOutHeader = new FairEventHeader();
@@ -387,8 +385,6 @@ Int_t FairMixedSource::ReadEvent(UInt_t i)
     return 0;
 }
 
-void FairMixedSource::Close() {}
-
 void FairMixedSource::FillEventHeader(FairEventHeader* feh)
 {
     feh->SetEventTime(fOutHeader->GetEventTime());
@@ -423,7 +419,10 @@ void FairMixedSource::SetSignalFile(TString name, UInt_t identifier)
     }
 }
 
-void FairMixedSource::AddSignalFile(TString name, UInt_t identifier) { SetSignalFile(name, identifier); }
+void FairMixedSource::AddSignalFile(TString name, UInt_t identifier)
+{
+    SetSignalFile(name, identifier);
+}
 
 TChain* FairMixedSource::GetSignalChainNo(UInt_t i)
 {

--- a/fairroot/base/source/FairMixedSource.h
+++ b/fairroot/base/source/FairMixedSource.h
@@ -43,11 +43,10 @@ class FairMixedSource : public FairFileSourceBase
                     const char* Title = "InputRootFile",
                     UInt_t identifier = 0);
     //  FairMixedSource(const FairMixedSource& file);
-    ~FairMixedSource() override;
+    ~FairMixedSource() override = default;
 
     Bool_t Init() override;
     Int_t ReadEvent(UInt_t i = 0) override;
-    void Close() override;
 
     /**Check the maximum event number we can run to*/
     Int_t CheckMaxEventNo(Int_t EvtEnd = 0) override;

--- a/fairroot/base/source/FairSource.h
+++ b/fairroot/base/source/FairSource.h
@@ -35,7 +35,7 @@ class FairSource : public TObject
     virtual Bool_t Init() = 0;
     virtual Int_t ReadEvent(UInt_t = 0) = 0;
     virtual Bool_t SpecifyRunId() = 0;
-    virtual void Close() = 0;
+    virtual void Close() {}
     virtual void Reset() = 0;
     virtual Bool_t ActivateObject(TObject**, const char*) { return kFALSE; }
     virtual Bool_t ActivateObjectAny(void**, const std::type_info&, const char*) { return kFALSE; }

--- a/fairroot/base/steer/FairRootManager.h
+++ b/fairroot/base/steer/FairRootManager.h
@@ -18,12 +18,12 @@
 #include <TRefArray.h>   // for TRefArray
 #include <TString.h>     // for TString, operator<
 #include <fairlogger/Logger.h>
+#include <list>
 #include <map>   // for map, multimap, etc
 #include <memory>
 #include <string>
 #include <type_traits>   // is_pointer, remove_pointer, is_const, remove...
 #include <typeinfo>
-#include <list>
 
 class BinaryFunctor;
 class FairEventHeader;
@@ -69,7 +69,7 @@ class FairRootManager : public TObject
 
     void CloseSink()
     {
-        if (fSink) {
+        if (fSink != nullptr) {
             fSink->Close();
         }
     }

--- a/fairroot/base/steer/FairRunAna.cxx
+++ b/fairroot/base/steer/FairRunAna.cxx
@@ -558,7 +558,6 @@ void FairRunAna::TerminateRun()
     //   cout << ">>>------------------------------------------------<<<" << endl;
     fRootManager->LastFill();
     fRootManager->Write();
-    fRootManager->CloseSink();
 }
 //_____________________________________________________________________________
 

--- a/fairroot/base/steer/FairRunSim.cxx
+++ b/fairroot/base/steer/FairRunSim.cxx
@@ -323,9 +323,6 @@ void FairRunSim::Run(Int_t NEvents, Int_t)
 {
     fApp->RunMC(NEvents);
     fWasMT = fApp->GetIsMT();
-    if (fSink) {
-        fSink->Close();
-    }
 }
 
 void FairRunSim::SetField(FairField* field)

--- a/fairroot/online/source/FairOnlineSource.h
+++ b/fairroot/online/source/FairOnlineSource.h
@@ -34,7 +34,6 @@ class FairOnlineSource : public FairSource
 
     Bool_t Init() override = 0;
     Int_t ReadEvent(UInt_t = 0) override = 0;
-    void Close() override = 0;
 
     void SetParUnpackers() override;
 

--- a/fairroot/online/steer/FairRunOnline.cxx
+++ b/fairroot/online/steer/FairRunOnline.cxx
@@ -309,9 +309,6 @@ void FairRunOnline::Finish()
     fTask->FinishTask();
     fRootManager->LastFill();
     fRootManager->Write();
-    GetSource()->Close();
-
-    fRootManager->CloseSink();
 }
 
 void FairRunOnline::ActivateHttpServer(Int_t refreshRate, Int_t httpServer)


### PR DESCRIPTION
- ~~Deprecation of Close method in FairSource/Sink.~~
- Move the Close executions in the derived classes to their dtor (if needed).
- Remove callings of the Close methods in FairRootManager and FairRun.

---

Checklist:

* [x] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
