### PR TITLE
fix(mcconfigurator): Fix to run without TGeant3

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
+# Copyright (C) 2014-2025 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
@@ -11,6 +11,10 @@ add_subdirectory(common/mcstack)
 
 set(mcEngine_list TGeant4)
 
+if(TARGET MCConfigurator)
+  add_subdirectory(common/gconfig)
+endif()
+
 if(Geant3_FOUND)
   if(ENABLE_GEANT3_TESTING)
     list(APPEND mcEngine_list TGeant3)
@@ -18,10 +22,6 @@ if(Geant3_FOUND)
   if(TARGET FairRoot::EventDisplay)
     add_subdirectory(common/eventdisplay)
   endif()
-  if(TARGET MCConfigurator)
-    add_subdirectory(common/gconfig)
-  endif()
-
 endif()
 
 if(TARGET FairRoot::FastSim AND TARGET Boost::program_options)

--- a/fairroot/CMakeLists.txt
+++ b/fairroot/CMakeLists.txt
@@ -40,8 +40,7 @@ else()
   message(STATUS "eventdisplay will not be built, because ROOT has no opengl support.")
 endif()
 
-if(Geant3_FOUND AND Geant4VMC_FOUND AND yaml-cpp_FOUND
-   AND TARGET FairRoot::FastSim)
+if(yaml-cpp_FOUND)
   add_subdirectory(mcconfigurator)
 endif()
 

--- a/fairroot/mcconfigurator/CMakeLists.txt
+++ b/fairroot/mcconfigurator/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (C) 2014-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
+# Copyright (C) 2014-2025 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
@@ -22,6 +22,17 @@ target_include_directories(${target} PUBLIC
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
+# Set compile definition
+if(Geant3_FOUND)
+    target_compile_definitions(${target} PUBLIC FAIRROOT_HAS_GEANT3)
+endif()
+if(Geant4VMC_FOUND)
+    target_compile_definitions(${target} PUBLIC FAIRROOT_HAS_GEANT4)
+endif()
+if(TARGET FairRoot::FastSim)
+    target_compile_definitions(${target} PUBLIC FAIRROOT_HAS_FASTSIM)
+endif()
+
 target_link_libraries(${target}
   PUBLIC
   FairRoot::Base # FairGenericVMCConfig
@@ -29,14 +40,25 @@ target_link_libraries(${target}
 
   PRIVATE
   FairRoot::Tools
-  FairRoot::FastSim # FairFastSimRunConfiguration
-
-  geant321
-  geant4vmc
 
   ROOT::Core
   ${VMCLIB}
 )
+
+if(Geant3_FOUND)
+  target_link_libraries(${target}
+    PUBLIC
+      geant321
+  )
+endif()
+
+if(Geant4VMC_FOUND)
+  target_link_libraries(${target}
+    PUBLIC
+      geant4vmc
+      $<IF:$<TARGET_EXISTS:FairRoot::FastSim>,FairRoot::FastSim,>  # FairFastSimRunConfiguration
+  )
+endif()
 
 fairroot_target_root_dictionary(${target}
   HEADERS ${headers}

--- a/fairroot/mcconfigurator/FairYamlVMCConfig.cxx
+++ b/fairroot/mcconfigurator/FairYamlVMCConfig.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2023 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2014-2025 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -11,15 +11,11 @@
 // -------------------------------------------------------------------------
 #include "FairYamlVMCConfig.h"
 
-#include "FairFastSimRunConfiguration.h"
 #include "FairLogger.h"
 #include "FairRunSim.h"
 #include "FairSink.h"   // for FairSink
 
 #include <Rtypes.h>
-#include <TGeant3.h>
-#include <TGeant3TGeo.h>
-#include <TGeant4.h>
 #include <TObjString.h>   // for TObjString
 #include <TObject.h>      // for TObject, TObject::kSingleKey
 #include <TString.h>
@@ -32,11 +28,21 @@
 #include <string>         // for string, basic_string, cha...
 #include <vector>         // for vector
 
+#ifdef FAIRROOT_HAS_FASTSIM
+#include "FairFastSimRunConfiguration.h"
+#endif
+#ifdef FAIRROOT_HAS_GEANT3
+#include <TGeant3.h>
+#include <TGeant3TGeo.h>
+#endif
+#ifdef FAIRROOT_HAS_GEANT4
+#include <TGeant4.h>
+#endif
+
 FairYamlVMCConfig::FairYamlVMCConfig()
     : FairGenericVMCConfig()
     , fMCEngine("")
-{
-}
+{}
 
 void FairYamlVMCConfig::Setup(const char* mcEngine)
 {
@@ -61,7 +67,8 @@ void FairYamlVMCConfig::Setup(const char* mcEngine)
 
 void FairYamlVMCConfig::SetupPostInit(const char* mcEngine)
 {
-    if ( !fPostInitFlag ) {
+#ifdef FAIRROOT_HAS_GEANT4
+    if (!fPostInitFlag) {
         LOG(info) << "FairYamlVMCConfig::SetupPostInit() OFF." << fPostInitName;
         return;
     }
@@ -85,7 +92,7 @@ void FairYamlVMCConfig::SetupPostInit(const char* mcEngine)
         g4Macro = "g4ConfigPostInit.C";
         fPostInitName = g4Macro;
     } else {
-        if (fPostInitName.find("/")!=std::string::npos) {
+        if (fPostInitName.find("/") != std::string::npos) {
             AbsPath = kTRUE;
         }
         g4Macro = fPostInitName;
@@ -105,8 +112,9 @@ void FairYamlVMCConfig::SetupPostInit(const char* mcEngine)
     fYamlConfigPostInit = YAML::LoadFile(ConfigMacro.Data());
 
     if (fYamlConfigPostInit["Geant4_PostInit_Commands"]) {
-        std::vector<std::string> g4commands = fYamlConfigPostInit["Geant4_PostInit_Commands"].as<std::vector<std::string>>();
-        for ( const auto& value: g4commands ) {
+        std::vector<std::string> g4commands =
+            fYamlConfigPostInit["Geant4_PostInit_Commands"].as<std::vector<std::string>>();
+        for (const auto& value : g4commands) {
             LOG(info) << " execute command \"" << value << "\"";
             TGeant4* geant4 = dynamic_cast<TGeant4*>(TVirtualMC::GetMC());
             geant4->ProcessGeantCommand(value.c_str());
@@ -114,10 +122,17 @@ void FairYamlVMCConfig::SetupPostInit(const char* mcEngine)
     }
 
     LOG(info) << "got info from " << fPostInitName;
+#else
+    LOG(fatal) << "FairYamlVMCConfig::SetupPostInit() - Geant4 support is not available! "
+               << "FairRoot was compiled without Geant4. "
+               << "Please use TGeant3 or recompile FairRoot with Geant4 support.";
+
+#endif
 }
 
 void FairYamlVMCConfig::SetupGeant3()
 {
+#ifdef FAIRROOT_HAS_GEANT3
     LOG(info) << "FairYamlVMCConfig::SetupGeant3() called";
     FairRunSim* fRun = FairRunSim::Instance();
     TString* gModel = fRun->GetGeoModel();
@@ -156,10 +171,18 @@ void FairYamlVMCConfig::SetupGeant3()
         geant3->SetERAN(fYamlConfig["G3_ERAN"].as<double>());
     if (fYamlConfig["G3_CKOV"])
         geant3->SetCKOV(fYamlConfig["G3_CKOV"].as<int>());
+
+    LOG(info) << geant3->GetName() << " MonteCarlo engine created!.";
+#else
+    LOG(fatal) << "FairYamlVMCConfig::SetupGeant3() - Geant3 support is not available! "
+               << "FairRoot was compiled without Geant3. "
+               << "Please use TGeant4 or recompile FairRoot with Geant3 support.";
+#endif
 }
 
 void FairYamlVMCConfig::SetupGeant4()
 {
+#ifdef FAIRROOT_HAS_GEANT4
     LOG(info) << "FairYamlVMCConfig::SetupGeant4() called";
 
     if (!fYamlConfig["Geant4_UserGeometry"]) {
@@ -191,13 +214,22 @@ void FairYamlVMCConfig::SetupGeant4()
 
     auto const useFastSim(fYamlConfig["UseFastSim"] ? fYamlConfig["UseFastSim"].as<bool>() : fUseFastSimDefault);
     std::unique_ptr<TG4RunConfiguration> runConfiguration;
+#ifdef FAIRROOT_HAS_FASTSIM
     if (useFastSim) {
         runConfiguration = std::make_unique<FairFastSimRunConfiguration>(
             g4UserGeometry, g4PhysicsList, g4SpecialProcess, specialStacking, mtMode);
-    } else {
+    } else
+#endif
+    {
         runConfiguration = std::make_unique<TG4RunConfiguration>(
             g4UserGeometry, g4PhysicsList, g4SpecialProcess, specialStacking, mtMode);
     }
+#ifndef FAIRROOT_HAS_FASTSIM
+    if (useFastSim) {
+        LOG(warning) << "UseFastSim is enabled but FairRoot was compiled without FastSim support. "
+                     << "Using standard TG4RunConfiguration instead.";
+    }
+#endif
 
     // Instantiate a singleton like object, "leaking" it is the current API
     TGeant4* geant4 = new TGeant4("TGeant4", "The Geant4 Monte Carlo", runConfiguration.release());
@@ -215,6 +247,11 @@ void FairYamlVMCConfig::SetupGeant4()
     }
 
     LOG(info) << geant4->GetName() << " MonteCarlo engine created!.";
+#else
+    LOG(fatal) << "FairYamlVMCConfig::SetupGeant4() - Geant4 support is not available! "
+               << "FairRoot was compiled without Geant4. "
+               << "Please use TGeant3 or recompile FairRoot with Geant4 support.";
+#endif
 }
 
 void FairYamlVMCConfig::SetCuts()


### PR DESCRIPTION
The MCConfigurator required TGeant3 and TGeant4 to run. Added compiler flags to enable running without any given transport engine.

Fixes issue #1620.

---

Checklist:

* [x] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
