### PR TITLE
ci: Do not check Geant3 on macos

### DIFF
--- a/FairRoot_build_test.cmake
+++ b/FairRoot_build_test.cmake
@@ -48,7 +48,9 @@ if (USE_CLANG_TIDY)
 endif()
 if ("$ENV{CHANGE_ID}" STREQUAL "")
   # Branch build
-  list(APPEND options "-DENABLE_GEANT3_TESTING:BOOL=ON")
+  if (NOT CMAKE_SYSTEM_NAME MATCHES Darwin)
+    list(APPEND options "-DENABLE_GEANT3_TESTING:BOOL=ON")
+  endif()
 endif()
 ctest_configure(OPTIONS "${options}")
 


### PR DESCRIPTION
It looks like Geant3 fails always on macos.
So disable it even in branch builds on macos.

See: https://alfa-ci.gsi.de/blue/organizations/jenkins/FairRootGroup%2FFairRoot/detail/pr%2Fci/1/pipeline/101

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
