### PR TITLE
feat(FairGenericStack): Provide better default functions

### DIFF
--- a/examples/common/mcstack/FairStack.cxx
+++ b/examples/common/mcstack/FairStack.cxx
@@ -35,7 +35,6 @@ FairStack::FairStack(Int_t size)
     , fStoreMap()
     , fIndexMap()
     , fPointsMap()
-    , fCurrentTrack(-1)
     , fNPrimaries(0)
     , fNParticles(0)
     , fNTracks(0)
@@ -149,8 +148,9 @@ TParticle* FairStack::PopNextTrack(Int_t& iTrack)
         return nullptr;
     }
 
-    fCurrentTrack = thisParticle->GetStatusCode();
-    iTrack = fCurrentTrack;
+    const auto currentTrack = thisParticle->GetStatusCode();
+    SetCurrentTrack(currentTrack);
+    iTrack = currentTrack;
 
     return thisParticle;
 }
@@ -177,7 +177,7 @@ TParticle* FairStack::PopPrimaryForTracking(Int_t iPrim)
 
 TParticle* FairStack::GetCurrentTrack() const
 {
-    TParticle* currentPart = GetParticle(fCurrentTrack);
+    TParticle* currentPart = GetParticle(FairGenericStack::GetCurrentTrackNumber());
     if (!currentPart) {
         LOG(warn) << "Current track not found in stack!";
     }
@@ -239,7 +239,7 @@ void FairStack::FillTrackArray()
 
 Int_t FairStack::GetCurrentTrackNumber() const
 {
-    return FSTrackMapLookup(fCurrentTrack);
+    return FSTrackMapLookup(FairGenericStack::GetCurrentTrackNumber());
 }
 
 void FairStack::UpdateTrackIndex(TRefArray* detList)
@@ -302,7 +302,6 @@ void FairStack::UpdateTrackIndex(TRefArray* detList)
 void FairStack::Reset()
 {
     fIndex = 0;
-    fCurrentTrack = -1;
     fNPrimaries = fNParticles = fNTracks = 0;
     while (!fStack.empty()) {
         fStack.pop();

--- a/examples/common/mcstack/FairStack.cxx
+++ b/examples/common/mcstack/FairStack.cxx
@@ -309,8 +309,8 @@ void FairStack::Reset()
     }
     fParticles->Clear();
     fTracks->Clear();
-    fFSTrackMap.clear();
     fPointsMap.clear();
+    FairGenericStack::Reset();
 }
 
 void FairStack::Register()

--- a/examples/common/mcstack/FairStack.h
+++ b/examples/common/mcstack/FairStack.h
@@ -124,12 +124,6 @@ class FairStack : public FairGenericStack
      **/
     TParticle* PopPrimaryForTracking(Int_t iPrim) override;
 
-    /** Set the current track number
-     ** Declared in TVirtualMCStack
-     *@param iTrack  track number
-     **/
-    void SetCurrentTrack(Int_t iTrack) override { fCurrentTrack = iTrack; }
-
     /** Get total number of tracks
      ** Declared in TVirtualMCStack
      **/
@@ -241,7 +235,6 @@ class FairStack : public FairGenericStack
     std::map<std::pair<Int_t, Int_t>, Int_t> fPointsMap;   //!
 
     /** Some indizes and counters **/
-    Int_t fCurrentTrack;   //! Index of current track
     Int_t fNPrimaries;     //! Number of primary particles
     Int_t fNParticles;     //! Number of entries in fParticles
     Int_t fNTracks;        //! Number of entries in fTracks

--- a/fairroot/base/sim/FairGenericStack.h
+++ b/fairroot/base/sim/FairGenericStack.h
@@ -48,6 +48,17 @@ class FairGenericStack : public TVirtualMCStack
      */
     Int_t GetCurrentTrackID() const { return GetCurrentTrackNumber(); }
 
+    /** Set the current track number
+     ** Declared in TVirtualMCStack
+     *@param iTrack  track number
+     **/
+    void SetCurrentTrack(Int_t iTrack) override { fCurrentTrack = iTrack; }
+
+    /** Get the number of the current track
+     ** Declared in TVirtualMCStack
+     **/
+    Int_t GetCurrentTrackNumber() const override { return fCurrentTrack; }
+
     /** Virtual method PushTrack.
      ** Add a TParticle to the stack.
      ** This function has an extra argument wrt to the function defined in the base class.
@@ -98,7 +109,11 @@ class FairGenericStack : public TVirtualMCStack
     virtual void FinishPrimary() {}
 
     /** Resets arrays and stack and deletes particles and tracks **/
-    virtual void Reset() { fFSTrackMap.clear(); }
+    virtual void Reset()
+    {
+        fCurrentTrack = -1;
+        fFSTrackMap.clear();
+    }
 
     /** Register the MCTrack array to the Root Manager  **/
     virtual void Register() {}
@@ -211,6 +226,9 @@ class FairGenericStack : public TVirtualMCStack
         }
         return track;
     }
+
+  private:
+    Int_t fCurrentTrack{-1};   //!< Index of current track
 
     ClassDefOverride(FairGenericStack, 1);
 };

--- a/fairroot/base/sim/FairGenericStack.h
+++ b/fairroot/base/sim/FairGenericStack.h
@@ -98,7 +98,7 @@ class FairGenericStack : public TVirtualMCStack
     virtual void FinishPrimary() {}
 
     /** Resets arrays and stack and deletes particles and tracks **/
-    virtual void Reset() {}
+    virtual void Reset() { fFSTrackMap.clear(); }
 
     /** Register the MCTrack array to the Root Manager  **/
     virtual void Register() {}

--- a/templates/project_root_containers/MyProjData/MyProjStack.cxx
+++ b/templates/project_root_containers/MyProjData/MyProjStack.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -350,6 +350,7 @@ void MyProjStack::Reset()
     fParticles->Clear();
     fTracks->Clear();
     fPointsMap.clear();
+    FairGenericStack::Reset();
 }
 // -------------------------------------------------------------------------
 

--- a/templates/project_root_containers/MyProjData/MyProjStack.cxx
+++ b/templates/project_root_containers/MyProjData/MyProjStack.cxx
@@ -45,7 +45,6 @@ MyProjStack::MyProjStack(Int_t size)
     , fIndexMap()
     , fIndexIter()
     , fPointsMap()
-    , fCurrentTrack(-1)
     , fNPrimaries(0)
     , fNParticles(0)
     , fNTracks(0)
@@ -68,7 +67,6 @@ MyProjStack::MyProjStack(const MyProjStack& right)
     , fIndexMap()
     , fIndexIter()
     , fPointsMap()
-    , fCurrentTrack()
     , fNPrimaries()
     , fNParticles()
     , fNTracks()
@@ -187,8 +185,9 @@ TParticle* MyProjStack::PopNextTrack(Int_t& iTrack)
         return NULL;
     }
 
-    fCurrentTrack = thisParticle->GetStatusCode();
-    iTrack = fCurrentTrack;
+    const auto currentTrack = thisParticle->GetStatusCode();
+    SetCurrentTrack(currentTrack);
+    iTrack = currentTrack;
 
     return thisParticle;
 }
@@ -220,7 +219,7 @@ TParticle* MyProjStack::PopPrimaryForTracking(Int_t iPrim)
 // -----   Virtual public method GetCurrentTrack   -------------------------
 TParticle* MyProjStack::GetCurrentTrack() const
 {
-    TParticle* currentPart = GetParticle(fCurrentTrack);
+    TParticle* currentPart = GetParticle(GetCurrentTrackNumber());
     if (!currentPart) {
         LOG(warning) << "MyProjStack: Current track not found in stack!";
     }
@@ -342,7 +341,6 @@ void MyProjStack::UpdateTrackIndex(TRefArray* detList)
 void MyProjStack::Reset()
 {
     fIndex = 0;
-    fCurrentTrack = -1;
     fNPrimaries = fNParticles = fNTracks = 0;
     while (!fStack.empty()) {
         fStack.pop();
@@ -384,7 +382,7 @@ void MyProjStack::AddPoint(DetectorId detId)
 {
     Int_t iDet = detId;
     // cout << "Add point for Detektor" << iDet << endl;
-    pair<Int_t, Int_t> a(fCurrentTrack, iDet);
+    pair<Int_t, Int_t> a(GetCurrentTrackID(), iDet);
     if (fPointsMap.find(a) == fPointsMap.end()) {
         fPointsMap[a] = 1;
     } else {

--- a/templates/project_root_containers/MyProjData/MyProjStack.h
+++ b/templates/project_root_containers/MyProjData/MyProjStack.h
@@ -125,12 +125,6 @@ class MyProjStack : public FairGenericStack
      **/
     virtual TParticle* PopPrimaryForTracking(Int_t iPrim);
 
-    /** Set the current track number
-     ** Declared in TVirtualMCStack
-     *@param iTrack  track number
-     **/
-    virtual void SetCurrentTrack(Int_t iTrack) { fCurrentTrack = iTrack; }
-
     /** Get total number of tracks
      ** Declared in TVirtualMCStack
      **/
@@ -145,11 +139,6 @@ class MyProjStack : public FairGenericStack
      ** Declared in TVirtualMCStack
      **/
     virtual TParticle* GetCurrentTrack() const;
-
-    /** Get the number of the current track
-     ** Declared in TVirtualMCStack
-     **/
-    virtual Int_t GetCurrentTrackNumber() const { return fCurrentTrack; }
 
     /** Get the track number of the parent of the current track
      ** Declared in TVirtualMCStack
@@ -224,7 +213,6 @@ class MyProjStack : public FairGenericStack
     std::map<std::pair<Int_t, Int_t>, Int_t> fPointsMap;   //!
 
     /** Some indizes and counters **/
-    Int_t fCurrentTrack;   //! Index of current track
     Int_t fNPrimaries;     //! Number of primary particles
     Int_t fNParticles;     //! Number of entries in fParticles
     Int_t fNTracks;        //! Number of entries in fTracks

--- a/templates/project_stl_containers/MyProjData/MyProjStack.cxx
+++ b/templates/project_stl_containers/MyProjData/MyProjStack.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -355,6 +355,7 @@ void MyProjStack::Reset()
     fParticles->Clear();
     fTracks->Clear();
     fPointsMap.clear();
+    FairGenericStack::Reset();
 }
 // -------------------------------------------------------------------------
 

--- a/templates/project_stl_containers/MyProjData/MyProjStack.cxx
+++ b/templates/project_stl_containers/MyProjData/MyProjStack.cxx
@@ -45,7 +45,6 @@ MyProjStack::MyProjStack(Int_t size)
     , fIndexMap()
     , fIndexIter()
     , fPointsMap()
-    , fCurrentTrack(-1)
     , fNPrimaries(0)
     , fNParticles(0)
     , fNTracks(0)
@@ -68,7 +67,6 @@ MyProjStack::MyProjStack(const MyProjStack& right)
     , fIndexMap()
     , fIndexIter()
     , fPointsMap()
-    , fCurrentTrack()
     , fNPrimaries()
     , fNParticles()
     , fNTracks()
@@ -187,8 +185,9 @@ TParticle* MyProjStack::PopNextTrack(Int_t& iTrack)
         return NULL;
     }
 
-    fCurrentTrack = thisParticle->GetStatusCode();
-    iTrack = fCurrentTrack;
+    const auto currentTrack = thisParticle->GetStatusCode();
+    SetCurrentTrack(currentTrack);
+    iTrack = currentTrack;
 
     return thisParticle;
 }
@@ -220,7 +219,7 @@ TParticle* MyProjStack::PopPrimaryForTracking(Int_t iPrim)
 // -----   Virtual public method GetCurrentTrack   -------------------------
 TParticle* MyProjStack::GetCurrentTrack() const
 {
-    TParticle* currentPart = GetParticle(fCurrentTrack);
+    TParticle* currentPart = GetParticle(GetCurrentTrackNumber());
     if (!currentPart) {
         LOG(warning) << "MyProjStack: Current track not found in stack!";
     }
@@ -347,7 +346,6 @@ void MyProjStack::UpdateTrackIndex(TRefArray* detList)
 void MyProjStack::Reset()
 {
     fIndex = 0;
-    fCurrentTrack = -1;
     fNPrimaries = fNParticles = fNTracks = 0;
     while (!fStack.empty()) {
         fStack.pop();
@@ -389,7 +387,7 @@ void MyProjStack::AddPoint(DetectorId detId)
 {
     Int_t iDet = detId;
     // cout << "Add point for Detektor" << iDet << endl;
-    pair<Int_t, Int_t> a(fCurrentTrack, iDet);
+    pair<Int_t, Int_t> a(GetCurrentTrackID(), iDet);
     if (fPointsMap.find(a) == fPointsMap.end()) {
         fPointsMap[a] = 1;
     } else {

--- a/templates/project_stl_containers/MyProjData/MyProjStack.h
+++ b/templates/project_stl_containers/MyProjData/MyProjStack.h
@@ -125,12 +125,6 @@ class MyProjStack : public FairGenericStack
      **/
     virtual TParticle* PopPrimaryForTracking(Int_t iPrim);
 
-    /** Set the current track number
-     ** Declared in TVirtualMCStack
-     *@param iTrack  track number
-     **/
-    virtual void SetCurrentTrack(Int_t iTrack) { fCurrentTrack = iTrack; }
-
     /** Get total number of tracks
      ** Declared in TVirtualMCStack
      **/
@@ -145,11 +139,6 @@ class MyProjStack : public FairGenericStack
      ** Declared in TVirtualMCStack
      **/
     virtual TParticle* GetCurrentTrack() const;
-
-    /** Get the number of the current track
-     ** Declared in TVirtualMCStack
-     **/
-    virtual Int_t GetCurrentTrackNumber() const { return fCurrentTrack; }
 
     /** Get the track number of the parent of the current track
      ** Declared in TVirtualMCStack
@@ -224,7 +213,6 @@ class MyProjStack : public FairGenericStack
     std::map<std::pair<Int_t, Int_t>, Int_t> fPointsMap;   //!
 
     /** Some indizes and counters **/
-    Int_t fCurrentTrack;   //! Index of current track
     Int_t fNPrimaries;     //! Number of primary particles
     Int_t fNParticles;     //! Number of entries in fParticles
     Int_t fNTracks;        //! Number of entries in fTracks


### PR DESCRIPTION
Instead of letting each derived "Stack" implement everything, provide some basic functionality in FairGenericStack.

Derived classes can just use it, extend it, or completely replace, as they see fit.

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
