### PR TITLE
Replace deprecated APIs from FairMQ and Geant4

### DIFF
--- a/examples/MQ/histogramServer/FairMQExHistoDevice.cxx
+++ b/examples/MQ/histogramServer/FairMQExHistoDevice.cxx
@@ -55,7 +55,7 @@ bool FairMQExHistoDevice::ConditionalRun()
     auto message(NewMessage());
     RootSerializer().Serialize(*message, &fArrayHisto);
 
-    for (auto& channel : fChannels) {
+    for (auto& channel : GetChannels()) {
         Send(message, channel.first);
     }
 

--- a/examples/MQ/pixelDetector/src/devices/FairMQRunDevice.cxx
+++ b/examples/MQ/pixelDetector/src/devices/FairMQRunDevice.cxx
@@ -66,7 +66,7 @@ void FairMQRunDevice::SendBranches(FairOnlineSink& sink)
 
     TList* branchNameList = FairRootManager::Instance()->GetBranchNameList();
 
-    for (auto& mi : fChannels) {
+    for (auto& mi : GetChannels()) {
         LOG(debug) << "trying channel >" << mi.first << "<";
 
         fair::mq::Parts parts;

--- a/examples/MQ/serialization/processor.cxx
+++ b/examples/MQ/serialization/processor.cxx
@@ -56,7 +56,7 @@ struct Processor : fair::mq::Device
                 partsOut.AddPart(std::move(partsIn.At(0)));
                 partsOut.AddPart(NewMessage());
 
-                BoostSerializer<MyHit>().Serialize(partsOut.AtRef(1), &hits);
+                BoostSerializer<MyHit>().Serialize(*(partsOut.At(1)), &hits);
                 if (Send(partsOut, "data2") >= 0) {
                     sentMsgs++;
                 }

--- a/fairroot/fastsim/FairFastSimModel.cxx
+++ b/fairroot/fastsim/FairFastSimModel.cxx
@@ -126,15 +126,15 @@ void FairFastSimModel::DoIt(const G4FastTrack& fastTrack, G4FastStep& fastStep)
         G4double len = 0.;
         G4double ek = particle->Ek() * 1000.;
 
-        fastStep.SetPrimaryTrackFinalPosition(pos, false);
-        fastStep.SetPrimaryTrackFinalTime(tim);
-        fastStep.SetPrimaryTrackFinalProperTime(tim);
-        fastStep.SetPrimaryTrackFinalMomentum(mom, false);
-        fastStep.SetPrimaryTrackFinalKineticEnergy(ek);
+        fastStep.ProposePrimaryTrackFinalPosition(pos, false);
+        fastStep.ProposePrimaryTrackFinalTime(tim);
+        fastStep.ProposePrimaryTrackProperTime(tim);
+        fastStep.ProposePrimaryTrackMomentumDirection(mom, false);
+        fastStep.ProposePrimaryTrackFinalKineticEnergy(ek);
         //    fastStep.SetPrimaryTrackFinalKineticEnergyAndDirection (G4double, const G4ThreeVector &, G4bool
         //    localCoordinates=true);
-        fastStep.SetPrimaryTrackFinalPolarization(pol, false);
-        fastStep.SetPrimaryTrackPathLength(len);
+        fastStep.ProposePrimaryTrackFinalPolarization(pol, false);
+        fastStep.ProposePrimaryTrackPathLength(len);
 
         if (FairTrajFilter::Instance()->IsAccepted(particle)) {
             FairTrajFilter::Instance()->GetCurrentTrk()->AddPoint(


### PR DESCRIPTION
Addresses issue #1501 in FairMQ part.
Also Geant4 deprecates functions like Set...() in favor of Propose...().

---

Checklist:

* [x] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
