### PR TITLE
New way to color tracks.

### DIFF
--- a/examples/advanced/propagator/macros/conf.xml
+++ b/examples/advanced/propagator/macros/conf.xml
@@ -5,15 +5,21 @@
         <detector name="Pixel2_0" color="kRed+1" transparency="30"  recursive="0"></detector>
         <detector name="Pixel3_0" color="kRed+2" transparency="30"  recursive="0"></detector>
         <detector name="Pixel4_0" color="kRed+3" transparency="30"  recursive="0"></detector>
-        <detector name="Pixel101_0" color="kCyan" transparency="30"  recursive="0"></detector>
-        <detector name="Pixel102_0" color="kCyan+1" transparency="30"  recursive="0"></detector>
-        <detector name="Pixel103_0" color="kCyan+2" transparency="30"  recursive="0"></detector>
-        <detector name="Pixel104_0" color="kCyan+3" transparency="30"  recursive="0"></detector>
+        <detector name="Pixel5_0" color="kCyan" transparency="30"  recursive="0"></detector>
+        <detector name="Pixel6_0" color="kCyan+1" transparency="30"  recursive="0"></detector>
+        <detector name="Pixel7_0" color="kCyan+2" transparency="30"  recursive="0"></detector>
+        <detector name="Pixel8_0" color="kGreen" transparency="30"  recursive="0"></detector>
     </detector>
 </Detectors>
-<MCTracksColors>
-    <mctrack color="kRed" pdg="2212"></mctrack>
-    <mctrack color="kGreen" pdg="211"></mctrack>
-    <mctrack color="kYellow" pdg="11"></mctrack>
-</MCTracksColors>
+<MCTrackColors>
+    <track color="kRed" pdg="2212"></track>
+    <track color="kGreen" pdg="211"></track>
+    <track color="kYellow" pdg="11"></track>
+</MCTrackColors>
+<GeoTracksColors>
+    <track color="kRed+2" pdg="2212"></track>
+    <track color="kGreen+2" pdg="211"></track>
+    <track color="kYellow+2" pdg="11"></track>
+</GeoTracksColors>
+
 </xmlconf>

--- a/examples/common/eventdisplay/FairEveMCTracks.cxx
+++ b/examples/common/eventdisplay/FairEveMCTracks.cxx
@@ -88,7 +88,7 @@ void FairEveMCTracks::DrawTrack(Int_t id)
     auto tr = static_cast<FairMCTrack*>(fContainer->UncheckedAt(id));
     if (!CheckCuts(tr))
         return;
-    Color_t color = GetEventManager()->Color(tr->GetPdgCode());
+    Color_t color = fPdgColor.GetColor(tr->GetPdgCode());
     TEveTrackList* trList = FindTrackGroup(Form("%i", tr->GetPdgCode()), color);
     TParticle p(tr->GetPdgCode(),
                 0,
@@ -149,6 +149,9 @@ InitStatus FairEveMCTracks::Init()
     if (status != kSUCCESS)
         return status;
     FairEventManager* eveManager = GetEventManager();
+    auto colorConf = eveManager->GetXMLConfigNode("MCTrackColors");
+    if (colorConf)
+        fPdgColor = FairXMLPdgColor(colorConf);
     FairRootManager* mngr = &(eveManager->GetRootManager());
     fContainer = dynamic_cast<TClonesArray*>(mngr->GetObject("MCTrack"));
     if (!fContainer) {

--- a/examples/common/eventdisplay/FairEveMCTracks.h
+++ b/examples/common/eventdisplay/FairEveMCTracks.h
@@ -16,8 +16,9 @@
 #ifndef FAIREVEMCTRACKS_H_
 #define FAIREVEMCTRACKS_H_
 
-#include "FairEveTracks.h"   // for FairEveTracks
-#include "FairTask.h"        // for InitStatus
+#include "FairEveTracks.h"     // for FairEveTracks
+#include "FairTask.h"          // for InitStatus
+#include "FairXMLPdgColor.h"   //for pdg color
 
 #include <FairRKPropagator.h>
 #include <Rtypes.h>       // for THashConsistencyHolder, ClassDef
@@ -37,11 +38,12 @@ class FairEveMCTracks : public FairEveTracks
     Bool_t fShowSecondary;
     Bool_t fUsePdg;
     Int_t fPdgCut;
+    FairXMLPdgColor fPdgColor;
     std::unique_ptr<FairRKPropagator> fRK{};
     TDatabasePDG* fPDG{nullptr};
 
   protected:
-    Bool_t CheckCuts(FairMCTrack *tr);
+    Bool_t CheckCuts(FairMCTrack* tr);
     void DrawTrack(Int_t id);
 
   public:

--- a/fairroot/eventdisplay/CMakeLists.txt
+++ b/fairroot/eventdisplay/CMakeLists.txt
@@ -41,6 +41,7 @@ set(sources
   tracks/FairGeoTrackHandler.cxx
   xml/FairXMLEveConf.cxx
   xml/FairXMLPdgColor.cxx
+  xml/FairXMLDetectorColor.cxx
 )
 
 fair_change_extensions_if_exists(.cxx .h FILES "${sources}" OUTVAR headers)

--- a/fairroot/eventdisplay/FairEventManager.h
+++ b/fairroot/eventdisplay/FairEventManager.h
@@ -34,6 +34,7 @@ class TEveViewer;
 class TEveText;
 class TGeoNode;
 class TGListTreeItem;
+class FairXMLFile;
 
 /**
  * \ingroup eventdisplay fairroot_singleton
@@ -44,14 +45,17 @@ class FairEventManager : public TEveEventManager
     static FairEventManager* Instance();
     FairEventManager();
     virtual ~FairEventManager();
-    virtual void SetXMLConfig(TString xml_config) { fXMLConfig = xml_config; };
+    virtual void SetXMLConfig(TString xml_config);
     virtual void Open();
     virtual void GotoEvent(Int_t event);   // *MENU*
     virtual void NextEvent();              // *MENU*
     virtual void PrevEvent();              // *MENU*
     virtual void Close();
     virtual void DisplaySettings();   //  *Menu*
-    virtual Int_t Color(Int_t pdg) { return fPDGColor.GetColor(pdg); }
+    [[deprecated("Use FairEventManager::GetXMLConfig")]] virtual Int_t Color(Int_t pdg)
+    {
+        return fPDGColor.GetColor(pdg);
+    }
     void AddTask(FairTask* t) { fRunAna->AddTask(t); }
     virtual void Init(Int_t visopt = 1, Int_t vislvl = 3, Int_t maxvisnds = 10000);
     virtual Int_t GetCurrentEvent() { return fEntry; }
@@ -126,6 +130,7 @@ class FairEventManager : public TEveEventManager
     Bool_t GetUseTimeOfEvent() const { return fUseTimeOfEvent; }
     Bool_t GetDrawAnimatedTracks() const { return fAnimatedTracks; }
     Bool_t GetClearHandler() const { return fClearHandler; }
+    FairXMLNode* GetXMLConfigNode(TString name) const;
     FairRootManager& GetRootManager() { return fRootManager; }
     FairRootManager const& GetRootManager() const { return fRootManager; }
 
@@ -151,7 +156,6 @@ class FairEventManager : public TEveEventManager
     TEveProjectionAxes* GetRPhiAxes() const { return fAxesPhi; };
     TEveProjectionAxes* GetRhoZAxes() const { return fAxesRho; };
     virtual void LoadXMLSettings();
-    void LoadXMLDetector(TGeoNode* node, FairXMLNode* xml, Int_t depth = 0);
     [[deprecated("Use FairXMLPdgColor::StringToColor")]] Int_t StringToColor(const TString& color) const
     {
         return FairXMLPdgColor::StringToColor(color);
@@ -186,7 +190,7 @@ class FairEventManager : public TEveEventManager
     TEveText* fEventTimeText{nullptr};                  //!
     TEveText* fEventNumberText{nullptr};                //!
     FairXMLPdgColor fPDGColor{};                        //!
-    TString fXMLConfig;
+    std::unique_ptr<FairXMLFile> fXMLFile;              //!
     void SetTransparencyForLayer(TGeoNode* node, Int_t depth, Char_t transparency);
     static FairEventManager* fgRinstance;   //!
     FairEventManager(const FairEventManager&);

--- a/fairroot/eventdisplay/tracks/FairEveGeoTracks.cxx
+++ b/fairroot/eventdisplay/tracks/FairEveGeoTracks.cxx
@@ -20,6 +20,7 @@
 #include "FairEventManager.h"   // for FairEventManager
 #include "FairGetEventTime.h"
 #include "FairRootManager.h"   // for FairRootManager
+#include "FairXMLNode.h"
 
 #include <TBranch.h>
 #include <TClonesArray.h>   // for TClonesArray
@@ -51,6 +52,10 @@ InitStatus FairEveGeoTracks::Init()
     if (status != kSUCCESS)
         return status;
     FairEventManager* eveManager = GetEventManager();
+    auto confColors = eveManager->GetXMLConfigNode("GeoTracksColors");
+    if (confColors) {
+        fPdgColor = FairXMLPdgColor(confColors);
+    }
     auto& mngr = eveManager->GetRootManager();
     fContainer = dynamic_cast<TClonesArray*>(mngr.GetObject("GeoTracks"));
     if (!fContainer) {
@@ -68,7 +73,7 @@ void FairEveGeoTracks::DrawTrack(Int_t id)
     if (!CheckCuts(tr))
         return;
     auto p = static_cast<TParticle*>(tr->GetParticle());
-    Color_t color = GetEventManager()->Color(p->GetPdgCode());
+    Color_t color = fPdgColor.GetColor(p->GetPdgCode());
     TEveTrackList* trList = FindTrackGroup(p->GetName(), color);
 
     auto track = new FairEveTrack(p, p->GetPdgCode(), trList->GetPropagator());
@@ -100,7 +105,7 @@ void FairEveGeoTracks::DrawAnimatedTrack(TGeoTrack* tr, double t0)
     if (tr->GetPoint(0)[3] * timeScale + t0 > fTMax)
         return;   // first point after tmax
     auto p = static_cast<TParticle*>(tr->GetParticle());
-    Color_t color = GetEventManager()->Color(p->GetPdgCode());
+    Color_t color = fPdgColor.GetColor(p->GetPdgCode());
     TEveTrackList* trList = FindTrackGroup(p->GetName(), color);
     auto track = new FairEveTrack(p, p->GetPdgCode(), trList->GetPropagator());
     track->SetElementTitle(Form("p={%4.3f,%4.3f,%4.3f}", p->Px(), p->Py(), p->Pz()));

--- a/fairroot/eventdisplay/tracks/FairEveGeoTracks.h
+++ b/fairroot/eventdisplay/tracks/FairEveGeoTracks.h
@@ -18,10 +18,12 @@
 
 #include "FairEveTracks.h"   // for FairEveTracks
 #include "FairTask.h"        // for InitStatus
+#include "FairXMLPdgColor.h"
 
 #include <FairTimebasedDataHandlerT.h>
 #include <Rtypes.h>       // for THashConsistencyHolder, ClassDef
 #include <RtypesCore.h>   // for Bool_t, Int_t, Double_t
+
 class TBuffer;
 class TClass;
 class TClonesArray;
@@ -41,6 +43,7 @@ class FairEveGeoTracks : public FairEveTracks
     Int_t fPdgCut;
     Double_t fTMin, fTMax;
     TBranch* fBranch = nullptr;
+    FairXMLPdgColor fPdgColor;
     FairTimebasedDataHandlerT<TGeoTrack> fGeoTrackHandler;
 
   protected:

--- a/fairroot/eventdisplay/xml/FairXMLDetectorColor.cxx
+++ b/fairroot/eventdisplay/xml/FairXMLDetectorColor.cxx
@@ -1,0 +1,71 @@
+/*
+ * FairXMLDetColor.cxx
+ *
+ *  Created on: 17 lip 2024
+ *      Author: daniel
+ */
+
+#include "FairXMLDetectorColor.h"
+
+#include "FairXMLNode.h"
+
+#include <RtypesCore.h>
+#include <TAttFill.h>
+#include <TGeoNode.h>
+#include <TGeoVolume.h>
+#include <TNamed.h>
+#include <TString.h>
+
+void FairXMLDetectorColor::ColorizeNode(TGeoNode* node, FairXMLNode* xml, Int_t depth) const
+{
+    TString name = xml->GetAttrib("name")->GetValue();
+    TString node_name = node->GetName();
+    Bool_t recursive = (xml->GetAttrib("recursive")->GetValue().Length() != 0 && !name.EqualTo(node_name));
+    if (recursive && depth == 0)
+        return;
+    TString transparency = xml->GetAttrib("transparency")->GetValue();
+    TString color = xml->GetAttrib("color")->GetValue();
+    if (!color.EqualTo("")) {
+        node->GetVolume()->SetFillColor(FairXMLEveConf::StringToColor(color));
+        node->GetVolume()->SetLineColor(FairXMLEveConf::StringToColor(color));
+    }
+    if (!transparency.EqualTo("")) {
+        node->GetVolume()->SetTransparency((Char_t)(transparency.Atoi()));
+    }
+    if (xml->GetAttrib("recursive")->GetValue().Length() > 0) {
+        TString val = xml->GetAttrib("recursive")->GetValue();
+        Int_t xml_depth = val.Atoi();
+        if (recursive) {
+            xml_depth = depth - 1;
+        }
+        for (int i = 0; i < node->GetNdaughters(); i++) {
+            TGeoNode* daughter_node = node->GetDaughter(i);
+            ColorizeNode(daughter_node, xml, xml_depth);
+        }
+    }
+    if (xml->GetNChildren() > 0 && !recursive) {
+        for (int i = 0; i < node->GetNdaughters(); i++) {
+            TString subdetector_name = node->GetDaughter(i)->GetName();
+            for (int j = 0; j < xml->GetNChildren(); j++) {
+                FairXMLNode* subnode = xml->GetChild(j);
+                TString subnode_name = subnode->GetAttrib("name")->GetValue();
+                if (subnode_name == subdetector_name) {
+                    ColorizeNode(node->GetDaughter(i), subnode, 0);
+                }
+            }
+        }
+    }
+}
+
+FairXMLDetectorColor::FairXMLDetectorColor(FairXMLNode* node)
+{
+    if (node)
+        fNode = *node;
+}
+
+void FairXMLDetectorColor::Colorize(TGeoNode* node)
+{
+    if (!node)
+        return;
+    ColorizeNode(node, &fNode, 0);
+}

--- a/fairroot/eventdisplay/xml/FairXMLDetectorColor.h
+++ b/fairroot/eventdisplay/xml/FairXMLDetectorColor.h
@@ -1,0 +1,35 @@
+/********************************************************************************
+ * Copyright (C) 2020-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ *                                                                              *
+ *              This software is distributed under the terms of the             *
+ *              GNU Lesser General Public Licence (LGPL) version 3,             *
+ *                  copied verbatim in the file "LICENSE"                       *
+ ********************************************************************************/
+/*
+ * FairXMLDetColor.h
+ *
+ *  Created on: 17 lip 2024
+ *      Author: daniel
+ */
+
+#ifndef FAIRROOT_EVENTDISPLAY_XML_FAIRXMLDETECTORCOLOR_H_
+#define FAIRROOT_EVENTDISPLAY_XML_FAIRXMLDETECTORCOLOR_H_
+
+#include "FairXMLEveConf.h"
+#include "FairXMLNode.h"
+
+class TGeoNode;
+
+class FairXMLDetectorColor : public FairXMLEveConf
+{
+  protected:
+    FairXMLNode fNode;
+    void ColorizeNode(TGeoNode* node, FairXMLNode* xml, Int_t depth) const;
+
+  public:
+    explicit FairXMLDetectorColor(FairXMLNode* node = nullptr);
+    ~FairXMLDetectorColor() override = default;
+    virtual void Colorize(TGeoNode* node);
+};
+
+#endif /* FAIRROOT_EVENTDISPLAY_XML_FAIRXMLDETECTORCOLOR_H_ */


### PR DESCRIPTION
Currently the tracks coloring depens on node MCTrack colors, and the color scheme is configured by FairEventManager.
In this commit I propose the following changes:
1. FairEventManager only provide the pointer to XML node with configuration
2. In examples there are different nodes for coloring of Geo and MC tracks (thank to the new policy)
3. Old coloring shame is marked as depreacted
4. The XML config for Event Display was updated (at some point the names of the last layers of examples was changed - the configuration was not working for last 4 stations of detector)

---

Checklist:

* [ ] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
