### PR TITLE
feat(base): Introduce FairDetector::GetRootManager

### DIFF
--- a/examples/MQ/pixelDetector/src/Pixel.cxx
+++ b/examples/MQ/pixelDetector/src/Pixel.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -138,7 +138,7 @@ void Pixel::Register()
       only during the simulation.
   */
 
-    FairRootManager::Instance()->Register("PixelPoint", "Pixel", fPixelPointCollection, kTRUE);
+    GetRootManager().Register("PixelPoint", "Pixel", fPixelPointCollection, kTRUE);
 }
 
 TClonesArray* Pixel::GetCollection(Int_t iColl) const

--- a/examples/advanced/Tutorial3/simulation/FairTestDetector.cxx
+++ b/examples/advanced/Tutorial3/simulation/FairTestDetector.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -120,15 +120,13 @@ void FairTestDetector::EndOfEvent()
 
 void FairTestDetector::Register()
 {
-
     /** This will create a branch in the output tree called
         FairTestDetectorPoint, setting the last parameter to kFALSE means:
         this collection will not be written to the file, it will exist
         only during the simulation.
     */
 
-    FairRootManager::Instance()->Register(
-        "FairTestDetectorPoint", "FairTestDetector", fFairTestDetectorPointCollection, kTRUE);
+    GetRootManager().Register("FairTestDetectorPoint", "FairTestDetector", fFairTestDetectorPointCollection, kTRUE);
 }
 
 TClonesArray* FairTestDetector::GetCollection(Int_t iColl) const

--- a/examples/advanced/propagator/src/FairTutPropDet.cxx
+++ b/examples/advanced/propagator/src/FairTutPropDet.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2019-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2019-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -117,15 +117,13 @@ void FairTutPropDet::EndOfEvent() { fFairTutPropPointCollection->Clear(); }
 
 void FairTutPropDet::Register()
 {
-
     /** This will create a branch in the output tree called
         FairTutPropPoint, setting the last parameter to kFALSE means:
         this collection will not be written to the file, it will exist
         only during the simulation.
     */
 
-    FairRootManager::Instance()->Register(
-        fPointsArrayName.c_str(), "FairTutPropDet", fFairTutPropPointCollection, kTRUE);
+    GetRootManager().Register(fPointsArrayName.c_str(), "FairTutPropDet", fFairTutPropPointCollection, kTRUE);
 }
 
 TClonesArray* FairTutPropDet::GetCollection(Int_t iColl) const

--- a/examples/simulation/Tutorial1/src/FairFastSimExample.cxx
+++ b/examples/simulation/Tutorial1/src/FairFastSimExample.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -122,7 +122,7 @@ void FairFastSimExample::Register()
         this collection will not be written to the file, it will exist
         only during the simulation.
     */
-    FairRootManager::Instance()->Register("FastSimPoint", "FastSimDetDet", fPointsArray, kTRUE);
+    GetRootManager().Register("FastSimPoint", "FastSimDetDet", fPointsArray, kTRUE);
 }
 
 TClonesArray* FairFastSimExample::GetCollection(Int_t iColl) const

--- a/examples/simulation/Tutorial1/src/FairFastSimExample2.cxx
+++ b/examples/simulation/Tutorial1/src/FairFastSimExample2.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -102,7 +102,7 @@ void FairFastSimExample2::Register()
         this collection will not be written to the file, it will exist
         only during the simulation.
     */
-    FairRootManager::Instance()->Register("FastSimPoint2", "FastSimDetDet", fPointsArray, kTRUE);
+    GetRootManager().Register("FastSimPoint2", "FastSimDetDet", fPointsArray, kTRUE);
 }
 
 TClonesArray* FairFastSimExample2::GetCollection(Int_t iColl) const

--- a/examples/simulation/Tutorial1/src/FairTutorialDet1.cxx
+++ b/examples/simulation/Tutorial1/src/FairTutorialDet1.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -101,8 +101,7 @@ void FairTutorialDet1::Register()
       only during the simulation.
   */
 
-    FairRootManager::Instance()->Register(
-        "TutorialDetPoint", "TutorialDet", fFairTutorialDet1PointCollection.get(), kTRUE);
+    GetRootManager().Register("TutorialDetPoint", "TutorialDet", fFairTutorialDet1PointCollection.get(), kTRUE);
 }
 
 TClonesArray* FairTutorialDet1::GetCollection(Int_t iColl) const

--- a/examples/simulation/Tutorial4/src/mc/FairTutorialDet4.cxx
+++ b/examples/simulation/Tutorial4/src/mc/FairTutorialDet4.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -220,7 +220,7 @@ void FairTutorialDet4::Register()
       only during the simulation.
   */
 
-    FairRootManager::Instance()->Register("TutorialDetPoint", "TutorialDet", fFairTutorialDet4PointCollection, kTRUE);
+    GetRootManager().Register("TutorialDetPoint", "TutorialDet", fFairTutorialDet4PointCollection, kTRUE);
 }
 
 TClonesArray* FairTutorialDet4::GetCollection(Int_t iColl) const

--- a/examples/simulation/rutherford/src/FairRutherford.cxx
+++ b/examples/simulation/rutherford/src/FairRutherford.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -92,8 +92,7 @@ void FairRutherford::Register()
       only during the simulation.
   */
 
-    FairRootManager::Instance()->Register(
-        "FairRutherfordPoint", "FairRutherford", fFairRutherfordPointCollection, kTRUE);
+    GetRootManager().Register("FairRutherfordPoint", "FairRutherford", fFairRutherfordPointCollection, kTRUE);
 }
 
 TClonesArray* FairRutherford::GetCollection(Int_t iColl) const

--- a/fairroot/base/sim/FairDetector.h
+++ b/fairroot/base/sim/FairDetector.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -12,11 +12,14 @@
 
 #include <Rtypes.h>   // for Int_t, Bool_t, etc
 #include <TClonesArray.h>
+#include <cassert>
 
 class FairVolume;
+class FairRootManager;
 
 /**
  * Base class for constructing detecors
+ * \ingroup base_sim
  * @author M. Al-Turany, Denis Bertini
  * @version 0.1
  * @since 12.01.04
@@ -40,8 +43,10 @@ class FairDetector : public FairModule
     */
     ~FairDetector() override;
     /**
-      Initialization of the detector is done here
-    */
+     * \brief Initialization of the detector is done here
+     *
+     * \note May use GetRootManager()
+     */
     virtual void Initialize();
     /**
       this method is called for each step during simulation (see FairMCApplication::Stepping())
@@ -52,8 +57,10 @@ class FairDetector : public FairModule
     */
     virtual void EndOfEvent() {}
     /**
-      Registers the produced collections in FAIRRootManager.
-    */
+     * \brief Registers the produced collections in FAIRRootManager.
+     *
+     * \note May use GetRootManager()
+     */
     virtual void Register() = 0;
 
     /**
@@ -98,7 +105,25 @@ class FairDetector : public FairModule
     void SaveGeoParams();
     Int_t GetDetId() { return fDetId; }
 
+    /**
+     * \brief For internal use: Set the manager
+     *
+     * \note Usually called from FairMCApplication::RegisterOutput()
+     */
+    void SetRootManager(FairRootManager* rm) { fRootManager = rm; }
+
   protected:
+    /**
+     * \brief Get the FairRootManager for this Detector
+     *
+     * \note Only valid during \ref Initialize() and Register()
+     */
+    FairRootManager& GetRootManager()
+    {
+        assert(fRootManager);
+        return *fRootManager;
+    }
+
     /** Copy constructor */
     FairDetector(const FairDetector&);
     /** Assignment operator */
@@ -107,6 +132,9 @@ class FairDetector : public FairModule
     void DefineSensitiveVolumes();
 
     Int_t fDetId;   // Detector Id has to be set from ctr.
+
+  private:
+    FairRootManager* fRootManager{nullptr};   //!
 
     ClassDefOverride(FairDetector, 1);
 };

--- a/fairroot/base/sim/FairMCApplication.cxx
+++ b/fairroot/base/sim/FairMCApplication.cxx
@@ -949,6 +949,7 @@ void FairMCApplication::RegisterOutput()
         }
         if (detector) {
             // check whether detector is active
+            detector->SetRootManager(fRootManager);
             if (detector->IsActive()) {
                 detector->Initialize();
                 detector->Register();

--- a/fairroot/base/steer/FairRootManager.h
+++ b/fairroot/base/steer/FairRootManager.h
@@ -43,6 +43,7 @@ class TTree;
 
 /**
  * I/O Manager class
+ * \ingroup base_steer
  * @author M. Al-Turany, Denis Bertini
  * @version 0.1
  * @since 12.01.04
@@ -135,7 +136,17 @@ class FairRootManager : public TObject
     void TerminateAllTSBuffer();
     FairTSBufferFunctional* GetTSBuffer(TString branchName) { return fTSBufferMap[branchName]; }
 
-    /** static access method */
+    /**
+     * \brief Access the singleton
+     *
+     * Please try avoid using it.
+     * It will likely be deprecated at some point.
+     * Consider using a getter instead:
+     *
+     * - FairRun::GetRootManager()
+     * - FairDetector::GetRootManager()
+     * - FairEventManager::GetRootManager()
+     */
     static FairRootManager* Instance();
 
     /**Read a single entry from background chain*/

--- a/templates/NewDetector_root_containers/NewDetector.cxx
+++ b/templates/NewDetector_root_containers/NewDetector.cxx
@@ -139,7 +139,6 @@ void NewDetector::EndOfEvent()
 
 void NewDetector::Register()
 {
-
     /** This will create a branch in the output tree called
       NewDetectorPoint, setting the last parameter to kFALSE means:
       this collection will not be written to the file, it will exist
@@ -147,9 +146,9 @@ void NewDetector::Register()
   */
 
     if (!gMC->IsMT()) {
-        FairRootManager::Instance()->Register("NewDetectorPoint", "NewDetector", fNewDetectorPointCollection, kTRUE);
+        GetRootManager().Register("NewDetectorPoint", "NewDetector", fNewDetectorPointCollection, kTRUE);
     } else {
-        FairRootManager::Instance()->RegisterAny("NewDetectorPoint", fNewDetectorPointCollection, kTRUE);
+        GetRootManager().RegisterAny("NewDetectorPoint", fNewDetectorPointCollection, kTRUE);
     }
 }
 

--- a/templates/NewDetector_stl_containers/NewDetector.cxx
+++ b/templates/NewDetector_stl_containers/NewDetector.cxx
@@ -145,7 +145,7 @@ void NewDetector::Register()
         this collection will not be written to the file, it will exist
         only during the simulation.
     */
-    FairRootManager::Instance()->RegisterAny("NewDetectorPoint", fVectorPoints, kTRUE);
+    GetRootManager().RegisterAny("NewDetectorPoint", fVectorPoints, kTRUE);
 }
 
 void NewDetector::Reset()

--- a/templates/project_root_containers/MyProjGenerators/Pythia8Generator.cxx
+++ b/templates/project_root_containers/MyProjGenerators/Pythia8Generator.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -145,9 +145,6 @@ Bool_t Pythia8Generator::ReadEvent(FairPrimaryGenerator* cpg)
             // cout<<"debug p8->geant4 "<< 0 << " "<< ii <<  " " << fake<< " "<< fPythia.event[ii].mother1()<<endl;
         };
     }
-
-    // make separate container ??
-    //    FairRootManager *ioman =FairRootManager::Instance();
 
     return kTRUE;
 }

--- a/templates/project_root_containers/NewDetector/NewDetector.cxx
+++ b/templates/project_root_containers/NewDetector/NewDetector.cxx
@@ -140,7 +140,6 @@ void NewDetector::EndOfEvent()
 
 void NewDetector::Register()
 {
-
     /** This will create a branch in the output tree called
       NewDetectorPoint, setting the last parameter to kFALSE means:
       this collection will not be written to the file, it will exist
@@ -148,9 +147,9 @@ void NewDetector::Register()
   */
 
     if (!gMC->IsMT()) {
-        FairRootManager::Instance()->Register("NewDetectorPoint", "NewDetector", fNewDetectorPointCollection, kTRUE);
+        GetRootManager().Register("NewDetectorPoint", "NewDetector", fNewDetectorPointCollection, kTRUE);
     } else {
-        FairRootManager::Instance()->RegisterAny("NewDetectorPoint", fNewDetectorPointCollection, kTRUE);
+        GetRootManager().RegisterAny("NewDetectorPoint", fNewDetectorPointCollection, kTRUE);
     }
 }
 

--- a/templates/project_stl_containers/MyProjGenerators/Pythia8Generator.cxx
+++ b/templates/project_stl_containers/MyProjGenerators/Pythia8Generator.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -145,9 +145,6 @@ Bool_t Pythia8Generator::ReadEvent(FairPrimaryGenerator* cpg)
             // cout<<"debug p8->geant4 "<< 0 << " "<< ii <<  " " << fake<< " "<< fPythia.event[ii].mother1()<<endl;
         };
     }
-
-    // make separate container ??
-    //    FairRootManager *ioman =FairRootManager::Instance();
 
     return kTRUE;
 }

--- a/templates/project_stl_containers/NewDetector/NewDetector.cxx
+++ b/templates/project_stl_containers/NewDetector/NewDetector.cxx
@@ -146,7 +146,7 @@ void NewDetector::Register()
         this collection will not be written to the file, it will exist
         only during the simulation.
     */
-    FairRootManager::Instance()->RegisterAny("NewDetectorPoint", fVectorPoints, kTRUE);
+    GetRootManager().RegisterAny("NewDetectorPoint", fVectorPoints, kTRUE);
 }
 
 void NewDetector::Reset()


### PR DESCRIPTION
Especially classes deriving from FairDetector and
implementing the Register member function need access to FairrootManager. Give them a proper getter.

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
