### PR TITLE
docs(CONTRIBUTING): Proposed updates to Contributing Guidelines

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -96,6 +96,11 @@
         },
         {
             "type": "Other",
+            "name": "Lalik, Rafa\u0142",
+            "orcid": "0000-0003-1313-3729"
+        },
+        {
+            "type": "Other",
             "name": "Lavezzi, Lia"
         },
         {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,10 @@ Create a [Github Pull Request](https://github.com/FairRootGroup/FairRoot/compare
    * In rare cases (e.g. backports, some hotfixes) base against the appropriate
      branch.
 2. If you are a first time contributor, add a separate commit in your PR which
-   adds your name to the [`CONTRIBUTORS`](CONTRIBUTORS) file.
+   adds your name to the:
+   * [`CONTRIBUTORS`](CONTRIBUTORS) file,
+   * [`.zenodo.json`](.zenodo.json) file, and
+   * [`codemeta.json`](codemeta.json) file.
 3. Follow our [Coding Guidelines](#coding-guidelines).
 4. Expect that a reviewer will ask you for restructuring your commits! This
    usually happens towards the end of the lifetime of a PR when it matured
@@ -53,7 +56,15 @@ This shall be an evolving list of explicitely adopted C++ Core Guidelines:
    * If an owning raw pointer cannot be avoided for legacy reasons,
      **you must add a comment documenting the ownership semantics!**
 
-### G.3 Write a good Git history
+### G.3 Other C++ Guidelines
+
+1. Use of ROOT types:
+   1. The data which are intended to be stored in the ROOT files should use ROOT data type.
+   2. Variables which control execution logic should use standard types.
+
+## V - Version control
+
+### V.1 Write a good Git history
 
 * Follow [the seven rules of a great Git commit message](https://cbea.ms/git-commit/#seven-rules)!
 * Use a meaningful commit granularity, e.g. do not mix
@@ -65,7 +76,7 @@ This shall be an evolving list of explicitely adopted C++ Core Guidelines:
 * Utilize [reference keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
   both in commit messages as well as in PR comments if applicable.
 
-### G.4 Conventional Commits
+### V.2 Conventional Commits
 
 * Follow the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/)
 * Adopted `type`s: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`,
@@ -73,7 +84,7 @@ This shall be an evolving list of explicitely adopted C++ Core Guidelines:
 * If a `scope` is used, prefer the library name (first directory level below
   `fairroot/`), e.g. `fix(base):` or `feat(geobase):`
 
-### G.5 Signed Commits and Tags
+### V.3 Signed Commits and Tags
 
 You may use any signature format Git and Github support (SSH e.g. may be more
 convenient, if one does not have a GPG key yet).

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -14,6 +14,7 @@ Klenze, Philipp
 Kollegger, Thorsten
 Koenig, Ilse
 Krzewicki, Mikolaj
+Lalik, Rafał [https://orcid.org/0000-0003-1313-3729]
 Lavezzi, Lia
 Lavrik, Evgeny
 Lantwin, Oliver

--- a/codemeta.json
+++ b/codemeta.json
@@ -152,6 +152,12 @@
     },
     {
       "@type": "Person",
+      "@id": "https://orcid.org/0000-0003-1313-3729",
+      "givenName": "Rafa\u0142",
+      "familyName": "Lalik"
+    },
+    {
+      "@type": "Person",
       "givenName": "Lia",
       "familyName": "Lavezzi"
     },


### PR DESCRIPTION
Following up discussion from #1628  and proposition by @ChristianTackeGSI to update Contributing Guidelines with my ideas, I open  this PR in Draft mode to work on updates.

#### N: Things I did now:

1. Separated git-related rules into separate `V (Version Control)` category
2. Added new G.3 rule category about `Other C++ Guidelines`, for those not matching G.2 related to CPPCG
3. Added G.3.1 as follow up to #1628  about use of ROOT/standard types
4. Updated `Contributing Code.2` rule and added other files to the list which need to be updated by the new contributors. 

#### S: Things I would (strongly) suggest to update:
1. Enumerate all guidelines instead of using bullets - it helps to refer to them by number, e.g. G.3.1.2
2. Specify exact `clang-format` version - different version may produce different result for the same config file. This update should be followed by update of `apply-format.sh` and `check-format.sh` (as separate PR).

#### O: Other ideas 
1. Could the rule:
> * In rare cases (e.g. backports, some hotfixes) base against the appropriate branch

be removed and commit cherry-picking be used instead (after being agreed in the PR comment section)? New rule could be:
> * If change should be applied to other branches, cherry picking is the preferred way to go.

Please refer to these list as N.1, S.2, O.1, etc... in the discussion section.

---

Checklist:

* [x] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
