### PR TITLE
refactor(Base): Call GetCurrentTrackNumber directly from FairGenericStack

### DIFF
--- a/fairroot/base/sim/FairGenericStack.cxx
+++ b/fairroot/base/sim/FairGenericStack.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -120,7 +120,7 @@ void FairGenericStack::FastSimMoveParticleTo(Double_t xx,
 
     PushTrack(tobedone, parent, pdg, px, py, pz, en, xx, yy, zz, tt, polx, poly, polz, proc, ntr, weight, status, -1);
     fFSMovedIndex = GetListOfParticles()->GetEntries() - 1;
-    Int_t trackID = TVirtualMC::GetMC()->GetStack()->GetCurrentTrackNumber();
+    Int_t trackID = GetCurrentTrackID();
     fFSTrackIter = fFSTrackMap.find(trackID);   // check if this track is not already created by FastSimulation
     if (fFSTrackIter != fFSTrackMap.end())      // indeed the track has been created by the FastSimulation mechanism
         trackID = fFSTrackIter->second;         // use the ID of the original track

--- a/fairroot/base/sim/FairGenericStack.h
+++ b/fairroot/base/sim/FairGenericStack.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -40,6 +40,13 @@ class FairGenericStack : public TVirtualMCStack
 
     /** Destructor  **/
     ~FairGenericStack() override;
+
+    /**
+     * \brief Get the Track ID of the current track
+     *
+     * Separate the calling from the customization of this API
+     */
+    Int_t GetCurrentTrackID() const { return GetCurrentTrackNumber(); }
 
     /** Virtual method PushTrack.
      ** Add a TParticle to the stack.


### PR DESCRIPTION
FairGenericStack is the base class of all "Stacks". Instead of redirecting via `TVirtualMC::GetMC()->GetStack()`, just use `this`.

discovered by @dennisklein here: https://github.com/FairRootGroup/FairRoot/pull/1584#discussion_r1718396204

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
