### PR TITLE
clang-format: Put braces on own line in special cases

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -26,6 +26,7 @@ BraceWrapping:
   SplitEmptyFunction: false
   SplitEmptyRecord: false
   SplitEmptyNamespace: false
+  AfterControlStatement: MultiLine
 BreakConstructorInitializers: BeforeComma
 ColumnLimit: 120
 ConstructorInitializerIndentWidth: 4

--- a/examples/MQ/pixelDetector/src/Pixel.cxx
+++ b/examples/MQ/pixelDetector/src/Pixel.cxx
@@ -90,7 +90,8 @@ Bool_t Pixel::ProcessHits(FairVolume* vol)
 
     // Create PixelPoint at exit of active volume
     if (TVirtualMC::GetMC()->IsTrackExiting() || TVirtualMC::GetMC()->IsTrackStop()
-        || TVirtualMC::GetMC()->IsTrackDisappeared()) {
+        || TVirtualMC::GetMC()->IsTrackDisappeared())
+    {
         fTrackID = TVirtualMC::GetMC()->GetStack()->GetCurrentTrackNumber();
         fVolumeID = vol->getMCid();
 

--- a/examples/MQ/pixelDetector/src/PixelDigitize.cxx
+++ b/examples/MQ/pixelDetector/src/PixelDigitize.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -144,7 +144,8 @@ void PixelDigitize::ActivatePixel(Int_t index,
     for (Int_t ipixel = 0; ipixel < fNDigis; ipixel++) {
         tempPixel = static_cast<PixelDigi*>(fDigis->At(ipixel));
         if (tempPixel->GetDetectorID() == detId && tempPixel->GetFeID() == feId && tempPixel->GetCol() == col
-            && tempPixel->GetRow() == row) {
+            && tempPixel->GetRow() == row)
+        {
             pixelAlreadyFired = kTRUE;
             tempPixel->SetCharge(tempPixel->GetCharge() + charge);
         }

--- a/examples/advanced/Tutorial3/simulation/FairTestDetector.cxx
+++ b/examples/advanced/Tutorial3/simulation/FairTestDetector.cxx
@@ -85,7 +85,8 @@ Bool_t FairTestDetector::ProcessHits(FairVolume* vol)
 
     // Create FairTestDetectorPoint at exit of active volume
     if (TVirtualMC::GetMC()->IsTrackExiting() || TVirtualMC::GetMC()->IsTrackStop()
-        || TVirtualMC::GetMC()->IsTrackDisappeared()) {
+        || TVirtualMC::GetMC()->IsTrackDisappeared())
+    {
         fTrackID = TVirtualMC::GetMC()->GetStack()->GetCurrentTrackNumber();
         fVolumeID = vol->getMCid();
         TVirtualMC::GetMC()->TrackPosition(fPosOut);

--- a/examples/advanced/propagator/src/FairTutPropDet.cxx
+++ b/examples/advanced/propagator/src/FairTutPropDet.cxx
@@ -80,7 +80,8 @@ Bool_t FairTutPropDet::ProcessHits(FairVolume* vol)
 
     // Create FairTutPropPoint at exit of active volume
     if (TVirtualMC::GetMC()->IsTrackExiting() || TVirtualMC::GetMC()->IsTrackStop()
-        || TVirtualMC::GetMC()->IsTrackDisappeared()) {
+        || TVirtualMC::GetMC()->IsTrackDisappeared())
+    {
         fTrackID = TVirtualMC::GetMC()->GetStack()->GetCurrentTrackNumber();
         fVolumeID = vol->getMCid();
 

--- a/fairroot/base/event/FairMultiLinkedData.cxx
+++ b/fairroot/base/event/FairMultiLinkedData.cxx
@@ -132,7 +132,8 @@ void FairMultiLinkedData::AddLink(FairLink link, Bool_t bypass, Float_t mult)
 
     if (!fPersistanceCheck || link.GetIndex() < 0
         || (link.GetType() != ioman->GetMCTrackBranchId()
-            && ioman->CheckBranch(ioman->GetBranchName(link.GetType())) == 0)) {
+            && ioman->CheckBranch(ioman->GetBranchName(link.GetType())) == 0))
+    {
         InsertLink(link);
         if (fInsertHistory)
             InsertHistory(link);
@@ -145,7 +146,8 @@ void FairMultiLinkedData::AddLink(FairLink link, Bool_t bypass, Float_t mult)
                       << " checkStatus: " << ioman->CheckBranch(ioman->GetBranchName(link.GetType())) << std::endl;
         }
         if (link.GetType() > ioman->GetMCTrackBranchId()
-            && ioman->CheckBranch(ioman->GetBranchName(link.GetType())) != 1) {
+            && ioman->CheckBranch(ioman->GetBranchName(link.GetType())) != 1)
+        {
             if (fVerbose > 1) {
                 std::cout << "BYPASS!" << std::endl;
             }

--- a/fairroot/base/steer/FairRadGridManager.cxx
+++ b/fairroot/base/steer/FairRadGridManager.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -143,7 +143,8 @@ Bool_t FairRadGridManager::IsTrackInside(TLorentzVector& pos, FairMesh* aMesh)
 {
     // check if inside volume
     if ((pos.X() >= aMesh->GetXmin()) && (pos.X() <= aMesh->GetXmax()) && (pos.Y() >= aMesh->GetYmin())
-        && (pos.Y() <= aMesh->GetYmax()) && (pos.Z() >= aMesh->GetZmin()) && (pos.Z() <= aMesh->GetZmax())) {
+        && (pos.Y() <= aMesh->GetYmax()) && (pos.Z() >= aMesh->GetZmin()) && (pos.Z() <= aMesh->GetZmax()))
+    {
         /*       cout << " inside Xpos: " << pos.X() << " Xmin: " << aMesh->GetXmin()
           << " Xmax: " << aMesh->GetXmax()  << endl;
            cout << " inside Ypos: " << pos.Y() << " Ymin: " << aMesh->GetYmin()

--- a/fairroot/base/steer/FairWriteoutBuffer.cxx
+++ b/fairroot/base/steer/FairWriteoutBuffer.cxx
@@ -175,7 +175,8 @@ void FairWriteoutBuffer::FillDataToDeadTimeMap(FairTimeStamp* data, double activ
             // PrintDeadTimeMap();
             for (DTMapIter it = fDeadTime_map.lower_bound(currentdeadtime);
                  it != fDeadTime_map.upper_bound(currentdeadtime);
-                 ++it) {
+                 ++it)
+            {
                 oldData = it->second;
                 if (fVerbose > 1) {
                     std::cout << "Check Data: " << it->first << " : " << oldData << std::endl;
@@ -195,8 +196,8 @@ void FairWriteoutBuffer::FillDataToDeadTimeMap(FairTimeStamp* data, double activ
             }
 
             if (dataFound) {
-                if (timeOfOldData
-                    > startTime) {   // if older active data can interference with the new data call modify function
+                if (timeOfOldData > startTime)
+                {   // if older active data can interference with the new data call modify function
                     std::vector<std::pair<double, FairTimeStamp*>> modifiedData =
                         Modify(std::pair<double, FairTimeStamp*>(currentdeadtime, oldData),
                                std::pair<double, FairTimeStamp*>(activeTime, data));

--- a/fairroot/generators/FairBoxGenerator.cxx
+++ b/fairroot/generators/FairBoxGenerator.cxx
@@ -161,8 +161,8 @@ Bool_t FairBoxGenerator::Init()
     if (fPRangeIsSet && fYRangeIsSet) {
         LOG(fatal) << "FairBoxGenerator:Init():  Cannot set P and Y ranges simultaneously";
     }
-    if ((fThetaRangeIsSet && fYRangeIsSet) || (fThetaRangeIsSet && fEtaRangeIsSet)
-        || (fYRangeIsSet && fEtaRangeIsSet)) {
+    if ((fThetaRangeIsSet && fYRangeIsSet) || (fThetaRangeIsSet && fEtaRangeIsSet) || (fYRangeIsSet && fEtaRangeIsSet))
+    {
         LOG(fatal) << "FairBoxGenerator:Init():  Cannot set Y, Theta or Eta ranges simultaneously";
     }
     return kTRUE;

--- a/fairroot/online/source/FairMbsSource.cxx
+++ b/fairroot/online/source/FairMbsSource.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -36,12 +36,14 @@ Bool_t FairMbsSource::Unpack(Int_t* data,
 
         if (unpack->GetSubCrate() < 0) {   // All sub-crates
             if (type != unpack->GetType() || subType != unpack->GetSubType() || procId != unpack->GetProcId()
-                || control != unpack->GetControl()) {
+                || control != unpack->GetControl())
+            {
                 continue;
             }
         } else {   // specified sub-crate
             if (type != unpack->GetType() || subType != unpack->GetSubType() || procId != unpack->GetProcId()
-                || subCrate != unpack->GetSubCrate() || control != unpack->GetControl()) {
+                || subCrate != unpack->GetSubCrate() || control != unpack->GetControl())
+            {
                 continue;
             }
         }

--- a/fairroot/online/source/FairRemoteSource.cxx
+++ b/fairroot/online/source/FairRemoteSource.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -65,7 +65,8 @@ Int_t FairRemoteSource::ReadEvent(UInt_t)
                    fREvent->subEvtSubType[i],
                    fREvent->subEvtProcId[i],
                    fREvent->subEvtSubCrate[i],
-                   fREvent->subEvtControl[i])) {
+                   fREvent->subEvtControl[i]))
+        {
             result = kTRUE;
         }
     }

--- a/templates/project_root_containers/NewDetector/NewDetector.cxx
+++ b/templates/project_root_containers/NewDetector/NewDetector.cxx
@@ -108,7 +108,8 @@ Bool_t NewDetector::ProcessHits(FairVolume* vol)
 
     // Create NewDetectorPoint at exit of active volume
     if (TVirtualMC::GetMC()->IsTrackExiting() || TVirtualMC::GetMC()->IsTrackStop()
-        || TVirtualMC::GetMC()->IsTrackDisappeared()) {
+        || TVirtualMC::GetMC()->IsTrackDisappeared())
+    {
         fTrackID = TVirtualMC::GetMC()->GetStack()->GetCurrentTrackNumber();
         fVolumeID = vol->getMCid();
         if (fELoss == 0.) {

--- a/templates/project_stl_containers/NewDetector/NewDetector.cxx
+++ b/templates/project_stl_containers/NewDetector/NewDetector.cxx
@@ -107,7 +107,8 @@ Bool_t NewDetector::ProcessHits(FairVolume* vol)
 
     // Create NewDetectorPoint at exit of active volume
     if (TVirtualMC::GetMC()->IsTrackExiting() || TVirtualMC::GetMC()->IsTrackStop()
-        || TVirtualMC::GetMC()->IsTrackDisappeared()) {
+        || TVirtualMC::GetMC()->IsTrackDisappeared())
+    {
         fTrackID = TVirtualMC::GetMC()->GetStack()->GetCurrentTrackNumber();
         fVolumeID = vol->getMCid();
         if (fELoss == 0.) {

--- a/tests/geobase/checks_FairGeoBasicShape.h
+++ b/tests/geobase/checks_FairGeoBasicShape.h
@@ -105,7 +105,8 @@ auto check_FairGeoShape_ReadWrite(FairGeoBasicShape& shape,
             CHECK_THAT(test->Y(), Catch::Matchers::WithinRel(parameters.at(1).at(i), 0.001f));
             CHECK_THAT(test->Z(), Catch::Matchers::WithinRel(parameters.at(2).at(i), 0.001f));
         } else if ("CONE" == shapeName || "CONS" == shapeName || "ELTU" == shapeName || "TUBE" == shapeName
-                   || "TUBS" == shapeName) {
+                   || "TUBS" == shapeName)
+        {
             if (0 == i || 2 == i) {
                 CHECK_THAT(test->X(), Catch::Matchers::WithinRel(parameters.at(0).at(i), 0.001f));
                 CHECK_THAT(test->Y(), Catch::Matchers::WithinRel(parameters.at(1).at(i), 0.001f));


### PR DESCRIPTION
Multi-line control statements with the opening brace on the last line can be a little confusing to read:

```cpp
if (auto foo = something;
    foo.extra_data.check_for(17)) {
    foo.extra_data.check_and_act(19);
}
```

It is not easy to see the end of the condition and the start of the "then" block.

This gets much easier when putting the opening brace on its own line:

```cpp
if (auto foo = something;
    foo.extra_data.check_for(17))
{
    foo.extra_data.check_and_act(19);
}
```

To show the difference, a few files have been reformatted with this.

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
