### PR TITLE
build: MCConfigurator needs FairRoot::FastSim

### DIFF
--- a/fairroot/CMakeLists.txt
+++ b/fairroot/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-#    Copyright (C) 2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    #
+# Copyright (C) 2023-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
@@ -40,7 +40,8 @@ else()
   message(STATUS "eventdisplay will not be built, because ROOT has no opengl support.")
 endif()
 
-if(Geant3_FOUND AND Geant4VMC_FOUND AND yaml-cpp_FOUND)
+if(Geant3_FOUND AND Geant4VMC_FOUND AND yaml-cpp_FOUND
+   AND TARGET FairRoot::FastSim)
   add_subdirectory(mcconfigurator)
 endif()
 


### PR DESCRIPTION
So only build it, if FairRoot::FastSim is available.

Before: https://cdash.gsi.de/viewConfigure.php?buildid=439647
After: https://cdash.gsi.de/viewConfigure.php?buildid=439706

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
