### PR TITLE
fix(build): Fix issue with cmake > 3.30

### DIFF
--- a/FairRoot_build_test.cmake
+++ b/FairRoot_build_test.cmake
@@ -30,7 +30,6 @@ ctest_start(Continuous)
 get_filename_component(test_install_prefix "${CTEST_BINARY_DIRECTORY}/install"
                        ABSOLUTE)
 list(APPEND options
-  "-Werror=dev"
   "-DDISABLE_COLOR=ON"
   "-DCMAKE_INSTALL_PREFIX:PATH=${test_install_prefix}"
 )


### PR DESCRIPTION
CMake 3.31 deprecates the compatibility with CMake < 3.10 which emits two warnings from Geant4 and vgm cmake macros. The usage of -Werror=dev turns the warning into an error which breaks the CI for some systems which already use cmake 3.31.

---

Checklist:

* [ x] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
