### PR TITLE
Use CTest instead of Dart module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ include(CheckSymbolExists)
 # Load some basic macros which are needed later on
 include(FairMacros)
 include(WriteConfigFile)
-include(Dart)
+include(CTest)
 include(CheckCompiler)
 
 #Check the compiler and set the compile and link flags


### PR DESCRIPTION
The Dart module is deprecated sine CMake version 3.27. The CTest module provides the same functionality.

https://cmake.org/cmake/help/latest/module/Dart.html

---

Checklist:

* [ x] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
