### PR TITLE
deprecate(base): FairModule::getFairVolume

### DIFF
--- a/fairroot/base/sim/FairModule.h
+++ b/fairroot/base/sim/FairModule.h
@@ -143,7 +143,10 @@ class FairModule : public TNamed
     static thread_local std::vector<FairVolume*> fAllSensitiveVolumes;   //!
 
     TString fMotherVolumeName{""};   //!
-    FairVolume* getFairVolume(FairGeoNode* fNode);
+    /**
+     * \deprecated Not used anywhere, will be removed in a future release
+     */
+    [[deprecated]] FairVolume* getFairVolume(FairGeoNode* fNode);
     void AddSensitiveVolume(TGeoVolume* v);
 
   private:


### PR DESCRIPTION
I could not find any caller anywhere.

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Deprecated the `getFairVolume` method in the `FairModule` class, scheduled for removal in version 20.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->