### PR TITLE
refactor: Avoid FairGeoLoader::Instance()

### DIFF
--- a/examples/common/passive/FairCave.cxx
+++ b/examples/common/passive/FairCave.cxx
@@ -24,14 +24,14 @@
 
 void FairCave::ConstructGeometry()
 {
-    FairGeoLoader* loader = FairGeoLoader::Instance();
-    FairGeoInterface* GeoInterface = loader->getGeoInterface();
+    FairGeoLoader& loader = GetGeometryLoader();
+    FairGeoInterface* GeoInterface = loader.getGeoInterface();
     FairGeoCave* MGeo = new FairGeoCave();
     MGeo->setGeomFile(GetGeometryFileName());
     GeoInterface->addGeoModule(MGeo);
     Bool_t rc = GeoInterface->readSet(MGeo);
     if (rc) {
-        MGeo->create(loader->getGeoBuilder());
+        MGeo->create(loader.getGeoBuilder());
     }
 
     TList* volList = MGeo->getListOfVolumes();

--- a/examples/common/passive/FairPipe.cxx
+++ b/examples/common/passive/FairPipe.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -43,10 +43,10 @@ void FairPipe::ConstructGeometry()
   FairGeoPassivePar* par=(FairGeoPassivePar*)(rtdb->getContainer("FairGeoPassivePar"));
 */
 
-    FairGeoLoader* loader = FairGeoLoader::Instance();
-    FairGeoInterface* GeoInterface = loader->getGeoInterface();
+    FairGeoLoader& loader = GetGeometryLoader();
+    FairGeoInterface* GeoInterface = loader.getGeoInterface();
     FairGeoMedia* Media = GeoInterface->getMedia();
-    FairGeoBuilder* geobuild = loader->getGeoBuilder();
+    FairGeoBuilder* geobuild = loader.getGeoBuilder();
 
     // Call materials
     FairGeoMedium* medVacuum = Media->getMedium("vacuum");

--- a/fairroot/base/sim/FairMCApplication.cxx
+++ b/fairroot/base/sim/FairMCApplication.cxx
@@ -706,8 +706,8 @@ void FairMCApplication::SetField(FairField* field)
 //_____________________________________________________________________________
 void FairMCApplication::ConstructOpGeometry()
 {
-    FairGeoLoader* loader = FairGeoLoader::Instance();
-    FairGeoInterface* GeoInterface = loader->getGeoInterface();
+    FairGeoLoader& loader = fRun->GetGeometryLoader();
+    FairGeoInterface* GeoInterface = loader.getGeoInterface();
     FairGeoMedia* media = GeoInterface->getMedia();
     TList* MediaList = media->getListOfMedia();
     Int_t NK = 0;

--- a/fairroot/base/steer/FairRunSim.cxx
+++ b/fairroot/base/steer/FairRunSim.cxx
@@ -37,6 +37,7 @@
 #include <TROOT.h>         //
 #include <TRandom.h>       // for gRandom
 #include <TSystem.h>       // for TSystem, gSystem
+#include <cassert>         //
 #include <iostream>        // for cout, endl, ostream
 #include <stdlib.h>        // for getenv, nullptr
 #include <string.h>        // for strcmp, strncmp
@@ -125,6 +126,8 @@ FairRunSim* FairRunSim::Instance()
 
 void FairRunSim::AddModule(FairModule* Mod)
 {
+    assert(Mod);
+    Mod->SetRunSim(this);
     ListOfModules->Add(Mod);
     Mod->SetModId(count++);
 }
@@ -388,6 +391,12 @@ FairMCEventHeader* FairRunSim::GetMCEventHeader()
         fMCEvHead = new FairMCEventHeader();
     }
     return fMCEvHead;
+}
+
+FairGeoLoader& FairRunSim::GetGeometryLoader()
+{
+    assert(fGeoLoader);
+    return *fGeoLoader;
 }
 
 void FairRunSim::ls(Option_t* option) const

--- a/fairroot/base/steer/FairRunSim.h
+++ b/fairroot/base/steer/FairRunSim.h
@@ -214,6 +214,13 @@ class FairRunSim : public FairRun
      */
     auto GetMCApplication() { return fApp; }
 
+    /**
+     * For internal use: Get the Geometry Loader Instance
+     *
+     * \note Only valid after `Init` was called, will assert otherwise
+     */
+    FairGeoLoader& GetGeometryLoader();
+
     void ls(Option_t* option = "") const override;
 
   private:

--- a/fairroot/fastsim/FairFastSimDetector.cxx
+++ b/fairroot/fastsim/FairFastSimDetector.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -35,10 +35,10 @@ FairFastSimDetector::~FairFastSimDetector() {}
 
 void FairFastSimDetector::ConstructGeometry()
 {
-    FairGeoLoader* geoLoad = FairGeoLoader::Instance();
-    FairGeoInterface* geoFace = geoLoad->getGeoInterface();
+    FairGeoLoader& geoLoad = GetGeometryLoader();
+    FairGeoInterface* geoFace = geoLoad.getGeoInterface();
     FairGeoMedia* geoMedia = geoFace->getMedia();
-    FairGeoBuilder* geoBuild = geoLoad->getGeoBuilder();
+    FairGeoBuilder* geoBuild = geoLoad.getGeoBuilder();
 
     TGeoMedium* medium = gGeoManager->GetMedium("FastSimMedium");
     if (!medium) {

--- a/templates/project_root_containers/passive/MyCave.cxx
+++ b/templates/project_root_containers/passive/MyCave.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -27,14 +27,14 @@
 
 void MyCave::ConstructGeometry()
 {
-    FairGeoLoader* loader = FairGeoLoader::Instance();
-    FairGeoInterface* GeoInterface = loader->getGeoInterface();
+    FairGeoLoader& loader = GetGeometryLoader();
+    FairGeoInterface* GeoInterface = loader.getGeoInterface();
     MyGeoCave* MGeo = new MyGeoCave();
     MGeo->setGeomFile(GetGeometryFileName());
     GeoInterface->addGeoModule(MGeo);
     Bool_t rc = GeoInterface->readSet(MGeo);
     if (rc) {
-        MGeo->create(loader->getGeoBuilder());
+        MGeo->create(loader.getGeoBuilder());
     }
 }
 MyCave::MyCave()

--- a/templates/project_stl_containers/passive/MyCave.cxx
+++ b/templates/project_stl_containers/passive/MyCave.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -27,14 +27,14 @@
 
 void MyCave::ConstructGeometry()
 {
-    FairGeoLoader* loader = FairGeoLoader::Instance();
-    FairGeoInterface* GeoInterface = loader->getGeoInterface();
+    FairGeoLoader& loader = GetGeometryLoader();
+    FairGeoInterface* GeoInterface = loader.getGeoInterface();
     MyGeoCave* MGeo = new MyGeoCave();
     MGeo->setGeomFile(GetGeometryFileName());
     GeoInterface->addGeoModule(MGeo);
     Bool_t rc = GeoInterface->readSet(MGeo);
     if (rc) {
-        MGeo->create(loader->getGeoBuilder());
+        MGeo->create(loader.getGeoBuilder());
     }
 }
 MyCave::MyCave()


### PR DESCRIPTION
Instead add a few GetGeometryLoader() getters and use them. Also let FairModule know to which FairRunSim it belongs.

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
