### PR TITLE
Remove sprintf

### DIFF
--- a/fairroot/generators/FairIonGenerator.cxx
+++ b/fairroot/generators/FairIonGenerator.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -20,8 +20,8 @@
 #include <TObjArray.h>      // for TObjArray
 #include <TParticle.h>      // for TParticle
 #include <TParticlePDG.h>   // for TParticlePDG
-#include <cstdio>           // for sprintf
 #include <fairlogger/Logger.h>
+#include <fmt/core.h>   // for format
 
 Int_t FairIonGenerator::fgNIon = 0;
 
@@ -107,9 +107,7 @@ FairIonGenerator::FairIonGenerator(Int_t z,
   fVy   = vy;
   fVz   = vz;
   */
-    char buffer[20];
-    sprintf(buffer, "FairIon%d", fgNIon);
-    fIon = new FairIon(buffer, z, a, q);
+    fIon = new FairIon(fmt::format("FairIon{}", fgNIon).c_str(), z, a, q);
     FairRunSim* run = FairRunSim::Instance();
     if (!run) {
         LOG(error) << "No FairRun instantised!";
@@ -141,9 +139,15 @@ FairIonGenerator::~FairIonGenerator()
     // if (fIon) delete fIon;
 }
 
-void FairIonGenerator::SetExcitationEnergy(Double_t eExc) { fIon->SetExcEnergy(eExc); }
+void FairIonGenerator::SetExcitationEnergy(Double_t eExc)
+{
+    fIon->SetExcEnergy(eExc);
+}
 
-void FairIonGenerator::SetMass(Double_t mass) { fIon->SetMass(mass); }
+void FairIonGenerator::SetMass(Double_t mass)
+{
+    fIon->SetMass(mass);
+}
 
 Bool_t FairIonGenerator::ReadEvent(FairPrimaryGenerator* primGen)
 {

--- a/fairroot/generators/FairShieldGenerator.cxx
+++ b/fairroot/generators/FairShieldGenerator.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -19,7 +19,7 @@
 #include <TDatabasePDG.h>   // for TDatabasePDG
 #include <TParticlePDG.h>   // for TParticlePDG
 #include <climits>          // for INT_MAX
-#include <cstdio>           // for sprintf
+#include <fmt/core.h>       // for format
 #include <fstream>          // for ifstream
 #include <utility>          // for pair
 
@@ -51,7 +51,10 @@ FairShieldGenerator::FairShieldGenerator(const char* fileName)
     fInputFile = new std::ifstream(fFileName);
 }
 
-FairShieldGenerator::~FairShieldGenerator() { CloseInput(); }
+FairShieldGenerator::~FairShieldGenerator()
+{
+    CloseInput();
+}
 
 Bool_t FairShieldGenerator::ReadEvent(FairPrimaryGenerator* primGen)
 {
@@ -101,9 +104,8 @@ Bool_t FairShieldGenerator::ReadEvent(FairPrimaryGenerator* primGen)
 
         // Case ion
         if (iPid == 1000) {
-            char ionName[20];
-            sprintf(ionName, "Ion_%d_%d", iMass, iCharge);
-            TParticlePDG* part = fPDG->GetParticle(ionName);
+            const auto ionName = fmt::format("Ion_{}_{}", iMass, iCharge);
+            TParticlePDG* part = fPDG->GetParticle(ionName.c_str());
             if (!part) {
                 LOG(warn) << "FairShieldGenerator::ReadEvent: Cannot find " << ionName << " in database!";
                 continue;
@@ -152,11 +154,9 @@ Int_t FairShieldGenerator::RegisterIons()
         for (Int_t iTrack = 0; iTrack < nTracks; iTrack++) {
             *fInputFile >> iPid >> iMass >> iCharge >> px >> py >> pz;
             if (iPid == 1000) {   // ion
-                char buffer[20];
-                sprintf(buffer, "Ion_%d_%d", iMass, iCharge);
-                TString ionName(buffer);
+                const auto ionName = fmt::format("Ion_{}_{}", iMass, iCharge);
                 if (fIonMap.find(ionName) == fIonMap.end()) {   // new ion
-                    FairIon* ion = new FairIon(ionName, iCharge, iMass, iCharge);
+                    FairIon* ion = new FairIon(ionName.c_str(), iCharge, iMass, iCharge);
                     fIonMap[ionName] = ion;
                     nIons++;
                 }   // new ion

--- a/fairroot/geobase/FairGeoAssembly.cxx
+++ b/fairroot/geobase/FairGeoAssembly.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -19,12 +19,11 @@
 #include "FairGeoVector.h"      // for FairGeoVector
 #include "FairGeoVolume.h"      // for FairGeoVolume
 
-#include <TArrayD.h>   // for TArrayD
-#include <TString.h>   // for TString
-#include <fstream>
-#include <ostream>    // for fstream, etc
-#include <stdio.h>    // for printf, sprintf
-#include <string.h>   // for strlen
+#include <TArrayD.h>    // for TArrayD
+#include <TString.h>    // for TString
+#include <cstdio>       // for printf
+#include <fmt/core.h>   // for format
+#include <fstream>      // for fstream, etc
 
 FairGeoAssembly::FairGeoAssembly()
     : FairGeoBasicShape()
@@ -73,11 +72,9 @@ Bool_t FairGeoAssembly::writePoints(std::fstream* pFile, FairGeoVolume* volu)
     if (!pFile) {
         return kFALSE;
     }
-    Text_t buf[155];
     for (Int_t i = 0; i < nPoints; i++) {
         FairGeoVector& v = *(volu->getPoint(i));
-        sprintf(buf, "%9.3f\n", v(0));
-        pFile->write(buf, strlen(buf));
+        *pFile << fmt::format("{:9.3f}\n", v(0));
     }
     return kTRUE;
 }

--- a/fairroot/geobase/FairGeoBasicShape.cxx
+++ b/fairroot/geobase/FairGeoBasicShape.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -22,11 +22,11 @@
 #include "FairGeoVector.h"      // for FairGeoVector
 #include "FairGeoVolume.h"      // for FairGeoVolume
 
-#include <TArrayD.h>   // for TArrayD
-#include <fstream>     // for fstream
-#include <iostream>    // for cout
-#include <stdio.h>     // for printf, sprintf, sscanf
-#include <string.h>    // for strlen
+#include <TArrayD.h>    // for TArrayD
+#include <cstdio>       // for printf, sscanf
+#include <fmt/core.h>   // for format
+#include <fstream>      // for fstream
+#include <iostream>     // for cout
 
 using std::cout;
 
@@ -87,11 +87,9 @@ Bool_t FairGeoBasicShape::writePoints(std::fstream* pFile, FairGeoVolume* volu)
     if (!pFile) {
         return kFALSE;
     }
-    Text_t buf[155];
     for (Int_t i = 0; i < volu->getNumPoints(); i++) {
         FairGeoVector& v = *(volu->getPoint(i));
-        sprintf(buf, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
-        pFile->write(buf, strlen(buf));
+        *pFile << fmt::format("{:9.3f}{:10.3f}{:10.3f}\n", v(0), v(1), v(2));
     }
     return kTRUE;
 }

--- a/fairroot/geobase/FairGeoCone.cxx
+++ b/fairroot/geobase/FairGeoCone.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -40,10 +40,9 @@
 #include <TArrayD.h>     // for TArrayD
 #include <TMathBase.h>   // for Abs
 #include <TString.h>     // for TString
-#include <fstream>
-#include <ostream>    // for fstream, etc
-#include <stdio.h>    // for printf, sprintf, sscanf
-#include <string.h>   // for strlen
+#include <cstdio>        // for printf, sscanf
+#include <fmt/core.h>    // for format
+#include <fstream>       // for fstream, etc
 
 FairGeoCone::FairGeoCone()
     : FairGeoBasicShape()
@@ -105,15 +104,13 @@ Bool_t FairGeoCone::writePoints(std::fstream* pFile, FairGeoVolume* volu)
     if (!pFile) {
         return kFALSE;
     }
-    Text_t buf[155];
     for (Int_t i = 0; i < nPoints; i++) {
         FairGeoVector& v = *(volu->getPoint(i));
         if (i == 0 || i == 2) {
-            sprintf(buf, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
+            *pFile << fmt::format("{:9.3f}{:10.3f}{:10.3f}\n", v(0), v(1), v(2));
         } else {
-            sprintf(buf, "%9.3f%10.3f\n", v(0), v(1));
+            *pFile << fmt::format("{:9.3f}{:10.3f}\n", v(0), v(1));
         }
-        pFile->write(buf, strlen(buf));
     }
     return kTRUE;
 }

--- a/fairroot/geobase/FairGeoCons.cxx
+++ b/fairroot/geobase/FairGeoCons.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -43,10 +43,9 @@
 #include <TArrayD.h>     // for TArrayD
 #include <TMathBase.h>   // for Abs
 #include <TString.h>     // for TString
-#include <fstream>
-#include <ostream>    // for fstream, etc
-#include <stdio.h>    // for printf, sprintf, sscanf
-#include <string.h>   // for strlen
+#include <cstdio>        // for printf, sscanf
+#include <fmt/core.h>    // for format
+#include <fstream>       // for fstream, etc
 
 FairGeoCons::FairGeoCons()
     : FairGeoBasicShape()
@@ -109,15 +108,13 @@ Bool_t FairGeoCons::writePoints(std::fstream* pFile, FairGeoVolume* volu)
     if (!pFile) {
         return kFALSE;
     }
-    Text_t buf[155];
     for (Int_t i = 0; i < nPoints; i++) {
         FairGeoVector& v = *(volu->getPoint(i));
         if (i == 0 || i == 2) {
-            sprintf(buf, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
+            *pFile << fmt::format("{:9.3f}{:10.3f}{:10.3f}\n", v(0), v(1), v(2));
         } else {
-            sprintf(buf, "%9.3f%10.3f\n", v(0), v(1));
+            *pFile << fmt::format("{:9.3f}{:10.3f}\n", v(0), v(1));
         }
-        pFile->write(buf, strlen(buf));
     }
     return kTRUE;
 }

--- a/fairroot/geobase/FairGeoEltu.cxx
+++ b/fairroot/geobase/FairGeoEltu.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -37,10 +37,9 @@
 #include <TArrayD.h>     // for TArrayD
 #include <TMathBase.h>   // for Abs
 #include <TString.h>     // for TString
-#include <fstream>
-#include <ostream>    // for fstream, etc
-#include <stdio.h>    // for printf, sprintf, sscanf
-#include <string.h>   // for strlen
+#include <cstdio>        // for printf, sscanf
+#include <fmt/core.h>    // for format
+#include <fstream>       // for fstream, etc
 
 FairGeoEltu::FairGeoEltu()
     : FairGeoBasicShape()
@@ -103,15 +102,13 @@ Bool_t FairGeoEltu::writePoints(std::fstream* pFile, FairGeoVolume* volu)
     if (!pFile) {
         return kFALSE;
     }
-    Text_t buf[155];
     for (Int_t i = 0; i < nPoints; i++) {
         FairGeoVector& v = *(volu->getPoint(i));
         if (i != 1) {
-            sprintf(buf, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
+            *pFile << fmt::format("{:9.3f}{:10.3f}{:10.3f}\n", v(0), v(1), v(2));
         } else {
-            sprintf(buf, "%9.3f%10.3f\n", v(0), v(1));
+            *pFile << fmt::format("{:9.3f}{:10.3f}\n", v(0), v(1));
         }
-        pFile->write(buf, strlen(buf));
     }
     return kTRUE;
 }

--- a/fairroot/geobase/FairGeoInterface.cxx
+++ b/fairroot/geobase/FairGeoInterface.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -33,9 +33,9 @@
 #include <TClass.h>       // for TClass
 #include <TList.h>        // for TList
 #include <TObjArray.h>    // for TObjArray
+#include <cstdio>         // for printf, sscanf
+#include <fmt/core.h>     // for format
 #include <iostream>       // for operator<<, basic_ostream, etc
-#include <stdio.h>        // for sprintf
-#include <string.h>       // for strcmp
 #include <sys/select.h>   // for time_t
 #include <time.h>         // for tm, localtime, time
 
@@ -100,7 +100,10 @@ void FairGeoInterface::addGeoModule(FairGeoSet* pSet)
     pSet->setMasterNodes(masterNodes);
     nActualSets++;
 }
-void FairGeoInterface::setMediaFile(const char* file) { media->setInputFile(file); }
+void FairGeoInterface::setMediaFile(const char* file)
+{
+    media->setInputFile(file);
+}
 
 void FairGeoInterface::addInputFile(const char* file)
 {
@@ -427,50 +430,19 @@ Bool_t FairGeoInterface::connectOutput(const char* name)
     // Connects the output (ASCII or Oracle)
     if (output) {
         if (strcmp(output->IsA()->GetName(), "FairGeoAsciiIo") == 0) {
-            TString fName(name);
-            char buf[80];
             struct tm* newtime;
             time_t t;
             time(&t);
             newtime = localtime(&t);
-            if (newtime->tm_mday < 10) {
-                sprintf(buf, "_0%i", newtime->tm_mday);
-            } else {
-                sprintf(buf, "_%i", newtime->tm_mday);
-            }
-            fName = fName + buf;
-            if (newtime->tm_mon < 9) {
-                sprintf(buf, "0%i", newtime->tm_mon + 1);
-            } else {
-                sprintf(buf, "%i", newtime->tm_mon + 1);
-            }
-            fName = fName + buf;
-            Int_t y = newtime->tm_year - 100;
-            if (y < 10) {
-                sprintf(buf, "0%i", y);
-            } else {
-                sprintf(buf, "%i", y);
-            }
-            fName = fName + buf;
-            if (newtime->tm_hour < 10) {
-                sprintf(buf, "0%i", newtime->tm_hour);
-            } else {
-                sprintf(buf, "%i", newtime->tm_hour);
-            }
-            fName = fName + buf;
-            if (newtime->tm_min < 10) {
-                sprintf(buf, "0%i", newtime->tm_min);
-            } else {
-                sprintf(buf, "%i", newtime->tm_min);
-            }
-            fName = fName + buf;
-            if (newtime->tm_sec < 10) {
-                sprintf(buf, "0%i", newtime->tm_sec);
-            } else {
-                sprintf(buf, "%i", newtime->tm_sec);
-            }
-            fName = fName + buf + ".geo";
-            output->open(fName, "out");
+            const auto fullName = fmt::format("{}_{:02d}{:02d}{:02d}{:02d}{:02d}{:02d}.geo",
+                                              name,
+                                              newtime->tm_mday,
+                                              newtime->tm_mon + 1,
+                                              newtime->tm_year - 100,
+                                              newtime->tm_hour,
+                                              newtime->tm_min,
+                                              newtime->tm_sec);
+            output->open(fullName.c_str(), "out");
             cout << "Output file for " << name << ":  " << (static_cast<FairGeoAsciiIo*>(output))->getFilename()
                  << endl;
         }

--- a/fairroot/geobase/FairGeoPcon.cxx
+++ b/fairroot/geobase/FairGeoPcon.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -35,12 +35,11 @@
 #include "FairGeoVector.h"      // for FairGeoVector
 #include "FairGeoVolume.h"      // for FairGeoVolume
 
-#include <TArrayD.h>   // for TArrayD
-#include <TString.h>   // for TString
-#include <fstream>
-#include <ostream>    // for fstream, etc
-#include <stdio.h>    // for printf, sprintf, sscanf
-#include <string.h>   // for strlen
+#include <TArrayD.h>    // for TArrayD
+#include <TString.h>    // for TString
+#include <cstdio>       // for printf, sscanf
+#include <fmt/core.h>   // for format
+#include <fstream>      // for fstream, etc
 
 FairGeoPcon::FairGeoPcon()
     : FairGeoBasicShape()
@@ -103,20 +102,18 @@ Bool_t FairGeoPcon::writePoints(std::fstream* pFile, FairGeoVolume* volu)
     if (!pFile) {
         return kFALSE;
     }
-    Text_t buf[155];
     for (Int_t i = 0; i < volu->getNumPoints(); i++) {
         FairGeoVector& v = *(volu->getPoint(i));
         switch (i) {
             case 0:
-                sprintf(buf, "%3i\n", static_cast<Int_t>(v(0)));
+                *pFile << fmt::format("{:3d}\n", static_cast<Int_t>(v(0)));
                 break;
             case 1:
-                sprintf(buf, "%9.3f%10.3f\n", v(0), v(1));
+                *pFile << fmt::format("{:9.3f}{:10.3f}\n", v(0), v(1));
                 break;
             default:
-                sprintf(buf, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
+                *pFile << fmt::format("{:9.3f}{:10.3f}{:10.3f}\n", v(0), v(1), v(2));
         }
-        pFile->write(buf, strlen(buf));
     }
     return kTRUE;
 }

--- a/fairroot/geobase/FairGeoPgon.cxx
+++ b/fairroot/geobase/FairGeoPgon.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -35,12 +35,11 @@
 #include "FairGeoVector.h"      // for FairGeoVector
 #include "FairGeoVolume.h"      // for FairGeoVolume
 
-#include <TArrayD.h>   // for TArrayD
-#include <TString.h>   // for TString
-#include <fstream>
-#include <ostream>    // for basic_ostream::write
-#include <stdio.h>    // for printf, sprintf, sscanf
-#include <string.h>   // for strlen
+#include <TArrayD.h>    // for TArrayD
+#include <TString.h>    // for TString
+#include <cstdio>       // for printf, sscanf
+#include <fmt/core.h>   // for format
+#include <fstream>      // for fstream, etc
 
 FairGeoPgon::FairGeoPgon()
     : FairGeoBasicShape()
@@ -98,15 +97,13 @@ Bool_t FairGeoPgon::writePoints(std::fstream* pFile, FairGeoVolume* volu)
     if (!pFile) {
         return kFALSE;
     }
-    Text_t buf[155];
     for (Int_t i = 0; i < volu->getNumPoints(); i++) {
         FairGeoVector& v = *(volu->getPoint(i));
         if (i != 0) {
-            sprintf(buf, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
+            *pFile << fmt::format("{:9.3f}{:10.3f}{:10.3f}\n", v(0), v(1), v(2));
         } else {
-            sprintf(buf, "%3i\n", static_cast<Int_t>(v(0)));
+            *pFile << fmt::format("{:3d}\n", static_cast<Int_t>(v(0)));
         }
-        pFile->write(buf, strlen(buf));
     }
     return kTRUE;
 }

--- a/fairroot/geobase/FairGeoSphe.cxx
+++ b/fairroot/geobase/FairGeoSphe.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -33,12 +33,11 @@
 #include "FairGeoVector.h"      // for FairGeoVector
 #include "FairGeoVolume.h"      // for FairGeoVolume
 
-#include <TArrayD.h>   // for TArrayD
-#include <TString.h>   // for TString
-#include <fstream>
-#include <ostream>    // for basic_ostream::write
-#include <stdio.h>    // for printf, sprintf, sscanf
-#include <string.h>   // for strlen
+#include <TArrayD.h>    // for TArrayD
+#include <TString.h>    // for TString
+#include <cstdio>       // for printf, sscanf
+#include <fmt/core.h>   // for format
+#include <fstream>      // for fstream, etc
 
 FairGeoSphe::FairGeoSphe()
     : FairGeoBasicShape()
@@ -90,11 +89,9 @@ Bool_t FairGeoSphe::writePoints(std::fstream* pFile, FairGeoVolume* volu)
     if (!pFile) {
         return kFALSE;
     } else {
-        Text_t buf[155];
         for (Int_t i = 0; i < nPoints; i++) {
             FairGeoVector& v = *(volu->getPoint(i));
-            sprintf(buf, "%9.3f%10.3f\n", v(0), v(1));
-            pFile->write(buf, strlen(buf));
+            *pFile << fmt::format("{:9.3f}{:10.3f}\n", v(0), v(1));
         }
         return kTRUE;
     }

--- a/fairroot/geobase/FairGeoTorus.cxx
+++ b/fairroot/geobase/FairGeoTorus.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -25,12 +25,11 @@
 #include "FairGeoVector.h"      // for FairGeoVector
 #include "FairGeoVolume.h"      // for FairGeoVolume
 
-#include <TArrayD.h>   // for TArrayD
-#include <TString.h>   // for TString
-#include <fstream>
-#include <ostream>    // for basic_ostream::write
-#include <stdio.h>    // for printf, sprintf, sscanf
-#include <string.h>   // for strlen
+#include <TArrayD.h>    // for TArrayD
+#include <TString.h>    // for TString
+#include <cstdio>       // for printf, sscanf
+#include <fmt/core.h>   // for format
+#include <fstream>      // for fstream, etc
 
 FairGeoTorus::FairGeoTorus()
     : FairGeoBasicShape()
@@ -106,11 +105,9 @@ Bool_t FairGeoTorus::writePoints(std::fstream* pFile, FairGeoVolume* volu)
     if (!pFile) {
         return kFALSE;
     }
-    Text_t buf[155];
     for (Int_t i = 0; i < nPoints; i++) {
         FairGeoVector& v = *(volu->getPoint(i));
-        sprintf(buf, "%9.3f\n", v(0));
-        pFile->write(buf, strlen(buf));
+        *pFile << fmt::format("{:9.3f}\n", v(0));
     }
     return kTRUE;
 }

--- a/fairroot/geobase/FairGeoTube.cxx
+++ b/fairroot/geobase/FairGeoTube.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -37,10 +37,9 @@
 #include <TArrayD.h>     // for TArrayD
 #include <TMathBase.h>   // for Abs
 #include <TString.h>     // for TString
-#include <fstream>
-#include <ostream>    // for basic_ostream::write
-#include <stdio.h>    // for printf, sprintf, sscanf
-#include <string.h>   // for strlen
+#include <cstdio>        // for printf, sscanf
+#include <fmt/core.h>    // for format
+#include <fstream>       // for fstream, etc
 
 FairGeoTube::FairGeoTube()
     : FairGeoBasicShape()
@@ -97,15 +96,13 @@ Bool_t FairGeoTube::writePoints(std::fstream* pFile, FairGeoVolume* volu)
     if (!pFile) {
         return kFALSE;
     }
-    Text_t buf[155];
     for (Int_t i = 0; i < nPoints; i++) {
         FairGeoVector& v = *(volu->getPoint(i));
         if (i != 1) {
-            sprintf(buf, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
+            *pFile << fmt::format("{:9.3f}{:10.3f}{:10.3f}\n", v(0), v(1), v(2));
         } else {
-            sprintf(buf, "%9.3f%10.3f\n", v(0), v(1));
+            *pFile << fmt::format("{:9.3f}{:10.3f}\n", v(0), v(1));
         }
-        pFile->write(buf, strlen(buf));
     }
     return kTRUE;
 }

--- a/fairroot/geobase/FairGeoTubs.cxx
+++ b/fairroot/geobase/FairGeoTubs.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -40,10 +40,9 @@
 #include <TArrayD.h>     // for TArrayD
 #include <TMathBase.h>   // for Abs
 #include <TString.h>     // for TString
-#include <fstream>
-#include <ostream>    // for basic_ostream::write
-#include <stdio.h>    // for printf, sprintf, sscanf
-#include <string.h>   // for strlen
+#include <cstdio>        // for printf, sscanf
+#include <fmt/core.h>    // for format
+#include <fstream>       // for fstream, etc
 
 FairGeoTubs::FairGeoTubs()
     : FairGeoBasicShape()
@@ -99,15 +98,13 @@ Bool_t FairGeoTubs::writePoints(std::fstream* pFile, FairGeoVolume* volu)
     if (!pFile) {
         return kFALSE;
     }
-    Text_t buf[155];
     for (Int_t i = 0; i < nPoints; i++) {
         FairGeoVector& v = *(volu->getPoint(i));
         if (i == 0 || i == 2) {
-            sprintf(buf, "%9.3f%10.3f%10.3f\n", v(0), v(1), v(2));
+            *pFile << fmt::format("{:9.3f}{:10.3f}{:10.3f}\n", v(0), v(1), v(2));
         } else {
-            sprintf(buf, "%9.3f%10.3f\n", v(0), v(1));
+            *pFile << fmt::format("{:9.3f}{:10.3f}\n", v(0), v(1));
         }
-        pFile->write(buf, strlen(buf));
     }
     return kTRUE;
 }

--- a/fairroot/parbase/FairDetParRootFileIo.cxx
+++ b/fairroot/parbase/FairDetParRootFileIo.cxx
@@ -30,13 +30,13 @@
 #include <TDirectory.h>   // for TDirectory, gDirectory
 #include <TKey.h>         // for TKey
 #include <TROOT.h>        // for TROOT, gROOT
+#include <fmt/core.h>     // for format
 #include <iostream>       // for operator<<, basic_ostream, etc
-#include <stdio.h>        // for sprintf
 
 using std::cout;
 using std::endl;
 
-FairDetParRootFileIo::FairDetParRootFileIo(FairParRootFile *f)
+FairDetParRootFileIo::FairDetParRootFileIo(FairParRootFile* f)
     : FairDetParIo()
     , pFile(f)
 {
@@ -44,7 +44,7 @@ FairDetParRootFileIo::FairDetParRootFileIo(FairParRootFile *f)
     //  pFile=f;
 }
 
-Bool_t FairDetParRootFileIo::read(FairParSet *pPar)
+Bool_t FairDetParRootFileIo::read(FairParSet* pPar)
 {
     // generic read function for parameter containers
     auto name = pPar->GetName();
@@ -74,7 +74,7 @@ Bool_t FairDetParRootFileIo::read(FairParSet *pPar)
     return kFALSE;
 }
 
-Int_t FairDetParRootFileIo::write(FairParSet *pPar)
+Int_t FairDetParRootFileIo::write(FairParSet* pPar)
 {
     // writes a parameter container to the ROOT file and returns the new version
     // number (returns -1 if the file is not writable)
@@ -98,7 +98,7 @@ Int_t FairDetParRootFileIo::getMaxVersion(const char* name)
 {
     // returns the maximum version of the container given by name in the ROOT
     // file (return -1 if not found)
-    TKey *key = pFile->GetKey(name);
+    TKey* key = pFile->GetKey(name);
     if (key) {
         return key->GetCycle();
     } else {
@@ -110,33 +110,31 @@ Int_t FairDetParRootFileIo::findInputVersion(const char* name)
 {
     // finds the input version to initialize the container given by name;
     // returns -1 if the version cannot be determined
-    FairParVersion *currVers = FairRuntimeDb::instance()->getCurrentRun()->getParVersion(name);
+    FairParVersion* currVers = FairRuntimeDb::instance()->getCurrentRun()->getParVersion(name);
     Int_t v = currVers->getInputVersion(inputNumber);
     if (v > 0) {
         return v;
     }   // predefined
-    FairRtdbRun *r = pFile->getRun();
+    FairRtdbRun* r = pFile->getRun();
     // cout << "-I- FairDetParRootFileIo::findInputVersion " << r << endl;
     if (!r) {
         return -1;
     }   // run not in ROOT file
-    FairParVersion *vers = r->getParVersion(name);
+    FairParVersion* vers = r->getParVersion(name);
     if (!vers) {
         return -1;
     }   // container not in ROOT file
     return vers->getRootVersion();
 }
 
-TObject *FairDetParRootFileIo::findContainer(Text_t *name, Int_t vers)
+TObject* FairDetParRootFileIo::findContainer(Text_t* name, Int_t vers)
 {
     // finds the parameter container given by its name with a special version in
     // the ROOT file (returns 0 if not successful)
     // This funtion uses internally the ROOT function FindObject(Text_t*), which
     // creates a new object. The calling function must therefore delete the
     // object after usage!
-    Text_t cn[80];
-    sprintf(cn, "%s;%i", name, vers);
     pFile->cd();
-    TObject *p = gROOT->FindObject(cn);
+    TObject* p = gROOT->FindObject(fmt::format("{};{}", name, vers).c_str());
     return p;
 }

--- a/fairroot/parbase/FairRtdbRun.cxx
+++ b/fairroot/parbase/FairRtdbRun.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -28,6 +28,7 @@
 #include <TCollection.h>   // for TIter
 #include <TList.h>         // for TList
 #include <TROOT.h>         // for TROOT
+#include <fmt/core.h>      // for format
 #include <fstream>         // for fstream
 #include <iomanip>         // for setw, operator<<
 #include <iostream>        // for cout
@@ -65,9 +66,7 @@ FairRtdbRun::FairRtdbRun(Int_t r, Int_t rr)
     , refRun("")
 {
     parVersions->SetName("parVersions");
-    char name[255];
-    sprintf(name, "%i", r);
-    SetName(name);
+    SetName(fmt::format("{}", r).c_str());
     setRefRun(rr);
 }
 

--- a/fairroot/parbase/FairRtdbRun.h
+++ b/fairroot/parbase/FairRtdbRun.h
@@ -101,9 +101,7 @@ inline void FairRtdbRun::setRefRun(Int_t r)
     if (r == -1) {
         refRun = "";
     } else {
-        char name[255];
-        sprintf(name, "%i", r);
-        refRun = name;
+        refRun.Form("%i", r);
     }
 }
 

--- a/fairroot/parbase/FairRuntimeDb.cxx
+++ b/fairroot/parbase/FairRuntimeDb.cxx
@@ -56,8 +56,9 @@
 #include <cstdio>          // for sprintf
 #include <cstring>         // for strcmp, strlen
 #include <fairlogger/Logger.h>
-#include <iomanip>    // for setw, operator<<
-#include <iostream>   // for operator<<, basic_ostream, etc
+#include <fmt/core.h>   // for format
+#include <iomanip>      // for setw, operator<<
+#include <iostream>     // for operator<<, basic_ostream, etc
 
 using std::cout;
 using std::endl;
@@ -272,9 +273,7 @@ FairRtdbRun* FairRuntimeDb::addRun(Int_t runId, Int_t refId)
 FairRtdbRun* FairRuntimeDb::getRun(Int_t id)
 {
     // returns a pointer to the run called by the run id
-    char name[255];
-    sprintf(name, "%i", id);
-    return static_cast<FairRtdbRun*>((runs->FindObject(name)));
+    return static_cast<FairRtdbRun*>((runs->FindObject(fmt::format("{}", id).c_str())));
 }
 
 FairRtdbRun* FairRuntimeDb::getRun(const char* name)
@@ -296,7 +295,10 @@ void FairRuntimeDb::removeRun(Text_t* name)
     }
 }
 
-void FairRuntimeDb::clearRunList() { runs->Delete(); }
+void FairRuntimeDb::clearRunList()
+{
+    runs->Delete();
+}
 
 void FairRuntimeDb::writeVersions()
 {


### PR DESCRIPTION
Remove `sprintf` from `generators`, `geobase` and `parbase` directories.

Mostly replaced by `fmt::format`, only in FairRtdbRun replaced by `TString::Form`.

---

Checklist:

* [x] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced string formatting in various modules by implementing the `fmt` library, replacing `sprintf` with `fmt::format` for improved code readability and maintenance. Affected modules include:
    - `FairDetParAsciiFileIo`
    - `FairDetParRootFileIo`
    - `FairRtdbRun`
    - `FairRuntimeDb`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->