### PR TITLE
fix: Avoid casting to void

### DIFF
--- a/examples/MQ/pixelDetector/src/PixelGeoPar.cxx
+++ b/examples/MQ/pixelDetector/src/PixelGeoPar.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -17,9 +17,9 @@ PixelGeoPar ::PixelGeoPar(const char* name, const char* title, const char* conte
     , fGeoPassNodes(new TObjArray())
 {}
 
-PixelGeoPar::~PixelGeoPar(void) {}
+PixelGeoPar::~PixelGeoPar() {}
 
-void PixelGeoPar::clear(void)
+void PixelGeoPar::clear()
 {
     delete fGeoSensNodes;
     delete fGeoPassNodes;

--- a/examples/advanced/Tutorial3/simulation/FairTestDetectorGeoPar.cxx
+++ b/examples/advanced/Tutorial3/simulation/FairTestDetectorGeoPar.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -17,9 +17,9 @@ FairTestDetectorGeoPar::FairTestDetectorGeoPar(const char* name, const char* tit
     , fGeoPassNodes(new TObjArray())
 {}
 
-FairTestDetectorGeoPar::~FairTestDetectorGeoPar(void) {}
+FairTestDetectorGeoPar::~FairTestDetectorGeoPar() {}
 
-void FairTestDetectorGeoPar::clear(void)
+void FairTestDetectorGeoPar::clear()
 {
     delete fGeoSensNodes;
     delete fGeoPassNodes;

--- a/examples/advanced/propagator/src/FairTutPropGeoPar.cxx
+++ b/examples/advanced/propagator/src/FairTutPropGeoPar.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2019-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2019-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -18,9 +18,9 @@ FairTutPropGeoPar ::FairTutPropGeoPar(const char* name, const char* title, const
     , fGeoPassNodes(new TObjArray())
 {}
 
-FairTutPropGeoPar::~FairTutPropGeoPar(void) {}
+FairTutPropGeoPar::~FairTutPropGeoPar() {}
 
-void FairTutPropGeoPar::clear(void)
+void FairTutPropGeoPar::clear()
 {
     delete fGeoSensNodes;
     delete fGeoPassNodes;

--- a/examples/common/passive/FairGeoPassivePar.cxx
+++ b/examples/common/passive/FairGeoPassivePar.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -20,9 +20,9 @@ FairGeoPassivePar::FairGeoPassivePar(const char* name, const char* title, const 
     , fGeoPassNodes(new TObjArray())
 {}
 
-FairGeoPassivePar::~FairGeoPassivePar(void) {}
+FairGeoPassivePar::~FairGeoPassivePar() {}
 
-void FairGeoPassivePar::clear(void)
+void FairGeoPassivePar::clear()
 {
     delete fGeoSensNodes;
     delete fGeoPassNodes;

--- a/examples/common/passive/FairGeoPassivePar.h
+++ b/examples/common/passive/FairGeoPassivePar.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -24,8 +24,8 @@ class FairGeoPassivePar : public FairParGenericSet
     FairGeoPassivePar(const char* name = "FairGeoPassivePar",
                       const char* title = "Passive Geometry Parameters",
                       const char* context = "TestDefaultContext");
-    ~FairGeoPassivePar(void);
-    void clear(void);
+    ~FairGeoPassivePar();
+    void clear();
     void putParams(FairParamList*);
     Bool_t getParams(FairParamList*);
     TObjArray* GetGeoSensitiveNodes() { return fGeoSensNodes; }

--- a/examples/simulation/Tutorial1/src/FairTutorialDet1GeoPar.cxx
+++ b/examples/simulation/Tutorial1/src/FairTutorialDet1GeoPar.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -17,9 +17,9 @@ FairTutorialDet1GeoPar ::FairTutorialDet1GeoPar(const char* name, const char* ti
     , fGeoPassNodes(new TObjArray())
 {}
 
-FairTutorialDet1GeoPar::~FairTutorialDet1GeoPar(void) {}
+FairTutorialDet1GeoPar::~FairTutorialDet1GeoPar() {}
 
-void FairTutorialDet1GeoPar::clear(void)
+void FairTutorialDet1GeoPar::clear()
 {
     delete fGeoSensNodes;
     delete fGeoPassNodes;

--- a/examples/simulation/Tutorial1/src/FairTutorialDet1GeoPar.h
+++ b/examples/simulation/Tutorial1/src/FairTutorialDet1GeoPar.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -27,8 +27,8 @@ class FairTutorialDet1GeoPar : public FairParGenericSet
     FairTutorialDet1GeoPar(const char* name = "FairTutorialDet1GeoPar",
                            const char* title = "FairTutorialDet1 Geometry Parameters",
                            const char* context = "TestDefaultContext");
-    ~FairTutorialDet1GeoPar(void);
-    void clear(void);
+    ~FairTutorialDet1GeoPar();
+    void clear();
     void putParams(FairParamList*);
     Bool_t getParams(FairParamList*);
     TObjArray* GetGeoSensitiveNodes() { return fGeoSensNodes; }

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2GeoPar.cxx
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2GeoPar.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -17,9 +17,9 @@ FairTutorialDet2GeoPar ::FairTutorialDet2GeoPar(const char* name, const char* ti
     , fGeoPassNodes(new TObjArray())
 {}
 
-FairTutorialDet2GeoPar::~FairTutorialDet2GeoPar(void) {}
+FairTutorialDet2GeoPar::~FairTutorialDet2GeoPar() {}
 
-void FairTutorialDet2GeoPar::clear(void)
+void FairTutorialDet2GeoPar::clear()
 {
     delete fGeoSensNodes;
     delete fGeoPassNodes;

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2GeoPar.h
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2GeoPar.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -27,8 +27,8 @@ class FairTutorialDet2GeoPar : public FairParGenericSet
     FairTutorialDet2GeoPar(const char* name = "FairTutorialDet2GeoPar",
                            const char* title = "FairTutorialDet2 Geometry Parameters",
                            const char* context = "TestDefaultContext");
-    ~FairTutorialDet2GeoPar(void);
-    void clear(void);
+    ~FairTutorialDet2GeoPar();
+    void clear();
     void putParams(FairParamList*);
     Bool_t getParams(FairParamList*);
     TObjArray* GetGeoSensitiveNodes() { return fGeoSensNodes; }

--- a/examples/simulation/Tutorial4/src/param/FairTutorialDet4GeoPar.cxx
+++ b/examples/simulation/Tutorial4/src/param/FairTutorialDet4GeoPar.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -18,7 +18,7 @@ FairTutorialDet4GeoPar ::FairTutorialDet4GeoPar(const char* name, const char* ti
     , fGlobalCoordinates(kFALSE)
 {}
 
-void FairTutorialDet4GeoPar::clear(void)
+void FairTutorialDet4GeoPar::clear()
 {
     delete fGeoSensNodes;
     delete fGeoPassNodes;

--- a/examples/simulation/Tutorial4/src/param/FairTutorialDet4GeoPar.h
+++ b/examples/simulation/Tutorial4/src/param/FairTutorialDet4GeoPar.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -21,9 +21,9 @@ class FairTutorialDet4GeoPar : public FairParGenericSet
     FairTutorialDet4GeoPar(const char* name = "FairTutorialDet4GeoPar",
                            const char* title = "FairTutorialDet4 Geometry Parameters",
                            const char* context = "TestDefaultContext");
-    ~FairTutorialDet4GeoPar(void) {}
+    ~FairTutorialDet4GeoPar() {}
 
-    void clear(void);
+    void clear();
     void putParams(FairParamList*);
     Bool_t getParams(FairParamList*);
     TObjArray* GetGeoSensitiveNodes() { return fGeoSensNodes; }

--- a/examples/simulation/Tutorial4/src/param/FairTutorialDet4MisalignPar.cxx
+++ b/examples/simulation/Tutorial4/src/param/FairTutorialDet4MisalignPar.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -20,9 +20,9 @@ FairTutorialDet4MisalignPar ::FairTutorialDet4MisalignPar(const char* name, cons
     , fNrOfDetectors(0)
 {}
 
-FairTutorialDet4MisalignPar::~FairTutorialDet4MisalignPar(void) {}
+FairTutorialDet4MisalignPar::~FairTutorialDet4MisalignPar() {}
 
-void FairTutorialDet4MisalignPar::clear(void) {}
+void FairTutorialDet4MisalignPar::clear() {}
 
 void FairTutorialDet4MisalignPar::putParams(FairParamList* l)
 {

--- a/examples/simulation/Tutorial4/src/param/FairTutorialDet4MisalignPar.h
+++ b/examples/simulation/Tutorial4/src/param/FairTutorialDet4MisalignPar.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -22,8 +22,8 @@ class FairTutorialDet4MisalignPar : public FairParGenericSet
         const char* name = "FairTutorialDet4MissallignPar",
         const char* title = "Missalignment parameter for FairTutorialDet4HitProducerIdealMissallign Parameters",
         const char* context = "TestDefaultContext");
-    ~FairTutorialDet4MisalignPar(void);
-    void clear(void);
+    ~FairTutorialDet4MisalignPar();
+    void clear();
     void putParams(FairParamList*);
     Bool_t getParams(FairParamList*);
 

--- a/fairroot/base/sim/FairBaseParSet.cxx
+++ b/fairroot/base/sim/FairBaseParSet.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -26,7 +26,7 @@ FairBaseParSet::FairBaseParSet(const char* name, const char* title, const char* 
     , fRandomSeed(99999999)
 {}
 
-FairBaseParSet::~FairBaseParSet(void)
+FairBaseParSet::~FairBaseParSet()
 {
     if (fContNameList) {
         fContNameList->Delete();
@@ -34,7 +34,10 @@ FairBaseParSet::~FairBaseParSet(void)
     }
 }
 
-void FairBaseParSet::clear(void) { fContNameList->Delete(); }
+void FairBaseParSet::clear()
+{
+    fContNameList->Delete();
+}
 
 void FairBaseParSet::putParams(FairParamList* l)
 {

--- a/fairroot/base/sim/FairGeoParSet.cxx
+++ b/fairroot/base/sim/FairGeoParSet.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -22,9 +22,9 @@ FairGeoParSet::FairGeoParSet(const char* name, const char* title, const char* co
     , fGeom(0)
 {}
 
-FairGeoParSet::~FairGeoParSet(void) {}
+FairGeoParSet::~FairGeoParSet() {}
 
-void FairGeoParSet::clear(void)
+void FairGeoParSet::clear()
 {
     // delete fGeoNodes;
     // delete fGeom;

--- a/fairroot/base/steer/FairRunSim.cxx
+++ b/fairroot/base/steer/FairRunSim.cxx
@@ -40,6 +40,7 @@
 #include <iostream>        // for cout, endl, ostream
 #include <stdlib.h>        // for getenv, nullptr
 #include <string.h>        // for strcmp, strncmp
+#include <tuple>           // for std::ignore
 
 using std::cout;
 using std::endl;
@@ -114,7 +115,7 @@ FairRunSim::~FairRunSim()
 
     /// \bug Leaks GeoLoader and related resources, prevents memory issues (probably a double free)
     ///      See: https://github.com/FairRootGroup/FairRoot/issues/1514
-    static_cast<void>(fGeoLoader.release());
+    std::ignore = fGeoLoader.release();
 }
 
 FairRunSim* FairRunSim::Instance()

--- a/fairroot/datamatch/FairMCObject.h
+++ b/fairroot/datamatch/FairMCObject.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -77,7 +77,7 @@ class FairMCObject : public TObject
     FairMCEntry GetEntry(int index) const { return fStage[index]; }
     FairLink GetSingleLink(int entryIndex, int linkIndex) const { return fStage.at(entryIndex).GetLink(linkIndex); }
 
-    Int_t GetStageId(void) const { return fStageId; }
+    Int_t GetStageId() const { return fStageId; }
 
     FairMCEntry GetMCLink(Int_t index) { return fStage.at(index); }
 

--- a/fairroot/datamatch/FairMCResult.h
+++ b/fairroot/datamatch/FairMCResult.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -56,8 +56,8 @@ class FairMCResult : public FairMCObject
     void SetStartType(Int_t start) { fStartType = start; }
     void SetStopType(Int_t stop) { fStopType = stop; }
 
-    Int_t GetStartType(void) const { return fStartType; }
-    Int_t GetStopType(void) const { return fStopType; }
+    Int_t GetStartType() const { return fStartType; }
+    Int_t GetStopType() const { return fStopType; }
 
     virtual void PrintInfo(std::ostream& out = std::cout) { out << *this; }
 

--- a/fairroot/datamatch/FairMCStage.h
+++ b/fairroot/datamatch/FairMCStage.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -65,11 +65,11 @@ class FairMCStage : public FairMCObject
     void SetLoaded(Bool_t loaded) { fLoaded = loaded; }
     void SetFill(Bool_t fill) { fFill = fill; }
 
-    std::string GetBranchName(void) const { return fBranchName; }
-    std::string GetFileName(void) const { return fFileName; }
-    Double_t GetWeight(void) const { return fWeight; }
-    Bool_t GetLoaded(void) const { return fLoaded; }
-    Bool_t GetFill(void) const { return fFill; }
+    std::string GetBranchName() const { return fBranchName; }
+    std::string GetFileName() const { return fFileName; }
+    Double_t GetWeight() const { return fWeight; }
+    Bool_t GetLoaded() const { return fLoaded; }
+    Bool_t GetFill() const { return fFill; }
 
     virtual void ClearEntries()
     {

--- a/fairroot/geobase/FairGeoMatrix.cxx
+++ b/fairroot/geobase/FairGeoMatrix.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -20,7 +20,7 @@
 //     added as needed
 /////////////////////////////////////////////////////////
 
-FairGeoMatrix::FairGeoMatrix(void)
+FairGeoMatrix::FairGeoMatrix()
     : TObject()
 {
     // Initializes the matrix to 0
@@ -29,9 +29,9 @@ FairGeoMatrix::FairGeoMatrix(void)
     }
 }
 
-FairGeoMatrix::~FairGeoMatrix(void) {}
+FairGeoMatrix::~FairGeoMatrix() {}
 
-Double_t FairGeoMatrix::det(void)
+Double_t FairGeoMatrix::det()
 {
     // Computes de determinat of the 3D matrix
     return (fM[0] * fM[4] * fM[8] + fM[1] * fM[5] * fM[6] + fM[3] * fM[7] * fM[2] - fM[2] * fM[4] * fM[6]

--- a/fairroot/geobase/FairGeoMatrix.h
+++ b/fairroot/geobase/FairGeoMatrix.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -22,10 +22,10 @@ class FairGeoMatrix : public TObject
     Double_t fM[9];
 
   public:
-    FairGeoMatrix(void);
+    FairGeoMatrix();
     ~FairGeoMatrix() override;
     Double_t& operator()(Int_t i, Int_t j) { return fM[i * 3 + j]; }
-    Double_t det(void);
+    Double_t det();
     FairGeoVector operator*(FairGeoVector& v);
     FairGeoMatrix& operator/=(Double_t d);
     ClassDefOverride(FairGeoMatrix, 0);

--- a/fairroot/geobase/FairGeoSet.h
+++ b/fairroot/geobase/FairGeoSet.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -74,11 +74,11 @@ class FairGeoSet : public TNamed
     void setMasterNodes(TList* m) { masterNodes = m; }
     void setGeomFile(const char* filename) { geoFile = filename; }
     const char* getGeomFile() { return geoFile.Data(); }
-    Int_t getMaxSectors(void) { return maxSectors; }
-    Int_t getMaxModules(void) { return maxModules; }
-    Int_t getMaxKeepinVolumes(void) { return maxKeepinVolumes; }
+    Int_t getMaxSectors() { return maxSectors; }
+    Int_t getMaxModules() { return maxModules; }
+    Int_t getMaxKeepinVolumes() { return maxKeepinVolumes; }
     void setModules(Int_t, Int_t*);
-    Int_t* getModules(void);
+    Int_t* getModules();
     Int_t getModule(Int_t, Int_t);
     FairGeoNode* getVolume(const char* name) { return dynamic_cast<FairGeoNode*>(volumes->FindObject(name)); }
     FairGeoNode* getMasterNode(const char* name) { return dynamic_cast<FairGeoNode*>(masterNodes->FindObject(name)); }

--- a/fairroot/geobase/FairGeoTransform.cxx
+++ b/fairroot/geobase/FairGeoTransform.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -133,7 +133,7 @@ void FairGeoTransform::print()
     trans.print();
 }
 
-void FairGeoTransform::invert(void)
+void FairGeoTransform::invert()
 {
     rot.invert();
     trans = rot * trans;

--- a/fairroot/geobase/FairGeoTransform.h
+++ b/fairroot/geobase/FairGeoTransform.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -41,7 +41,7 @@ class FairGeoTransform : public TObject
     FairGeoVector transTo(const FairGeoVector& p) const;
     void transFrom(const FairGeoTransform&);
     void transTo(const FairGeoTransform&);
-    void invert(void);
+    void invert();
     void clear();
     void print();
     const FairGeoVector& getTranslation()

--- a/fairroot/parbase/FairRtdbRun.h
+++ b/fairroot/parbase/FairRtdbRun.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -67,7 +67,7 @@ class FairRtdbRun : public TNamed
     FairRtdbRun(Int_t r, Int_t rr = -1);
     FairRtdbRun(FairRtdbRun& run);
     ~FairRtdbRun();
-    inline UInt_t getRunId(void);
+    inline UInt_t getRunId();
     void addParVersion(FairParVersion* pv);
     FairParVersion* getParVersion(const Text_t* name);
     TList* getParVersions() { return parVersions; }
@@ -89,7 +89,7 @@ class FairRtdbRun : public TNamed
 
 // -------------------- inlines ---------------------------
 
-inline UInt_t FairRtdbRun::getRunId(void)
+inline UInt_t FairRtdbRun::getRunId()
 {
     UInt_t r;
     sscanf(GetName(), "%i", &r);

--- a/fairroot/parbase/FairRuntimeDb.cxx
+++ b/fairroot/parbase/FairRuntimeDb.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -68,7 +68,7 @@ static TList contFactories;   //! list of container factories
 
 FairRuntimeDb* FairRuntimeDb::gRtdb = 0;
 
-FairRuntimeDb* FairRuntimeDb::instance(void)
+FairRuntimeDb* FairRuntimeDb::instance()
 {
     // Singleton instance
     if (gRtdb == 0) {
@@ -77,7 +77,7 @@ FairRuntimeDb* FairRuntimeDb::instance(void)
     return gRtdb;
 }
 
-FairRuntimeDb::FairRuntimeDb(void)
+FairRuntimeDb::FairRuntimeDb()
     : TObject()
     , containerList(new TList())
     , runs(new TList())
@@ -234,7 +234,7 @@ void FairRuntimeDb::removeContainer(const char* name)
     }
 }
 
-void FairRuntimeDb::removeAllContainers(void)
+void FairRuntimeDb::removeAllContainers()
 {
     // removes all containers from the list and deletes them
     containerList->Delete();
@@ -503,7 +503,7 @@ Bool_t FairRuntimeDb::readAll()
     return kTRUE;
 }
 
-Bool_t FairRuntimeDb::initContainers(void)
+Bool_t FairRuntimeDb::initContainers()
 {
     // private function
     auto refRunName = currentRun->getRefRun();

--- a/fairroot/parbase/FairRuntimeDb.h
+++ b/fairroot/parbase/FairRuntimeDb.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -29,7 +29,7 @@ class FairRuntimeDb : public TObject
     static FairRuntimeDb* gRtdb;   //!
 
   protected:
-    FairRuntimeDb(void);
+    FairRuntimeDb();
     TList* containerList;      // list of parameter containers
     TList* runs;               // list of runs
     FairParIo* firstInput;     // first (prefered) input for parameters
@@ -53,7 +53,7 @@ class FairRuntimeDb : public TObject
     ParamIOType ioType;   // IO Type
 
   public:
-    static FairRuntimeDb* instance(void);
+    static FairRuntimeDb* instance();
     ~FairRuntimeDb() override;
 
     Bool_t addParamContext(const char*);
@@ -69,41 +69,41 @@ class FairRuntimeDb : public TObject
     void removeAllContainers();
     [[nodiscard]] bool initContainers(UInt_t runId, Int_t refId = -1, const char* fileName = "");
     void setContainersStatic(Bool_t f = kTRUE);
-    Bool_t writeContainers(void);
+    Bool_t writeContainers();
     Bool_t writeContainer(FairParSet*, FairRtdbRun*, FairRtdbRun* refRun = 0);
 
     FairRtdbRun* addRun(Int_t runId, Int_t refId = -1);
     FairRtdbRun* getRun(Int_t);
     FairRtdbRun* getRun(const char*);
-    FairRtdbRun* getCurrentRun(void) { return currentRun; }
+    FairRtdbRun* getCurrentRun() { return currentRun; }
     Text_t const* getCurrentFileName() { return currentFileName.Data(); }
-    void clearRunList(void);
+    void clearRunList();
 
     void removeRun(Text_t*);
 
     Bool_t setInputVersion(Int_t run, Text_t* container, Int_t version, Int_t inputNumber);
     Bool_t setRootOutputVersion(Int_t run, Text_t* container, Int_t version);
     void setVersionsChanged(Bool_t f = kTRUE) { versionsChanged = f; }
-    void resetInputVersions(void);
-    void resetOutputVersions(void);
-    void resetAllVersions(void);
+    void resetInputVersions();
+    void resetOutputVersions();
+    void resetAllVersions();
 
-    Bool_t readAll(void);
-    void writeVersions(void);
-    void saveOutput(void);
+    Bool_t readAll();
+    void writeVersions();
+    void saveOutput();
 
     Bool_t setFirstInput(FairParIo*);
     Bool_t setSecondInput(FairParIo*);
     Bool_t setOutput(FairParIo*);
-    FairParIo* getFirstInput(void);
-    FairParIo* getSecondInput(void);
-    FairParIo* getOutput(void);
-    void closeFirstInput(void);
-    void closeSecondInput(void);
-    void closeOutput(void);
+    FairParIo* getFirstInput();
+    FairParIo* getSecondInput();
+    FairParIo* getOutput();
+    void closeFirstInput();
+    void closeSecondInput();
+    void closeOutput();
     void activateParIo(FairParIo*);
     TList* getListOfContainers() { return containerList; }
-    void print(void);
+    void print();
     void ls(Option_t* option = "") const override;
 
     Int_t findOutputVersion(FairParSet*);

--- a/templates/NewDetector_root_containers/NewDetectorGeoPar.cxx
+++ b/templates/NewDetector_root_containers/NewDetectorGeoPar.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -18,9 +18,9 @@ NewDetectorGeoPar ::NewDetectorGeoPar(const char* name, const char* title, const
     , fGeoPassNodes(new TObjArray())
 {}
 
-NewDetectorGeoPar::~NewDetectorGeoPar(void) {}
+NewDetectorGeoPar::~NewDetectorGeoPar() {}
 
-void NewDetectorGeoPar::clear(void)
+void NewDetectorGeoPar::clear()
 {
     delete fGeoSensNodes;
     delete fGeoPassNodes;

--- a/templates/NewDetector_root_containers/NewDetectorGeoPar.h
+++ b/templates/NewDetector_root_containers/NewDetectorGeoPar.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -25,8 +25,8 @@ class NewDetectorGeoPar : public FairParGenericSet
     NewDetectorGeoPar(const char* name = "NewDetectorGeoPar",
                       const char* title = "NewDetector Geometry Parameters",
                       const char* context = "TestDefaultContext");
-    ~NewDetectorGeoPar(void);
-    void clear(void);
+    ~NewDetectorGeoPar();
+    void clear();
     void putParams(FairParamList*);
     Bool_t getParams(FairParamList*);
     TObjArray* GetGeoSensitiveNodes() { return fGeoSensNodes; }

--- a/templates/NewDetector_stl_containers/NewDetectorGeoPar.cxx
+++ b/templates/NewDetector_stl_containers/NewDetectorGeoPar.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -18,9 +18,9 @@ NewDetectorGeoPar ::NewDetectorGeoPar(const char* name, const char* title, const
     , fGeoPassNodes(new TObjArray())
 {}
 
-NewDetectorGeoPar::~NewDetectorGeoPar(void) {}
+NewDetectorGeoPar::~NewDetectorGeoPar() {}
 
-void NewDetectorGeoPar::clear(void)
+void NewDetectorGeoPar::clear()
 {
     delete fGeoSensNodes;
     delete fGeoPassNodes;

--- a/templates/NewDetector_stl_containers/NewDetectorGeoPar.h
+++ b/templates/NewDetector_stl_containers/NewDetectorGeoPar.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -25,8 +25,8 @@ class NewDetectorGeoPar : public FairParGenericSet
     NewDetectorGeoPar(const char* name = "NewDetectorGeoPar",
                       const char* title = "NewDetector Geometry Parameters",
                       const char* context = "TestDefaultContext");
-    ~NewDetectorGeoPar(void);
-    void clear(void);
+    ~NewDetectorGeoPar();
+    void clear();
     void putParams(FairParamList*);
     Bool_t getParams(FairParamList*);
     TObjArray* GetGeoSensitiveNodes() { return fGeoSensNodes; }

--- a/templates/NewParameterContainer/NewParameterContainer.cxx
+++ b/templates/NewParameterContainer/NewParameterContainer.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -15,9 +15,9 @@ NewParameterContainer ::NewParameterContainer(const char* name, const char* titl
     : FairParGenericSet(name, title, context)
 {}
 
-NewParameterContainer::~NewParameterContainer(void) {}
+NewParameterContainer::~NewParameterContainer() {}
 
-void NewParameterContainer::clear(void) {}
+void NewParameterContainer::clear() {}
 
 void NewParameterContainer::putParams(FairParamList* l)
 {

--- a/templates/NewParameterContainer/NewParameterContainer.h
+++ b/templates/NewParameterContainer/NewParameterContainer.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -18,8 +18,8 @@ class NewParameterContainer : public FairParGenericSet
     NewParameterContainer(const char* name = "NewParameterContainer",
                           const char* title = "NewParameterContainer Parameters",
                           const char* context = "TestDefaultContext");
-    ~NewParameterContainer(void);
-    void clear(void);
+    ~NewParameterContainer();
+    void clear();
     void putParams(FairParamList*);
     Bool_t getParams(FairParamList*);
 

--- a/templates/project_root_containers/NewDetector/NewDetectorGeoPar.cxx
+++ b/templates/project_root_containers/NewDetector/NewDetectorGeoPar.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -18,9 +18,9 @@ NewDetectorGeoPar ::NewDetectorGeoPar(const char* name, const char* title, const
     , fGeoPassNodes(new TObjArray())
 {}
 
-NewDetectorGeoPar::~NewDetectorGeoPar(void) {}
+NewDetectorGeoPar::~NewDetectorGeoPar() {}
 
-void NewDetectorGeoPar::clear(void)
+void NewDetectorGeoPar::clear()
 {
     delete fGeoSensNodes;
     delete fGeoPassNodes;

--- a/templates/project_root_containers/NewDetector/NewDetectorGeoPar.h
+++ b/templates/project_root_containers/NewDetector/NewDetectorGeoPar.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -25,8 +25,8 @@ class NewDetectorGeoPar : public FairParGenericSet
     NewDetectorGeoPar(const char* name = "NewDetectorGeoPar",
                       const char* title = "NewDetector Geometry Parameters",
                       const char* context = "TestDefaultContext");
-    ~NewDetectorGeoPar(void);
-    void clear(void);
+    ~NewDetectorGeoPar();
+    void clear();
     void putParams(FairParamList*);
     Bool_t getParams(FairParamList*);
     TObjArray* GetGeoSensitiveNodes() { return fGeoSensNodes; }

--- a/templates/project_stl_containers/NewDetector/NewDetectorGeoPar.cxx
+++ b/templates/project_stl_containers/NewDetector/NewDetectorGeoPar.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -18,9 +18,9 @@ NewDetectorGeoPar ::NewDetectorGeoPar(const char* name, const char* title, const
     , fGeoPassNodes(new TObjArray())
 {}
 
-NewDetectorGeoPar::~NewDetectorGeoPar(void) {}
+NewDetectorGeoPar::~NewDetectorGeoPar() {}
 
-void NewDetectorGeoPar::clear(void)
+void NewDetectorGeoPar::clear()
 {
     delete fGeoSensNodes;
     delete fGeoPassNodes;

--- a/templates/project_stl_containers/NewDetector/NewDetectorGeoPar.h
+++ b/templates/project_stl_containers/NewDetector/NewDetectorGeoPar.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -25,8 +25,8 @@ class NewDetectorGeoPar : public FairParGenericSet
     NewDetectorGeoPar(const char* name = "NewDetectorGeoPar",
                       const char* title = "NewDetector Geometry Parameters",
                       const char* context = "TestDefaultContext");
-    ~NewDetectorGeoPar(void);
-    void clear(void);
+    ~NewDetectorGeoPar();
+    void clear();
     void putParams(FairParamList*);
     Bool_t getParams(FairParamList*);
     TObjArray* GetGeoSensitiveNodes() { return fGeoSensNodes; }


### PR DESCRIPTION
Instead of casting to void to ignore a return value, use `std::ignore`.

See: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-casts

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
