### PR TITLE
Moving non-deterministic info line to debug output

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -8,6 +8,7 @@ Eulisse, Giulio
 Friese, Volker
 Gertsenberger, Konstantin
 Hřivnáčová, Ivana
+Kholoimov, Valerii
 Klasen, Roman
 Kliemt, Ralf
 Klenze, Philipp

--- a/fairroot/base/sink/FairRootFileSink.cxx
+++ b/fairroot/base/sink/FairRootFileSink.cxx
@@ -281,7 +281,7 @@ bool FairRootFileSink::CreatePersistentBranchesAny()
         // create the branch
         auto obj = iter.second->ptraddr;
 
-        LOG(info) << "Creating branch for " << iter.first.c_str() << " with address " << obj;
+        LOG(debug) << "Creating branch for " << iter.first.c_str() << " with address " << obj;
         fOutTree->Branch(iter.first.c_str(), tname.c_str(), obj);
     }
     fPersistentBranchesDone = true;


### PR DESCRIPTION

This PR moves the branch-address log from info to debug.

That output includes a raw pointer address, which is not deterministic across runs because it depends on runtime memory layout. Because of that, the logs are not deterministic even when the simulation result is the same. This makes automatic testing by direct log comparison difficult unless the output is cleaned up first. 
It also exposes low-level technical detail that is mainly useful for debugging, not for normal simulation logs.

We want to make this change to keep FairShip output cleaner and more deterministic for testing.

---

Checklist:

* [ ] Followed the [Contributing Guidelines](https://github.com/FairRootGroup/FairRoot/blob/dev/CONTRIBUTING.md)
