### PR TITLE
refactor: Drop empty overriden methods in FairDetector classes

### DIFF
--- a/examples/MQ/pixelDetector/src/Pixel.h
+++ b/examples/MQ/pixelDetector/src/Pixel.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -60,16 +60,7 @@ class Pixel : public FairDetector
      *  any optional action in your detector during the transport.
      */
 
-    //    virtual void   CopyClones( TClonesArray* cl1,  TClonesArray* cl2 ,
-    //                               Int_t offset) {;}
-    void SetSpecialPhysicsCuts() override { ; }
     void EndOfEvent() override;
-    void FinishPrimary() override { ; }
-    void FinishRun() override { ; }
-    void BeginPrimary() override { ; }
-    void PostTrack() override { ; }
-    void PreTrack() override { ; }
-    void BeginEvent() override { ; }
 
     Bool_t IsSensitive(const std::string& name) override;
     FairModule* CloneModule() const override;

--- a/examples/advanced/Tutorial3/simulation/FairTestDetector.h
+++ b/examples/advanced/Tutorial3/simulation/FairTestDetector.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -70,20 +70,7 @@ class FairTestDetector : public FairDetector
      *  any optional action in your detector during the transport.
      */
 
-    /*
-    virtual void CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
-    {
-        ;
-    }
-*/
-    void SetSpecialPhysicsCuts() override { ; }
     void EndOfEvent() override;
-    void FinishPrimary() override { ; }
-    void FinishRun() override { ; }
-    void BeginPrimary() override { ; }
-    void PostTrack() override { ; }
-    void PreTrack() override { ; }
-    void BeginEvent() override { ; }
 
   private:
     /** Track information to be stored until the track leaves the

--- a/examples/advanced/propagator/src/FairTutPropDet.h
+++ b/examples/advanced/propagator/src/FairTutPropDet.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2019-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2019-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -18,7 +18,6 @@ class TClonesArray;
 
 class FairTutPropDet : public FairDetector
 {
-
   public:
     /**      Name :  Detector Name
      *       Active: kTRUE for active detectors (ProcessHits() will be called)
@@ -59,16 +58,7 @@ class FairTutPropDet : public FairDetector
      *  any optional action in your detector during the transport.
      */
 
-    //    virtual void   CopyClones( TClonesArray* cl1,  TClonesArray* cl2 ,
-    //                               Int_t offset) {;}
-    void SetSpecialPhysicsCuts() override { ; }
     void EndOfEvent() override;
-    void FinishPrimary() override { ; }
-    void FinishRun() override { ; }
-    void BeginPrimary() override { ; }
-    void PostTrack() override { ; }
-    void PreTrack() override { ; }
-    void BeginEvent() override { ; }
 
     void SetPointsArrayName(const std::string& tempName) { fPointsArrayName = tempName; };
 

--- a/examples/simulation/Tutorial1/src/FairTutorialDet1.h
+++ b/examples/simulation/Tutorial1/src/FairTutorialDet1.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -66,16 +66,7 @@ class FairTutorialDet1 : public FairDetector
      *  any optional action in your detector during the transport.
      */
 
-    //    virtual void   CopyClones( TClonesArray* cl1,  TClonesArray* cl2 ,
-    //                               Int_t offset) {;}
-    void SetSpecialPhysicsCuts() override { ; }
     void EndOfEvent() override;
-    void FinishPrimary() override { ; }
-    void FinishRun() override { ; }
-    void BeginPrimary() override { ; }
-    void PostTrack() override { ; }
-    void PreTrack() override { ; }
-    void BeginEvent() override { ; }
 
     FairModule* CloneModule() const override;
 

--- a/examples/simulation/Tutorial2/src/FairTutorialDet2.h
+++ b/examples/simulation/Tutorial2/src/FairTutorialDet2.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -63,16 +63,7 @@ class FairTutorialDet2 : public FairDetector
      *  any optional action in your detector during the transport.
      */
 
-    //    virtual void   CopyClones( TClonesArray* cl1,  TClonesArray* cl2 ,
-    //                               Int_t offset) {;}
-    virtual void SetSpecialPhysicsCuts() { ; }
     virtual void EndOfEvent();
-    virtual void FinishPrimary() { ; }
-    virtual void FinishRun() { ; }
-    virtual void BeginPrimary() { ; }
-    virtual void PostTrack() { ; }
-    virtual void PreTrack() { ; }
-    virtual void BeginEvent() { ; }
 
     virtual FairModule* CloneModule() const;
 

--- a/examples/simulation/Tutorial4/src/mc/FairTutorialDet4.h
+++ b/examples/simulation/Tutorial4/src/mc/FairTutorialDet4.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -76,15 +76,7 @@ class FairTutorialDet4 : public FairDetector
      *  any optional action in your detector during the transport.
      */
 
-    // virtual void CopyClones(TClonesArray* cl1,  TClonesArray* cl2 , Int_t offset) {}
-    virtual void SetSpecialPhysicsCuts() {}
     virtual void EndOfEvent();
-    virtual void FinishPrimary() {}
-    virtual void FinishRun() {}
-    virtual void BeginPrimary() {}
-    virtual void PostTrack() {}
-    virtual void PreTrack() {}
-    virtual void BeginEvent() {}
 
     void SetModifyGeometry(Bool_t val) { fModifyGeometry = val; }
     void SetGlobalCoordinates(Bool_t val) { fGlobalCoordinates = val; }

--- a/examples/simulation/rutherford/src/FairRutherford.h
+++ b/examples/simulation/rutherford/src/FairRutherford.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -62,16 +62,7 @@ class FairRutherford : public FairDetector
      *  any optional action in your detector during the transport.
      */
 
-    //    virtual void   CopyClones( TClonesArray* cl1,  TClonesArray* cl2 ,
-    //                               Int_t offset) {;}
-    void SetSpecialPhysicsCuts() override {}
     void EndOfEvent() override;
-    void FinishPrimary() override {}
-    void FinishRun() override {}
-    void BeginPrimary() override {}
-    void PostTrack() override {}
-    void PreTrack() override {}
-    void BeginEvent() override {}
 
     FairModule* CloneModule() const override;
 

--- a/fairroot/base/sim/FairModule.h
+++ b/fairroot/base/sim/FairModule.h
@@ -86,7 +86,7 @@ class FairModule : public TNamed
     virtual void ConstructGDMLGeometry(__attribute__((unused)) TGeoMatrix* posrot);
     /** custom settings of processes and cuts for media to be forwarded to the
      ** detector simulation */
-    virtual void SetSpecialPhysicsCuts() { ; }
+    virtual void SetSpecialPhysicsCuts() {}
     /** Clone this object (used in MT mode only)*/
     virtual FairModule* CloneModule() const;
     /** Init worker run (used in MT mode only) */

--- a/templates/NewDetector_root_containers/NewDetector.h
+++ b/templates/NewDetector_root_containers/NewDetector.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -19,7 +19,6 @@ class TClonesArray;
 
 class NewDetector : public FairDetector
 {
-
   public:
     /**      Name :  Detector Name
      *       Active: kTRUE for active detectors (ProcessHits() will be called)
@@ -63,14 +62,7 @@ class NewDetector : public FairDetector
      *  any optional action in your detector during the transport.
      */
 
-    virtual void SetSpecialPhysicsCuts() { ; }
     virtual void EndOfEvent();
-    virtual void FinishPrimary() { ; }
-    virtual void FinishRun() { ; }
-    virtual void BeginPrimary() { ; }
-    virtual void PostTrack() { ; }
-    virtual void PreTrack() { ; }
-    virtual void BeginEvent() { ; }
 
     virtual FairModule* CloneModule() const;
 

--- a/templates/NewDetector_stl_containers/NewDetector.h
+++ b/templates/NewDetector_stl_containers/NewDetector.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -60,14 +60,7 @@ class NewDetector : public FairDetector
      *  any optional action in your detector during the transport.
      */
 
-    virtual void SetSpecialPhysicsCuts() { ; }
     virtual void EndOfEvent();
-    virtual void FinishPrimary() { ; }
-    virtual void FinishRun() { ; }
-    virtual void BeginPrimary() { ; }
-    virtual void PostTrack() { ; }
-    virtual void PreTrack() { ; }
-    virtual void BeginEvent() { ; }
 
     virtual FairModule* CloneModule() const;
 

--- a/templates/project_root_containers/NewDetector/NewDetector.h
+++ b/templates/project_root_containers/NewDetector/NewDetector.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -19,7 +19,6 @@ class TClonesArray;
 
 class NewDetector : public FairDetector
 {
-
   public:
     /**      Name :  Detector Name
      *       Active: kTRUE for active detectors (ProcessHits() will be called)
@@ -63,14 +62,7 @@ class NewDetector : public FairDetector
      *  any optional action in your detector during the transport.
      */
 
-    virtual void SetSpecialPhysicsCuts() { ; }
     virtual void EndOfEvent();
-    virtual void FinishPrimary() { ; }
-    virtual void FinishRun() { ; }
-    virtual void BeginPrimary() { ; }
-    virtual void PostTrack() { ; }
-    virtual void PreTrack() { ; }
-    virtual void BeginEvent() { ; }
 
     virtual FairModule* CloneModule() const;
 

--- a/templates/project_stl_containers/NewDetector/NewDetector.h
+++ b/templates/project_stl_containers/NewDetector/NewDetector.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- *    Copyright (C) 2014 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    *
+ * Copyright (C) 2014-2024 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -60,14 +60,7 @@ class NewDetector : public FairDetector
      *  any optional action in your detector during the transport.
      */
 
-    virtual void SetSpecialPhysicsCuts() { ; }
     virtual void EndOfEvent();
-    virtual void FinishPrimary() { ; }
-    virtual void FinishRun() { ; }
-    virtual void BeginPrimary() { ; }
-    virtual void PostTrack() { ; }
-    virtual void PreTrack() { ; }
-    virtual void BeginEvent() { ; }
 
     virtual FairModule* CloneModule() const;
 


### PR DESCRIPTION
Most classes that derive from FairDetector override a bunch of member functions with an empty function. But the original one is already empty. So there is no need to override them.

Just remove all of this.

If someone wants to customize / use those hooks, they can override the hook that they need.

---

Checklist:

* [X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
