### PR TITLE
fix(base): Do not copy FairModule::vList

### DIFF
--- a/fairroot/base/sim/FairModule.cxx
+++ b/fairroot/base/sim/FairModule.cxx
@@ -85,9 +85,6 @@ FairModule::FairModule(const FairModule& rhs)
 {
     if (!vList) {
         vList = new FairVolumeList();
-        for (Int_t i = 0; i < rhs.vList->getEntries(); i++) {
-            vList->addVolume(rhs.vList->At(i));
-        }
     }
 
     // Initialize cached pointer to MC (on worker)
@@ -159,7 +156,6 @@ void FairModule::Streamer(TBuffer& b)
 
 void FairModule::SetGeometryFileName(TString fname, TString)
 {
-
     // If absolute path is given as argument, try to find it there.
     // If the file don't exist break. Don't look anywhere else.
     if (fname.BeginsWith("/")) {


### PR DESCRIPTION
The copy ctor tried to copy vList.

But this is a thread local variable.  So either it already exists, then nothing happens in the current code.
Otherwise a new (empty) one is created and then copied into itself.

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Optimized the constructor in the module to enhance initialization efficiency.
	- Streamlined a method for setting geometry filenames, improving code clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->