### PR TITLE
build: Replace exec_program by execute_process

### DIFF
--- a/cmake/modules/CheckCompiler.cmake
+++ b/cmake/modules/CheckCompiler.cmake
@@ -123,7 +123,10 @@ endif (CMAKE_SYSTEM_NAME MATCHES Linux)
 
 
 if (CMAKE_SYSTEM_NAME MATCHES Darwin)
-   EXEC_PROGRAM("sw_vers -productVersion | cut -d . -f 1-2" OUTPUT_VARIABLE MAC_OS_VERSION)
+   execute_process(COMMAND sw_vers -productVersion
+                   COMMAND cut -d . -f 1-2
+                   OUTPUT_STRIP_TRAILING_WHITESPACE
+                   OUTPUT_VARIABLE MAC_OS_VERSION)
    MESSAGE("-- Found a Mac OS X System ${MAC_OS_VERSION}")
    if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
       MESSAGE("-- Found GNU compiler collection")

--- a/cmake/modules/ROOTMacros.cmake
+++ b/cmake/modules/ROOTMacros.cmake
@@ -107,7 +107,6 @@ macro(FAIRROOT_GENERATE_DICTIONARY)
     Configure_File(${FAIRROOTPATH}/share/fairbase/cmake/scripts/generate_dictionary_root.sh.in
                    ${CMAKE_CURRENT_BINARY_DIR}/generate_dictionary_${script_name}.sh
                   )
-    #EXEC_PROGRAM(/bin/chmod ARGS "u+x ${CMAKE_CURRENT_BINARY_DIR}/generate_dictionary_${script_name}.sh")
     execute_process(COMMAND /bin/chmod u+x ${CMAKE_CURRENT_BINARY_DIR}/generate_dictionary_${script_name}.sh OUTPUT_QUIET)
 
     Add_Custom_Command(OUTPUT  ${OUTPUT_FILES}


### PR DESCRIPTION
exec_program was deprecated in CMake 3.0.
It got a FATAL_ERROR with CMake 3.28.
See CMP0153.

So replace with the newer execute_process.

See: https://cmake.org/cmake/help/latest/policy/CMP0153.html

(extracted from #1486)