### PR TITLE
docs: breaking change of FairModule::svList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
     * `basemq/tasks/FairMQSamplerTask.h` -> `examples/advanced/Tutorial3/MQ/samplerTask/SamplerTask.h`
   * FairTimeStamp
     * `virtual bool operator<(const FairTimeStamp* rValue) const` changed to `bool operator<(const FairTimeStamp& rValue) const`
+  * FairModule::svList is gone. This was never intended as a public
+    API.
 
 ### Deprecations
 

--- a/fairroot/base/sim/FairModule.h
+++ b/fairroot/base/sim/FairModule.h
@@ -140,7 +140,9 @@ class FairModule : public TNamed
     static thread_local inline FairVolumeList* vList{nullptr};   //!
     /**total number of volumes in a simulaion session*/
     static thread_local inline Int_t fNbOfVolumes{0};   //!
-    /**list of all sensitive volumes in  a simulaion session*/
+    /**
+     * For internal use only: list of all sensitive volumes in a simulaion session
+     */
     static thread_local std::vector<FairVolume*> fAllSensitiveVolumes;   //!
 
     TString fMotherVolumeName{""};   //!


### PR DESCRIPTION
(prompted by <https://github.com/FairRootGroup/FairRoot/pull/1500#issuecomment-2152317249>)

The FairModule::svList API was dropped in 19.0.
It was thought of as an internal API anyway. But let's at least document
- that it's gone
- that the new fAllSensitiveVolumes IS an internal API

See: 54ad232ffe416e9c650b3d0d4aadce7b48e48746

(Should be backported to 19.0 after it's merged.)

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
