### PR TITLE
refactor(*Stack): Use local variables

### DIFF
--- a/fairroot/base/sim/FairGenericStack.cxx
+++ b/fairroot/base/sim/FairGenericStack.cxx
@@ -20,6 +20,8 @@
 #include <cstring>   // strcmp
 #include <fairlogger/Logger.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 FairGenericStack::FairGenericStack()
     : TVirtualMCStack()
     , fDetList(0)
@@ -31,8 +33,11 @@ FairGenericStack::FairGenericStack()
     , fFSFirstSecondary(-2)
     , fFSNofSecondaries(0)
 {}
+#pragma GCC diagnostic pop
 
 // -----   Constructor with estimated array dimension   --------------------
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 FairGenericStack::FairGenericStack(Int_t)
     : TVirtualMCStack()
     , fDetList(0)
@@ -44,15 +49,20 @@ FairGenericStack::FairGenericStack(Int_t)
     , fFSFirstSecondary(-2)
     , fFSNofSecondaries(0)
 {}
+#pragma GCC diagnostic pop
 
 FairGenericStack::~FairGenericStack() { delete fDetIter; }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 FairGenericStack::FairGenericStack(const FairGenericStack& rhs)
     : TVirtualMCStack(rhs)
     , fDetList(rhs.fDetList)
     , fDetIter(0)
     , fVerbose(rhs.fVerbose)
+    , fFSTrackIter()
 {}
+#pragma GCC diagnostic pop
 
 FairGenericStack& FairGenericStack::operator=(const FairGenericStack& rhs)
 {
@@ -120,10 +130,7 @@ void FairGenericStack::FastSimMoveParticleTo(Double_t xx,
 
     PushTrack(tobedone, parent, pdg, px, py, pz, en, xx, yy, zz, tt, polx, poly, polz, proc, ntr, weight, status, -1);
     fFSMovedIndex = GetListOfParticles()->GetEntries() - 1;
-    Int_t trackID = GetCurrentTrackID();
-    fFSTrackIter = fFSTrackMap.find(trackID);   // check if this track is not already created by FastSimulation
-    if (fFSTrackIter != fFSTrackMap.end())      // indeed the track has been created by the FastSimulation mechanism
-        trackID = fFSTrackIter->second;         // use the ID of the original track
+    Int_t const trackID = FSTrackMapLookup(GetCurrentTrackID());
     fFSTrackMap[ntr] = trackID;
 
     LOG(debug) << "FairStack::FastSimMoveParticleTo() created track number " << ntr << " to replace track number "

--- a/fairroot/base/sim/FairGenericStack.h
+++ b/fairroot/base/sim/FairGenericStack.h
@@ -172,7 +172,7 @@ class FairGenericStack : public TVirtualMCStack
     }
 
     template<typename T>
-    void FastSimUpdateTrackIndex(T* point, Int_t& iTrack);
+    void FastSimUpdateTrackIndex(T* point, Int_t& iTrack) const;
 
   protected:
     /** Copy constructor */
@@ -191,20 +191,37 @@ class FairGenericStack : public TVirtualMCStack
 
     /** FastSimulation: STL map from new track index to original track index  **/
     std::map<Int_t, Int_t> fFSTrackMap;              //!
-    std::map<Int_t, Int_t>::iterator fFSTrackIter;   //!
+
+    /**
+     * \deprecated Use a local variable
+     */
+    [[deprecated("Use a local variable")]] std::map<Int_t, Int_t>::iterator fFSTrackIter;   //!
+
     Int_t fFSMovedIndex;                             //!
     Int_t fFSFirstSecondary;                         //!
     Int_t fFSNofSecondaries;                         //!
+
+    Int_t FSTrackMapLookup(Int_t track) const
+    {
+        // check if this track is not already created by FastSimulation
+        if (auto it = fFSTrackMap.find(track);   // force line-break
+            it != fFSTrackMap.end())
+        {                        // indeed the track has been created by the FastSimulation mechanism
+            return it->second;   // use the ID of the original track
+        }
+        return track;
+    }
 
     ClassDefOverride(FairGenericStack, 1);
 };
 
 template<typename T>
-void FairGenericStack::FastSimUpdateTrackIndex(T* point, Int_t& iTrack)
+void FairGenericStack::FastSimUpdateTrackIndex(T* point, Int_t& iTrack) const
 {
-    fFSTrackIter = fFSTrackMap.find(iTrack);   // check if point created by FastSimulation
-    if (fFSTrackIter != fFSTrackMap.end()) {   // indeed the point has been created by the FastSimulation mechanism
-        iTrack = fFSTrackIter->second;
+    if (auto it = fFSTrackMap.find(iTrack);   // force line-break
+        it != fFSTrackMap.end())
+    {
+        iTrack = it->second;
         point->SetTrackID(iTrack);   // set proper TrackID
     }
 }


### PR DESCRIPTION
... instead of member variable fFSTrackIter.

Deprecate that member variable.

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
