### PR TITLE
Disable streamer for FairRootManager and fix unconditional dereference in `SetSink()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to FairRoot will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+## x.x.0 - xxxx-xx-xx
+
+### Breaking Changes
+
+* No streamer is generated for `FairRootManager` any more
+
 ## 19.0.0 - 2024-05-17
 
 ### Breaking Changes

--- a/fairroot/base/LinkDef.h
+++ b/fairroot/base/LinkDef.h
@@ -35,7 +35,7 @@
 #pragma link C++ class FairParticle+;
 #pragma link C++ class FairPrimaryGenerator+;
 #pragma link C++ class FairRecoEventHeader+;
-#pragma link C++ class FairRootManager+;
+#pragma link C++ class FairRootManager;
 #pragma link C++ class FairRun+;
 #pragma link C++ class FairRunAna;
 #pragma link C++ class FairRunIdGenerator;

--- a/fairroot/base/steer/FairRootManager.h
+++ b/fairroot/base/steer/FairRootManager.h
@@ -395,7 +395,7 @@ class FairRootManager : public TObject
     // data members
     Int_t fId{0};   //! This manager ID
 
-    ClassDefOverride(FairRootManager, 14);
+    ClassDefOverride(FairRootManager, 0);
 };
 
 // FIXME: move to source since we can make it non-template dependent

--- a/fairroot/base/steer/FairRun.cxx
+++ b/fairroot/base/steer/FairRun.cxx
@@ -191,14 +191,11 @@ void FairRun::SetSink(std::unique_ptr<FairSink> newsink)
 {
     fSink = std::move(newsink);
     fRootManager->fSink = maybe_owning_ptr<FairSink>{fSink.get(), non_owning};
-    fUserOutputFileName = fSink->GetFileName();
-}
-
-void FairRun::SetSink(FairSink* tempSink)
-{
-    fSink.reset(tempSink);
-    fRootManager->fSink = maybe_owning_ptr<FairSink>{fSink.get(), non_owning};
-    fUserOutputFileName = fSink->GetFileName();
+    if (fSink) {
+        fUserOutputFileName = fSink->GetFileName();
+    } else {
+        fUserOutputFileName.Clear();
+    }
 }
 
 void FairRun::SetOutputFile(const char* fname)

--- a/fairroot/base/steer/FairRun.h
+++ b/fairroot/base/steer/FairRun.h
@@ -87,7 +87,7 @@ class FairRun : public TNamed
      * Set the sink
      */
     void SetSink(std::unique_ptr<FairSink> newsink);
-    void SetSink(FairSink* tempSink);
+    void SetSink(FairSink* newsink) { SetSink(std::unique_ptr<FairSink>{newsink}); }
     /**
      * return a non-owning pointer to the sink
      */


### PR DESCRIPTION
@ChristianTackeGSI Here are some bits of the FairRootManager work I am currently preparing as separate PR as requested.
