### PR TITLE
refactor(Base): Introduce FairRootManager::CreateOutputFolder

### DIFF
--- a/fairroot/base/sink/FairRootFileSink.cxx
+++ b/fairroot/base/sink/FairRootFileSink.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *         GNU Lesser General Public Licence version 3 (LGPL) version 3,        *
@@ -87,7 +87,7 @@ Bool_t FairRootFileSink::InitSink()
 
     // FairRun* fRun = FairRun::Instance();
     /**Check if a simulation run!*/
-    fOutFolder = gROOT->GetRootFolder()->AddFolder(FairRootManager::GetFolderName(), "Main Folder");
+    fOutFolder = FairRootManager::Instance()->CreateOutputFolder();
     gROOT->GetListOfBrowsables()->Add(fOutFolder);
 
     LOG(info) << "FairRootFileSink initialized.";

--- a/fairroot/base/source/FairFileSource.cxx
+++ b/fairroot/base/source/FairFileSource.cxx
@@ -167,7 +167,7 @@ Bool_t FairFileSource::Init()
         if (!fCbmroot) {
             fCbmroot = fRootFile->Get<TFolder>("cbmout");
             if (!fCbmroot) {
-                fCbmroot = gROOT->GetRootFolder()->AddFolder(FairRootManager::GetFolderName(), "Main Folder");
+                fCbmroot = FairRootManager::Instance()->CreateOutputFolder();
             } else {
                 fCbmroot->SetName(FairRootManager::GetFolderName());
             }

--- a/fairroot/base/source/FairMixedSource.cxx
+++ b/fairroot/base/source/FairMixedSource.cxx
@@ -212,7 +212,7 @@ Bool_t FairMixedSource::Init()
         if (!fCbmroot) {
             fCbmroot = fRootFile->Get<TFolder>("cbmout");
             if (!fCbmroot) {
-                fCbmroot = gROOT->GetRootFolder()->AddFolder(FairRootManager::GetFolderName(), "Main Folder");
+                fCbmroot = fRootManager->CreateOutputFolder();
             } else {
                 fCbmroot->SetName(FairRootManager::GetFolderName());
             }
@@ -475,7 +475,7 @@ Bool_t FairMixedSource::OpenBackgroundChain()
         if (!fCbmroot) {
             fCbmroot = fRootFile->Get<TFolder>("cbmout");
             if (!fCbmroot) {
-                fCbmroot = gROOT->GetRootFolder()->AddFolder(FairRootManager::GetFolderName(), "Main Folder");
+                fCbmroot = fRootManager->CreateOutputFolder();
             } else {
                 fCbmroot->SetName(FairRootManager::GetFolderName());
             }

--- a/fairroot/base/steer/FairRootManager.cxx
+++ b/fairroot/base/steer/FairRootManager.cxx
@@ -375,6 +375,11 @@ void FairRootManager::CreateGeometryFile(const char* geofile)
     file->Close();
 }
 
+TFolder* FairRootManager::CreateOutputFolder()
+{
+    return gROOT->GetRootFolder()->AddFolder(GetFolderName(), "Main Folder");
+}
+
 void FairRootManager::WriteFolder()
 {
     if (fSink) {
@@ -386,7 +391,7 @@ void FairRootManager::WriteFolder()
 
 void FairRootManager::RemoveOutputFolderForMtMode()
 {
-    auto rootFolder = static_cast<TFolder*>(gROOT->GetRootFolder());
+    auto rootFolder = gROOT->GetRootFolder();
     rootFolder->Remove(rootFolder->FindObject(GetFolderName()));
 }
 

--- a/fairroot/base/steer/FairRootManager.h
+++ b/fairroot/base/steer/FairRootManager.h
@@ -216,6 +216,12 @@ class FairRootManager : public TObject
     void WriteGeometry();
     /**Write the file header object to the output file*/
     void WriteFileHeader(FairFileHeader* f);
+
+    /**
+     * \brief Internal: Create the folder describing the output tree structure from gROOT
+     */
+    TFolder* CreateOutputFolder();
+
     /**Write the folder structure used to create the tree to the output file */
     void WriteFolder();
     /**


### PR DESCRIPTION
After introducing RemoveOutputFolder, let's also introduce `Create…` to improve the lifecycle management.

Using `FairRootManager::Instance` is not nice, but fixing that is not in scope for this PR.

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
