### PR TITLE
refactor(generators): FairShieldGenerator::RegisterIons

### DIFF
--- a/fairroot/generators/FairShieldGenerator.cxx
+++ b/fairroot/generators/FairShieldGenerator.cxx
@@ -19,26 +19,21 @@
 #include <TParticlePDG.h>   // for TParticlePDG
 #include <climits>          // for INT_MAX
 #include <fmt/core.h>       // for format
-#include <fstream>          // for ifstream
 #include <set>
-#include <string>
 
 FairShieldGenerator::FairShieldGenerator()
     : FairGenerator()
-    , fInputFile(nullptr)
-    , fFileName(nullptr)
     , fPDG(nullptr)
 {}
 
 FairShieldGenerator::FairShieldGenerator(const char* fileName)
     : FairGenerator()
-    , fInputFile(nullptr)
     , fFileName(fileName)
     , fPDG(TDatabasePDG::Instance())
 {
     LOG(info) << "FairShieldGenerator: Opening input file " << fileName;
-    fInputFile = new std::ifstream(fFileName);
-    if (!fInputFile->is_open()) {
+    fInputFile.open(fFileName);
+    if (!fInputFile.is_open()) {
         LOG(fatal) << "Cannot open input file.";
     }
     LOG(info) << "FairShieldGenerator: Looking for ions...";
@@ -46,18 +41,15 @@ FairShieldGenerator::FairShieldGenerator(const char* fileName)
     LOG(info) << "FairShieldGenerator: " << nIons << " ions registered.";
     CloseInput();
     LOG(info) << "FairShieldGenerator: Reopening input file " << fileName;
-    fInputFile = new std::ifstream(fFileName);
+    fInputFile.open(fFileName);
 }
 
-FairShieldGenerator::~FairShieldGenerator()
-{
-    CloseInput();
-}
+FairShieldGenerator::~FairShieldGenerator() = default;
 
 Bool_t FairShieldGenerator::ReadEvent(FairPrimaryGenerator* primGen)
 {
     // Check for input file
-    if (!fInputFile->is_open()) {
+    if (!fInputFile.is_open()) {
         LOG(error) << "FairShieldGenerator: Input file not open!";
         return kFALSE;
     }
@@ -78,14 +70,14 @@ Bool_t FairShieldGenerator::ReadEvent(FairPrimaryGenerator* primGen)
     Int_t pdgType = 0;
 
     // Read event header line from input file
-    *fInputFile >> eventId;
-    *fInputFile >> nTracks;
+    fInputFile >> eventId;
+    fInputFile >> nTracks;
     if (nTracks < 0 || nTracks > (INT_MAX - 1))
         LOG(fatal) << "Error reading the number of events from event header.";
-    *fInputFile >> pBeam >> b;
+    fInputFile >> pBeam >> b;
 
     // If end of input file is reached : close it and abort run
-    if (fInputFile->eof()) {
+    if (fInputFile.eof()) {
         LOG(info) << "FairShieldGenerator: End of input file reached ";
         CloseInput();
         return kFALSE;
@@ -98,7 +90,7 @@ Bool_t FairShieldGenerator::ReadEvent(FairPrimaryGenerator* primGen)
     for (Int_t itrack = 0; itrack < nTracks; itrack++) {
 
         // Read PID and momentum from file
-        *fInputFile >> iPid >> iMass >> iCharge >> px >> py >> pz;
+        fInputFile >> iPid >> iMass >> iCharge >> px >> py >> pz;
 
         // Case ion
         if (iPid == 1000) {
@@ -122,13 +114,9 @@ Bool_t FairShieldGenerator::ReadEvent(FairPrimaryGenerator* primGen)
 
 void FairShieldGenerator::CloseInput()
 {
-    if (fInputFile) {
-        if (fInputFile->is_open()) {
-            LOG(info) << "FairShieldGenerator: Closing input file " << fFileName;
-            fInputFile->close();
-        }
-        delete fInputFile;
-        fInputFile = nullptr;
+    if (fInputFile.is_open()) {
+        LOG(info) << "FairShieldGenerator: Closing input file " << fFileName;
+        fInputFile.close();
     }
 }
 
@@ -138,22 +126,22 @@ Int_t FairShieldGenerator::RegisterIons()
     Int_t nIons = 0;
     std::set<std::string> duplicatecheck;
 
-    while (!fInputFile->eof()) {
+    while (!fInputFile.eof()) {
         Int_t eventId, nTracks;
 
-        *fInputFile >> eventId;
-        *fInputFile >> nTracks;
+        fInputFile >> eventId;
+        fInputFile >> nTracks;
         if (nTracks < 0 || nTracks > (INT_MAX - 1))
             LOG(fatal) << "Error reading the number of events from event header.";
         Double_t pBeam, b;
-        *fInputFile >> pBeam >> b;
-        if (fInputFile->eof()) {
+        fInputFile >> pBeam >> b;
+        if (fInputFile.eof()) {
             continue;
         }
         for (Int_t iTrack = 0; iTrack < nTracks; iTrack++) {
             Int_t iPid, iMass, iCharge;
             Double_t px, py, pz;
-            *fInputFile >> iPid >> iMass >> iCharge >> px >> py >> pz;
+            fInputFile >> iPid >> iMass >> iCharge >> px >> py >> pz;
             if (iPid == 1000) {   // ion
                 const auto ionName = fmt::format("Ion_{}_{}", iMass, iCharge);
                 if (duplicatecheck.count(ionName) == 0) {

--- a/fairroot/generators/FairShieldGenerator.h
+++ b/fairroot/generators/FairShieldGenerator.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -10,35 +10,31 @@
 // -----                Created 15/09/06 by V. Friese                  -----
 // -------------------------------------------------------------------------
 
-/** FairShieldGenerator
- *@author V.Friese  <v.friese@gsi.de>
- *@since 15.09.06
- *@version 1.0
- *
- ** The FairShieldGenerator is similar to the FairAsciiGenerator. It uses the
- ** ASCII output of the SHIELD code as input for simulation.
- ** The format of the event header is:
- ** event nr.; number of particles; beam momentum; impact parameter
- ** followed by a line for each particle of the format
- ** PID; A; Z; px; py; pz
- ** The PID must be given as for Geant3. For ions, it is 1000. The total
- ** momentum is required, not momentum per nucleon.
- **/
-
 #ifndef FAIRSHIELDGENERATOR_H
 #define FAIRSHIELDGENERATOR_H 1
 
 #include "FairGenerator.h"   // for FairGenerator
 
-#include <Rtypes.h>    // for FairShieldGenerator::Class, etc
-#include <TString.h>   // for TString
-#include <iosfwd>      // for ifstream
-#include <map>         // for map
+#include <Rtypes.h>   // for FairShieldGenerator::Class, etc
+#include <TDatabasePDG.h>
+#include <iosfwd>   // for ifstream
 
-class TDatabasePDG;
 class FairPrimaryGenerator;
-class FairIon;
 
+/**
+ *@author V.Friese  <v.friese@gsi.de>
+ *@since 15.09.06
+ *@version 1.0
+ *
+ * The FairShieldGenerator is similar to the FairAsciiGenerator. It uses the
+ * ASCII output of the SHIELD code as input for simulation.
+ * The format of the event header is:
+ * event nr.; number of particles; beam momentum; impact parameter
+ * followed by a line for each particle of the format
+ * PID; A; Z; px; py; pz
+ * The PID must be given as for Geant3. For ions, it is 1000. The total
+ * momentum is required, not momentum per nucleon.
+ **/
 class FairShieldGenerator : public FairGenerator
 {
   public:
@@ -71,9 +67,6 @@ class FairShieldGenerator : public FairGenerator
     /** Private method RegisterIons. Goes through the input file and registers
      ** any ion needed. **/
     Int_t RegisterIons();
-
-    /** STL map from ion name to FairIon **/
-    std::map<TString, FairIon*> fIonMap;   //!
 
     FairShieldGenerator(const FairShieldGenerator&);
     FairShieldGenerator& operator=(const FairShieldGenerator&);

--- a/fairroot/generators/FairShieldGenerator.h
+++ b/fairroot/generators/FairShieldGenerator.h
@@ -17,7 +17,8 @@
 
 #include <Rtypes.h>   // for FairShieldGenerator::Class, etc
 #include <TDatabasePDG.h>
-#include <iosfwd>   // for ifstream
+#include <fstream>   // for ifstream
+#include <string>
 
 class FairPrimaryGenerator;
 
@@ -47,18 +48,18 @@ class FairShieldGenerator : public FairGenerator
     FairShieldGenerator(const char* fileName);
 
     /** Destructor. **/
-    virtual ~FairShieldGenerator();
+    ~FairShieldGenerator() override;
 
     /** Reads on event from the input file and pushes the tracks onto
      ** the stack. Abstract method in base class.
      ** @param primGen  pointer to the FairPrimaryGenerator
      **/
-    virtual Bool_t ReadEvent(FairPrimaryGenerator* primGen);
+    Bool_t ReadEvent(FairPrimaryGenerator* primGen) override;
 
   private:
-    std::ifstream* fInputFile;   //! Input file stream
-    const Char_t* fFileName;     //! Input file Name
-    TDatabasePDG* fPDG;          //!  PDG database
+    std::ifstream fInputFile;   //! Input file stream
+    std::string fFileName;      //! Input file Name
+    TDatabasePDG* fPDG;         //!  PDG database
 
     /** Private method CloseInput. Just for convenience. Closes the
      ** input file properly. Called from destructor and from ReadEvent. **/
@@ -71,7 +72,7 @@ class FairShieldGenerator : public FairGenerator
     FairShieldGenerator(const FairShieldGenerator&);
     FairShieldGenerator& operator=(const FairShieldGenerator&);
 
-    ClassDef(FairShieldGenerator, 1);
+    ClassDefOverride(FairShieldGenerator, 1);
 };
 
 #endif


### PR DESCRIPTION
- The fIonMap member variable is not needed as a member variable. This is only needed in RegisterIons
- Rewrite using a set.

Some general cleanups (add override).

- [x] waiting for #1529

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Improvements**
  - Enhanced efficiency in ion registration by using a set for duplicate checking, resulting in faster performance.
  - Improved code quality by removing unused includes and initializing variables within the loop.
  
- **Documentation**
  - Updated author information in the `FairShieldGenerator` class header.

- **Code Modernization**
  - Updated method and destructor declarations to use `override` for better type safety and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->