### PR TITLE
backport(workflow): Mark issues/PRs as stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,38 @@
+---
+# SPDX-FileCopyrightText: 2025 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH, Darmstadt, Germany
+#
+# SPDX-License-Identifier: CC0-1.0
+
+name: Mark stale issues and PRs
+
+on:
+  schedule:
+    # At 02:17 UTC on every 5th day-of-month from 3
+    - cron: '17 2 3,8,13,18,23,28 * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+  # For managing the operation state cache
+  # https://github.com/actions/stale/issues/1159
+  actions: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 365
+          days-before-close: -1
+          ascending: true
+          operations-per-run: 5
+          stale-issue-message: >-
+            This issue has been automatically marked as stale
+            because it has not had recent activity.
+            It will not be closed.
+          stale-pr-message: >-
+            This PR has been automatically marked as stale
+            because it has not had recent activity.
+            It will not be closed.


### PR DESCRIPTION
This runs in the master branch only.
But still backport it, so it's in sync the dev branch.

See-Also: 0c088da8426d2a6017007035af337af0fcf4062c
See-Also: d6b91e10bda05978b64d6def8d66d8c55b88ffb6
See-Also: f4f8e6ef644430d1aace2212513954b3b14b7fc8
See-Also: b3a0a269b9fdbbfb982411eea3fb8a7007339ae7
See-Also: 586302732b438ca1b03a25b4847689ee8161d826