### PR TITLE
[backport 18.8] Fix a runtime error with newer XCode versions

### DIFF
--- a/examples/simulation/Tutorial1/src/FairSimConfig.cxx
+++ b/examples/simulation/Tutorial1/src/FairSimConfig.cxx
@@ -1,13 +1,16 @@
-/********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
- *                                                                              *
- *              This software is distributed under the terms of the             *
- *              GNU Lesser General Public Licence (LGPL) version 3,             *
- *                  copied verbatim in the file "LICENSE"                       *
- ********************************************************************************/
+/*********************************************************************************
+ *  Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ *                                                                               *
+ *              This software is distributed under the terms of the              *
+ *              GNU Lesser General Public Licence (LGPL) version 3,              *
+ *                  copied verbatim in the file "LICENSE"                        *
+ *********************************************************************************/
 #include "FairSimConfig.h"
 
 #include "FairLogger.h"
+
+#include <boost/program_options.hpp>
+namespace po = boost::program_options;
 
 #include <iostream>
 #include <vector>
@@ -15,18 +18,11 @@
 using std::string;
 using std::vector;
 
-FairSimConfig::FairSimConfig()
-    : fDescription("Options")
-    , fHelp(false)
-    , fnEvents(1)
-    , fEngine("TGeant3")
-    , fMultiThreaded(false)
-    , fOutputFile("sim.root")
-    , fParameterFile("par.root")
-    , fRandomSeed(0)
+static auto makeDescription()
 {
+    po::options_description description{"Options"};
     // clang-format off
-    fDescription.add_options()
+    description.add_options()
         ("help",                                        "Print this message")
         ("nevents",        po::value<int>(),            "Number of events to simulate")
         ("engine",         po::value<vector<string>>(), "Monte Carlo engine")
@@ -35,52 +31,55 @@ FairSimConfig::FairSimConfig()
         ("parameter-file", po::value<vector<string>>(), "Parameter file")
         ("random-seed",    po::value<int>(),            "Seed for the random number generator");
     // clang-format on
+    return description;
 }
-
-FairSimConfig::~FairSimConfig() {}
 
 int FairSimConfig::ParseCommandLine(int argc, char* argv[])
 {
+    po::variables_map map;
+    auto description = makeDescription();
     try {
-        po::store(po::parse_command_line(argc, argv, fDescription), fMap);
+        po::store(po::parse_command_line(argc, argv, description), map);
 
-        po::notify(fMap);
+        po::notify(map);
     } catch (po::error& e) {
         LOG(error) << e.what();
         fHelp = true;
         return 0;
     }
 
-    if (fMap.count("help")) {
+    if (map.count("help")) {
         fHelp = true;
         return 0;
     }
-    if (fMap.count("nevents")) {
-        fnEvents = fMap["nevents"].as<int>();
+    if (map.count("nevents")) {
+        fnEvents = map["nevents"].as<int>();
     }
-    if (fMap.count("engine")) {
-        fEngine = fMap["engine"].as<vector<string>>().at(0);
+    if (map.count("engine")) {
+        fEngine = map["engine"].as<vector<string>>().at(0);
         if (!GetEngine().EqualTo("TGeant3") && !GetEngine().EqualTo("TGeant4")) {
             LOG(error) << "Option engine can be either TGeant3 or TGeant4";
             return 1;
         }
     }
-    if (fMap.count("output-file")) {
-        fOutputFile = fMap["output-file"].as<vector<string>>().at(0);
+    if (map.count("output-file")) {
+        fOutputFile = map["output-file"].as<vector<string>>().at(0);
     }
-    if (fMap.count("parameter-file")) {
-        fParameterFile = fMap["parameter-file"].as<vector<string>>().at(0);
+    if (map.count("parameter-file")) {
+        fParameterFile = map["parameter-file"].as<vector<string>>().at(0);
     }
-    if (fMap.count("random-seed")) {
-        fRandomSeed = fMap["random-seed"].as<int>();
+    if (map.count("random-seed")) {
+        fRandomSeed = map["random-seed"].as<int>();
     }
-    if (fMap.count("multi-threaded")) {
+    if (map.count("multi-threaded")) {
         LOG(info) << "YUPYUPYUP";
         fMultiThreaded = true;
     }
     return 0;
 }
 
-void FairSimConfig::PrintHelpMessage() { std::cout << fDescription << std::endl; }
-
-ClassImp(FairSimConfig);
+void FairSimConfig::PrintHelpMessage()
+{
+    auto description = makeDescription();
+    std::cout << description << std::endl;
+}

--- a/examples/simulation/Tutorial1/src/FairSimConfig.h
+++ b/examples/simulation/Tutorial1/src/FairSimConfig.h
@@ -1,26 +1,22 @@
-/********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
- *                                                                              *
- *              This software is distributed under the terms of the             *
- *              GNU Lesser General Public Licence (LGPL) version 3,             *
- *                  copied verbatim in the file "LICENSE"                       *
- ********************************************************************************/
+/*********************************************************************************
+ *  Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ *                                                                               *
+ *              This software is distributed under the terms of the              *
+ *              GNU Lesser General Public Licence (LGPL) version 3,              *
+ *                  copied verbatim in the file "LICENSE"                        *
+ *********************************************************************************/
 #ifndef FAIRSIMCONFIG
 #define FAIRSIMCONFIG
-
-#include "boost/program_options.hpp"
 
 #include <Rtypes.h>
 #include <TString.h>
 #include <string>
 
-namespace po = boost::program_options;
-
 class FairSimConfig
 {
   public:
-    FairSimConfig();
-    virtual ~FairSimConfig();
+    FairSimConfig() = default;
+    virtual ~FairSimConfig() = default;
 
     int ParseCommandLine(int argc, char* argv[]);
 
@@ -35,18 +31,15 @@ class FairSimConfig
     int GetRandomSeed() const { return fRandomSeed; }
 
   private:
-    po::options_description fDescription;   //!
-    po::variables_map fMap;                 //!
+    bool fHelp{false};
+    int fnEvents{1};
+    std::string fEngine{"TGeant3"};
+    bool fMultiThreaded{false};
+    std::string fOutputFile{"sim.root"};
+    std::string fParameterFile{"par.root"};
+    int fRandomSeed{0};
 
-    bool fHelp;
-    int fnEvents;
-    std::string fEngine;
-    bool fMultiThreaded;
-    std::string fOutputFile;
-    std::string fParameterFile;
-    int fRandomSeed;
-
-    ClassDef(FairSimConfig, 1);
+    ClassDef(FairSimConfig, 0);
 };
 
 #endif


### PR DESCRIPTION
When using boost/program_options in a header file the generated dictinonary can't be loaded at runtime and the macro crashes.
Don't use boost in the header file such that there is no problem when using cling.
The problem was already reported to the ROOT team and will not be fixed since the underlying problem is obviously in the libc++ shipped by Apple. (see https://github.com/root-project/root/issues/12762)

(cherry picked from commit 65ea0a8a4acbc22c39598f34b7ce1ea2715dbbf4)

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
