### PR TITLE
chore: Mark some functions static, Remove some useless casts

### DIFF
--- a/examples/MQ/pixelDetector/src/PixelDigiSource.cxx
+++ b/examples/MQ/pixelDetector/src/PixelDigiSource.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -64,7 +64,7 @@ Bool_t PixelDigiSource::Init()
     return kTRUE;
 }
 
-int ReadIntFromString(const std::string& wholestr, const std::string& pattern)
+static int ReadIntFromString(const std::string& wholestr, const std::string& pattern)
 {
     std::string tempstr = wholestr;
     tempstr.replace(0, tempstr.find(pattern) + pattern.length(), "");

--- a/examples/MQ/serialization/data_generator/dataGenerator.cxx
+++ b/examples/MQ/serialization/data_generator/dataGenerator.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH       *
+ * Copyright (C) 2023-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -40,7 +40,7 @@ using std::string;
 using std::vector;
 
 // fill data payload and save to file
-void SaveDataToFile(RootOutFileManager<MyDigi>& outMan, RooDataSet& dataset)
+static void SaveDataToFile(RootOutFileManager<MyDigi>& outMan, RooDataSet& dataset)
 {
     vector<MyDigi> dataBunch;
     dataBunch.reserve(dataset.numEntries());

--- a/fairroot/base/event/FairMultiLinkedData.cxx
+++ b/fairroot/base/event/FairMultiLinkedData.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -284,7 +284,10 @@ FairMultiLinkedData FairMultiLinkedData::GetLinksWithType(Int_t type) const
     return result;
 }
 
-bool LargerWeight(FairLink val1, FairLink val2) { return val1.GetWeight() > val2.GetWeight(); }
+static bool LargerWeight(FairLink const& val1, FairLink const& val2)
+{
+    return val1.GetWeight() > val2.GetWeight();
+}
 
 std::vector<FairLink> FairMultiLinkedData::GetSortedMCTracks()
 {

--- a/fairroot/base/sim/FairVolumeList.cxx
+++ b/fairroot/base/sim/FairVolumeList.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -58,7 +58,7 @@ FairVolume* FairVolumeList::findObject(TString name)
         obj = static_cast<FairVolume*>(fData->At(i));
         if (obj) {
             if (obj->GetName() == name) {
-                return static_cast<FairVolume*>(obj);
+                return obj;
             }
         }
     }
@@ -68,7 +68,7 @@ FairVolume* FairVolumeList::findObject(TString name)
 
 void FairVolumeList::addVolume(FairVolume* elem)
 {
-    FairVolume* v = static_cast<FairVolume*>(findObject(elem->GetName()));
+    FairVolume* v = findObject(elem->GetName());
 
     if (v) {
         LOG(error) << "FairVolumeList element: " << elem->GetName() << " VolId : " << elem->getVolumeId()

--- a/fairroot/base/source/FairFileSource.cxx
+++ b/fairroot/base/source/FairFileSource.cxx
@@ -388,7 +388,7 @@ void FairFileSource::AddFriendsToChain()
         }
 
         TChain* chain = fFriendTypeList[inputLevel];
-        chain->AddFile(fileName, 1234567890, FairRootManager::GetTreeName());
+        chain->AddFile(fileName, TTree::kMaxEntries, FairRootManager::GetTreeName());
     }
 
     // Check if all friend chains have the same runids and the same

--- a/fairroot/base/source/FairFileSource.cxx
+++ b/fairroot/base/source/FairFileSource.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -296,7 +296,7 @@ void FairFileSource::SetInTree(TTree* tempTree)
 {
     fInTree = nullptr;
     fInTree = tempTree;
-    fRootFile = static_cast<TFile*>(tempTree->GetCurrentFile());
+    fRootFile = tempTree->GetCurrentFile();
     fInChain->Reset();
     IsInitialized = kFALSE;
     Init();
@@ -387,7 +387,7 @@ void FairFileSource::AddFriendsToChain()
             friendType++;
         }
 
-        TChain* chain = static_cast<TChain*>(fFriendTypeList[inputLevel]);
+        TChain* chain = fFriendTypeList[inputLevel];
         chain->AddFile(fileName, 1234567890, FairRootManager::GetTreeName());
     }
 

--- a/fairroot/base/steer/FairRingSorterTask.cxx
+++ b/fairroot/base/steer/FairRingSorterTask.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -97,7 +97,7 @@ void FairRingSorterTask::FinishTask()
     }
     for (int i = 0; i < fInputArray->GetEntriesFast(); i++) {
         FairTimeStamp* myDigi = static_cast<FairTimeStamp*>(fInputArray->At(i));
-        fSorter->AddElement(myDigi, (static_cast<FairTimeStamp*>(myDigi))->GetTimeStamp());
+        fSorter->AddElement(myDigi, myDigi->GetTimeStamp());
     }
     fSorter->Print();
     fSorter->WriteOutAll();

--- a/fairroot/base/steer/FairRunAna.cxx
+++ b/fairroot/base/steer/FairRunAna.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -46,10 +46,10 @@
 using std::cout;
 using std::endl;
 
-Bool_t gFRAIsInterrupted;
+static Bool_t gFRAIsInterrupted;
 
 //_____________________________________________________________________________
-void FRA_handler_ctrlc(int)
+static void FRA_handler_ctrlc(int)
 {
     LOG(info) << "*********** CTRL C PRESSED *************";
     gFRAIsInterrupted = kTRUE;

--- a/fairroot/base/steer/FairTSBufferFunctional.cxx
+++ b/fairroot/base/steer/FairTSBufferFunctional.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -49,7 +49,7 @@ TClonesArray* FairTSBufferFunctional::GetData(Double_t stopParameter)
 
     if (fStopFunction == 0) {   // no function is given ==> read in data in traditional way event by event
         ReadInNextEntry();
-        fOutputArray->AbsorbObjects(static_cast<TClonesArray*>(fInputArray), 0, fInputArray->GetEntriesFast() - 1);
+        fOutputArray->AbsorbObjects(fInputArray, 0, fInputArray->GetEntriesFast() - 1);
         return fOutputArray;
     }
     if (fVerbose > 1) {

--- a/fairroot/geobase/FairGeoMedium.cxx
+++ b/fairroot/geobase/FairGeoMedium.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -99,7 +99,7 @@ void FairGeoMedium::setNComponents(Int_t n)
         cz = new Double_t[k];
         cw = new Double_t[k];
     }
-    weightFac = static_cast<Int_t>(n / nComponents);
+    weightFac = n / nComponents;
 }
 
 Bool_t FairGeoMedium::setComponent(Int_t i, Double_t a, Double_t z, Double_t weight)

--- a/fairroot/geobase/FairGeoNode.cxx
+++ b/fairroot/geobase/FairGeoNode.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -202,14 +202,14 @@ Bool_t FairGeoNode::write(std::fstream& fout)
     // Writes all parameters of a volume to file
     fout << fName.Data() << '\n';
     if (pMother) {
-        fout << (const_cast<const char*>(mother.Data())) << '\n';
+        fout << mother.Data() << '\n';
     } else {
         Error("write", "Unknown mother for %s\n", fName.Data());
         return kFALSE;
     }
     if (!copyNode) {
         if (pShape) {
-            fout << (const_cast<const char*>(shape.Data())) << '\n';
+            fout << shape.Data() << '\n';
         } else {
             Error("write", "Unknown shape for %s\n", fName.Data());
             return kFALSE;

--- a/fairroot/geobase/FairGeoNode.h
+++ b/fairroot/geobase/FairGeoNode.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -64,10 +64,10 @@ class FairGeoNode : public FairGeoVolume
     void AddDaughter(FairGeoNode* fNode) { fDaughterList->AddLast(fNode); }
     TObjArray* GetListOfDaughters() { return fDaughterList; }
     EFairGeoNodeType getVolumeType() { return volumeType; }
-    Bool_t isTopNode() { return static_cast<Bool_t>((volumeType == kFairGeoTopNode)); }
-    Bool_t isRefNode() { return static_cast<Bool_t>((volumeType == kFairGeoRefNode)); }
-    Bool_t isKeepin() { return static_cast<Bool_t>((volumeType == kFairGeoKeepin)); }
-    Bool_t isModule() { return static_cast<Bool_t>((volumeType == kFairGeoModule)); }
+    Bool_t isTopNode() { return volumeType == kFairGeoTopNode; }
+    Bool_t isRefNode() { return volumeType == kFairGeoRefNode; }
+    Bool_t isKeepin() { return volumeType == kFairGeoKeepin; }
+    Bool_t isModule() { return volumeType == kFairGeoModule; }
     Int_t getCopyNo();
     FairGeoBasicShape* getShapePointer() { return pShape; }
     FairGeoNode* getMotherNode() { return pMother; }

--- a/fairroot/geobase/FairGeoVolume.cxx
+++ b/fairroot/geobase/FairGeoVolume.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -128,9 +128,7 @@ void FairGeoVolume::clear()
 void FairGeoVolume::print()
 {
     // prints all parameters of a volume
-    cout << "Volume: " << (const_cast<const char*>(fName.Data()))
-         << "  Shape: " << (const_cast<const char*>(shape.Data()))
-         << "  Mother: " << (const_cast<const char*>(mother.Data())) << '\n';
+    cout << "Volume: " << fName.Data() << "  Shape: " << shape.Data() << "  Mother: " << mother.Data() << '\n';
     cout << "Points definition " << endl;
     if (points) {
         for (Int_t i = 0; i < nPoints; i++) {

--- a/fairroot/online/steer/FairRunOnline.cxx
+++ b/fairroot/online/steer/FairRunOnline.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -97,9 +97,9 @@ FairRunOnline::~FairRunOnline()
     }
 }
 
-Bool_t gIsInterrupted;
+static Bool_t gIsInterrupted;
 
-void handler_ctrlc(int)
+static void handler_ctrlc(int)
 {
     gIsInterrupted = kTRUE;
 }

--- a/fairroot/parbase/FairDetParRootFileIo.cxx
+++ b/fairroot/parbase/FairDetParRootFileIo.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -61,7 +61,7 @@ Bool_t FairDetParRootFileIo::read(FairParSet *pPar)
         return kTRUE;
     }
 
-    TKey *key = dynamic_cast<TKey *>(gDirectory->GetKey(name, version));
+    TKey* key = gDirectory->GetKey(name, version);
     if (key) {
         pPar->clear();
         key->Read(pPar);

--- a/fairroot/parbase/FairParRootFileIo.cxx
+++ b/fairroot/parbase/FairParRootFileIo.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -211,7 +211,7 @@ void FairParRootFileIo::MergeFiles(TFile* newParFile, const TList* fnamelist)
             continue;
         }
 
-        TList* inputKeys = static_cast<TList*>(inFile->GetListOfKeys());
+        TList* inputKeys = inFile->GetListOfKeys();
 
         TListIter keyIter(inputKeys);
         TKey* inpKey;

--- a/fairroot/parbase/FairParSet.h
+++ b/fairroot/parbase/FairParSet.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -32,8 +32,8 @@ class FairParSet : public TObject
     FairParSet(const char* name = "", const char* title = "", const char* context = "", Bool_t owner = kFALSE);
     virtual ~FairParSet() {}
 
-    const char* GetName() const override { return static_cast<const char*>(fName.Data()); }
-    const char* GetTitle() const override { return static_cast<const char*>(fTitle.Data()); }
+    const char* GetName() const override { return fName.Data(); }
+    const char* GetTitle() const override { return fTitle.Data(); }
 
     virtual Bool_t init();
     virtual Bool_t init(FairParIo*) { return kFALSE; }

--- a/fairroot/trackbase/FairTrackParH.cxx
+++ b/fairroot/trackbase/FairTrackParH.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -180,7 +180,7 @@ FairTrackParH::FairTrackParH(TVector3 pos, TVector3 Mom, TVector3 posErr, TVecto
     SetY(pos.y());   // y (lab)
     SetZ(pos.z());   // z (lab)
 
-    fq = int(q / TMath::Abs(q));
+    fq = q / TMath::Abs(q);
     Double_t P = TMath::Sqrt(fPx * fPx + fPy * fPy + fPz * fPz);
     fLm = TMath::ASin(fPz / P);
 
@@ -317,7 +317,7 @@ void FairTrackParH::SetTrackPar(Double_t X,
 
     fPhi = TMath::ATan2(Py, Px);
     if (Q != 0) {
-        fq = int(TMath::Abs(Q) / Q);
+        fq = TMath::Abs(Q) / Q;
     }
     fQp = fq / P;
 


### PR DESCRIPTION
- chore: Mark some free standing functions static

  If free standing functions are only ever used in one compile unit, they should be marked `static` to not pollute the namespace during linking.

- chore: Remove useless casts

  Casting to the exact same type is quite useless.

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
