### PR TITLE
Use std containers for FairModule::svList

### DIFF
--- a/fairroot/base/sim/FairDetector.cxx
+++ b/fairroot/base/sim/FairDetector.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -13,7 +13,6 @@
 #include "FairDetector.h"
 
 #include "FairGeoNode.h"   // for FairGeoNode
-#include "FairModule.h"    // for FairModule::svList, etc
 #include "FairRootManager.h"
 #include "FairVolume.h"   // for FairVolume
 
@@ -94,13 +93,11 @@ void FairDetector::Initialize()
         DefineSensitiveVolumes();
     }
 
-    Int_t NoOfEntries = svList->GetEntries();
     Int_t fMCid;
     FairGeoNode* fN;
     TString cutName;
     TString copysign = "#";
-    for (Int_t i = 0; i < NoOfEntries; i++) {
-        FairVolume* aVol = static_cast<FairVolume*>(svList->At(i));
+    for (auto aVol : fAllSensitiveVolumes) {
         cutName = aVol->GetName();
         Ssiz_t pos = cutName.Index(copysign, 1);
         if (pos > 1) {

--- a/fairroot/base/sim/FairMCApplication.cxx
+++ b/fairroot/base/sim/FairMCApplication.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -885,13 +885,9 @@ void FairMCApplication::InitGeometry()
     }
     fMCEventHeader->SetRunID(runId);
 
-    // Get static thread local svList
-    auto sen_volumes = FairModule::svList;
-
     // Fill sensitive volumes in fVolMap
-    for (auto fv : TRangeDynCast<FairVolume>(sen_volumes)) {
+    for (auto fv : FairModule::fAllSensitiveVolumes) {
         if (!fv) {
-            LOG(error) << "Not a FairVolume in FairModule::svList";
             continue;
         }
         auto id = fv->getMCid();

--- a/fairroot/base/sim/FairModule.cxx
+++ b/fairroot/base/sim/FairModule.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -47,6 +47,8 @@
 #include <map>
 #include <memory>
 
+thread_local std::vector<FairVolume*> FairModule::fAllSensitiveVolumes;
+
 void FairModule::ConstructGeometry()
 {
     LOG(warn)
@@ -65,9 +67,6 @@ FairModule::FairModule(const char* Name, const char* title, Bool_t Active)
     : TNamed(Name, title)
     , fActive(Active)
 {
-    if (!svList) {
-        svList = new TRefArray();
-    }
     if (!vList) {
         vList = new FairVolumeList();
     }
@@ -84,13 +83,6 @@ FairModule::FairModule(const FairModule& rhs)
     , fVerboseLevel(rhs.fVerboseLevel)
     , fGeoSaved(rhs.fGeoSaved)
 {
-    if (!svList) {
-        svList = new TRefArray();
-        for (Int_t i = 0; i < rhs.svList->GetEntries(); i++) {
-            svList->Add(rhs.svList->At(i));
-        }
-    }
-
     if (!vList) {
         vList = new FairVolumeList();
         for (Int_t i = 0; i < rhs.vList->getEntries(); i++) {
@@ -218,9 +210,6 @@ void FairModule::ProcessNodes(TList* aList)
       from ConstructGeometry() of your detector class. Aborting...";
     }
 
-    if (!svList) {
-        svList = new TRefArray();
-    }
     if (!vList) {
         vList = new FairVolumeList();
     }
@@ -251,7 +240,7 @@ void FairModule::ProcessNodes(TList* aList)
         if (node->isSensitive() && fActive) {
             volume->setModId(fModId);
             volume->SetModule(this);
-            svList->Add(volume);
+            fAllSensitiveVolumes.push_back(volume);
             aVol = dynamic_cast<FairGeoVolume*>(node);
             fNodes->AddLast(aVol);
             fNbOfSensitiveVol++;
@@ -271,7 +260,7 @@ void FairModule::AddSensitiveVolume(TGeoVolume* v)
         vList->addVolume(volume);
         volume->setModId(fModId);
         volume->SetModule(this);
-        svList->Add(volume);
+        fAllSensitiveVolumes.push_back(volume);
         fNbOfSensitiveVol++;
     }
 }

--- a/fairroot/base/sim/FairModule.h
+++ b/fairroot/base/sim/FairModule.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -26,6 +26,7 @@
 #include <TString.h>     // for TString, operator!=
 #include <TVirtualMC.h>
 #include <string>
+#include <vector>
 
 class FairVolumeList;
 class FairVolume;
@@ -139,7 +140,7 @@ class FairModule : public TNamed
     /**total number of volumes in a simulaion session*/
     static thread_local inline Int_t fNbOfVolumes{0};   //!
     /**list of all sensitive volumes in  a simulaion session*/
-    static thread_local inline TRefArray* svList{nullptr};   //!
+    static thread_local std::vector<FairVolume*> fAllSensitiveVolumes;   //!
 
     TString fMotherVolumeName{""};   //!
     FairVolume* getFairVolume(FairGeoNode* fNode);

--- a/templates/NewDetector_root_containers/NewDetector.cxx
+++ b/templates/NewDetector_root_containers/NewDetector.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -81,8 +81,6 @@ void NewDetector::Initialize()
 {
     /**
      * WORKAROUND needed for Geant4 in MT mode
-     * Call AddSensitiveVolume for sensitive volumes in order to fill
-     * thread-local FairModule::svList.
      */
     DefineSensitiveVolumes();
 

--- a/templates/NewDetector_stl_containers/NewDetector.cxx
+++ b/templates/NewDetector_stl_containers/NewDetector.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -80,8 +80,6 @@ void NewDetector::Initialize()
 {
     /**
      * WORKAROUND needed for Geant4 in MT mode
-     * Call AddSensitiveVolume for sensitive volumes in order to fill
-     * thread-local FairModule::svList.
      */
     DefineSensitiveVolumes();
 

--- a/templates/project_root_containers/NewDetector/NewDetector.cxx
+++ b/templates/project_root_containers/NewDetector/NewDetector.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -81,8 +81,6 @@ void NewDetector::Initialize()
 {
     /**
      * WORKAROUND needed for Geant4 in MT mode
-     * Call AddSensitiveVolume for sensitive volumes in order to fill
-     * thread-local FairModule::svList.
      */
     DefineSensitiveVolumes();
 

--- a/templates/project_stl_containers/NewDetector/NewDetector.cxx
+++ b/templates/project_stl_containers/NewDetector/NewDetector.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -80,8 +80,6 @@ void NewDetector::Initialize()
 {
     /**
      * WORKAROUND needed for Geant4 in MT mode
-     * Call AddSensitiveVolume for sensitive volumes in order to fill
-     * thread-local FairModule::svList.
      */
     DefineSensitiveVolumes();
 


### PR DESCRIPTION
`FairModule::svList` can very well be implemented using `std::vector` without all the casting.

And rename to `fAllSensitiveVolumes`.

Follow up from #1497

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
