### PR TITLE
FairModule IsSensitive checks medium property not volume name

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -96,6 +96,11 @@
         },
         {
             "type": "Other",
+            "name": "Lalik, Rafa\u0142",
+            "orcid": "0000-0003-1313-3729"
+        },
+        {
+            "type": "Other",
             "name": "Lavezzi, Lia"
         },
         {

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -14,6 +14,7 @@ Klenze, Philipp
 Kollegger, Thorsten
 Koenig, Ilse
 Krzewicki, Mikolaj
+Lalik, Rafał [https://orcid.org/0000-0003-1313-3729]
 Lavezzi, Lia
 Lavrik, Evgeny
 Lantwin, Oliver

--- a/codemeta.json
+++ b/codemeta.json
@@ -152,6 +152,12 @@
     },
     {
       "@type": "Person",
+      "@id": "https://orcid.org/0000-0003-1313-3729",
+      "givenName": "Rafa\u0142",
+      "familyName": "Lalik"
+    },
+    {
+      "@type": "Person",
       "givenName": "Lia",
       "familyName": "Lavezzi"
     },

--- a/examples/MQ/pixelDetector/src/Pixel.cxx
+++ b/examples/MQ/pixelDetector/src/Pixel.cxx
@@ -162,11 +162,6 @@ void Pixel::ConstructGeometry()
     ConstructASCIIGeometry<PixelGeo, PixelGeoPar>("PixelGeoPar");
 }
 
-Bool_t Pixel::IsSensitive(const std::string& name)
-{
-    return name.find("Pixel") != std::string::npos;
-}
-
 PixelPoint* Pixel::AddHit(Int_t trackID,
                           Int_t detID,
                           TVector3 pos,

--- a/examples/MQ/pixelDetector/src/Pixel.h
+++ b/examples/MQ/pixelDetector/src/Pixel.h
@@ -62,7 +62,6 @@ class Pixel : public FairDetector
 
     void EndOfEvent() override;
 
-    Bool_t IsSensitive(const std::string& name) override;
     FairModule* CloneModule() const override;
 
   private:

--- a/examples/common/passive/FairMagnet.cxx
+++ b/examples/common/passive/FairMagnet.cxx
@@ -41,12 +41,6 @@ void FairMagnet::ConstructGeometry()
     }
 }
 
-Bool_t FairMagnet::IsSensitive(const std::string& /*name*/)
-{
-    // just to get rid of the warrning during run, not need this is a passive element!
-    return kFALSE;
-}
-
 void FairMagnet::ConstructASCIIGeometry()
 {
     FairModule::ConstructASCIIGeometry<FairGeoMagnet, FairGeoPassivePar>("FairGeoPassivePar");

--- a/examples/common/passive/FairMagnet.h
+++ b/examples/common/passive/FairMagnet.h
@@ -21,7 +21,6 @@ class FairMagnet : public FairModule
     virtual ~FairMagnet();
     void ConstructGeometry();
     void ConstructASCIIGeometry();
-    Bool_t IsSensitive(const std::string& name);
 
     virtual FairModule* CloneModule() const;
 

--- a/examples/simulation/Tutorial1/src/FairFastSimExample.cxx
+++ b/examples/simulation/Tutorial1/src/FairFastSimExample.cxx
@@ -172,8 +172,6 @@ FairTutorialDet1Point* FairFastSimExample::AddHit(Int_t trackID,
     return new (clref[size]) FairTutorialDet1Point(trackID, detID, pos, mom, time, length, eLoss);
 }
 
-Bool_t FairFastSimExample::IsSensitive(const std::string& name) { return name == "fast_sim_vol"; }
-
 FairModule* FairFastSimExample::CloneModule() const
 {
     return new FairFastSimExample(*this);

--- a/examples/simulation/Tutorial1/src/FairFastSimExample.h
+++ b/examples/simulation/Tutorial1/src/FairFastSimExample.h
@@ -53,8 +53,6 @@ class FairFastSimExample : public FairFastSimDetector
      */
     virtual void EndOfEvent();
 
-    virtual Bool_t IsSensitive(const std::string& name);
-
     virtual FairModule* CloneModule() const;
 
   protected:

--- a/examples/simulation/Tutorial1/src/FairFastSimExample2.cxx
+++ b/examples/simulation/Tutorial1/src/FairFastSimExample2.cxx
@@ -152,8 +152,6 @@ FairTutorialDet1Point* FairFastSimExample2::AddHit(Int_t trackID,
     return new (clref[size]) FairTutorialDet1Point(trackID, detID, pos, mom, time, length, eLoss);
 }
 
-Bool_t FairFastSimExample2::IsSensitive(const std::string& name) { return name == "fast_sim_vol_n2"; }
-
 FairModule* FairFastSimExample2::CloneModule() const
 {
     return new FairFastSimExample2(*this);

--- a/examples/simulation/Tutorial1/src/FairFastSimExample2.h
+++ b/examples/simulation/Tutorial1/src/FairFastSimExample2.h
@@ -53,8 +53,6 @@ class FairFastSimExample2 : public FairFastSimDetector
      */
     virtual void EndOfEvent();
 
-    virtual Bool_t IsSensitive(const std::string& name);
-
     virtual FairModule* CloneModule() const;
 
   protected:

--- a/examples/simulation/Tutorial1/src/FairTutorialDet1.cxx
+++ b/examples/simulation/Tutorial1/src/FairTutorialDet1.cxx
@@ -115,11 +115,6 @@ TClonesArray* FairTutorialDet1::GetCollection(Int_t iColl) const
 
 void FairTutorialDet1::Reset() { fFairTutorialDet1PointCollection->Clear(); }
 
-Bool_t FairTutorialDet1::IsSensitive(const std::string& name)
-{
-    return name.find("tutdet") != std::string::npos;
-}
-
 void FairTutorialDet1::ConstructGeometry()
 {
     /** If you are using the standard ASCII input for the geometry

--- a/examples/simulation/Tutorial1/src/FairTutorialDet1.h
+++ b/examples/simulation/Tutorial1/src/FairTutorialDet1.h
@@ -70,8 +70,6 @@ class FairTutorialDet1 : public FairDetector
 
     FairModule* CloneModule() const override;
 
-    Bool_t IsSensitive(const std::string& name) override;
-
   private:
     /** Track information to be stored until the track leaves the
     active volume.

--- a/examples/simulation/Tutorial4/src/mc/FairTutorialDet4.cxx
+++ b/examples/simulation/Tutorial4/src/mc/FairTutorialDet4.cxx
@@ -248,11 +248,6 @@ void FairTutorialDet4::ConstructGeometry()
     }
 }
 
-Bool_t FairTutorialDet4::IsSensitive(const std::string& name)
-{
-    return name.find("tut4") != std::string::npos;
-}
-
 void FairTutorialDet4::ConstructASCIIGeometry()
 {
     /** If you are using the standard ASCII input for the geometry

--- a/examples/simulation/Tutorial4/src/mc/FairTutorialDet4.h
+++ b/examples/simulation/Tutorial4/src/mc/FairTutorialDet4.h
@@ -87,8 +87,6 @@ class FairTutorialDet4 : public FairDetector
 
     virtual void RegisterAlignmentMatrices();
 
-    virtual Bool_t IsSensitive(const std::string& name);
-
   private:
     /** Track information to be stored until the track leaves the
     active volume.

--- a/fairroot/base/sim/FairDetector.cxx
+++ b/fairroot/base/sim/FairDetector.cxx
@@ -75,7 +75,7 @@ void FairDetector::DefineSensitiveVolumes()
     TIter next(volumes);
     TGeoVolume* volume;
     while ((volume = static_cast<TGeoVolume*>(next()))) {
-        if (IsSensitive(volume->GetName())) {
+        if (IsSensitive(volume)) {
             LOG(debug) << "Sensitive Volume " << volume->GetName();
             AddSensitiveVolume(volume);
         }

--- a/fairroot/base/sim/FairModule.cxx
+++ b/fairroot/base/sim/FairModule.cxx
@@ -459,7 +459,7 @@ void FairModule::ExpandNodeForGDML(TGeoNode* curNode)
     AssignMediumAtImport(curVol);
 
     // Check if the volume is sensitive
-    if ((this->InheritsFrom("FairDetector")) && IsSensitive(curVol->GetName())) {
+    if ((this->InheritsFrom("FairDetector")) && IsSensitive(curVol)) {
         LOG(debug2) << "Sensitive Volume " << curVol->GetName();
         AddSensitiveVolume(curVol);
     }
@@ -564,7 +564,7 @@ void FairModule::ExpandNode(TGeoNode* fN)
             LOG(debug2) << "Register Volume " << v->GetName();
             v->RegisterYourself();
         }
-        if ((this->InheritsFrom("FairDetector")) && IsSensitive(v->GetName())) {
+        if ((this->InheritsFrom("FairDetector")) && IsSensitive(v)) {
             LOG(debug2) << "Sensitive Volume " << v->GetName();
             AddSensitiveVolume(v);
         }

--- a/fairroot/base/sim/FairModule.h
+++ b/fairroot/base/sim/FairModule.h
@@ -17,6 +17,7 @@
 #include "FairRuntimeDb.h"   // for FairRuntimeDb
 
 #include <TCollection.h>   // for TRangeDynCast
+#include <TGeoManager.h>
 #include <TGeoMatrix.h>
 #include <TGeoNode.h>
 #include <TGeoVolume.h>
@@ -103,9 +104,14 @@ class FairModule : public TNamed
     template<class T, class U>
     void ConstructASCIIGeometry(TString containerName = "");
 
+    /** Check volume sensitivity by probing medium sensitivity flag. */
+    virtual Bool_t IsSensitive(TGeoVolume* vol) { return (vol->GetMedium()->GetParam(0) == 1.0); }
+
     /**Set the sensitivity flag for volumes, called from ConstructASCIIRootGeometry(), and has to be implimented for
      * detectors which use ConstructASCIIRootGeometry() to build the geometry */
-    virtual Bool_t IsSensitive(const std::string& name);
+    virtual Bool_t IsSensitive(const std::string& name) __attribute__((deprecated(
+        "The method IfSensitive(const std::string& name) is deprecated and may be removed in the future releases.")));
+
     /**The function below is depracated, please change to the new method above */
     virtual Bool_t CheckIfSensitive(__attribute__((unused)) std::string name) __attribute__((
         deprecated("The method CheckIfSensitive is deprecated. Implement IsSensitive in the detector classes.")))

--- a/fairroot/base/sim/FairModule.h
+++ b/fairroot/base/sim/FairModule.h
@@ -104,17 +104,28 @@ class FairModule : public TNamed
     template<class T, class U>
     void ConstructASCIIGeometry(TString containerName = "");
 
-    /** Check volume sensitivity by probing medium sensitivity flag. */
-    virtual Bool_t IsSensitive(TGeoVolume* vol) { return (vol->GetMedium()->GetParam(0) == 1.0); }
+    /**
+     * Check volume sensitivity by probing medium sensitivity flag.
+     *
+     * Function checks the sensitivity property of the medium. This is generic approach and should work for any volume.
+     * Override this _only_ in case of specific customisation.
+     *
+     * See Bool_t IsSensitive(const std::string& name) for deprecation notice.
+     */
+    virtual bool IsSensitive(TGeoVolume* vol) { return (vol->GetMedium()->GetParam(0) == 1.0); }
 
-    /**Set the sensitivity flag for volumes, called from ConstructASCIIRootGeometry(), and has to be implimented for
-     * detectors which use ConstructASCIIRootGeometry() to build the geometry */
-    virtual Bool_t IsSensitive(const std::string& name) __attribute__((deprecated(
-        "The method IfSensitive(const std::string& name) is deprecated and may be removed in the future releases.")));
+    /**
+     * Set the sensitivity flag for volumes, called from ConstructASCIIRootGeometry(), and has to be implimented for
+     * detectors which use ConstructASCIIRootGeometry() to build the geometry
+     */
+    [[deprecated("Remove override of this function. Use override of IsSensitive(TGeoVolume* vol) only if customisation "
+                 "required. This function will be removed in the future releases.")]]
+    virtual Bool_t IsSensitive(const std::string& name) final;
 
     /**The function below is depracated, please change to the new method above */
-    virtual Bool_t CheckIfSensitive(__attribute__((unused)) std::string name) __attribute__((
-        deprecated("The method CheckIfSensitive is deprecated. Implement IsSensitive in the detector classes.")))
+    [[deprecated("The method CheckIfSensitive is deprecated. Implement IsSensitive in the detector "
+                 "classes. To be removed in the future.")]]
+    virtual Bool_t CheckIfSensitive(__attribute__((unused)) std::string name) final
     {
         return kFALSE;
     }


### PR DESCRIPTION
This is faster way of checking the sensitivity property however medium needs to have proper sensitivity flag set.

See the discussion in this MR: https://git.cbm.gsi.de/CbmSoft/cbmroot_geometry/-/merge_requests/342#note_60660

@fuhlig1 is this is something you wanted to have?

I tried to check all the modified examples and tests whether they are still correct (all tests are passing), I need someone who is more familiar to check as well.

But it is not easy to test against cbmroot
---

Checklist:

* [x] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)