### PR TITLE
Change operator< from FairTimeStamp* to FairTimeStamp&

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
     * `basemq/devices/FairMQSampler.h` -> `examples/advanced/Tutorial3/MQ/sampler.cxx`
     * `basemq/tasks/FairMQProcessorTask.h` -> `examples/advanced/Tutorial3/MQ/processorTask/ProcessorTask.h`
     * `basemq/tasks/FairMQSamplerTask.h` -> `examples/advanced/Tutorial3/MQ/samplerTask/SamplerTask.h`
-
+  * FairTimeStamp
+    * `virtual bool operator<(const FairTimeStamp* rValue) const` changed to `bool operator<(const FairTimeStamp& rValue) const`
+ 
 ### Deprecations
 
 If you think you really require a deprecated API, please

--- a/fairroot/base/event/FairTimeStamp.h
+++ b/fairroot/base/event/FairTimeStamp.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -74,7 +74,7 @@ class FairTimeStamp : public FairMultiLinkedData_Interface
         return out;
     }
 
-    virtual bool operator<(const FairTimeStamp* rValue) const { return GetTimeStamp() < rValue->GetTimeStamp(); }
+    bool operator<(const FairTimeStamp& rValue) const { return fTimeStamp < rValue.fTimeStamp; }
 
   protected:
     Double_t fTimeStamp{-1};        //< Time of digit or Hit  [ns]


### PR DESCRIPTION
The behaviour of the FairTimeStamp::operator< does no follow standard behaviour by dealing with the FairTimeStamp* instead of a FairTimeStamp&. This is fixed in this merge request.
Should fix issue #1519.

Describe your proposal.

Mention any issue this PR resolves or is related to.

---

Checklist:

* [ ] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved the comparison operation in the `FairTimeStamp` class for enhanced reliability and performance.
	- Updated the `CHANGELOG.md` file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->