### PR TITLE
    Use CTest instead of Dart module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ include(FairRootPackage)
 include(FairRootSummary)
 include(FairMacros)
 include(WriteConfigFile)
-include(Dart)
+include(CTest)
 include(CheckCompiler)
 include(FairRootCodemeta)
 


### PR DESCRIPTION
    The Dart module is deprecated sine CMake version 3.27. The CTest module
    provides the same functionality.

    https://cmake.org/cmake/help/latest/module/Dart.html

---

Checklist:

* [ x] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
