### PR TITLE
Fix FairRootManager::GetObject

### DIFF
--- a/fairroot/base/steer/FairRootManager.h
+++ b/fairroot/base/steer/FairRootManager.h
@@ -23,7 +23,7 @@
 #include <string>
 #include <type_traits>   // is_pointer, remove_pointer, is_const, remove...
 #include <typeinfo>
-#include <vector>
+#include <list>
 
 class BinaryFunctor;
 class FairEventHeader;
@@ -333,7 +333,7 @@ class FairRootManager : public TObject
 
     /** current time in ns*/
     Double_t fCurrentTime;
-    std::vector<TObject*> fObj2{};   //!
+    std::list<TObject*> fObj2{};   //!
     /** A list which hold the pointer to the branch
      * and the name of the branch in memory, it contains all branches (TClonesArrays)
      * persistance and Memory only branches


### PR DESCRIPTION
## Describe your proposal.

Fix the UB found in the issue #1556 related to `FairRootManager::GetObject`.

## Cause of the issue

The branch address of the TTree must be fixed during the data reading. In other words, if an object of type `T` needs to be read from a tree, the value `T**` must be fixed and cannot be changed during the whole reading process.  However, in the GetObject function, the variable `newentry` is a reference to the `T*` pointer stored in the `std::vector<T*>`. If the size of the vector grows beyond its capacity, the whole vector will be moved to another memory location, which means the `T**` value will be changed.

This makes sense as in my real practice from R3BRoot, I didn't get all zeros but rather direct segmentation fault.

Let `newentry` refer to the `T*` in the object of `std::map<TString, TObject*>` fixes the issue. `std::map` doesn't reallocate its entries during the runtime.

## TODO

1. `AddMemoryBranch` now returns `TObject*&`, which is ugly and asking for troubles in the future. Unfortunately, there isn't any better way to deal with this issue if we still use TTree raw API for the data reading. It must take a `TObject**` for calling `SetBranchAddress`.
2. As I have suggested from #1556, `TTreeReader` is a much better choice as we don't need to deal with `T**` situation anymore.

---

Checklist:

* [x] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
