### PR TITLE
Use snprintf instead of sprintf

### DIFF
--- a/examples/MQ/pixelDetector/src/PixelGeo.cxx
+++ b/examples/MQ/pixelDetector/src/PixelGeo.cxx
@@ -8,7 +8,6 @@
 #include "PixelGeo.h"
 
 #include <fairlogger/Logger.h>
-
 #include <stdio.h>   // for sprintf
 
 PixelGeo::PixelGeo()
@@ -28,9 +27,9 @@ const char* PixelGeo::getModuleName(Int_t m)
       ASCII file should start with Pixel otherwise they will
       not be constructed
   */
-    int result_length = snprintf(modName, maxbuf-1, "Pixel%i", m + 1);
+    int result_length = snprintf(modName, maxbuf - 1, "Pixel%i", m + 1);
     if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-      LOG(fatal) << "Buffer overrun in snprintf.";
+        LOG(fatal) << "Buffer overrun in snprintf.";
     }
     return modName;
 }
@@ -38,9 +37,9 @@ const char* PixelGeo::getModuleName(Int_t m)
 const char* PixelGeo::getEleName(Int_t m)
 {
     /** Returns the element name of Det number m */
-    int result_length = snprintf(eleName, maxbuf-1, "Pixel%i", m + 1);
+    int result_length = snprintf(eleName, maxbuf - 1, "Pixel%i", m + 1);
     if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-      LOG(fatal) << "Buffer overrun in snprintf.";
+        LOG(fatal) << "Buffer overrun in snprintf.";
     }
     return eleName;
 }

--- a/examples/MQ/pixelDetector/src/PixelGeo.cxx
+++ b/examples/MQ/pixelDetector/src/PixelGeo.cxx
@@ -7,6 +7,8 @@
  ********************************************************************************/
 #include "PixelGeo.h"
 
+#include <fairlogger/Logger.h>
+
 #include <stdio.h>   // for sprintf
 
 PixelGeo::PixelGeo()
@@ -26,13 +28,19 @@ const char* PixelGeo::getModuleName(Int_t m)
       ASCII file should start with Pixel otherwise they will
       not be constructed
   */
-    sprintf(modName, "Pixel%i", m + 1);
+    int result_length = snprintf(modName, maxbuf-1, "Pixel%i", m + 1);
+    if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+      LOG(fatal) << "Buffer overrun in snprintf.";
+    }
     return modName;
 }
 
 const char* PixelGeo::getEleName(Int_t m)
 {
     /** Returns the element name of Det number m */
-    sprintf(eleName, "Pixel%i", m + 1);
+    int result_length = snprintf(eleName, maxbuf-1, "Pixel%i", m + 1);
+    if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+      LOG(fatal) << "Buffer overrun in snprintf.";
+    }
     return eleName;
 }

--- a/examples/MQ/pixelDetector/src/PixelGeo.h
+++ b/examples/MQ/pixelDetector/src/PixelGeo.h
@@ -16,8 +16,9 @@
 class PixelGeo : public FairGeoSet
 {
   protected:
-    char modName[20]{"Pixel"};   // name of module
-    char eleName[20]{"Pixel"};   // substring for elements in module
+    static constexpr int maxbuf{20}; //!
+    char modName[maxbuf]{"Pixel"};   // name of module
+    char eleName[maxbuf]{"Pixel"};   // substring for elements in module
 
   public:
     PixelGeo();

--- a/examples/MQ/pixelDetector/src/PixelGeo.h
+++ b/examples/MQ/pixelDetector/src/PixelGeo.h
@@ -16,9 +16,9 @@
 class PixelGeo : public FairGeoSet
 {
   protected:
-    static constexpr int maxbuf{20}; //!
-    char modName[maxbuf]{"Pixel"};   // name of module
-    char eleName[maxbuf]{"Pixel"};   // substring for elements in module
+    static constexpr int maxbuf{20};   //!
+    char modName[maxbuf]{"Pixel"};     // name of module
+    char eleName[maxbuf]{"Pixel"};     // substring for elements in module
 
   public:
     PixelGeo();

--- a/examples/advanced/Tutorial3/simulation/FairTestDetectorGeo.cxx
+++ b/examples/advanced/Tutorial3/simulation/FairTestDetectorGeo.cxx
@@ -7,6 +7,8 @@
  ********************************************************************************/
 #include "FairTestDetectorGeo.h"
 
+#include <fairlogger/Logger.h>
+
 #include <cstdio>   // for sprintf
 
 FairTestDetectorGeo::FairTestDetectorGeo()
@@ -26,13 +28,19 @@ const char* FairTestDetectorGeo::getModuleName(Int_t m)
         ASCII file should start with FairTestDetector otherwise they will
         not be constructed
     */
-    sprintf(modName, "torino%i", m + 1);
+    int result_length = snprintf(modName, maxbuf-1, "torino%i", m + 1);
+    if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+      LOG(fatal) << "Buffer overrun in snprintf.";
+    }
     return modName;
 }
 
 const char* FairTestDetectorGeo::getEleName(Int_t m)
 {
     /** Returns the element name of Det number m */
-    sprintf(eleName, "torino%i", m + 1);
+    int result_length = snprintf(eleName, maxbuf-1, "torino%i", m + 1);
+    if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+      LOG(fatal) << "Buffer overrun in snprintf.";
+    }
     return eleName;
 }

--- a/examples/advanced/Tutorial3/simulation/FairTestDetectorGeo.cxx
+++ b/examples/advanced/Tutorial3/simulation/FairTestDetectorGeo.cxx
@@ -7,9 +7,8 @@
  ********************************************************************************/
 #include "FairTestDetectorGeo.h"
 
-#include <fairlogger/Logger.h>
-
 #include <cstdio>   // for sprintf
+#include <fairlogger/Logger.h>
 
 FairTestDetectorGeo::FairTestDetectorGeo()
     : FairGeoSet()
@@ -28,9 +27,9 @@ const char* FairTestDetectorGeo::getModuleName(Int_t m)
         ASCII file should start with FairTestDetector otherwise they will
         not be constructed
     */
-    int result_length = snprintf(modName, maxbuf-1, "torino%i", m + 1);
+    int result_length = snprintf(modName, maxbuf - 1, "torino%i", m + 1);
     if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-      LOG(fatal) << "Buffer overrun in snprintf.";
+        LOG(fatal) << "Buffer overrun in snprintf.";
     }
     return modName;
 }
@@ -38,9 +37,9 @@ const char* FairTestDetectorGeo::getModuleName(Int_t m)
 const char* FairTestDetectorGeo::getEleName(Int_t m)
 {
     /** Returns the element name of Det number m */
-    int result_length = snprintf(eleName, maxbuf-1, "torino%i", m + 1);
+    int result_length = snprintf(eleName, maxbuf - 1, "torino%i", m + 1);
     if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-      LOG(fatal) << "Buffer overrun in snprintf.";
+        LOG(fatal) << "Buffer overrun in snprintf.";
     }
     return eleName;
 }

--- a/examples/advanced/Tutorial3/simulation/FairTestDetectorGeo.h
+++ b/examples/advanced/Tutorial3/simulation/FairTestDetectorGeo.h
@@ -16,9 +16,9 @@
 class FairTestDetectorGeo : public FairGeoSet
 {
   protected:
-    static constexpr int maxbuf{20}; //!
-    char modName[maxbuf]{"torino"};   // name of module
-    char eleName[maxbuf]{"torino"};   // substring for elements in module
+    static constexpr int maxbuf{20};   //!
+    char modName[maxbuf]{"torino"};    // name of module
+    char eleName[maxbuf]{"torino"};    // substring for elements in module
   public:
     FairTestDetectorGeo();
     ~FairTestDetectorGeo() override = default;

--- a/examples/advanced/Tutorial3/simulation/FairTestDetectorGeo.h
+++ b/examples/advanced/Tutorial3/simulation/FairTestDetectorGeo.h
@@ -16,8 +16,9 @@
 class FairTestDetectorGeo : public FairGeoSet
 {
   protected:
-    char modName[20]{"torino"};   // name of module
-    char eleName[20]{"torino"};   // substring for elements in module
+    static constexpr int maxbuf{20}; //!
+    char modName[maxbuf]{"torino"};   // name of module
+    char eleName[maxbuf]{"torino"};   // substring for elements in module
   public:
     FairTestDetectorGeo();
     ~FairTestDetectorGeo() override = default;

--- a/examples/advanced/propagator/src/FairTutPropGeo.cxx
+++ b/examples/advanced/propagator/src/FairTutPropGeo.cxx
@@ -8,7 +8,6 @@
 #include "FairTutPropGeo.h"
 
 #include <fairlogger/Logger.h>
-
 #include <stdio.h>   // for sprintf
 
 // -----   Default constructor   -------------------------------------------
@@ -31,9 +30,9 @@ const char* FairTutPropGeo::getModuleName(Int_t m)
       ASCII file should start with Pixel otherwise they will
       not be constructed
   */
-    int result_length = snprintf(modName, maxbuf-1, "Pixel%i", m + 1);
+    int result_length = snprintf(modName, maxbuf - 1, "Pixel%i", m + 1);
     if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-      LOG(fatal) << "Buffer overrun in snprintf.";
+        LOG(fatal) << "Buffer overrun in snprintf.";
     }
     return modName;
 }
@@ -41,9 +40,9 @@ const char* FairTutPropGeo::getModuleName(Int_t m)
 const char* FairTutPropGeo::getEleName(Int_t m)
 {
     /** Returns the element name of Det number m */
-    int result_length = snprintf(eleName, maxbuf-1, "Pixel%i", m + 1);
+    int result_length = snprintf(eleName, maxbuf - 1, "Pixel%i", m + 1);
     if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-      LOG(fatal) << "Buffer overrun in snprintf.";
+        LOG(fatal) << "Buffer overrun in snprintf.";
     }
     return eleName;
 }

--- a/examples/advanced/propagator/src/FairTutPropGeo.cxx
+++ b/examples/advanced/propagator/src/FairTutPropGeo.cxx
@@ -7,6 +7,8 @@
  ********************************************************************************/
 #include "FairTutPropGeo.h"
 
+#include <fairlogger/Logger.h>
+
 #include <stdio.h>   // for sprintf
 
 // -----   Default constructor   -------------------------------------------
@@ -29,13 +31,19 @@ const char* FairTutPropGeo::getModuleName(Int_t m)
       ASCII file should start with Pixel otherwise they will
       not be constructed
   */
-    sprintf(modName, "Pixel%i", m + 1);
+    int result_length = snprintf(modName, maxbuf-1, "Pixel%i", m + 1);
+    if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+      LOG(fatal) << "Buffer overrun in snprintf.";
+    }
     return modName;
 }
 
 const char* FairTutPropGeo::getEleName(Int_t m)
 {
     /** Returns the element name of Det number m */
-    sprintf(eleName, "Pixel%i", m + 1);
+    int result_length = snprintf(eleName, maxbuf-1, "Pixel%i", m + 1);
+    if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+      LOG(fatal) << "Buffer overrun in snprintf.";
+    }
     return eleName;
 }

--- a/examples/advanced/propagator/src/FairTutPropGeo.h
+++ b/examples/advanced/propagator/src/FairTutPropGeo.h
@@ -15,9 +15,9 @@
 class FairTutPropGeo : public FairGeoSet
 {
   protected:
-    static constexpr int maxbuf{20}; //!
-    char modName[maxbuf]{"Pixel"};   // name of module
-    char eleName[maxbuf]{"Pixel"};   // substring for elements in module
+    static constexpr int maxbuf{20};   //!
+    char modName[maxbuf]{"Pixel"};     // name of module
+    char eleName[maxbuf]{"Pixel"};     // substring for elements in module
   public:
     FairTutPropGeo();
     ~FairTutPropGeo() override = default;

--- a/examples/advanced/propagator/src/FairTutPropGeo.h
+++ b/examples/advanced/propagator/src/FairTutPropGeo.h
@@ -15,8 +15,9 @@
 class FairTutPropGeo : public FairGeoSet
 {
   protected:
-    char modName[20]{"Pixel"};   // name of module
-    char eleName[20]{"Pixel"};   // substring for elements in module
+    static constexpr int maxbuf{20}; //!
+    char modName[maxbuf]{"Pixel"};   // name of module
+    char eleName[maxbuf]{"Pixel"};   // substring for elements in module
   public:
     FairTutPropGeo();
     ~FairTutPropGeo() override = default;

--- a/examples/simulation/Tutorial1/src/FairTutorialDet1Geo.cxx
+++ b/examples/simulation/Tutorial1/src/FairTutorialDet1Geo.cxx
@@ -7,9 +7,8 @@
  ********************************************************************************/
 #include "FairTutorialDet1Geo.h"
 
-#include <fairlogger/Logger.h>
-
 #include <cstdio>   // for sprintf
+#include <fairlogger/Logger.h>
 
 FairTutorialDet1Geo::FairTutorialDet1Geo()
     : FairGeoSet()
@@ -26,9 +25,9 @@ const char* FairTutorialDet1Geo::getModuleName(Int_t m)
       ASCII file should start with TutorialDet otherwise they will
       not be constructed
   */
-    int result_length = snprintf(modName, maxbuf-1, "tutdet%i", m + 1);
+    int result_length = snprintf(modName, maxbuf - 1, "tutdet%i", m + 1);
     if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-      LOG(fatal) << "Buffer overrun in snprintf.";
+        LOG(fatal) << "Buffer overrun in snprintf.";
     }
     return modName;
 }
@@ -36,9 +35,9 @@ const char* FairTutorialDet1Geo::getModuleName(Int_t m)
 const char* FairTutorialDet1Geo::getEleName(Int_t m)
 {
     /** Returns the element name of Det number m */
-    int result_length = snprintf(eleName, maxbuf-1, "tutdet%i", m + 1);
+    int result_length = snprintf(eleName, maxbuf - 1, "tutdet%i", m + 1);
     if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-      LOG(fatal) << "Buffer overrun in snprintf.";
+        LOG(fatal) << "Buffer overrun in snprintf.";
     }
     return eleName;
 }

--- a/examples/simulation/Tutorial1/src/FairTutorialDet1Geo.cxx
+++ b/examples/simulation/Tutorial1/src/FairTutorialDet1Geo.cxx
@@ -7,6 +7,8 @@
  ********************************************************************************/
 #include "FairTutorialDet1Geo.h"
 
+#include <fairlogger/Logger.h>
+
 #include <cstdio>   // for sprintf
 
 FairTutorialDet1Geo::FairTutorialDet1Geo()
@@ -24,13 +26,19 @@ const char* FairTutorialDet1Geo::getModuleName(Int_t m)
       ASCII file should start with TutorialDet otherwise they will
       not be constructed
   */
-    sprintf(modName, "tutdet%i", m + 1);
+    int result_length = snprintf(modName, maxbuf-1, "tutdet%i", m + 1);
+    if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+      LOG(fatal) << "Buffer overrun in snprintf.";
+    }
     return modName;
 }
 
 const char* FairTutorialDet1Geo::getEleName(Int_t m)
 {
     /** Returns the element name of Det number m */
-    sprintf(eleName, "tutdet%i", m + 1);
+    int result_length = snprintf(eleName, maxbuf-1, "tutdet%i", m + 1);
+    if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+      LOG(fatal) << "Buffer overrun in snprintf.";
+    }
     return eleName;
 }

--- a/examples/simulation/Tutorial1/src/FairTutorialDet1Geo.h
+++ b/examples/simulation/Tutorial1/src/FairTutorialDet1Geo.h
@@ -16,8 +16,9 @@
 class FairTutorialDet1Geo : public FairGeoSet
 {
   protected:
-    char modName[20]{"tutdet"};   // name of module
-    char eleName[20]{"tutdet"};   // substring for elements in module
+    static constexpr int maxbuf{20}; //!
+    char modName[maxbuf]{"tutdet"};   // name of module
+    char eleName[maxbuf]{"tutdet"};   // substring for elements in module
 
   public:
     FairTutorialDet1Geo();

--- a/examples/simulation/Tutorial1/src/FairTutorialDet1Geo.h
+++ b/examples/simulation/Tutorial1/src/FairTutorialDet1Geo.h
@@ -16,9 +16,9 @@
 class FairTutorialDet1Geo : public FairGeoSet
 {
   protected:
-    static constexpr int maxbuf{20}; //!
-    char modName[maxbuf]{"tutdet"};   // name of module
-    char eleName[maxbuf]{"tutdet"};   // substring for elements in module
+    static constexpr int maxbuf{20};   //!
+    char modName[maxbuf]{"tutdet"};    // name of module
+    char eleName[maxbuf]{"tutdet"};    // substring for elements in module
 
   public:
     FairTutorialDet1Geo();

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2Geo.cxx
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2Geo.cxx
@@ -7,9 +7,8 @@
  ********************************************************************************/
 #include "FairTutorialDet2Geo.h"
 
-#include <fairlogger/Logger.h>
-
 #include <cstdio>
+#include <fairlogger/Logger.h>
 
 FairTutorialDet2Geo::FairTutorialDet2Geo()
     : FairGeoSet()
@@ -26,9 +25,9 @@ const char* FairTutorialDet2Geo::getModuleName(Int_t m)
       ASCII file should start with TutorialDet otherwise they will
       not be constructed
   */
-    int result_length = snprintf(modName, maxbuf-1, "tutdet%i", m + 1);
+    int result_length = snprintf(modName, maxbuf - 1, "tutdet%i", m + 1);
     if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-      LOG(fatal) << "Buffer overrun in snprintf.";
+        LOG(fatal) << "Buffer overrun in snprintf.";
     }
     return modName;
 }
@@ -36,9 +35,9 @@ const char* FairTutorialDet2Geo::getModuleName(Int_t m)
 const char* FairTutorialDet2Geo::getEleName(Int_t m)
 {
     /** Returns the element name of Det number m */
-    int result_length = snprintf(eleName, maxbuf-1, "tutdet%i", m + 1);
+    int result_length = snprintf(eleName, maxbuf - 1, "tutdet%i", m + 1);
     if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-      LOG(fatal) << "Buffer overrun in snprintf.";
+        LOG(fatal) << "Buffer overrun in snprintf.";
     }
     return eleName;
 }

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2Geo.cxx
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2Geo.cxx
@@ -7,6 +7,8 @@
  ********************************************************************************/
 #include "FairTutorialDet2Geo.h"
 
+#include <fairlogger/Logger.h>
+
 #include <cstdio>
 
 FairTutorialDet2Geo::FairTutorialDet2Geo()
@@ -24,13 +26,19 @@ const char* FairTutorialDet2Geo::getModuleName(Int_t m)
       ASCII file should start with TutorialDet otherwise they will
       not be constructed
   */
-    sprintf(modName, "tutdet%i", m + 1);
+    int result_length = snprintf(modName, maxbuf-1, "tutdet%i", m + 1);
+    if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+      LOG(fatal) << "Buffer overrun in snprintf.";
+    }
     return modName;
 }
 
 const char* FairTutorialDet2Geo::getEleName(Int_t m)
 {
     /** Returns the element name of Det number m */
-    sprintf(eleName, "tutdet%i", m + 1);
+    int result_length = snprintf(eleName, maxbuf-1, "tutdet%i", m + 1);
+    if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+      LOG(fatal) << "Buffer overrun in snprintf.";
+    }
     return eleName;
 }

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2Geo.h
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2Geo.h
@@ -15,9 +15,9 @@
 class FairTutorialDet2Geo : public FairGeoSet
 {
   protected:
-    static constexpr int maxbuf{20}; //!
-    char modName[maxbuf]{"tutdet"};   // name of module
-    char eleName[maxbuf]{"tutdet"};   // substring for elements in module
+    static constexpr int maxbuf{20};   //!
+    char modName[maxbuf]{"tutdet"};    // name of module
+    char eleName[maxbuf]{"tutdet"};    // substring for elements in module
 
   public:
     FairTutorialDet2Geo();

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2Geo.h
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2Geo.h
@@ -15,8 +15,9 @@
 class FairTutorialDet2Geo : public FairGeoSet
 {
   protected:
-    char modName[20]{"tutdet"};   // name of module
-    char eleName[20]{"tutdet"};   // substring for elements in module
+    static constexpr int maxbuf{20}; //!
+    char modName[maxbuf]{"tutdet"};   // name of module
+    char eleName[maxbuf]{"tutdet"};   // substring for elements in module
 
   public:
     FairTutorialDet2Geo();

--- a/examples/simulation/Tutorial4/src/mc/FairTutorialDet4Geo.cxx
+++ b/examples/simulation/Tutorial4/src/mc/FairTutorialDet4Geo.cxx
@@ -8,7 +8,6 @@
 #include "FairTutorialDet4Geo.h"
 
 #include <fairlogger/Logger.h>
-
 #include <stdio.h>   // for sprintf
 
 FairTutorialDet4Geo::FairTutorialDet4Geo()
@@ -26,9 +25,9 @@ const char* FairTutorialDet4Geo::getModuleName(Int_t m)
       ASCII file should start with TutorialDet otherwise they will
       not be constructed
   */
-    int result_length = snprintf(modName, maxbuf-1, "tutdet%i", m + 1);
+    int result_length = snprintf(modName, maxbuf - 1, "tutdet%i", m + 1);
     if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-      LOG(fatal) << "Buffer overrun in snprintf.";
+        LOG(fatal) << "Buffer overrun in snprintf.";
     }
     return modName;
 }
@@ -36,9 +35,9 @@ const char* FairTutorialDet4Geo::getModuleName(Int_t m)
 const char* FairTutorialDet4Geo::getEleName(Int_t m)
 {
     /** Returns the element name of Det number m */
-    int result_length = snprintf(eleName, maxbuf-1, "tutdet%i", m + 1);
+    int result_length = snprintf(eleName, maxbuf - 1, "tutdet%i", m + 1);
     if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-      LOG(fatal) << "Buffer overrun in snprintf.";
+        LOG(fatal) << "Buffer overrun in snprintf.";
     }
     return eleName;
 }

--- a/examples/simulation/Tutorial4/src/mc/FairTutorialDet4Geo.cxx
+++ b/examples/simulation/Tutorial4/src/mc/FairTutorialDet4Geo.cxx
@@ -7,6 +7,8 @@
  ********************************************************************************/
 #include "FairTutorialDet4Geo.h"
 
+#include <fairlogger/Logger.h>
+
 #include <stdio.h>   // for sprintf
 
 FairTutorialDet4Geo::FairTutorialDet4Geo()
@@ -24,13 +26,19 @@ const char* FairTutorialDet4Geo::getModuleName(Int_t m)
       ASCII file should start with TutorialDet otherwise they will
       not be constructed
   */
-    sprintf(modName, "tutdet%i", m + 1);
+    int result_length = snprintf(modName, maxbuf-1, "tutdet%i", m + 1);
+    if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+      LOG(fatal) << "Buffer overrun in snprintf.";
+    }
     return modName;
 }
 
 const char* FairTutorialDet4Geo::getEleName(Int_t m)
 {
     /** Returns the element name of Det number m */
-    sprintf(eleName, "tutdet%i", m + 1);
+    int result_length = snprintf(eleName, maxbuf-1, "tutdet%i", m + 1);
+    if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+      LOG(fatal) << "Buffer overrun in snprintf.";
+    }
     return eleName;
 }

--- a/examples/simulation/Tutorial4/src/mc/FairTutorialDet4Geo.h
+++ b/examples/simulation/Tutorial4/src/mc/FairTutorialDet4Geo.h
@@ -16,8 +16,9 @@
 class FairTutorialDet4Geo : public FairGeoSet
 {
   protected:
-    char modName[20]{"tutdet"};   // name of module
-    char eleName[20]{"tutdet"};   // substring for elements in module
+    static constexpr int maxbuf{20}; //!
+    char modName[maxbuf]{"tutdet"};   // name of module
+    char eleName[maxbuf]{"tutdet"};   // substring for elements in module
 
   public:
     FairTutorialDet4Geo();

--- a/examples/simulation/Tutorial4/src/mc/FairTutorialDet4Geo.h
+++ b/examples/simulation/Tutorial4/src/mc/FairTutorialDet4Geo.h
@@ -16,9 +16,9 @@
 class FairTutorialDet4Geo : public FairGeoSet
 {
   protected:
-    static constexpr int maxbuf{20}; //!
-    char modName[maxbuf]{"tutdet"};   // name of module
-    char eleName[maxbuf]{"tutdet"};   // substring for elements in module
+    static constexpr int maxbuf{20};   //!
+    char modName[maxbuf]{"tutdet"};    // name of module
+    char eleName[maxbuf]{"tutdet"};    // substring for elements in module
 
   public:
     FairTutorialDet4Geo();

--- a/fairroot/generators/FairIonGenerator.cxx
+++ b/fairroot/generators/FairIonGenerator.cxx
@@ -109,9 +109,9 @@ FairIonGenerator::FairIonGenerator(Int_t z,
   */
     int maxbuf{20};
     char buffer[maxbuf];
-    int result_length = snprintf(buffer, maxbuf-1, "FairIon%d", fgNIon);
+    int result_length = snprintf(buffer, maxbuf - 1, "FairIon%d", fgNIon);
     if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-      LOG(fatal) << "Buffer overrun in snprintf.";
+        LOG(fatal) << "Buffer overrun in snprintf.";
     }
     fIon = new FairIon(buffer, z, a, q);
     FairRunSim* run = FairRunSim::Instance();
@@ -145,9 +145,15 @@ FairIonGenerator::~FairIonGenerator()
     // if (fIon) delete fIon;
 }
 
-void FairIonGenerator::SetExcitationEnergy(Double_t eExc) { fIon->SetExcEnergy(eExc); }
+void FairIonGenerator::SetExcitationEnergy(Double_t eExc)
+{
+    fIon->SetExcEnergy(eExc);
+}
 
-void FairIonGenerator::SetMass(Double_t mass) { fIon->SetMass(mass); }
+void FairIonGenerator::SetMass(Double_t mass)
+{
+    fIon->SetMass(mass);
+}
 
 Bool_t FairIonGenerator::ReadEvent(FairPrimaryGenerator* primGen)
 {

--- a/fairroot/generators/FairIonGenerator.cxx
+++ b/fairroot/generators/FairIonGenerator.cxx
@@ -107,8 +107,12 @@ FairIonGenerator::FairIonGenerator(Int_t z,
   fVy   = vy;
   fVz   = vz;
   */
-    char buffer[20];
-    sprintf(buffer, "FairIon%d", fgNIon);
+    int maxbuf{20};
+    char buffer[maxbuf];
+    int result_length = snprintf(buffer, maxbuf-1, "FairIon%d", fgNIon);
+    if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+      LOG(fatal) << "Buffer overrun in snprintf.";
+    }
     fIon = new FairIon(buffer, z, a, q);
     FairRunSim* run = FairRunSim::Instance();
     if (!run) {

--- a/fairroot/generators/FairShieldGenerator.cxx
+++ b/fairroot/generators/FairShieldGenerator.cxx
@@ -51,7 +51,10 @@ FairShieldGenerator::FairShieldGenerator(const char* fileName)
     fInputFile = new std::ifstream(fFileName);
 }
 
-FairShieldGenerator::~FairShieldGenerator() { CloseInput(); }
+FairShieldGenerator::~FairShieldGenerator()
+{
+    CloseInput();
+}
 
 Bool_t FairShieldGenerator::ReadEvent(FairPrimaryGenerator* primGen)
 {
@@ -103,9 +106,9 @@ Bool_t FairShieldGenerator::ReadEvent(FairPrimaryGenerator* primGen)
         if (iPid == 1000) {
             int maxbuf{20};
             char ionName[maxbuf];
-            int result_length = snprintf(ionName, maxbuf-1, "Ion_%d_%d", iMass, iCharge);
+            int result_length = snprintf(ionName, maxbuf - 1, "Ion_%d_%d", iMass, iCharge);
             if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-              LOG(fatal) << "Buffer overrun in snprintf.";
+                LOG(fatal) << "Buffer overrun in snprintf.";
             }
             TParticlePDG* part = fPDG->GetParticle(ionName);
             if (!part) {
@@ -158,9 +161,9 @@ Int_t FairShieldGenerator::RegisterIons()
             if (iPid == 1000) {   // ion
                 int maxbuf{20};
                 char buffer[maxbuf];
-                int result_length = snprintf(buffer, maxbuf-1, "Ion_%d_%d", iMass, iCharge);
+                int result_length = snprintf(buffer, maxbuf - 1, "Ion_%d_%d", iMass, iCharge);
                 if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-                  LOG(fatal) << "Buffer overrun in snprintf.";
+                    LOG(fatal) << "Buffer overrun in snprintf.";
                 }
                 TString ionName(buffer);
                 if (fIonMap.find(ionName) == fIonMap.end()) {   // new ion

--- a/fairroot/generators/FairShieldGenerator.cxx
+++ b/fairroot/generators/FairShieldGenerator.cxx
@@ -101,8 +101,12 @@ Bool_t FairShieldGenerator::ReadEvent(FairPrimaryGenerator* primGen)
 
         // Case ion
         if (iPid == 1000) {
-            char ionName[20];
-            sprintf(ionName, "Ion_%d_%d", iMass, iCharge);
+            int maxbuf{20};
+            char ionName[maxbuf];
+            int result_length = snprintf(ionName, maxbuf-1, "Ion_%d_%d", iMass, iCharge);
+            if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+              LOG(fatal) << "Buffer overrun in snprintf.";
+            }
             TParticlePDG* part = fPDG->GetParticle(ionName);
             if (!part) {
                 LOG(warn) << "FairShieldGenerator::ReadEvent: Cannot find " << ionName << " in database!";
@@ -152,8 +156,12 @@ Int_t FairShieldGenerator::RegisterIons()
         for (Int_t iTrack = 0; iTrack < nTracks; iTrack++) {
             *fInputFile >> iPid >> iMass >> iCharge >> px >> py >> pz;
             if (iPid == 1000) {   // ion
-                char buffer[20];
-                sprintf(buffer, "Ion_%d_%d", iMass, iCharge);
+                int maxbuf{20};
+                char buffer[maxbuf];
+                int result_length = snprintf(buffer, maxbuf-1, "Ion_%d_%d", iMass, iCharge);
+                if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                  LOG(fatal) << "Buffer overrun in snprintf.";
+                }
                 TString ionName(buffer);
                 if (fIonMap.find(ionName) == fIonMap.end()) {   // new ion
                     FairIon* ion = new FairIon(ionName, iCharge, iMass, iCharge);

--- a/fairroot/geobase/CMakeLists.txt
+++ b/fairroot/geobase/CMakeLists.txt
@@ -60,6 +60,7 @@ target_link_libraries(${target}
 
   PRIVATE
   FairRoot::Tools
+  FairLogger::FairLogger
 
   ROOT::Geom
   ROOT::Graf3d # TRotMatrix

--- a/fairroot/geobase/FairGeoAssembly.cxx
+++ b/fairroot/geobase/FairGeoAssembly.cxx
@@ -19,10 +19,9 @@
 #include "FairGeoVector.h"      // for FairGeoVector
 #include "FairGeoVolume.h"      // for FairGeoVolume
 
-#include <fairlogger/Logger.h>
-
 #include <TArrayD.h>   // for TArrayD
 #include <TString.h>   // for TString
+#include <fairlogger/Logger.h>
 #include <fstream>
 #include <ostream>    // for fstream, etc
 #include <stdio.h>    // for printf, sprintf
@@ -79,9 +78,9 @@ Bool_t FairGeoAssembly::writePoints(std::fstream* pFile, FairGeoVolume* volu)
     Text_t buf[maxbuf];
     for (Int_t i = 0; i < nPoints; i++) {
         FairGeoVector& v = *(volu->getPoint(i));
-        int result_length = snprintf(buf, maxbuf-1, "%9.3f\n", v(0));
+        int result_length = snprintf(buf, maxbuf - 1, "%9.3f\n", v(0));
         if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-          LOG(fatal) << "Buffer overrun in snprintf.";
+            LOG(fatal) << "Buffer overrun in snprintf.";
         }
         pFile->write(buf, strlen(buf));
     }

--- a/fairroot/geobase/FairGeoAssembly.cxx
+++ b/fairroot/geobase/FairGeoAssembly.cxx
@@ -19,6 +19,8 @@
 #include "FairGeoVector.h"      // for FairGeoVector
 #include "FairGeoVolume.h"      // for FairGeoVolume
 
+#include <fairlogger/Logger.h>
+
 #include <TArrayD.h>   // for TArrayD
 #include <TString.h>   // for TString
 #include <fstream>
@@ -73,10 +75,14 @@ Bool_t FairGeoAssembly::writePoints(std::fstream* pFile, FairGeoVolume* volu)
     if (!pFile) {
         return kFALSE;
     }
-    Text_t buf[155];
+    int maxbuf{155};
+    Text_t buf[maxbuf];
     for (Int_t i = 0; i < nPoints; i++) {
         FairGeoVector& v = *(volu->getPoint(i));
-        sprintf(buf, "%9.3f\n", v(0));
+        int result_length = snprintf(buf, maxbuf-1, "%9.3f\n", v(0));
+        if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+          LOG(fatal) << "Buffer overrun in snprintf.";
+        }
         pFile->write(buf, strlen(buf));
     }
     return kTRUE;

--- a/fairroot/geobase/FairGeoCone.cxx
+++ b/fairroot/geobase/FairGeoCone.cxx
@@ -37,11 +37,10 @@
 #include "FairGeoVector.h"      // for FairGeoVector
 #include "FairGeoVolume.h"      // for FairGeoVolume
 
-#include <fairlogger/Logger.h>
-
 #include <TArrayD.h>     // for TArrayD
 #include <TMathBase.h>   // for Abs
 #include <TString.h>     // for TString
+#include <fairlogger/Logger.h>
 #include <fstream>
 #include <ostream>    // for fstream, etc
 #include <stdio.h>    // for printf, sprintf, sscanf
@@ -112,15 +111,15 @@ Bool_t FairGeoCone::writePoints(std::fstream* pFile, FairGeoVolume* volu)
     for (Int_t i = 0; i < nPoints; i++) {
         FairGeoVector& v = *(volu->getPoint(i));
         if (i == 0 || i == 2) {
-          int result_length = snprintf(buf, maxbuf-1, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
-          if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-            LOG(fatal) << "Buffer overrun in snprintf.";
-          }
+            int result_length = snprintf(buf, maxbuf - 1, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
+            if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                LOG(fatal) << "Buffer overrun in snprintf.";
+            }
         } else {
-          int result_length = snprintf(buf, maxbuf-1, "%9.3f%10.3f\n", v(0), v(1));
-          if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-            LOG(fatal) << "Buffer overrun in snprintf.";
-          }
+            int result_length = snprintf(buf, maxbuf - 1, "%9.3f%10.3f\n", v(0), v(1));
+            if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                LOG(fatal) << "Buffer overrun in snprintf.";
+            }
         }
         pFile->write(buf, strlen(buf));
     }

--- a/fairroot/geobase/FairGeoCone.cxx
+++ b/fairroot/geobase/FairGeoCone.cxx
@@ -37,6 +37,8 @@
 #include "FairGeoVector.h"      // for FairGeoVector
 #include "FairGeoVolume.h"      // for FairGeoVolume
 
+#include <fairlogger/Logger.h>
+
 #include <TArrayD.h>     // for TArrayD
 #include <TMathBase.h>   // for Abs
 #include <TString.h>     // for TString
@@ -105,13 +107,20 @@ Bool_t FairGeoCone::writePoints(std::fstream* pFile, FairGeoVolume* volu)
     if (!pFile) {
         return kFALSE;
     }
-    Text_t buf[155];
+    int maxbuf{155};
+    Text_t buf[maxbuf];
     for (Int_t i = 0; i < nPoints; i++) {
         FairGeoVector& v = *(volu->getPoint(i));
         if (i == 0 || i == 2) {
-            sprintf(buf, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
+          int result_length = snprintf(buf, maxbuf-1, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
+          if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+            LOG(fatal) << "Buffer overrun in snprintf.";
+          }
         } else {
-            sprintf(buf, "%9.3f%10.3f\n", v(0), v(1));
+          int result_length = snprintf(buf, maxbuf-1, "%9.3f%10.3f\n", v(0), v(1));
+          if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+            LOG(fatal) << "Buffer overrun in snprintf.";
+          }
         }
         pFile->write(buf, strlen(buf));
     }

--- a/fairroot/geobase/FairGeoCons.cxx
+++ b/fairroot/geobase/FairGeoCons.cxx
@@ -40,11 +40,10 @@
 #include "FairGeoVector.h"      // for FairGeoVector
 #include "FairGeoVolume.h"      // for FairGeoVolume
 
-#include <fairlogger/Logger.h>
-
 #include <TArrayD.h>     // for TArrayD
 #include <TMathBase.h>   // for Abs
 #include <TString.h>     // for TString
+#include <fairlogger/Logger.h>
 #include <fstream>
 #include <ostream>    // for fstream, etc
 #include <stdio.h>    // for printf, sprintf, sscanf
@@ -116,15 +115,15 @@ Bool_t FairGeoCons::writePoints(std::fstream* pFile, FairGeoVolume* volu)
     for (Int_t i = 0; i < nPoints; i++) {
         FairGeoVector& v = *(volu->getPoint(i));
         if (i == 0 || i == 2) {
-          int result_length = snprintf(buf, maxbuf-1, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
-          if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-            LOG(fatal) << "Buffer overrun in snprintf.";
-          }
+            int result_length = snprintf(buf, maxbuf - 1, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
+            if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                LOG(fatal) << "Buffer overrun in snprintf.";
+            }
         } else {
-          int result_length = snprintf(buf, maxbuf-1, "%9.3f%10.3f\n", v(0), v(1));
-          if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-            LOG(fatal) << "Buffer overrun in snprintf.";
-          }
+            int result_length = snprintf(buf, maxbuf - 1, "%9.3f%10.3f\n", v(0), v(1));
+            if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                LOG(fatal) << "Buffer overrun in snprintf.";
+            }
         }
         pFile->write(buf, strlen(buf));
     }

--- a/fairroot/geobase/FairGeoCons.cxx
+++ b/fairroot/geobase/FairGeoCons.cxx
@@ -40,6 +40,8 @@
 #include "FairGeoVector.h"      // for FairGeoVector
 #include "FairGeoVolume.h"      // for FairGeoVolume
 
+#include <fairlogger/Logger.h>
+
 #include <TArrayD.h>     // for TArrayD
 #include <TMathBase.h>   // for Abs
 #include <TString.h>     // for TString
@@ -109,13 +111,20 @@ Bool_t FairGeoCons::writePoints(std::fstream* pFile, FairGeoVolume* volu)
     if (!pFile) {
         return kFALSE;
     }
-    Text_t buf[155];
+    int maxbuf{155};
+    Text_t buf[maxbuf];
     for (Int_t i = 0; i < nPoints; i++) {
         FairGeoVector& v = *(volu->getPoint(i));
         if (i == 0 || i == 2) {
-            sprintf(buf, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
+          int result_length = snprintf(buf, maxbuf-1, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
+          if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+            LOG(fatal) << "Buffer overrun in snprintf.";
+          }
         } else {
-            sprintf(buf, "%9.3f%10.3f\n", v(0), v(1));
+          int result_length = snprintf(buf, maxbuf-1, "%9.3f%10.3f\n", v(0), v(1));
+          if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+            LOG(fatal) << "Buffer overrun in snprintf.";
+          }
         }
         pFile->write(buf, strlen(buf));
     }

--- a/fairroot/geobase/FairGeoEltu.cxx
+++ b/fairroot/geobase/FairGeoEltu.cxx
@@ -34,11 +34,10 @@
 #include "FairGeoVector.h"      // for FairGeoVector
 #include "FairGeoVolume.h"      // for FairGeoVolume
 
-#include <fairlogger/Logger.h>
-
 #include <TArrayD.h>     // for TArrayD
 #include <TMathBase.h>   // for Abs
 #include <TString.h>     // for TString
+#include <fairlogger/Logger.h>
 #include <fstream>
 #include <ostream>    // for fstream, etc
 #include <stdio.h>    // for printf, sprintf, sscanf
@@ -110,15 +109,15 @@ Bool_t FairGeoEltu::writePoints(std::fstream* pFile, FairGeoVolume* volu)
     for (Int_t i = 0; i < nPoints; i++) {
         FairGeoVector& v = *(volu->getPoint(i));
         if (i != 1) {
-          int result_length = snprintf(buf, maxbuf-1, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
-          if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-            LOG(fatal) << "Buffer overrun in snprintf.";
-          }
+            int result_length = snprintf(buf, maxbuf - 1, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
+            if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                LOG(fatal) << "Buffer overrun in snprintf.";
+            }
         } else {
-          int result_length = snprintf(buf, maxbuf-1, "%9.3f%10.3f\n", v(0), v(1));
-          if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-            LOG(fatal) << "Buffer overrun in snprintf.";
-          }
+            int result_length = snprintf(buf, maxbuf - 1, "%9.3f%10.3f\n", v(0), v(1));
+            if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                LOG(fatal) << "Buffer overrun in snprintf.";
+            }
         }
         pFile->write(buf, strlen(buf));
     }

--- a/fairroot/geobase/FairGeoEltu.cxx
+++ b/fairroot/geobase/FairGeoEltu.cxx
@@ -34,6 +34,8 @@
 #include "FairGeoVector.h"      // for FairGeoVector
 #include "FairGeoVolume.h"      // for FairGeoVolume
 
+#include <fairlogger/Logger.h>
+
 #include <TArrayD.h>     // for TArrayD
 #include <TMathBase.h>   // for Abs
 #include <TString.h>     // for TString
@@ -103,13 +105,20 @@ Bool_t FairGeoEltu::writePoints(std::fstream* pFile, FairGeoVolume* volu)
     if (!pFile) {
         return kFALSE;
     }
-    Text_t buf[155];
+    int maxbuf{155};
+    Text_t buf[maxbuf];
     for (Int_t i = 0; i < nPoints; i++) {
         FairGeoVector& v = *(volu->getPoint(i));
         if (i != 1) {
-            sprintf(buf, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
+          int result_length = snprintf(buf, maxbuf-1, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
+          if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+            LOG(fatal) << "Buffer overrun in snprintf.";
+          }
         } else {
-            sprintf(buf, "%9.3f%10.3f\n", v(0), v(1));
+          int result_length = snprintf(buf, maxbuf-1, "%9.3f%10.3f\n", v(0), v(1));
+          if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+            LOG(fatal) << "Buffer overrun in snprintf.";
+          }
         }
         pFile->write(buf, strlen(buf));
     }

--- a/fairroot/geobase/FairGeoInterface.cxx
+++ b/fairroot/geobase/FairGeoInterface.cxx
@@ -30,6 +30,8 @@
 #include "FairGeoSet.h"       // for FairGeoSet
 #include "FairGeoShapes.h"    // for FairGeoShapes
 
+#include <fairlogger/Logger.h>
+
 #include <TClass.h>       // for TClass
 #include <TList.h>        // for TList
 #include <TObjArray.h>    // for TObjArray
@@ -428,46 +430,83 @@ Bool_t FairGeoInterface::connectOutput(const char* name)
     if (output) {
         if (strcmp(output->IsA()->GetName(), "FairGeoAsciiIo") == 0) {
             TString fName(name);
-            char buf[80];
+            int maxbuf{80};
+            char buf[maxbuf];
             struct tm* newtime;
             time_t t;
             time(&t);
             newtime = localtime(&t);
             if (newtime->tm_mday < 10) {
-                sprintf(buf, "_0%i", newtime->tm_mday);
+              int result_length = snprintf(buf, maxbuf-1, "_0%i", newtime->tm_mday);
+              if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                LOG(fatal) << "Buffer overrun in snprintf.";
+              }
             } else {
-                sprintf(buf, "_%i", newtime->tm_mday);
+              int result_length = snprintf(buf, maxbuf-1, "_%i", newtime->tm_mday);
+              if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                LOG(fatal) << "Buffer overrun in snprintf.";
+              }
             }
             fName = fName + buf;
             if (newtime->tm_mon < 9) {
-                sprintf(buf, "0%i", newtime->tm_mon + 1);
+              int result_length = snprintf(buf, maxbuf-1, "0%i", newtime->tm_mon + 1);
+              if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                LOG(fatal) << "Buffer overrun in snprintf.";
+              }
             } else {
-                sprintf(buf, "%i", newtime->tm_mon + 1);
+              int result_length = snprintf(buf, maxbuf-1, "%i", newtime->tm_mon + 1);
+              if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                LOG(fatal) << "Buffer overrun in snprintf.";
+              }
             }
             fName = fName + buf;
             Int_t y = newtime->tm_year - 100;
             if (y < 10) {
-                sprintf(buf, "0%i", y);
+              int result_length = snprintf(buf, maxbuf-1, "0%i", y);
+              if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                LOG(fatal) << "Buffer overrun in snprintf.";
+              }
             } else {
-                sprintf(buf, "%i", y);
+              int result_length = snprintf(buf, maxbuf-1, "%i", y);
+              if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                LOG(fatal) << "Buffer overrun in snprintf.";
+              }
             }
             fName = fName + buf;
             if (newtime->tm_hour < 10) {
-                sprintf(buf, "0%i", newtime->tm_hour);
+              int result_length = snprintf(buf, maxbuf-1, "0%i", newtime->tm_hour);
+              if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                LOG(fatal) << "Buffer overrun in snprintf.";
+              }
             } else {
-                sprintf(buf, "%i", newtime->tm_hour);
+              int result_length = snprintf(buf, maxbuf-1, "%i", newtime->tm_hour);
+              if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                LOG(fatal) << "Buffer overrun in snprintf.";
+              }
             }
             fName = fName + buf;
             if (newtime->tm_min < 10) {
-                sprintf(buf, "0%i", newtime->tm_min);
+              int result_length = snprintf(buf, maxbuf-1, "0%i", newtime->tm_min);
+              if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                LOG(fatal) << "Buffer overrun in snprintf.";
+              }
             } else {
-                sprintf(buf, "%i", newtime->tm_min);
+              int result_length = snprintf(buf, maxbuf-1, "%i", newtime->tm_min);
+              if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                LOG(fatal) << "Buffer overrun in snprintf.";
+              }
             }
             fName = fName + buf;
             if (newtime->tm_sec < 10) {
-                sprintf(buf, "0%i", newtime->tm_sec);
+              int result_length = snprintf(buf, maxbuf-1, "0%i", newtime->tm_sec);
+              if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                LOG(fatal) << "Buffer overrun in snprintf.";
+              }
             } else {
-                sprintf(buf, "%i", newtime->tm_sec);
+              int result_length = snprintf(buf, maxbuf-1, "%i", newtime->tm_sec);
+              if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                LOG(fatal) << "Buffer overrun in snprintf.";
+              }
             }
             fName = fName + buf + ".geo";
             output->open(fName, "out");

--- a/fairroot/geobase/FairGeoInterface.cxx
+++ b/fairroot/geobase/FairGeoInterface.cxx
@@ -30,11 +30,10 @@
 #include "FairGeoSet.h"       // for FairGeoSet
 #include "FairGeoShapes.h"    // for FairGeoShapes
 
+#include <TClass.h>      // for TClass
+#include <TList.h>       // for TList
+#include <TObjArray.h>   // for TObjArray
 #include <fairlogger/Logger.h>
-
-#include <TClass.h>       // for TClass
-#include <TList.h>        // for TList
-#include <TObjArray.h>    // for TObjArray
 #include <iostream>       // for operator<<, basic_ostream, etc
 #include <stdio.h>        // for sprintf
 #include <string.h>       // for strcmp
@@ -102,7 +101,10 @@ void FairGeoInterface::addGeoModule(FairGeoSet* pSet)
     pSet->setMasterNodes(masterNodes);
     nActualSets++;
 }
-void FairGeoInterface::setMediaFile(const char* file) { media->setInputFile(file); }
+void FairGeoInterface::setMediaFile(const char* file)
+{
+    media->setInputFile(file);
+}
 
 void FairGeoInterface::addInputFile(const char* file)
 {
@@ -437,76 +439,76 @@ Bool_t FairGeoInterface::connectOutput(const char* name)
             time(&t);
             newtime = localtime(&t);
             if (newtime->tm_mday < 10) {
-              int result_length = snprintf(buf, maxbuf-1, "_0%i", newtime->tm_mday);
-              if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-                LOG(fatal) << "Buffer overrun in snprintf.";
-              }
+                int result_length = snprintf(buf, maxbuf - 1, "_0%i", newtime->tm_mday);
+                if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                    LOG(fatal) << "Buffer overrun in snprintf.";
+                }
             } else {
-              int result_length = snprintf(buf, maxbuf-1, "_%i", newtime->tm_mday);
-              if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-                LOG(fatal) << "Buffer overrun in snprintf.";
-              }
+                int result_length = snprintf(buf, maxbuf - 1, "_%i", newtime->tm_mday);
+                if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                    LOG(fatal) << "Buffer overrun in snprintf.";
+                }
             }
             fName = fName + buf;
             if (newtime->tm_mon < 9) {
-              int result_length = snprintf(buf, maxbuf-1, "0%i", newtime->tm_mon + 1);
-              if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-                LOG(fatal) << "Buffer overrun in snprintf.";
-              }
+                int result_length = snprintf(buf, maxbuf - 1, "0%i", newtime->tm_mon + 1);
+                if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                    LOG(fatal) << "Buffer overrun in snprintf.";
+                }
             } else {
-              int result_length = snprintf(buf, maxbuf-1, "%i", newtime->tm_mon + 1);
-              if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-                LOG(fatal) << "Buffer overrun in snprintf.";
-              }
+                int result_length = snprintf(buf, maxbuf - 1, "%i", newtime->tm_mon + 1);
+                if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                    LOG(fatal) << "Buffer overrun in snprintf.";
+                }
             }
             fName = fName + buf;
             Int_t y = newtime->tm_year - 100;
             if (y < 10) {
-              int result_length = snprintf(buf, maxbuf-1, "0%i", y);
-              if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-                LOG(fatal) << "Buffer overrun in snprintf.";
-              }
+                int result_length = snprintf(buf, maxbuf - 1, "0%i", y);
+                if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                    LOG(fatal) << "Buffer overrun in snprintf.";
+                }
             } else {
-              int result_length = snprintf(buf, maxbuf-1, "%i", y);
-              if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-                LOG(fatal) << "Buffer overrun in snprintf.";
-              }
+                int result_length = snprintf(buf, maxbuf - 1, "%i", y);
+                if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                    LOG(fatal) << "Buffer overrun in snprintf.";
+                }
             }
             fName = fName + buf;
             if (newtime->tm_hour < 10) {
-              int result_length = snprintf(buf, maxbuf-1, "0%i", newtime->tm_hour);
-              if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-                LOG(fatal) << "Buffer overrun in snprintf.";
-              }
+                int result_length = snprintf(buf, maxbuf - 1, "0%i", newtime->tm_hour);
+                if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                    LOG(fatal) << "Buffer overrun in snprintf.";
+                }
             } else {
-              int result_length = snprintf(buf, maxbuf-1, "%i", newtime->tm_hour);
-              if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-                LOG(fatal) << "Buffer overrun in snprintf.";
-              }
+                int result_length = snprintf(buf, maxbuf - 1, "%i", newtime->tm_hour);
+                if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                    LOG(fatal) << "Buffer overrun in snprintf.";
+                }
             }
             fName = fName + buf;
             if (newtime->tm_min < 10) {
-              int result_length = snprintf(buf, maxbuf-1, "0%i", newtime->tm_min);
-              if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-                LOG(fatal) << "Buffer overrun in snprintf.";
-              }
+                int result_length = snprintf(buf, maxbuf - 1, "0%i", newtime->tm_min);
+                if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                    LOG(fatal) << "Buffer overrun in snprintf.";
+                }
             } else {
-              int result_length = snprintf(buf, maxbuf-1, "%i", newtime->tm_min);
-              if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-                LOG(fatal) << "Buffer overrun in snprintf.";
-              }
+                int result_length = snprintf(buf, maxbuf - 1, "%i", newtime->tm_min);
+                if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                    LOG(fatal) << "Buffer overrun in snprintf.";
+                }
             }
             fName = fName + buf;
             if (newtime->tm_sec < 10) {
-              int result_length = snprintf(buf, maxbuf-1, "0%i", newtime->tm_sec);
-              if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-                LOG(fatal) << "Buffer overrun in snprintf.";
-              }
+                int result_length = snprintf(buf, maxbuf - 1, "0%i", newtime->tm_sec);
+                if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                    LOG(fatal) << "Buffer overrun in snprintf.";
+                }
             } else {
-              int result_length = snprintf(buf, maxbuf-1, "%i", newtime->tm_sec);
-              if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-                LOG(fatal) << "Buffer overrun in snprintf.";
-              }
+                int result_length = snprintf(buf, maxbuf - 1, "%i", newtime->tm_sec);
+                if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                    LOG(fatal) << "Buffer overrun in snprintf.";
+                }
             }
             fName = fName + buf + ".geo";
             output->open(fName, "out");

--- a/fairroot/geobase/FairGeoPcon.cxx
+++ b/fairroot/geobase/FairGeoPcon.cxx
@@ -35,6 +35,8 @@
 #include "FairGeoVector.h"      // for FairGeoVector
 #include "FairGeoVolume.h"      // for FairGeoVolume
 
+#include <fairlogger/Logger.h>
+
 #include <TArrayD.h>   // for TArrayD
 #include <TString.h>   // for TString
 #include <fstream>
@@ -103,18 +105,29 @@ Bool_t FairGeoPcon::writePoints(std::fstream* pFile, FairGeoVolume* volu)
     if (!pFile) {
         return kFALSE;
     }
-    Text_t buf[155];
+    int maxbuf{155};
+    Text_t buf[maxbuf];
     for (Int_t i = 0; i < volu->getNumPoints(); i++) {
         FairGeoVector& v = *(volu->getPoint(i));
+        int result_length{-1};
         switch (i) {
             case 0:
-                sprintf(buf, "%3i\n", static_cast<Int_t>(v(0)));
+                result_length = snprintf(buf, maxbuf-1,"%3i\n", static_cast<Int_t>(v(0)));
+                if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                  LOG(fatal) << "Buffer overrun in snprintf.";
+                }
                 break;
             case 1:
-                sprintf(buf, "%9.3f%10.3f\n", v(0), v(1));
+                result_length = snprintf(buf, maxbuf-1, "%9.3f%10.3f\n", v(0), v(1));
+                if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                  LOG(fatal) << "Buffer overrun in snprintf.";
+                }
                 break;
             default:
-                sprintf(buf, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
+                result_length = snprintf(buf, maxbuf-1, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
+                if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                  LOG(fatal) << "Buffer overrun in snprintf.";
+                }
         }
         pFile->write(buf, strlen(buf));
     }

--- a/fairroot/geobase/FairGeoPcon.cxx
+++ b/fairroot/geobase/FairGeoPcon.cxx
@@ -35,10 +35,9 @@
 #include "FairGeoVector.h"      // for FairGeoVector
 #include "FairGeoVolume.h"      // for FairGeoVolume
 
-#include <fairlogger/Logger.h>
-
 #include <TArrayD.h>   // for TArrayD
 #include <TString.h>   // for TString
+#include <fairlogger/Logger.h>
 #include <fstream>
 #include <ostream>    // for fstream, etc
 #include <stdio.h>    // for printf, sprintf, sscanf
@@ -112,21 +111,21 @@ Bool_t FairGeoPcon::writePoints(std::fstream* pFile, FairGeoVolume* volu)
         int result_length{-1};
         switch (i) {
             case 0:
-                result_length = snprintf(buf, maxbuf-1,"%3i\n", static_cast<Int_t>(v(0)));
+                result_length = snprintf(buf, maxbuf - 1, "%3i\n", static_cast<Int_t>(v(0)));
                 if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-                  LOG(fatal) << "Buffer overrun in snprintf.";
+                    LOG(fatal) << "Buffer overrun in snprintf.";
                 }
                 break;
             case 1:
-                result_length = snprintf(buf, maxbuf-1, "%9.3f%10.3f\n", v(0), v(1));
+                result_length = snprintf(buf, maxbuf - 1, "%9.3f%10.3f\n", v(0), v(1));
                 if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-                  LOG(fatal) << "Buffer overrun in snprintf.";
+                    LOG(fatal) << "Buffer overrun in snprintf.";
                 }
                 break;
             default:
-                result_length = snprintf(buf, maxbuf-1, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
+                result_length = snprintf(buf, maxbuf - 1, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
                 if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-                  LOG(fatal) << "Buffer overrun in snprintf.";
+                    LOG(fatal) << "Buffer overrun in snprintf.";
                 }
         }
         pFile->write(buf, strlen(buf));

--- a/fairroot/geobase/FairGeoPgon.cxx
+++ b/fairroot/geobase/FairGeoPgon.cxx
@@ -35,6 +35,8 @@
 #include "FairGeoVector.h"      // for FairGeoVector
 #include "FairGeoVolume.h"      // for FairGeoVolume
 
+#include <fairlogger/Logger.h>
+
 #include <TArrayD.h>   // for TArrayD
 #include <TString.h>   // for TString
 #include <fstream>
@@ -98,13 +100,20 @@ Bool_t FairGeoPgon::writePoints(std::fstream* pFile, FairGeoVolume* volu)
     if (!pFile) {
         return kFALSE;
     }
-    Text_t buf[155];
+    int maxbuf{155};
+    Text_t buf[maxbuf];
     for (Int_t i = 0; i < volu->getNumPoints(); i++) {
         FairGeoVector& v = *(volu->getPoint(i));
         if (i != 0) {
-            sprintf(buf, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
+            int result_length = snprintf(buf, maxbuf-1, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
+            if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+              LOG(fatal) << "Buffer overrun in snprintf.";
+            }
         } else {
-            sprintf(buf, "%3i\n", static_cast<Int_t>(v(0)));
+            int result_length = snprintf(buf, maxbuf-1, "%3i\n", static_cast<Int_t>(v(0)));
+            if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+              LOG(fatal) << "Buffer overrun in snprintf.";
+            }
         }
         pFile->write(buf, strlen(buf));
     }

--- a/fairroot/geobase/FairGeoPgon.cxx
+++ b/fairroot/geobase/FairGeoPgon.cxx
@@ -35,10 +35,9 @@
 #include "FairGeoVector.h"      // for FairGeoVector
 #include "FairGeoVolume.h"      // for FairGeoVolume
 
-#include <fairlogger/Logger.h>
-
 #include <TArrayD.h>   // for TArrayD
 #include <TString.h>   // for TString
+#include <fairlogger/Logger.h>
 #include <fstream>
 #include <ostream>    // for basic_ostream::write
 #include <stdio.h>    // for printf, sprintf, sscanf
@@ -105,14 +104,14 @@ Bool_t FairGeoPgon::writePoints(std::fstream* pFile, FairGeoVolume* volu)
     for (Int_t i = 0; i < volu->getNumPoints(); i++) {
         FairGeoVector& v = *(volu->getPoint(i));
         if (i != 0) {
-            int result_length = snprintf(buf, maxbuf-1, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
+            int result_length = snprintf(buf, maxbuf - 1, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
             if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-              LOG(fatal) << "Buffer overrun in snprintf.";
+                LOG(fatal) << "Buffer overrun in snprintf.";
             }
         } else {
-            int result_length = snprintf(buf, maxbuf-1, "%3i\n", static_cast<Int_t>(v(0)));
+            int result_length = snprintf(buf, maxbuf - 1, "%3i\n", static_cast<Int_t>(v(0)));
             if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-              LOG(fatal) << "Buffer overrun in snprintf.";
+                LOG(fatal) << "Buffer overrun in snprintf.";
             }
         }
         pFile->write(buf, strlen(buf));

--- a/fairroot/geobase/FairGeoSphe.cxx
+++ b/fairroot/geobase/FairGeoSphe.cxx
@@ -33,6 +33,8 @@
 #include "FairGeoVector.h"      // for FairGeoVector
 #include "FairGeoVolume.h"      // for FairGeoVolume
 
+#include <fairlogger/Logger.h>
+
 #include <TArrayD.h>   // for TArrayD
 #include <TString.h>   // for TString
 #include <fstream>
@@ -90,10 +92,14 @@ Bool_t FairGeoSphe::writePoints(std::fstream* pFile, FairGeoVolume* volu)
     if (!pFile) {
         return kFALSE;
     } else {
+        int maxbuf{155};
         Text_t buf[155];
         for (Int_t i = 0; i < nPoints; i++) {
             FairGeoVector& v = *(volu->getPoint(i));
-            sprintf(buf, "%9.3f%10.3f\n", v(0), v(1));
+            int result_length = snprintf(buf, maxbuf-1, "%9.3f%10.3f\n", v(0), v(1));
+            if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+              LOG(fatal) << "Buffer overrun in snprintf.";
+            }
             pFile->write(buf, strlen(buf));
         }
         return kTRUE;

--- a/fairroot/geobase/FairGeoSphe.cxx
+++ b/fairroot/geobase/FairGeoSphe.cxx
@@ -33,10 +33,9 @@
 #include "FairGeoVector.h"      // for FairGeoVector
 #include "FairGeoVolume.h"      // for FairGeoVolume
 
-#include <fairlogger/Logger.h>
-
 #include <TArrayD.h>   // for TArrayD
 #include <TString.h>   // for TString
+#include <fairlogger/Logger.h>
 #include <fstream>
 #include <ostream>    // for basic_ostream::write
 #include <stdio.h>    // for printf, sprintf, sscanf
@@ -96,9 +95,9 @@ Bool_t FairGeoSphe::writePoints(std::fstream* pFile, FairGeoVolume* volu)
         Text_t buf[155];
         for (Int_t i = 0; i < nPoints; i++) {
             FairGeoVector& v = *(volu->getPoint(i));
-            int result_length = snprintf(buf, maxbuf-1, "%9.3f%10.3f\n", v(0), v(1));
+            int result_length = snprintf(buf, maxbuf - 1, "%9.3f%10.3f\n", v(0), v(1));
             if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-              LOG(fatal) << "Buffer overrun in snprintf.";
+                LOG(fatal) << "Buffer overrun in snprintf.";
             }
             pFile->write(buf, strlen(buf));
         }

--- a/fairroot/geobase/FairGeoTorus.cxx
+++ b/fairroot/geobase/FairGeoTorus.cxx
@@ -25,6 +25,8 @@
 #include "FairGeoVector.h"      // for FairGeoVector
 #include "FairGeoVolume.h"      // for FairGeoVolume
 
+#include <fairlogger/Logger.h>
+
 #include <TArrayD.h>   // for TArrayD
 #include <TString.h>   // for TString
 #include <fstream>
@@ -106,10 +108,14 @@ Bool_t FairGeoTorus::writePoints(std::fstream* pFile, FairGeoVolume* volu)
     if (!pFile) {
         return kFALSE;
     }
-    Text_t buf[155];
+    int maxbuf{155};
+    Text_t buf[maxbuf];
     for (Int_t i = 0; i < nPoints; i++) {
         FairGeoVector& v = *(volu->getPoint(i));
-        sprintf(buf, "%9.3f\n", v(0));
+        int result_length = snprintf(buf, maxbuf-1, "%9.3f\n", v(0));
+        if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+          LOG(fatal) << "Buffer overrun in snprintf.";
+        }
         pFile->write(buf, strlen(buf));
     }
     return kTRUE;

--- a/fairroot/geobase/FairGeoTorus.cxx
+++ b/fairroot/geobase/FairGeoTorus.cxx
@@ -25,10 +25,9 @@
 #include "FairGeoVector.h"      // for FairGeoVector
 #include "FairGeoVolume.h"      // for FairGeoVolume
 
-#include <fairlogger/Logger.h>
-
 #include <TArrayD.h>   // for TArrayD
 #include <TString.h>   // for TString
+#include <fairlogger/Logger.h>
 #include <fstream>
 #include <ostream>    // for basic_ostream::write
 #include <stdio.h>    // for printf, sprintf, sscanf
@@ -112,9 +111,9 @@ Bool_t FairGeoTorus::writePoints(std::fstream* pFile, FairGeoVolume* volu)
     Text_t buf[maxbuf];
     for (Int_t i = 0; i < nPoints; i++) {
         FairGeoVector& v = *(volu->getPoint(i));
-        int result_length = snprintf(buf, maxbuf-1, "%9.3f\n", v(0));
+        int result_length = snprintf(buf, maxbuf - 1, "%9.3f\n", v(0));
         if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-          LOG(fatal) << "Buffer overrun in snprintf.";
+            LOG(fatal) << "Buffer overrun in snprintf.";
         }
         pFile->write(buf, strlen(buf));
     }

--- a/fairroot/geobase/FairGeoTube.cxx
+++ b/fairroot/geobase/FairGeoTube.cxx
@@ -34,6 +34,8 @@
 #include "FairGeoVector.h"      // for FairGeoVector
 #include "FairGeoVolume.h"      // for FairGeoVolume
 
+#include <fairlogger/Logger.h>
+
 #include <TArrayD.h>     // for TArrayD
 #include <TMathBase.h>   // for Abs
 #include <TString.h>     // for TString
@@ -97,13 +99,20 @@ Bool_t FairGeoTube::writePoints(std::fstream* pFile, FairGeoVolume* volu)
     if (!pFile) {
         return kFALSE;
     }
-    Text_t buf[155];
+    int maxbuf{155};
+    Text_t buf[maxbuf];
     for (Int_t i = 0; i < nPoints; i++) {
         FairGeoVector& v = *(volu->getPoint(i));
         if (i != 1) {
-            sprintf(buf, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
+          int result_length = snprintf(buf, maxbuf-1, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
+          if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+            LOG(fatal) << "Buffer overrun in snprintf.";
+          }
         } else {
-            sprintf(buf, "%9.3f%10.3f\n", v(0), v(1));
+          int result_length = snprintf(buf, maxbuf-1, "%9.3f%10.3f\n", v(0), v(1));
+          if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+            LOG(fatal) << "Buffer overrun in snprintf.";
+          }
         }
         pFile->write(buf, strlen(buf));
     }

--- a/fairroot/geobase/FairGeoTube.cxx
+++ b/fairroot/geobase/FairGeoTube.cxx
@@ -34,11 +34,10 @@
 #include "FairGeoVector.h"      // for FairGeoVector
 #include "FairGeoVolume.h"      // for FairGeoVolume
 
-#include <fairlogger/Logger.h>
-
 #include <TArrayD.h>     // for TArrayD
 #include <TMathBase.h>   // for Abs
 #include <TString.h>     // for TString
+#include <fairlogger/Logger.h>
 #include <fstream>
 #include <ostream>    // for basic_ostream::write
 #include <stdio.h>    // for printf, sprintf, sscanf
@@ -104,15 +103,15 @@ Bool_t FairGeoTube::writePoints(std::fstream* pFile, FairGeoVolume* volu)
     for (Int_t i = 0; i < nPoints; i++) {
         FairGeoVector& v = *(volu->getPoint(i));
         if (i != 1) {
-          int result_length = snprintf(buf, maxbuf-1, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
-          if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-            LOG(fatal) << "Buffer overrun in snprintf.";
-          }
+            int result_length = snprintf(buf, maxbuf - 1, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
+            if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                LOG(fatal) << "Buffer overrun in snprintf.";
+            }
         } else {
-          int result_length = snprintf(buf, maxbuf-1, "%9.3f%10.3f\n", v(0), v(1));
-          if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-            LOG(fatal) << "Buffer overrun in snprintf.";
-          }
+            int result_length = snprintf(buf, maxbuf - 1, "%9.3f%10.3f\n", v(0), v(1));
+            if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+                LOG(fatal) << "Buffer overrun in snprintf.";
+            }
         }
         pFile->write(buf, strlen(buf));
     }

--- a/fairroot/geobase/FairGeoTubs.cxx
+++ b/fairroot/geobase/FairGeoTubs.cxx
@@ -37,11 +37,10 @@
 #include "FairGeoVector.h"      // for FairGeoVector
 #include "FairGeoVolume.h"      // for FairGeoVolume
 
-#include <fairlogger/Logger.h>
-
 #include <TArrayD.h>     // for TArrayD
 #include <TMathBase.h>   // for Abs
 #include <TString.h>     // for TString
+#include <fairlogger/Logger.h>
 #include <fstream>
 #include <ostream>    // for basic_ostream::write
 #include <stdio.h>    // for printf, sprintf, sscanf
@@ -106,14 +105,14 @@ Bool_t FairGeoTubs::writePoints(std::fstream* pFile, FairGeoVolume* volu)
     for (Int_t i = 0; i < nPoints; i++) {
         FairGeoVector& v = *(volu->getPoint(i));
         if (i == 0 || i == 2) {
-            int result_length = snprintf(buf, maxbuf-1, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
+            int result_length = snprintf(buf, maxbuf - 1, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
             if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-              LOG(fatal) << "Buffer overrun in snprintf.";
+                LOG(fatal) << "Buffer overrun in snprintf.";
             }
         } else {
-            int result_length = snprintf(buf, maxbuf-1, "%9.3f%10.3f\n", v(0), v(1));
+            int result_length = snprintf(buf, maxbuf - 1, "%9.3f%10.3f\n", v(0), v(1));
             if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-              LOG(fatal) << "Buffer overrun in snprintf.";
+                LOG(fatal) << "Buffer overrun in snprintf.";
             }
         }
         pFile->write(buf, strlen(buf));

--- a/fairroot/geobase/FairGeoTubs.cxx
+++ b/fairroot/geobase/FairGeoTubs.cxx
@@ -37,6 +37,8 @@
 #include "FairGeoVector.h"      // for FairGeoVector
 #include "FairGeoVolume.h"      // for FairGeoVolume
 
+#include <fairlogger/Logger.h>
+
 #include <TArrayD.h>     // for TArrayD
 #include <TMathBase.h>   // for Abs
 #include <TString.h>     // for TString
@@ -99,13 +101,20 @@ Bool_t FairGeoTubs::writePoints(std::fstream* pFile, FairGeoVolume* volu)
     if (!pFile) {
         return kFALSE;
     }
-    Text_t buf[155];
+    int maxbuf{155};
+    Text_t buf[maxbuf];
     for (Int_t i = 0; i < nPoints; i++) {
         FairGeoVector& v = *(volu->getPoint(i));
         if (i == 0 || i == 2) {
-            sprintf(buf, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
+            int result_length = snprintf(buf, maxbuf-1, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
+            if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+              LOG(fatal) << "Buffer overrun in snprintf.";
+            }
         } else {
-            sprintf(buf, "%9.3f%10.3f\n", v(0), v(1));
+            int result_length = snprintf(buf, maxbuf-1, "%9.3f%10.3f\n", v(0), v(1));
+            if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+              LOG(fatal) << "Buffer overrun in snprintf.";
+            }
         }
         pFile->write(buf, strlen(buf));
     }

--- a/fairroot/parbase/FairDetParAsciiFileIo.cxx
+++ b/fairroot/parbase/FairDetParAsciiFileIo.cxx
@@ -21,7 +21,6 @@
 #include "FairParSet.h"   // for FairParSet
 
 #include <fairlogger/Logger.h>
-
 #include <fstream>    // for fstream
 #include <stdio.h>    // for printf, sprintf
 #include <string.h>   // for strlen, strncmp
@@ -48,9 +47,9 @@ Bool_t FairDetParAsciiFileIo::findContainer(const Text_t* name)
     Text_t buf[maxbuf];
     Text_t buf2[maxbuf];
 
-    int result_length = snprintf(buf2, maxbuf-1, "%s%s%s", "[", name, "]");
+    int result_length = snprintf(buf2, maxbuf - 1, "%s%s%s", "[", name, "]");
     if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-      LOG(fatal) << "Buffer overrun in snprintf.";
+        LOG(fatal) << "Buffer overrun in snprintf.";
     }
 
     // cout << " buf2 " <<  buf2 << endl;
@@ -174,7 +173,7 @@ Bool_t FairDetParAsciiFileIo::findContainer(const Text_t* name) {
   const Int_t maxbuf=4000;
   Text_t buf[maxbuf];
   Text_t buf2[maxbuf];
-  
+
   int result_length = snprintf(buf2, maxbuf-1, "%s%s%s", "[", name, "]");
   if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
     LOG(fatal) << "Buffer overrun in snprintf.";

--- a/fairroot/parbase/FairDetParAsciiFileIo.cxx
+++ b/fairroot/parbase/FairDetParAsciiFileIo.cxx
@@ -20,6 +20,8 @@
 
 #include "FairParSet.h"   // for FairParSet
 
+#include <fairlogger/Logger.h>
+
 #include <fstream>    // for fstream
 #include <stdio.h>    // for printf, sprintf
 #include <string.h>   // for strlen, strncmp
@@ -45,7 +47,12 @@ Bool_t FairDetParAsciiFileIo::findContainer(const Text_t* name)
     const Int_t maxbuf = 4000;
     Text_t buf[maxbuf];
     Text_t buf2[maxbuf];
-    sprintf(buf2, "%s%s%s", "[", name, "]");
+
+    int result_length = snprintf(buf2, maxbuf-1, "%s%s%s", "[", name, "]");
+    if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+      LOG(fatal) << "Buffer overrun in snprintf.";
+    }
+
     // cout << " buf2 " <<  buf2 << endl;
     pFile->clear();
     pFile->seekg(0, ios::beg);
@@ -163,20 +170,25 @@ sepLine=
 }
 
 Bool_t FairDetParAsciiFileIo::findContainer(const Text_t* name) {
-// searches the container in the file
-const Int_t maxbuf=4000;
-Text_t buf[maxbuf];
-Text_t buf2[maxbuf];
-sprintf(buf2,"%s%s%s","[",name,"]");
-pFile->clear();
-pFile->seekg(0,ios::beg);
-while (!pFile->eof()) {
-pFile->getline(buf,maxbuf);
-if (buf[0]!='[') continue;
-if (!strncmp(buf,buf2,strlen(buf2))) break;
-}
-if (pFile->eof()) return kFALSE;
-return kTRUE;
+  // searches the container in the file
+  const Int_t maxbuf=4000;
+  Text_t buf[maxbuf];
+  Text_t buf2[maxbuf];
+  
+  int result_length = snprintf(buf2, maxbuf-1, "%s%s%s", "[", name, "]");
+  if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+    LOG(fatal) << "Buffer overrun in snprintf.";
+  }
+
+  pFile->clear();
+  pFile->seekg(0,ios::beg);
+  while (!pFile->eof()) {
+    pFile->getline(buf,maxbuf);
+    if (buf[0]!='[') continue;
+    if (!strncmp(buf,buf2,strlen(buf2))) break;
+  }
+  if (pFile->eof()) return kFALSE;
+  return kTRUE;
 }
 
 void FairDetParAsciiFileIo::writeHeader(const Text_t* name, const Text_t* context,

--- a/fairroot/parbase/FairDetParRootFileIo.cxx
+++ b/fairroot/parbase/FairDetParRootFileIo.cxx
@@ -27,18 +27,17 @@
 #include "FairRtdbRun.h"         // for FairParVersion, FairRtdbRun
 #include "FairRuntimeDb.h"       // for FairRuntimeDb
 
-#include <fairlogger/Logger.h>
-
 #include <TDirectory.h>   // for TDirectory, gDirectory
 #include <TKey.h>         // for TKey
 #include <TROOT.h>        // for TROOT, gROOT
-#include <iostream>       // for operator<<, basic_ostream, etc
-#include <stdio.h>        // for sprintf
+#include <fairlogger/Logger.h>
+#include <iostream>   // for operator<<, basic_ostream, etc
+#include <stdio.h>    // for sprintf
 
 using std::cout;
 using std::endl;
 
-FairDetParRootFileIo::FairDetParRootFileIo(FairParRootFile *f)
+FairDetParRootFileIo::FairDetParRootFileIo(FairParRootFile* f)
     : FairDetParIo()
     , pFile(f)
 {
@@ -46,7 +45,7 @@ FairDetParRootFileIo::FairDetParRootFileIo(FairParRootFile *f)
     //  pFile=f;
 }
 
-Bool_t FairDetParRootFileIo::read(FairParSet *pPar)
+Bool_t FairDetParRootFileIo::read(FairParSet* pPar)
 {
     // generic read function for parameter containers
     auto name = pPar->GetName();
@@ -76,7 +75,7 @@ Bool_t FairDetParRootFileIo::read(FairParSet *pPar)
     return kFALSE;
 }
 
-Int_t FairDetParRootFileIo::write(FairParSet *pPar)
+Int_t FairDetParRootFileIo::write(FairParSet* pPar)
 {
     // writes a parameter container to the ROOT file and returns the new version
     // number (returns -1 if the file is not writable)
@@ -100,7 +99,7 @@ Int_t FairDetParRootFileIo::getMaxVersion(const char* name)
 {
     // returns the maximum version of the container given by name in the ROOT
     // file (return -1 if not found)
-    TKey *key = pFile->GetKey(name);
+    TKey* key = pFile->GetKey(name);
     if (key) {
         return key->GetCycle();
     } else {
@@ -112,24 +111,24 @@ Int_t FairDetParRootFileIo::findInputVersion(const char* name)
 {
     // finds the input version to initialize the container given by name;
     // returns -1 if the version cannot be determined
-    FairParVersion *currVers = FairRuntimeDb::instance()->getCurrentRun()->getParVersion(name);
+    FairParVersion* currVers = FairRuntimeDb::instance()->getCurrentRun()->getParVersion(name);
     Int_t v = currVers->getInputVersion(inputNumber);
     if (v > 0) {
         return v;
     }   // predefined
-    FairRtdbRun *r = pFile->getRun();
+    FairRtdbRun* r = pFile->getRun();
     // cout << "-I- FairDetParRootFileIo::findInputVersion " << r << endl;
     if (!r) {
         return -1;
     }   // run not in ROOT file
-    FairParVersion *vers = r->getParVersion(name);
+    FairParVersion* vers = r->getParVersion(name);
     if (!vers) {
         return -1;
     }   // container not in ROOT file
     return vers->getRootVersion();
 }
 
-TObject *FairDetParRootFileIo::findContainer(Text_t *name, Int_t vers)
+TObject* FairDetParRootFileIo::findContainer(Text_t* name, Int_t vers)
 {
     // finds the parameter container given by its name with a special version in
     // the ROOT file (returns 0 if not successful)
@@ -138,13 +137,13 @@ TObject *FairDetParRootFileIo::findContainer(Text_t *name, Int_t vers)
     // object after usage!
     int maxbuf{80};
     Text_t cn[maxbuf];
-    
-    int result_length = snprintf(cn, maxbuf-1, "%s;%i", name, vers);
+
+    int result_length = snprintf(cn, maxbuf - 1, "%s;%i", name, vers);
     if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-      LOG(fatal) << "Buffer overrun in snprintf.";
+        LOG(fatal) << "Buffer overrun in snprintf.";
     }
 
     pFile->cd();
-    TObject *p = gROOT->FindObject(cn);
+    TObject* p = gROOT->FindObject(cn);
     return p;
 }

--- a/fairroot/parbase/FairDetParRootFileIo.cxx
+++ b/fairroot/parbase/FairDetParRootFileIo.cxx
@@ -27,6 +27,8 @@
 #include "FairRtdbRun.h"         // for FairParVersion, FairRtdbRun
 #include "FairRuntimeDb.h"       // for FairRuntimeDb
 
+#include <fairlogger/Logger.h>
+
 #include <TDirectory.h>   // for TDirectory, gDirectory
 #include <TKey.h>         // for TKey
 #include <TROOT.h>        // for TROOT, gROOT
@@ -134,8 +136,14 @@ TObject *FairDetParRootFileIo::findContainer(Text_t *name, Int_t vers)
     // This funtion uses internally the ROOT function FindObject(Text_t*), which
     // creates a new object. The calling function must therefore delete the
     // object after usage!
-    Text_t cn[80];
-    sprintf(cn, "%s;%i", name, vers);
+    int maxbuf{80};
+    Text_t cn[maxbuf];
+    
+    int result_length = snprintf(cn, maxbuf-1, "%s;%i", name, vers);
+    if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+      LOG(fatal) << "Buffer overrun in snprintf.";
+    }
+
     pFile->cd();
     TObject *p = gROOT->FindObject(cn);
     return p;

--- a/fairroot/parbase/FairRtdbRun.cxx
+++ b/fairroot/parbase/FairRtdbRun.cxx
@@ -67,9 +67,9 @@ FairRtdbRun::FairRtdbRun(Int_t r, Int_t rr)
     parVersions->SetName("parVersions");
     int maxbuf{255};
     char name[maxbuf];
-    int result_length = snprintf(name, maxbuf-1, "%i", r);
+    int result_length = snprintf(name, maxbuf - 1, "%i", r);
     if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-      LOG(fatal) << "Buffer overrun in snprintf.";
+        LOG(fatal) << "Buffer overrun in snprintf.";
     }
 
     SetName(name);

--- a/fairroot/parbase/FairRtdbRun.cxx
+++ b/fairroot/parbase/FairRtdbRun.cxx
@@ -65,8 +65,13 @@ FairRtdbRun::FairRtdbRun(Int_t r, Int_t rr)
     , refRun("")
 {
     parVersions->SetName("parVersions");
-    char name[255];
-    sprintf(name, "%i", r);
+    int maxbuf{255};
+    char name[maxbuf];
+    int result_length = snprintf(name, maxbuf-1, "%i", r);
+    if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+      LOG(fatal) << "Buffer overrun in snprintf.";
+    }
+
     SetName(name);
     setRefRun(rr);
 }

--- a/fairroot/parbase/FairRtdbRun.h
+++ b/fairroot/parbase/FairRtdbRun.h
@@ -8,6 +8,8 @@
 #ifndef FAIRRTDBRUN_H
 #define FAIRRTDBRUN_H
 
+#include <fairlogger/Logger.h>
+
 #include <Rtypes.h>    // for Int_t, Text_t, UInt_t, etc
 #include <TNamed.h>    // for TNamed
 #include <TString.h>   // for TString
@@ -101,8 +103,13 @@ inline void FairRtdbRun::setRefRun(Int_t r)
     if (r == -1) {
         refRun = "";
     } else {
-        char name[255];
-        sprintf(name, "%i", r);
+        int maxbuf{255};
+        char name[maxbuf];
+
+        int result_length = snprintf(name, maxbuf-1, "%i", r);
+        if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+          LOG(fatal) << "Buffer overrun in snprintf.";
+        }
         refRun = name;
     }
 }

--- a/fairroot/parbase/FairRtdbRun.h
+++ b/fairroot/parbase/FairRtdbRun.h
@@ -8,13 +8,12 @@
 #ifndef FAIRRTDBRUN_H
 #define FAIRRTDBRUN_H
 
-#include <fairlogger/Logger.h>
-
 #include <Rtypes.h>    // for Int_t, Text_t, UInt_t, etc
 #include <TNamed.h>    // for TNamed
 #include <TString.h>   // for TString
-#include <iosfwd>      // for fstream
-#include <stdio.h>     // for sprintf, sscanf
+#include <fairlogger/Logger.h>
+#include <iosfwd>    // for fstream
+#include <stdio.h>   // for sprintf, sscanf
 
 class TList;
 using std::fstream;
@@ -106,9 +105,9 @@ inline void FairRtdbRun::setRefRun(Int_t r)
         int maxbuf{255};
         char name[maxbuf];
 
-        int result_length = snprintf(name, maxbuf-1, "%i", r);
+        int result_length = snprintf(name, maxbuf - 1, "%i", r);
         if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-          LOG(fatal) << "Buffer overrun in snprintf.";
+            LOG(fatal) << "Buffer overrun in snprintf.";
         }
         refRun = name;
     }

--- a/fairroot/parbase/FairRuntimeDb.cxx
+++ b/fairroot/parbase/FairRuntimeDb.cxx
@@ -272,8 +272,14 @@ FairRtdbRun* FairRuntimeDb::addRun(Int_t runId, Int_t refId)
 FairRtdbRun* FairRuntimeDb::getRun(Int_t id)
 {
     // returns a pointer to the run called by the run id
-    char name[255];
-    sprintf(name, "%i", id);
+    int maxbuf{255};
+    char name[maxbuf];
+
+    int result_length = snprintf(name, maxbuf-1, "%i", id);
+    if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
+      LOG(fatal) << "Buffer overrun in snprintf.";
+    }
+
     return static_cast<FairRtdbRun*>((runs->FindObject(name)));
 }
 

--- a/fairroot/parbase/FairRuntimeDb.cxx
+++ b/fairroot/parbase/FairRuntimeDb.cxx
@@ -275,9 +275,9 @@ FairRtdbRun* FairRuntimeDb::getRun(Int_t id)
     int maxbuf{255};
     char name[maxbuf];
 
-    int result_length = snprintf(name, maxbuf-1, "%i", id);
+    int result_length = snprintf(name, maxbuf - 1, "%i", id);
     if (!(result_length > 0 && result_length < static_cast<int>(maxbuf))) {
-      LOG(fatal) << "Buffer overrun in snprintf.";
+        LOG(fatal) << "Buffer overrun in snprintf.";
     }
 
     return static_cast<FairRtdbRun*>((runs->FindObject(name)));
@@ -302,7 +302,10 @@ void FairRuntimeDb::removeRun(Text_t* name)
     }
 }
 
-void FairRuntimeDb::clearRunList() { runs->Delete(); }
+void FairRuntimeDb::clearRunList()
+{
+    runs->Delete();
+}
 
 void FairRuntimeDb::writeVersions()
 {


### PR DESCRIPTION
Use snprintf instead of sprintf
    
The usage of sprintf is unsafe and deprecated. Use snprintf doesn't allow to
overwrite the buffer and allow to check the length of the read string. In case
of buffer overflow stop the execution.

---

Checklist:

* [ x] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
