### PR TITLE
 Add `setCreationMode` to `FairParSet`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## 19.0.1 (unreleased)
 
+### Deprecations
+
+If you think you really require a deprecated API, please
+[file an issue](https://github.com/FairRootGroup/FairRoot/issues/new).
+
+* Deprecated `FairParSet::fill()` and `FairParSet::store()` while these methods are not being used anywhere in `FairRoot`.
+
 ### Other Notable Changes
 
 * Introduced `FairParSet::setCreateMode()` setter which allows disabling error message when initializing `FairParSet` object

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to FairRoot will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+## 19.0.1 (unreleased)
+
+### Other Notable Changes
+
+* Introduced `FairParSet::setCreateMode()` setter which allows disabling error message when initializing `FairParSet` object
+  that should be created rather than read from the input parameter file.
+
 ## 19.0.0 - 2024-05-17
 
 ### Breaking Changes
@@ -76,9 +83,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
     * `virtual bool operator<(const FairTimeStamp* rValue) const` changed to `bool operator<(const FairTimeStamp& rValue) const`
 
 ### Deprecations
-
-If you think you really require a deprecated API, please
-[file an issue](https://github.com/FairRootGroup/FairRoot/issues/new).
 
 * Deprecated MbsAPI
   * We plan to remove it completely in the next major release

--- a/fairroot/parbase/FairParSet.cxx
+++ b/fairroot/parbase/FairParSet.cxx
@@ -36,7 +36,7 @@ FairParSet::FairParSet(const char* name, const char* title, const char* context,
     , author("")
     , description("")
 {
-    for (Int_t i = 0; i < 3; i++) {
+    for (int i = 0; i < 3; i++) {
         versions[i] = -1;
     }
 }
@@ -51,7 +51,7 @@ Bool_t FairParSet::init()
     // FairRunAna* fRun =FairRunAna::Instance();
     // cout << "-I-  FairParSet::init() " << GetName() << endl;
 
-    Bool_t allFound = kFALSE;
+    bool allFound = false;
     FairParIo* io = 0;
     if (rtdb) {
         io = rtdb->getFirstInput();
@@ -96,33 +96,25 @@ Int_t FairParSet::write()
 void FairParSet::print()
 {
     // prints information about container (versions,status,hasChanged...)
-    cout << "-----  " << GetName() << "  -----" << '\n';
+    LOG(info) << "-----  " << GetName() << "  -----";
     if (!paramContext.IsNull()) {
-        cout << "Context/Purpose:       " << paramContext << '\n';
+        LOG(info) << "Context/Purpose:       " << paramContext;
     }
     if (!author.IsNull()) {
-        cout << "Author:                " << author << '\n';
+        LOG(info) << "Author:                " << author;
     }
     if (!description.IsNull()) {
-        cout << "Description:           " << description << '\n';
+        LOG(info) << "Description:           " << description;
     }
-    cout << "first input version:   " << versions[1] << '\n';
-    cout << "second input version:  " << versions[2] << '\n';
-    if (changed) {
-        cout << "has changed" << '\n';
-    } else {
-        cout << "has not changed" << '\n';
-    }
-    if (status) {
-        cout << "is static" << '\n';
-    } else {
-        cout << "is not static" << '\n';
-    }
+    LOG(info) << "first input version:   " << versions[1];
+    LOG(info) << "second input version:  " << versions[2];
+    LOG(info) << "has" << (changed ? "" : " not") << " changed";
+    LOG(info) << "is" << (status ? "" : " not") << " static";
 }
 
 void FairParSet::clear()
 {
-    status = kFALSE;
+    status = false;
     resetInputVersions();
 }
 
@@ -130,10 +122,10 @@ void FairParSet::resetInputVersions()
 {
     // resets the input versions if the container is not static
     if (!status) {
-        for (Int_t i = 0; i < 3; i++) {
+        for (int i = 0; i < 3; i++) {
             versions[i] = -1;
         }
-        changed = kFALSE;
+        changed = false;
     }
 }
 
@@ -155,7 +147,7 @@ FairParSet::FairParSet(const FairParSet& from)
  fTitle   = from.fTitle;
  detName  = from.detName;
 */
-    for (Int_t i = 0; i < 3; i++)
+    for (int i = 0; i < 3; i++)
         versions[i] = from.versions[i];
     /*
  status   = from.status;

--- a/fairroot/parbase/FairParSet.cxx
+++ b/fairroot/parbase/FairParSet.cxx
@@ -31,6 +31,7 @@ FairParSet::FairParSet(const char* name, const char* title, const char* context,
     , status(kFALSE)
     , changed(kFALSE)
     , owned(owner)
+    , creationMode(false)
     , paramContext(context)
     , author("")
     , description("")
@@ -68,6 +69,10 @@ Bool_t FairParSet::init()
         }
     }
     if (allFound) {
+        return kTRUE;
+    }
+    if (creationMode) {
+        LOG(debug) << "init() " << GetName() << "[creationMode=ON] not initialized.";
         return kTRUE;
     }
     LOG(error) << "init() " << GetName() << " not initialized";

--- a/fairroot/parbase/FairParSet.h
+++ b/fairroot/parbase/FairParSet.h
@@ -20,17 +20,17 @@ class FairParSet : public TObject
     TString fName;          //
     TString fTitle;         //
     TString detName;        //! name of the detector the container belongs to
-    Int_t versions[3];      //! versions of container in the 2 possible inputs
-    Bool_t status;          //! static flag
-    Bool_t changed;         //! flag is kTRUE if parameters have changed
-    Bool_t owned;           //! if flag is KTRUE FairDB has the par. class ownership
+    int versions[3];        //! versions of container in the 2 possible inputs
+    bool status;            //! static flag
+    bool changed;           //! flag is kTRUE if parameters have changed
+    bool owned;             //! if flag is KTRUE FairDB has the par. class ownership
     bool creationMode;      //! allow creation mode, it suppresses error message in the init
     TString paramContext;   // Context/purpose for parameters and conditions
     TString author;         // Author of parameters
     TString description;    // Description of parameters
 
   public:
-    FairParSet(const char* name = "", const char* title = "", const char* context = "", Bool_t owner = kFALSE);
+    FairParSet(const char* name = "", const char* title = "", const char* context = "", bool owner = false);
     virtual ~FairParSet() {}
 
     const char* GetName() const override { return fName.Data(); }
@@ -46,13 +46,13 @@ class FairParSet : public TObject
     const char* getDetectorName() { return detName.Data(); }
     void resetInputVersions();
 
-    void setInputVersion(Int_t v = -1, Int_t i = 0)
+    void setInputVersion(int v = -1, int i = 0)
     {
         if (i >= 0 && i < 3) {
             versions[i] = v;
         }
     }
-    Int_t getInputVersion(Int_t i)
+    int getInputVersion(int i)
     {
         if (i >= 0 && i < 3) {
             return versions[i];
@@ -61,14 +61,14 @@ class FairParSet : public TObject
         }
     }
 
-    void setStatic(Bool_t flag = kTRUE) { status = flag; }
-    Bool_t isStatic() { return status; }
+    void setStatic(bool flag = kTRUE) { status = flag; }
+    bool isStatic() { return status; }
 
-    void setOwnership(Bool_t flag = kTRUE) { owned = flag; }
-    Bool_t isOwned() { return owned; }
+    void setOwnership(bool flag = kTRUE) { owned = flag; }
+    bool isOwned() { return owned; }
 
-    void setChanged(Bool_t flag = kTRUE) { changed = flag; }
-    Bool_t hasChanged() { return changed; }
+    void setChanged(bool flag = kTRUE) { changed = flag; }
+    bool hasChanged() { return changed; }
 
     void setCreationMode(bool flag = true) { creationMode = flag; }
     bool isCreationMode() { return creationMode; }

--- a/fairroot/parbase/FairParSet.h
+++ b/fairroot/parbase/FairParSet.h
@@ -87,11 +87,10 @@ class FairParSet : public TObject
         description = r.getDescription();
     }
 
-    // TODO These two methods are not used in FairRoot at all.
-    // They probably should be marked deprecated (or final, or = delete)
-    // and later removed.
-    virtual void fill(UInt_t){};
-    virtual void store(UInt_t){};
+    // These two methods are not used in FairRoot at all.
+    // Therefore mark them deprecated.
+    [[deprecated("fill function is not used, report back to FairRoot team should you need the function")]] virtual void fill(UInt_t){};
+    [[deprecated("store function is not used, report back to FairRoot team should you need the function")]] virtual void store(UInt_t){};
 
     FairParSet& operator=(const FairParSet&);
     FairParSet(const FairParSet&);

--- a/fairroot/parbase/FairParSet.h
+++ b/fairroot/parbase/FairParSet.h
@@ -24,6 +24,7 @@ class FairParSet : public TObject
     Bool_t status;          //! static flag
     Bool_t changed;         //! flag is kTRUE if parameters have changed
     Bool_t owned;           //! if flag is KTRUE FairDB has the par. class ownership
+    bool creationMode;      //! allow creation mode, it suppresses error message in the init
     TString paramContext;   // Context/purpose for parameters and conditions
     TString author;         // Author of parameters
     TString description;    // Description of parameters
@@ -69,6 +70,9 @@ class FairParSet : public TObject
     void setChanged(Bool_t flag = kTRUE) { changed = flag; }
     Bool_t hasChanged() { return changed; }
 
+    void setCreationMode(bool flag = true) { creationMode = flag; }
+    bool isCreationMode() { return creationMode; }
+
     const char* getParamContext() const { return paramContext.Data(); }
 
     void setAuthor(const char* s) { author = s; }
@@ -92,7 +96,7 @@ class FairParSet : public TObject
     FairParSet& operator=(const FairParSet&);
     FairParSet(const FairParSet&);
 
-    ClassDefOverride(FairParSet, 2);   // Base class for all parameter containers
+    ClassDefOverride(FairParSet, 3);   // Base class for all parameter containers
 };
 
 #endif /* !FAIRPARSET_H */


### PR DESCRIPTION
In rare cases, when parameteres deriving from `FairParSet`
are not present in the input parameter file and are meant
to be created during the run, `FairParSet::init()` throws
an error message.
    
By using the newly introduced setter `setCreationMode`
this message is suppressed.

This allows solution to issue #1541.

The PR also does some clean-up in `FairParSet`.

---

Checklist:

* [ ] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
