### PR TITLE
workaround: Avoid geoloader memory issues

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ if (env.CHANGE_ID != null) { // only run checks for PRs
   ]
 }
 
-def jobMatrix(String type, String sourcedir, List specs) {
+def jobMatrix(String type, String src, List specs) {
   def nodes = [:]
   for (spec in specs) {
     def arch = spec.getOrDefault("arch", "x86_64")
@@ -68,6 +68,7 @@ def jobMatrix(String type, String sourcedir, List specs) {
       node(selector) {
         githubNotify(context: "${label}", description: "Building ...", status: "PENDING")
         try {
+          def sourcedir = src
           if (!sourcedir) {
             deleteDir()
             checkout scm

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -117,7 +117,7 @@ def jobMatrix(String type, String sourcedir, List specs) {
               exec ${sourcedir}/tests/ci/slurm-create-jobscript.sh "${label}" "${container}" "${jobscript}" ${ctestcmd}
             """)
             dir(sourcedir) {
-              sh "tests/ci/slurm-submit.sh \"FairRoot \${JOB_BASE_NAME} ${label}\" ${jobscript}"
+              sh "tests/ci/slurm-submit.sh \"${type}\" \"FairRoot \${JOB_BASE_NAME} ${label}\" ${jobscript}"
             }
           }
 

--- a/fairroot/base/steer/FairRunSim.cxx
+++ b/fairroot/base/steer/FairRunSim.cxx
@@ -111,6 +111,10 @@ FairRunSim::~FairRunSim()
         // Do not point to a destructed object!
         fginstance = nullptr;
     }
+
+    /// \bug Leaks GeoLoader and related resources, prevents memory issues (probably a double free)
+    ///      See: https://github.com/FairRootGroup/FairRoot/issues/1514
+    static_cast<void>(fGeoLoader.release());
 }
 
 FairRunSim* FairRunSim::Instance()

--- a/tests/ci/slurm-submit.sh
+++ b/tests/ci/slurm-submit.sh
@@ -1,13 +1,14 @@
 #! /bin/bash
 
-if [ $# != 2 ]
+if [ $# != 3 ]
 then
-	echo "*** Please call like: $0 LABEL JOBSH"
+	echo "*** Please call like: $0 TYPE LABEL JOBSH"
 	exit 1
 fi
 
-label="$1"
-jobsh="$2"
+type="$1"
+label="$2"
+jobsh="$3"
 
 if [ -z "$ALFACI_SLURM_CPUS" ]
 then
@@ -26,8 +27,8 @@ if [ -z "$ALFACI_SLURM_QUEUE" ]
 then
 	ALFACI_SLURM_QUEUE=main
 fi
-case "${label}" in
-	*check/*)
+case "${type}" in
+	*check*)
 		slurm_requested_features=localworkspace
 		;;
 esac


### PR DESCRIPTION
Not leaking fGeoLoader on FairRunSim seems to cause some memory issues (probbaly a double free/delete). Until we find it, let's leak the Geoloader, as before.

See: https://github.com/FairRootGroup/FairRoot/issues/1514
See: ede7137bd698df6ba9a6b4e6807e8225e68e121b

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
