### PR TITLE
Allow using CMAKE_OSX_SYSROOT

### DIFF
--- a/cmake/modules/FairRootTargetRootDictionary.cmake
+++ b/cmake/modules/FairRootTargetRootDictionary.cmake
@@ -125,23 +125,45 @@ function(fairroot_target_root_dictionary target)
   # add a custom command to generate the dictionary using rootcling
   # cmake-format: off
   set(space " ")
+  if (APPLE AND CMAKE_OSX_SYSROOT)
+    add_custom_command(
+      OUTPUT ${dictionaryFile} ${pcmFile} ${rootmapFile}
+      VERBATIM
+      COMMAND ${CMAKE_COMMAND} -E env
+        "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$ENV{LD_LIBRARY_PATH}"
+        "SDKROOT=${CMAKE_OSX_SYSROOT}"
+        $<TARGET_FILE:ROOT::rootcling>
+        -f ${dictionaryFile}
+        -inlineInputHeader
+        -rmf ${rootmapFile}
+        -rml $<TARGET_FILE_NAME:${target}>
+        -I$<JOIN:${includeDirs},$<SEMICOLON>-I>
+        ${extra_includes}
+        -excludePath "${CMAKE_BINARY_DIR}"
+        $<$<BOOL:${prop}>:-D$<JOIN:${prop},$<SEMICOLON>-D>>
+        ${headers}
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/${pcmBase} ${pcmFile}
+      COMMAND_EXPAND_LISTS
+      DEPENDS ${headers})
+  else()
   add_custom_command(
-    OUTPUT ${dictionaryFile} ${pcmFile} ${rootmapFile}
-    VERBATIM
-    COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$ENV{LD_LIBRARY_PATH}"
-      $<TARGET_FILE:ROOT::rootcling>
-      -f ${dictionaryFile}
-      -inlineInputHeader
-      -rmf ${rootmapFile}
-      -rml $<TARGET_FILE_NAME:${target}>
-      -I$<JOIN:${includeDirs},$<SEMICOLON>-I>
-      ${extra_includes}
-      -excludePath "${CMAKE_BINARY_DIR}"
-      $<$<BOOL:${prop}>:-D$<JOIN:${prop},$<SEMICOLON>-D>>
-      ${headers}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/${pcmBase} ${pcmFile}
-    COMMAND_EXPAND_LISTS
-    DEPENDS ${headers})
+      OUTPUT ${dictionaryFile} ${pcmFile} ${rootmapFile}
+      VERBATIM
+      COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$ENV{LD_LIBRARY_PATH}"
+        $<TARGET_FILE:ROOT::rootcling>
+        -f ${dictionaryFile}
+        -inlineInputHeader
+        -rmf ${rootmapFile}
+        -rml $<TARGET_FILE_NAME:${target}>
+        -I$<JOIN:${includeDirs},$<SEMICOLON>-I>
+        ${extra_includes}
+        -excludePath "${CMAKE_BINARY_DIR}"
+        $<$<BOOL:${prop}>:-D$<JOIN:${prop},$<SEMICOLON>-D>>
+        ${headers}
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/${pcmBase} ${pcmFile}
+      COMMAND_EXPAND_LISTS
+      DEPENDS ${headers})
+  endif()
   # cmake-format: on
 
   # add dictionary source to the target sources


### PR DESCRIPTION
This change allows to build dictionaries with a non default macosx software development package (SDK). This is needed to be able to compile older ROOT versions on new compiler versions.

---

Checklist:

* [ X] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
