### PR TITLE
feat: Improve test logging

### DIFF
--- a/examples/MQ/pixelSimSplit/run/scripts/test-splitMQ.sh.in
+++ b/examples/MQ/pixelSimSplit/run/scripts/test-splitMQ.sh.in
@@ -99,7 +99,13 @@ echo "Terminating topology ..."
 kill ${PIDS[TRANSPORTER]} ${PIDS[MERGER]} ${PIDS[PARMQSERVER]} ${PIDS[FILESINK]}
 for DEVICE in TRANSPORTER MERGER PARMQSERVER FILESINK
 do
-  wait ${PIDS[$DEVICE]} || { ret=$?; echo "$DEVICE failed with exit code $ret"; RC=$(($RC + $ret)); }
+  wait ${PIDS[$DEVICE]} || {
+    ret=$?
+    echo "*** $DEVICE failed with exit code $ret"
+    RC=$(($RC + $ret))
+    echo "    Last lines of log:"
+    tail -n 50 "${LOGS[$DEVICE]}" | sed -e 's/^/    | /'
+  }
 done
 echo "... terminated (RC=$RC)."
 


### PR DESCRIPTION
ex_MQ_pixel_split seems to fail sometimes.
Let's output the last lines of the logs of the failing processes.

See for example: https://cdash.gsi.de/testDetails.php?test=19708497&build=448242

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
