### PR TITLE
feat(sim): Allow branch registration in `FairGenerator`

### DIFF
--- a/examples/simulation/rutherford/macros/CMakeLists.txt
+++ b/examples/simulation/rutherford/macros/CMakeLists.txt
@@ -13,7 +13,7 @@ set(maxTestTime 60)
 
 foreach(mcEngine IN LISTS mcEngine_list)
   add_test(NAME ex_sim_rutherford_${mcEngine}
-           COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_rutherford.sh 10 \"${mcEngine}\")
+           COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run_rutherford.sh 10 \"${mcEngine}\" false)
   set_tests_properties(ex_sim_rutherford_${mcEngine} PROPERTIES
     TIMEOUT ${maxTestTime}
     PASS_REGULAR_EXPRESSION "Macro finished successfully"

--- a/fairroot/base/sim/FairMCApplication.cxx
+++ b/fairroot/base/sim/FairMCApplication.cxx
@@ -874,7 +874,7 @@ void FairMCApplication::InitGeometry()
     if (fRootManager && !fParent) {
         RegisterOutput();
         if (GetIsMT()) {
-            fRootManager->WriteFolder();
+            fRootManager->RemoveOutputFolderForMtMode();
         }
     }
     fMCEventHeader->SetRunID(runId);
@@ -937,6 +937,7 @@ void FairMCApplication::InitFinalizer()
     {
         std::lock_guard guard(mtx);
         fRootManager->WriteFolder();
+        fRootManager->RemoveOutputFolderForMtMode();
     }
 }
 

--- a/fairroot/base/sim/FairMCApplication.h
+++ b/fairroot/base/sim/FairMCApplication.h
@@ -46,9 +46,12 @@ class TTask;
 
 enum class FairMCApplicationState
 {
-    kUnknownState,
+    kPreInit,
     kConstructGeometry,
-    kInitGeometry
+    kInit,
+    kInitGeometry,
+    kPostInit,
+    kRun
 };
 
 /**
@@ -323,7 +326,7 @@ class FairMCApplication : public TVirtualMCApplication
     Bool_t fSaveCurrentEvent;
 
     /** Current state */
-    FairMCApplicationState fState;   //!
+    FairMCApplicationState fState{FairMCApplicationState::kPreInit};   //!
 
     ClassDefOverride(FairMCApplication, 5);
 

--- a/fairroot/base/sim/FairMCApplication.h
+++ b/fairroot/base/sim/FairMCApplication.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -88,8 +88,7 @@ class FairMCApplication : public TVirtualMCApplication
     /** Add user defined ions (optional)
         Called by TVirtualMC.
         TGeant3 calls AddIons() first, then InitGeometry().
-        TGeant4 calls InitGeometry() first, then AddIons().
-        This function also initializes event generators.*/
+        TGeant4 calls InitGeometry() first, then AddIons().*/
     void AddIons() override;   // MC Application
     /**
      *Add user defined Tasks to be executed after each event (optional)
@@ -127,8 +126,7 @@ class FairMCApplication : public TVirtualMCApplication
     /** Initialize geometry
         Called by TVirtualMC.
         TGeant3 calls AddIons() first, then InitGeometry().
-        TGeant4 calls InitGeometry() first, then AddIons().
-        This function also registers detectors.*/
+        TGeant4 calls InitGeometry() first, then AddIons().*/
     void InitGeometry() override;   // MC Application
     /** Initialize MC engine */
     void InitMC(const char* setup, const char* cuts);
@@ -241,6 +239,11 @@ class FairMCApplication : public TVirtualMCApplication
 
     /** Register output */
     void RegisterOutput();
+    /** Finalize the init stage:
+        initialize event generator,
+        initialize tasks,
+        write output folder.*/
+    void InitFinalizer();
 
     void UndoGeometryModifications();
 

--- a/fairroot/base/sink/FairRootFileSink.cxx
+++ b/fairroot/base/sink/FairRootFileSink.cxx
@@ -245,9 +245,6 @@ void FairRootFileSink::WriteFolder()
         fOutTree = new TTree(FairRootManager::GetTreeName(), Form("/%s", FairRootManager::GetFolderName()), 99);
         TruncateBranchNames();
         CreatePersistentBranchesAny();
-
-        // Delete the folder to make place in the gROOT for fOutFolder created by the Geant4MT threads
-        gROOT->GetRootFolder()->Remove(fOutFolder);
     }
 }
 

--- a/fairroot/base/steer/FairRootManager.cxx
+++ b/fairroot/base/steer/FairRootManager.cxx
@@ -38,6 +38,7 @@
 #include <TNamed.h>
 #include <TObjArray.h>    // for TObjArray
 #include <TObjString.h>   // for TObjString
+#include <TROOT.h>        // for gROOT
 #include <TTree.h>        // for TTree
 #include <algorithm>      // for find
 #include <atomic>
@@ -221,8 +222,8 @@ TClonesArray* FairRootManager::Register(TString branchName, TString className, T
 
 TClonesArray* FairRootManager::GetEmptyTClonesArray(TString branchName)
 {
-    if (fActiveContainer.find(branchName)
-        != fActiveContainer.end()) {               // if a TClonesArray is registered in the active container
+    if (fActiveContainer.find(branchName) != fActiveContainer.end())
+    {                                              // if a TClonesArray is registered in the active container
         if (fActiveContainer[branchName] == 0) {   // the address of the TClonesArray is still valid
             std::cout << "-E- FairRootManager::GetEmptyTClonesArray: Container deleted outside FairRootManager!"
                       << std::endl;
@@ -381,6 +382,12 @@ void FairRootManager::WriteFolder()
         fSink->WriteObject(&fBranchNameList, "BranchList", TObject::kSingleKey);
         fSink->WriteObject(fTimeBasedBranchNameList, "TimeBasedBranchList", TObject::kSingleKey);
     }
+}
+
+void FairRootManager::RemoveOutputFolderForMtMode()
+{
+    auto rootFolder = static_cast<TFolder*>(gROOT->GetRootFolder());
+    rootFolder->Remove(rootFolder->FindObject(GetFolderName()));
 }
 
 Bool_t FairRootManager::SpecifyRunId()

--- a/fairroot/base/steer/FairRootManager.h
+++ b/fairroot/base/steer/FairRootManager.h
@@ -18,12 +18,12 @@
 #include <TRefArray.h>   // for TRefArray
 #include <TString.h>     // for TString, operator<
 #include <fairlogger/Logger.h>
+#include <list>
 #include <map>   // for map, multimap, etc
 #include <memory>
 #include <string>
 #include <type_traits>   // is_pointer, remove_pointer, is_const, remove...
 #include <typeinfo>
-#include <list>
 
 class BinaryFunctor;
 class FairEventHeader;
@@ -218,6 +218,11 @@ class FairRootManager : public TObject
     void WriteFileHeader(FairFileHeader* f);
     /**Write the folder structure used to create the tree to the output file */
     void WriteFolder();
+    /**
+     * \brief Internal: Remove the folder describing the output tree structure from gROOT, called in TGeant4 MT
+     * simulation mode
+     */
+    void RemoveOutputFolderForMtMode();
 
     /**Check the maximum event number we can run to*/
     Int_t CheckMaxEventNo(Int_t EvtEnd = 0);

--- a/fairroot/base/steer/FairRunSim.h
+++ b/fairroot/base/steer/FairRunSim.h
@@ -226,6 +226,12 @@ class FairRunSim : public FairRun
   private:
     FairRunSim(const FairRunSim& M);
     FairRunSim& operator=(const FairRunSim&) { return *this; }
+    /**
+     * Performs simulation initialization:
+     * - runs simulation config (construct TGeant3/TGeant4, configure TGeant3/TGeant4, create stack),
+     * - runs FairMCApplication->InitMC() (set stack, run fMC->Init(), run fMC->BuildPhysics()),
+     * - runs postinit config (sets some VMC properties, which are only allowed after init).
+     */
     void SetMCConfig();
     void CheckFlukaExec();
 


### PR DESCRIPTION
Introduced new function `FairMCApplication::InitFinalizer()` which initializes event generator, tasks, and triggers `FairRootManager::WriteFolder()` function.
This new function is called from the latter of
`InitGeometry()` and `AddIons()`.

Previously the funcionality of `InitFinalizer` was split between `InitGeometry()` and `AddIons()`, which caused problems because
TGeant3 calls `AddIons()` first, `InitGeometry()` second, TGeant4 calls `InitGeometry()` first, `AddIons()` second.

Current implementation assures that initialization of event generators and tasks come before `WriteFolder`.

Fixes issues #1183 and #1567.


---

Checklist:

* [x] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
