### PR TITLE
ci: Check codemeta/zenodo with AUTHORS/CONTRIBUTORS

### DIFF
--- a/.github/workflows/check_metadata.yaml
+++ b/.github/workflows/check_metadata.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH, Darmstadt, Germany
+#
+# SPDX-License-Identifier: CC0-1.0
+
+name: Check AUTHORS and CONTRIBUTORS in metadata
+
+on:
+  push:
+    paths:
+    - AUTHORS
+    - CONTRIBUTORS
+    - codemeta.json
+    - .zenodo.json
+  pull_request:
+    paths:
+    - AUTHORS
+    - CONTRIBUTORS
+    - codemeta.json
+    - .zenodo.json
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Try updating metadata
+        run: python meta_update.py
+      - name: Check for Updates
+        run: git diff --exit-code


### PR DESCRIPTION
If AUTHORS or CONTRIBUTORS are changed,
check that the changes are merged into codemeta.json, and .zenodo.json.

See: https://github.com/ChristianTackeGSI/FairRoot/actions/runs/7267260698/job/19800680021

And a failing one: https://github.com/ChristianTackeGSI/FairRoot/actions/runs/7267235927/job/19800601329

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
